### PR TITLE
Introduce count_EQ and deprecate the implicit count filter.

### DIFF
--- a/.changeset/beige-students-check.md
+++ b/.changeset/beige-students-check.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+Deprecated implicit aggregation filter: `count`, `{ count: 10 }` in favor of the explicit version: `{ count_EQ: 10 }`.

--- a/.changeset/shaggy-swans-collect.md
+++ b/.changeset/shaggy-swans-collect.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": minor
+---
+
+Added aggregation filter `count_EQ` filters: `{ count_EQ: 10 }`, this is an alternative version of the deprecated version `{ count: 10 }`. 

--- a/.changeset/shaggy-swans-collect.md
+++ b/.changeset/shaggy-swans-collect.md
@@ -2,4 +2,4 @@
 "@neo4j/graphql": minor
 ---
 
-Added aggregation filter `count_EQ` filters: `{ count_EQ: 10 }`, this is an alternative version of the deprecated version `{ count: 10 }`. 
+Added aggregation filter `count_EQ` filters: `{ count_EQ: 10 }`, this is the replacement for the deprecated version `{ count: 10 }`. 

--- a/packages/graphql/src/schema/constants.ts
+++ b/packages/graphql/src/schema/constants.ts
@@ -26,7 +26,7 @@ export const DEPRECATE_IMPLICIT_LENGTH_AGGREGATION_FILTERS = {
     },
 };
 
-export const DEPRECATE_EQUAL_FILTERS = {
+export const DEPRECATE_IMPLICIT_EQUAL_FILTERS = {
     name: DEPRECATED,
     args: {
         reason: "Please use the explicit _EQ version",

--- a/packages/graphql/src/schema/generation/where-input.ts
+++ b/packages/graphql/src/schema/generation/where-input.ts
@@ -32,7 +32,7 @@ import { UnionEntityAdapter } from "../../schema-model/entity/model-adapters/Uni
 import { RelationshipAdapter } from "../../schema-model/relationship/model-adapters/RelationshipAdapter";
 import type { RelationshipDeclarationAdapter } from "../../schema-model/relationship/model-adapters/RelationshipDeclarationAdapter";
 import type { Neo4jFeaturesSettings } from "../../types";
-import { DEPRECATE_EQUAL_FILTERS } from "../constants";
+import { DEPRECATE_IMPLICIT_EQUAL_FILTERS } from "../constants";
 import { getWhereFieldsForAttributes } from "../get-where-fields";
 import { withAggregateInputType } from "./aggregate-types";
 import {
@@ -59,7 +59,7 @@ export function withUniqueWhereInputType({
         if (shouldAddDeprecatedFields(features, "implicitEqualFilters")) {
             uniqueWhereFields[attribute.name] = {
                 type: attribute.getFieldTypeName(),
-                directives: [DEPRECATE_EQUAL_FILTERS],
+                directives: [DEPRECATE_IMPLICIT_EQUAL_FILTERS],
             };
         }
         uniqueWhereFields[`${attribute.name}_EQ`] = {

--- a/packages/graphql/src/schema/get-where-fields.ts
+++ b/packages/graphql/src/schema/get-where-fields.ts
@@ -22,7 +22,7 @@ import type { Directive } from "graphql-compose";
 import { DEPRECATED } from "../constants";
 import type { AttributeAdapter } from "../schema-model/attribute/model-adapters/AttributeAdapter";
 import type { Neo4jFeaturesSettings } from "../types";
-import { DEPRECATE_EQUAL_FILTERS } from "./constants";
+import { DEPRECATE_IMPLICIT_EQUAL_FILTERS } from "./constants";
 import { shouldAddDeprecatedFields } from "./generation/utils";
 import { graphqlDirectivesToCompose } from "./to-compose";
 
@@ -79,7 +79,7 @@ export function getWhereFieldsForAttributes({
         if (shouldAddDeprecatedFields(features, "implicitEqualFilters")) {
             result[field.name] = {
                 type: field.getInputTypeNames().where.pretty,
-                directives: deprecatedDirectives.length ? deprecatedDirectives : [DEPRECATE_EQUAL_FILTERS],
+                directives: deprecatedDirectives.length ? deprecatedDirectives : [DEPRECATE_IMPLICIT_EQUAL_FILTERS],
             };
         }
         result[`${field.name}_EQ`] = {

--- a/packages/graphql/src/translate/queryAST/factory/FilterFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/FilterFactory.ts
@@ -555,9 +555,7 @@ export class FilterFactory {
                     return [logicalFilter];
                 }
                 const { fieldName, operator, isNot } = parseWhereField(key);
-                if (!operator && fieldName === "count") {
-                    throw new Error("wooo");
-                }
+
                 const filterOperator = operator ?? "EQ";
                 if (fieldName === "count") {
                     const countFilter = new CountFilter({

--- a/packages/graphql/src/translate/queryAST/factory/FilterFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/FilterFactory.ts
@@ -555,8 +555,10 @@ export class FilterFactory {
                     return [logicalFilter];
                 }
                 const { fieldName, operator, isNot } = parseWhereField(key);
-
-                const filterOperator = operator || "EQ";
+                if (!operator && fieldName === "count") {
+                    throw new Error("wooo");
+                }
+                const filterOperator = operator ?? "EQ";
                 if (fieldName === "count") {
                     const countFilter = new CountFilter({
                         operator: filterOperator,

--- a/packages/graphql/tests/integration/aggregations/field-level/where/field-aggregation-where.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/field-level/where/field-aggregation-where.int.test.ts
@@ -102,7 +102,7 @@ describe("Field Level Aggregations Where", () => {
         const query = `
             query {
               ${typeMovie.plural} {
-                actorsAggregate(where: {moviesAggregate: {count:1}}) {
+                actorsAggregate(where: {moviesAggregate: { count_EQ: 1}}) {
                   count
                 }
               }
@@ -120,7 +120,7 @@ describe("Field Level Aggregations Where", () => {
             const query = `
             query {
                 ${typePerson.plural} {
-                    moviesAggregate(where:{actorsConnection: {node: {name_EQ: "Linda"}}}){
+                    moviesAggregate(where:{actorsConnection: { node: { name_EQ: "Linda" } }}){
                         count
                     }
                 }

--- a/packages/graphql/tests/integration/aggregations/where/AND-OR-operations.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/AND-OR-operations.int.test.ts
@@ -79,7 +79,7 @@ describe("Nested within AND/OR", () => {
             query {
                 ${postType.plural}(where: { 
                     likesAggregate: {
-                        count: 3
+                        count_EQ: 3
                         node: {
                             testString_SHORTEST_EQUAL: 3
                         }
@@ -108,7 +108,7 @@ describe("Nested within AND/OR", () => {
                 ${postType.plural}(where: { 
                     likesAggregate: {
                         OR: [
-                            { count: 3 }
+                            { count_EQ: 3 }
                             {
                                 node: {
                                     testString_SHORTEST_EQUAL: 3
@@ -149,7 +149,7 @@ describe("Nested within AND/OR", () => {
                 ${postType.plural}(where: { 
                     likesAggregate: {
                         AND: [
-                            { count: 3 }
+                            { count_EQ: 3 }
                             {
                                 node: {
                                     testString_SHORTEST_EQUAL: 3

--- a/packages/graphql/tests/integration/aggregations/where/count.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/count.int.test.ts
@@ -62,7 +62,7 @@ describe("aggregations-where-count", () => {
 
         const query = /* GraphQL */ `
                 {
-                    ${Post.plural}(where: { testString_EQ: "${testString}", likesAggregate: { count: 1 } }) {
+                    ${Post.plural}(where: { testString_EQ: "${testString}", likesAggregate: { count_EQ: 1 } }) {
                         testString
                         likes {
                             testString
@@ -305,7 +305,7 @@ describe("aggregations-where-count  interface relationships of concrete types", 
 
         const query = `
                 {
-                    ${Post.plural}(where: { testString_EQ: "${testString}", likesAggregate: { count: 1 } }) {
+                    ${Post.plural}(where: { testString_EQ: "${testString}", likesAggregate: { count_EQ: 1 } }) {
                         testString
                         likes {
                             testString

--- a/packages/graphql/tests/integration/aggregations/where/mutations/delete/top-level-where.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/mutations/delete/top-level-where.int.test.ts
@@ -79,7 +79,7 @@ describe("Delete using top level aggregate where", () => {
             mutation {
                 ${postType.operations.delete}(where: { 
                     likesAggregate: {
-                        count: 3
+                        count_EQ: 3
                         node: {
                             testString_SHORTEST_EQUAL: 3
                         }
@@ -106,7 +106,7 @@ describe("Delete using top level aggregate where", () => {
                 ${postType.operations.delete}(where: { 
                     likesAggregate: {
                         OR: [
-                            { count: 3 }
+                            { count_EQ: 3 }
                             {
                                 node: {
                                     testString_SHORTEST_EQUAL: 3
@@ -136,7 +136,7 @@ describe("Delete using top level aggregate where", () => {
                 ${postType.operations.delete}(where: { 
                     likesAggregate: {
                         AND: [
-                            { count: 3 }
+                            { count_EQ: 3 }
                             {
                                 node: {
                                     testString_SHORTEST_EQUAL: 3

--- a/packages/graphql/tests/integration/aggregations/where/mutations/update/connect-arg.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/mutations/update/connect-arg.int.test.ts
@@ -89,7 +89,7 @@ describe("Connect using aggregate where", () => {
                                 where: { 
                                     node: {
                                         likesAggregate: {
-                                            count: 2
+                                            count_EQ: 2
                                         }
                                     } 
                                 } 
@@ -137,10 +137,10 @@ describe("Connect using aggregate where", () => {
                                         likesAggregate: {
                                             OR: [
                                                 {
-                                                    count: 2
+                                                    count_EQ: 2
                                                 },
                                                 {
-                                                    count: 0
+                                                    count_EQ: 0
                                                 }
                                             ]
                                         }
@@ -201,7 +201,7 @@ describe("Connect using aggregate where", () => {
                                                     node: {
                                                         name_SHORTEST_LT: 2 
                                                     }
-                                                    count: 2
+                                                    count_EQ: 2
                                                 }
                                             ]
                                         }
@@ -263,7 +263,7 @@ describe("Connect using aggregate where", () => {
                                                     node: {
                                                         NOT: { name_SHORTEST_GTE: 2 } 
                                                     }
-                                                    count: 2
+                                                    count_EQ: 2
                                                 }
                                             ]
                                         }
@@ -394,7 +394,7 @@ describe("Connect UNIONs using aggregate where", () => {
                                 where: {
                                     node: {
                                         likedPostsAggregate: {
-                                            count: 2
+                                            count_EQ: 2
                                         }
                                     }
                                 }

--- a/packages/graphql/tests/integration/aggregations/where/mutations/update/disconnect-arg.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/mutations/update/disconnect-arg.int.test.ts
@@ -83,7 +83,7 @@ describe("Disconnect using aggregate where", () => {
                                 where: { 
                                     node: {
                                         likesAggregate: {
-                                            count: 2
+                                            count_EQ: 2
                                         }
                                     } 
                                 } 
@@ -129,7 +129,7 @@ describe("Disconnect using aggregate where", () => {
                                          likesAggregate: {
                                             OR: [
                                             {
-                                                count: 2
+                                                count_EQ: 2
                                                 
                                             },
                                             {
@@ -191,7 +191,7 @@ describe("Disconnect using aggregate where", () => {
                                                     node: {
                                                         name_SHORTEST_GT: 2 
                                                     }
-                                                    count: 2
+                                                    count_EQ: 2
                                                 }
                                             ]
                                         }
@@ -317,7 +317,7 @@ describe("Disconnect UNIONs using aggregate where", () => {
                                 where: {
                                     node: {
                                         likedPostsAggregate: {
-                                            count: 2
+                                            count_EQ: 2
                                         }
                                     }
                                 }
@@ -375,7 +375,7 @@ describe("Disconnect UNIONs using aggregate where", () => {
                                         AND: [
                                             {
                                                 likedPostsAggregate: {
-                                                    count: 2
+                                                    count_EQ: 2
                                                 }
                                             },
                                             {
@@ -445,7 +445,7 @@ describe("Disconnect UNIONs using aggregate where", () => {
                                         AND: [
                                             {
                                                 likedPostsAggregate: {
-                                                    count: 2
+                                                    count_EQ: 2
                                                 }
                                             },
                                             {
@@ -517,7 +517,7 @@ describe("Disconnect UNIONs using aggregate where", () => {
                                                 AND: [
                                                     {
                                                         likedPostsAggregate: {
-                                                            count: 2
+                                                            count_EQ: 2
                                                         }
                                                     },
                                                     {

--- a/packages/graphql/tests/integration/aggregations/where/mutations/update/top-level-where.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/mutations/update/top-level-where.int.test.ts
@@ -82,7 +82,7 @@ describe("Delete using top level aggregate where", () => {
                 ${postType.operations.update}(
                     where: { 
                         likesAggregate: {
-                            count: 3
+                            count_EQ: 3
                             node: {
                                 testString_SHORTEST_EQUAL: 3
                             }
@@ -114,7 +114,7 @@ describe("Delete using top level aggregate where", () => {
                 ${postType.operations.update}(where: { 
                     likesAggregate: {
                         OR: [
-                            { count: 3 }
+                            { count_EQ: 3 }
                             {
                                 node: {
                                     testString_SHORTEST_EQUAL: 3
@@ -147,7 +147,7 @@ describe("Delete using top level aggregate where", () => {
                 ${postType.operations.update}(where: { 
                     likesAggregate: {
                         AND: [
-                            { count: 3 }
+                            { count_EQ: 3 }
                             {
                                 node: {
                                     testString_SHORTEST_EQUAL: 3

--- a/packages/graphql/tests/integration/aggregations/where/mutations/update/update-arg.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/mutations/update/update-arg.int.test.ts
@@ -88,7 +88,7 @@ describe("Update using aggregate where", () => {
                             where: { 
                                 node: {
                                     likesAggregate: {
-                                        count: 2
+                                        count_EQ: 2
                                     }
                                 } 
                             } 
@@ -161,7 +161,7 @@ describe("Update using aggregate where", () => {
                                     likesAggregate: {
                                        OR: [
                                        {
-                                           count: 2
+                                           count_EQ: 2
                                            
                                        },
                                        {
@@ -246,7 +246,7 @@ describe("Update using aggregate where", () => {
                                         node: {
                                             name_SHORTEST_LT: 10 
                                         }
-                                        count: 1
+                                        count_EQ: 1
                                     }
                                 }
                             }

--- a/packages/graphql/tests/integration/deprecations/implicit-count-eq.int.test.ts
+++ b/packages/graphql/tests/integration/deprecations/implicit-count-eq.int.test.ts
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { UniqueType } from "../../utils/graphql-types";
+import { TestHelper } from "../../utils/tests-helper";
+
+describe("aggregations-where-count", () => {
+    const testHelper = new TestHelper();
+    let User: UniqueType;
+    let Post: UniqueType;
+
+    beforeEach(async () => {
+        User = testHelper.createUniqueType("User");
+        Post = testHelper.createUniqueType("Post");
+
+        const typeDefs = /* GraphQL */ `
+            type ${User} @node {
+                name: String!
+            }
+
+            type ${Post} @node {
+              title: String!
+              likes: [${User}!]! @relationship(type: "LIKES", direction: IN)
+            }
+        `;
+        await testHelper.initNeo4jGraphQL({ typeDefs });
+    });
+
+    afterEach(async () => {
+        await testHelper.close();
+    });
+
+    test("should return posts where the count of likes equal one", async () => {
+        await testHelper.executeCypher(
+            `
+                    CREATE (p1:${Post} {title: "hello world"})
+                    CREATE (:${Post} {title: "Post 1"})
+                    CREATE (u1:${User} {name: "Alice"})
+                    CREATE (u2:${User} {name: "Stefano"})
+                    CREATE (p1)<-[:LIKES]-(u1)
+                    CREATE (p1)<-[:LIKES]-(u2)
+                `
+        );
+
+        const query = /* GraphQL */ `
+                {
+                    ${Post.plural}(where: { title_EQ: "hello world", likesAggregate: { count: 2 } }) {
+                        title
+                        likes {
+                            name
+                        }
+                    }
+                }
+            `;
+
+        const gqlResult = await testHelper.executeGraphQL(query);
+
+        if (gqlResult.errors) {
+            console.log(JSON.stringify(gqlResult.errors, null, 2));
+        }
+
+        expect(gqlResult.errors).toBeUndefined();
+
+        expect((gqlResult.data as any)[Post.plural]).toEqual([
+            {
+                title: "hello world",
+                likes: expect.toIncludeSameMembers([{ name: "Alice" }, { name: "Stefano" }]),
+            },
+        ]);
+    });
+});
+
+describe("aggregations-where-count interface relationships of concrete types", () => {
+    let testHelper: TestHelper;
+    let User: UniqueType;
+    let Post: UniqueType;
+    let Person: UniqueType;
+
+    beforeEach(async () => {
+        testHelper = new TestHelper();
+        User = testHelper.createUniqueType("User");
+        Post = testHelper.createUniqueType("Post");
+        Person = testHelper.createUniqueType("Person");
+
+        const typeDefs = /* GraphQL */ `
+            interface Human {
+                name: String!
+            }
+
+            type ${User} implements Human @node {
+                name: String!
+            }
+
+            type ${Person} implements Human @node {
+                name: String!
+            }
+
+            type ${Post} @node {
+              title: String!
+              likes: [Human!]! @relationship(type: "LIKES", direction: IN)
+            }
+        `;
+        await testHelper.initNeo4jGraphQL({ typeDefs });
+    });
+
+    afterEach(async () => {
+        await testHelper.close();
+    });
+
+    test("should return posts where the count of likes equal one", async () => {
+        await testHelper.executeCypher(
+            `       CREATE (p1:${Post} {title: "hello world"})
+                    CREATE (:${Post} {title: "Post 1"})
+                    CREATE (u1:${User} {name: "Alice"})
+                    CREATE (u2:${Person} {name: "Stefano"})
+                    CREATE (p1)<-[:LIKES]-(u1)
+                    CREATE (p1)<-[:LIKES]-(u2)
+            `
+        );
+
+        const query = /* GraphQL */ `
+                {
+                    ${Post.plural}(where: { title_EQ: "hello world", likesAggregate: { count_EQ: 2 } }) {
+                        title
+                        likes {
+                            name
+                        }
+                    }
+                }
+            `;
+
+        const gqlResult = await testHelper.executeGraphQL(query);
+
+        if (gqlResult.errors) {
+            console.log(JSON.stringify(gqlResult.errors, null, 2));
+        }
+
+        expect(gqlResult.errors).toBeUndefined();
+
+        expect((gqlResult.data as any)[Post.plural]).toEqual([
+            {
+                title: "hello world",
+                likes: expect.toIncludeSameMembers([{ name: "Alice" }, { name: "Stefano" }]),
+            },
+        ]);
+    });
+});

--- a/packages/graphql/tests/integration/issues/1640.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1640.int.test.ts
@@ -56,7 +56,7 @@ describe("https://github.com/neo4j/graphql/issues/1640", () => {
             mutation DeleteOrganizations {
                 ${testOrganization.operations.delete}(
                     where: { name_EQ: "Org1" }
-                    delete: { admins: [{ where: { node: { organizationsAggregate: { count: 1 } } } }] }
+                    delete: { admins: [{ where: { node: { organizationsAggregate: { count_EQ: 1 } } } }] }
                 ) {
                     nodesDeleted
                     relationshipsDeleted

--- a/packages/graphql/tests/integration/issues/1751.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1751.int.test.ts
@@ -60,7 +60,7 @@ describe("https://github.com/neo4j/graphql/issues/1735", () => {
             mutation DeleteOrganizations {
                 ${organizationType.operations.delete}(
                     where: { title_EQ: "Google" }
-                    delete: { admins: [{ where: { node: { organizationsAggregate: { count: 1 } } } }] }
+                    delete: { admins: [{ where: { node: { organizationsAggregate: { count_EQ: 1 } } } }] }
                 ) {
                     nodesDeleted
                     relationshipsDeleted

--- a/packages/graphql/tests/integration/issues/2670.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2670.int.test.ts
@@ -97,7 +97,7 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
     test("should find where moviesAggregate count equal", async () => {
         const query = `
             {
-                ${movieType.plural}(where: { genresConnection: { node: { moviesAggregate: { count: 2 } } } }) {
+                ${movieType.plural}(where: { genresConnection: { node: { moviesAggregate: { count_EQ: 2 } } } }) {
                     title
                 }
             }
@@ -274,7 +274,7 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
     test("should find where genresConnection_SOME and nested count", async () => {
         const query = `
             {
-                ${movieType.plural}(where: { genresConnection_SOME: { node: { moviesAggregate: { count: 2 } } } }) {
+                ${movieType.plural}(where: { genresConnection_SOME: { node: { moviesAggregate: { count_EQ: 2 } } } }) {
                     title
                 }
             }
@@ -298,7 +298,7 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
     test("should find where genresConnection_NONE", async () => {
         const query = `
             {
-                ${movieType.plural}(where: { genresConnection_NONE: { node: { moviesAggregate: { count: 2 } } } }) {
+                ${movieType.plural}(where: { genresConnection_NONE: { node: { moviesAggregate: { count_EQ: 2 } } } }) {
                     title
                 }
             }
@@ -325,7 +325,7 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
     test("should find where genresConnection_ALL", async () => {
         const query = `
             {
-                ${movieType.plural}(where: { genresConnection_ALL: { node: { moviesAggregate: { count: 2 } } } }) {
+                ${movieType.plural}(where: { genresConnection_ALL: { node: { moviesAggregate: { count_EQ: 2 } } } }) {
                     title
                 }
             }
@@ -346,7 +346,7 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
     test("should find where genresConnection_SINGLE", async () => {
         const query = `
             {
-                ${movieType.plural}(where: { genresConnection_SINGLE: { node: { moviesAggregate: { count: 2 } } } }) {
+                ${movieType.plural}(where: { genresConnection_SINGLE: { node: { moviesAggregate: { count_EQ: 2 } } } }) {
                     title
                 }
             }
@@ -370,7 +370,7 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
     test("should find genresConnection with multiple AND aggregates", async () => {
         const query = `
             {
-                ${movieType.plural}(where: { genresConnection: { AND: [{ node: { moviesAggregate: { count: 2 } } }, { node: { seriesAggregate: { node: { name_SHORTEST_EQUAL: ${seriesName1.length} } } } }] } }) {
+                ${movieType.plural}(where: { genresConnection: { AND: [{ node: { moviesAggregate: { count_EQ: 2 } } }, { node: { seriesAggregate: { node: { name_SHORTEST_EQUAL: ${seriesName1.length} } } } }] } }) {
                     title
                 }
             }
@@ -394,7 +394,7 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
     test("should find genresConnection with multiple OR aggregates", async () => {
         const query = `
             {
-                ${movieType.plural}(where: { genresConnection: { OR: [{ node: { moviesAggregate: { count: 3 } } }, { node: { seriesAggregate: { node: { name_SHORTEST_EQUAL: ${seriesName1.length} } } } }] } }) {
+                ${movieType.plural}(where: { genresConnection: { OR: [{ node: { moviesAggregate: { count_EQ: 3 } } }, { node: { seriesAggregate: { node: { name_SHORTEST_EQUAL: ${seriesName1.length} } } } }] } }) {
                     title
                 }
             }
@@ -424,7 +424,7 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
     test("should find genresConnection with multiple implicit AND aggregates", async () => {
         const query = `
             {
-                ${movieType.plural}(where: { genresConnection: { node: { moviesAggregate: { count: 2 }, seriesAggregate: { node: { name_SHORTEST_EQUAL: ${seriesName1.length} } } } } }) {
+                ${movieType.plural}(where: { genresConnection: { node: { moviesAggregate: { count_EQ: 2 }, seriesAggregate: { node: { name_SHORTEST_EQUAL: ${seriesName1.length} } } } } }) {
                     title
                 }
             }
@@ -448,7 +448,7 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
     test("should find genresConnection with aggregation at the same level", async () => {
         const query = `
             {
-                ${movieType.plural}(where: { genresConnection: { node: { moviesAggregate: { count: 3 } } }, genresAggregate: { count: 1 } }) {
+                ${movieType.plural}(where: { genresConnection: { node: { moviesAggregate: { count_EQ: 3 } } }, genresAggregate: { count_EQ: 1 } }) {
                     title
                 }
             }

--- a/packages/graphql/tests/integration/issues/2708.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2708.int.test.ts
@@ -95,7 +95,7 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
     test("should find where moviesAggregate count equal", async () => {
         const query = `
             {
-                ${movieType.plural}(where: { genres: { moviesAggregate: { count: 2 } } }) {
+                ${movieType.plural}(where: { genres: { moviesAggregate: { count_EQ: 2 } } }) {
                     title
                 }
             }
@@ -272,7 +272,7 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
     test("should find where genres_SOME", async () => {
         const query = `
             {
-                ${movieType.plural}(where: { genres_SOME: { moviesAggregate: { count: 2 } } }) {
+                ${movieType.plural}(where: { genres_SOME: { moviesAggregate: { count_EQ: 2 } } }) {
                     title
                 }
             }
@@ -296,7 +296,7 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
     test("should find where genres_NONE", async () => {
         const query = `
             {
-                ${movieType.plural}(where: { genres_NONE: { moviesAggregate: { count: 2 } } }) {
+                ${movieType.plural}(where: { genres_NONE: { moviesAggregate: { count_EQ: 2 } } }) {
                     title
                 }
             }
@@ -323,7 +323,7 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
     test("should find where genres_ALL", async () => {
         const query = `
             {
-                ${movieType.plural}(where: { genres_ALL: { moviesAggregate: { count: 2 } } }) {
+                ${movieType.plural}(where: { genres_ALL: { moviesAggregate: { count_EQ: 2 } } }) {
                     title
                 }
             }
@@ -344,7 +344,7 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
     test("should find where genres_SINGLE", async () => {
         const query = `
             {
-                ${movieType.plural}(where: { genres_SINGLE: { moviesAggregate: { count: 2 } } }) {
+                ${movieType.plural}(where: { genres_SINGLE: { moviesAggregate: { count_EQ: 2 } } }) {
                     title
                 }
             }
@@ -368,7 +368,7 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
     test("should not find genres_ALL where NONE true", async () => {
         const query = `
             {
-                ${movieType.plural}(where: { genres_ALL: { moviesAggregate: { count: 0 } } }) {
+                ${movieType.plural}(where: { genres_ALL: { moviesAggregate: { count_EQ: 0 } } }) {
                     title
                 }
             }
@@ -385,7 +385,7 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
     test("should find genres with multiple AND aggregates", async () => {
         const query = `
             {
-                ${movieType.plural}(where: { genres: { AND: [{ moviesAggregate: { count: 2 } }, { seriesAggregate: { node: { name_SHORTEST_EQUAL: ${seriesName1.length} } } }] } }) {
+                ${movieType.plural}(where: { genres: { AND: [{ moviesAggregate: { count_EQ: 2 } }, { seriesAggregate: { node: { name_SHORTEST_EQUAL: ${seriesName1.length} } } }] } }) {
                     title
                 }
             }
@@ -409,7 +409,7 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
     test("should find genres with multiple OR aggregates", async () => {
         const query = `
             {
-                ${movieType.plural}(where: { genres: { OR: [{ moviesAggregate: { count: 3 } }, { seriesAggregate: { node: { name_SHORTEST_EQUAL: ${seriesName1.length} } } }] } }) {
+                ${movieType.plural}(where: { genres: { OR: [{ moviesAggregate: { count_EQ: 3 } }, { seriesAggregate: { node: { name_SHORTEST_EQUAL: ${seriesName1.length} } } }] } }) {
                     title
                 }
             }
@@ -439,7 +439,7 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
     test("should find genres with multiple implicit AND aggregates", async () => {
         const query = `
             {
-                ${movieType.plural}(where: { genres: { moviesAggregate: { count: 2 }, seriesAggregate: { node: { name_SHORTEST_EQUAL: ${seriesName1.length} } } } }) {
+                ${movieType.plural}(where: { genres: { moviesAggregate: { count_EQ: 2 }, seriesAggregate: { node: { name_SHORTEST_EQUAL: ${seriesName1.length} } } } }) {
                     title
                 }
             }
@@ -463,7 +463,7 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
     test("should find genres with aggregation at the same level", async () => {
         const query = `
             {
-                ${movieType.plural}(where: { genres: { moviesAggregate: { count: 3 } }, genresAggregate: { count: 1 } }) {
+                ${movieType.plural}(where: { genres: { moviesAggregate: { count_EQ: 3 } }, genresAggregate: { count_EQ: 1 } }) {
                     title
                 }
             }

--- a/packages/graphql/tests/integration/issues/2713.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2713.int.test.ts
@@ -79,7 +79,7 @@ describe("https://github.com/neo4j/graphql/issues/2713", () => {
     test("should not find genresConnection_ALL where NONE true", async () => {
         const query = `
             {
-                ${movieType.plural}(where: { genresConnection_ALL: { node: { moviesAggregate: { count: 0 } } } }) {
+                ${movieType.plural}(where: { genresConnection_ALL: { node: { moviesAggregate: { count_EQ: 0 } } } }) {
                     title
                 }
             }

--- a/packages/graphql/tests/integration/issues/2803.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2803.int.test.ts
@@ -189,7 +189,7 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
                             actors_ALL: {
                                 moviesAggregate: { count_GT: 1 }
                             },
-                            actorsAggregate: { count: 1 }
+                            actorsAggregate: { count_EQ: 1 }
                         }
                     }
                 ) {
@@ -301,7 +301,7 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
                                     moviesAggregate: { count_GT: 1 }
                                 }
                             },
-                            actorsAggregate: { count: 1 }
+                            actorsAggregate: { count_EQ: 1 }
                         }
                     }
                 ) {

--- a/packages/graphql/tests/integration/issues/4477.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4477.int.test.ts
@@ -83,7 +83,7 @@ describe("https://github.com/neo4j/graphql/issues/4477", () => {
             query {
                 ${Brand.plural} {
                     name
-                    services(where: { collectionAggregate: { count: 1 } }) {
+                    services(where: { collectionAggregate: { count_EQ: 1 } }) {
                         collectionAggregate {
                             count
                         }

--- a/packages/graphql/tests/integration/subscriptions/delete/top-level-where.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/delete/top-level-where.int.test.ts
@@ -86,7 +86,7 @@ describe("Delete using top level aggregate where - subscriptions enabled", () =>
             mutation {
                 ${postType.operations.delete}(where: { 
                     likesAggregate: {
-                        count: 3
+                        count_EQ: 3
                         node: {
                             testString_SHORTEST_EQUAL: 3
                         }
@@ -113,7 +113,7 @@ describe("Delete using top level aggregate where - subscriptions enabled", () =>
                 ${postType.operations.delete}(where: { 
                     likesAggregate: {
                         OR: [
-                            { count: 3 }
+                            { count_EQ: 3 }
                             {
                                 node: {
                                     testString_SHORTEST_EQUAL: 3
@@ -143,7 +143,7 @@ describe("Delete using top level aggregate where - subscriptions enabled", () =>
                 ${postType.operations.delete}(where: { 
                     likesAggregate: {
                         AND: [
-                            { count: 3 }
+                            { count_EQ: 3 }
                             {
                                 node: {
                                     testString_SHORTEST_EQUAL: 3

--- a/packages/graphql/tests/integration/subscriptions/update/top-level-where.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/update/top-level-where.int.test.ts
@@ -89,7 +89,7 @@ describe("Delete using top level aggregate where - subscriptions enabled", () =>
                 ${postType.operations.update}(
                     where: { 
                         likesAggregate: {
-                            count: 3
+                            count_EQ: 3
                             node: {
                                 testString_SHORTEST_EQUAL: 3
                             }
@@ -121,7 +121,7 @@ describe("Delete using top level aggregate where - subscriptions enabled", () =>
                 ${postType.operations.update}(where: { 
                     likesAggregate: {
                         OR: [
-                            { count: 3 }
+                            { count_EQ: 3 }
                             {
                                 node: {
                                     testString_SHORTEST_EQUAL: 3
@@ -154,7 +154,7 @@ describe("Delete using top level aggregate where - subscriptions enabled", () =>
                 ${postType.operations.update}(where: { 
                     likesAggregate: {
                         AND: [
-                            { count: 3 }
+                            { count_EQ: 3 }
                             {
                                 node: {
                                     testString_SHORTEST_EQUAL: 3

--- a/packages/graphql/tests/schema/aggregations.test.ts
+++ b/packages/graphql/tests/schema/aggregations.test.ts
@@ -902,7 +902,8 @@ describe("Aggregations", () => {
               AND: [PostLikesAggregateInput!]
               NOT: PostLikesAggregateInput
               OR: [PostLikesAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int

--- a/packages/graphql/tests/schema/array-methods.test.ts
+++ b/packages/graphql/tests/schema/array-methods.test.ts
@@ -93,7 +93,8 @@ describe("Arrays Methods", () => {
               AND: [ActorActedInAggregateInput!]
               NOT: ActorActedInAggregateInput
               OR: [ActorActedInAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -375,7 +376,8 @@ describe("Arrays Methods", () => {
               AND: [MovieActorsAggregateInput!]
               NOT: MovieActorsAggregateInput
               OR: [MovieActorsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int

--- a/packages/graphql/tests/schema/authorization.test.ts
+++ b/packages/graphql/tests/schema/authorization.test.ts
@@ -115,7 +115,8 @@ describe("Authorization", () => {
               AND: [PostAuthorAggregateInput!]
               NOT: PostAuthorAggregateInput
               OR: [PostAuthorAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -412,7 +413,8 @@ describe("Authorization", () => {
               AND: [UserPostsAggregateInput!]
               NOT: UserPostsAggregateInput
               OR: [UserPostsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int

--- a/packages/graphql/tests/schema/comments.test.ts
+++ b/packages/graphql/tests/schema/comments.test.ts
@@ -413,7 +413,8 @@ describe("Comments", () => {
                   AND: [MovieActorsAggregateInput!]
                   NOT: MovieActorsAggregateInput
                   OR: [MovieActorsAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int
@@ -794,7 +795,8 @@ describe("Comments", () => {
                   AND: [ActorActedInAggregateInput!]
                   NOT: ActorActedInAggregateInput
                   OR: [ActorActedInAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int

--- a/packages/graphql/tests/schema/connect-or-create-id.test.ts
+++ b/packages/graphql/tests/schema/connect-or-create-id.test.ts
@@ -96,7 +96,8 @@ describe("connect or create with id", () => {
               AND: [ActorMoviesAggregateInput!]
               NOT: ActorMoviesAggregateInput
               OR: [ActorMoviesAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -589,7 +590,8 @@ describe("connect or create with id", () => {
               AND: [PostCreatorAggregateInput!]
               NOT: PostCreatorAggregateInput
               OR: [PostCreatorAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -929,7 +931,8 @@ describe("connect or create with id", () => {
               AND: [UserPostsAggregateInput!]
               NOT: UserPostsAggregateInput
               OR: [UserPostsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int

--- a/packages/graphql/tests/schema/connect-or-create.test.ts
+++ b/packages/graphql/tests/schema/connect-or-create.test.ts
@@ -96,7 +96,8 @@ describe("Connect Or Create", () => {
               AND: [ActorMoviesAggregateInput!]
               NOT: ActorMoviesAggregateInput
               OR: [ActorMoviesAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -691,7 +692,8 @@ describe("Connect Or Create", () => {
               AND: [ActorMoviesAggregateInput!]
               NOT: ActorMoviesAggregateInput
               OR: [ActorMoviesAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int

--- a/packages/graphql/tests/schema/connections/enums.test.ts
+++ b/packages/graphql/tests/schema/connections/enums.test.ts
@@ -134,7 +134,8 @@ describe("Enums", () => {
               AND: [ActorMoviesAggregateInput!]
               NOT: ActorMoviesAggregateInput
               OR: [ActorMoviesAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -370,7 +371,8 @@ describe("Enums", () => {
               AND: [MovieActorsAggregateInput!]
               NOT: MovieActorsAggregateInput
               OR: [MovieActorsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int

--- a/packages/graphql/tests/schema/connections/interfaces.test.ts
+++ b/packages/graphql/tests/schema/connections/interfaces.test.ts
@@ -130,7 +130,8 @@ describe("Connection with interfaces", () => {
               AND: [CreatureMoviesAggregateInput!]
               NOT: CreatureMoviesAggregateInput
               OR: [CreatureMoviesAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -304,7 +305,8 @@ describe("Connection with interfaces", () => {
               AND: [MovieDirectorAggregateInput!]
               NOT: MovieDirectorAggregateInput
               OR: [MovieDirectorAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -507,7 +509,8 @@ describe("Connection with interfaces", () => {
               AND: [PersonMoviesAggregateInput!]
               NOT: PersonMoviesAggregateInput
               OR: [PersonMoviesAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -640,7 +643,8 @@ describe("Connection with interfaces", () => {
               AND: [ProductionDirectorAggregateInput!]
               NOT: ProductionDirectorAggregateInput
               OR: [ProductionDirectorAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -866,7 +870,8 @@ describe("Connection with interfaces", () => {
               AND: [SeriesDirectorAggregateInput!]
               NOT: SeriesDirectorAggregateInput
               OR: [SeriesDirectorAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int

--- a/packages/graphql/tests/schema/connections/sort.test.ts
+++ b/packages/graphql/tests/schema/connections/sort.test.ts
@@ -135,7 +135,8 @@ describe("Sort", () => {
               AND: [Node1RelatedToAggregateInput!]
               NOT: Node1RelatedToAggregateInput
               OR: [Node1RelatedToAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -315,7 +316,8 @@ describe("Sort", () => {
               AND: [Node2RelatedToAggregateInput!]
               NOT: Node2RelatedToAggregateInput
               OR: [Node2RelatedToAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int

--- a/packages/graphql/tests/schema/connections/unions.test.ts
+++ b/packages/graphql/tests/schema/connections/unions.test.ts
@@ -328,7 +328,8 @@ describe("Unions", () => {
               AND: [BookAuthorAggregateInput!]
               NOT: BookAuthorAggregateInput
               OR: [BookAuthorAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -613,7 +614,8 @@ describe("Unions", () => {
               AND: [JournalAuthorAggregateInput!]
               NOT: JournalAuthorAggregateInput
               OR: [JournalAuthorAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int

--- a/packages/graphql/tests/schema/directive-preserve.test.ts
+++ b/packages/graphql/tests/schema/directive-preserve.test.ts
@@ -287,7 +287,8 @@ describe("Directive-preserve", () => {
               AND: [GenreMoviesAggregateInput!]
               NOT: GenreMoviesAggregateInput
               OR: [GenreMoviesAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -583,7 +584,8 @@ describe("Directive-preserve", () => {
               AND: [MovieGenresAggregateInput!]
               NOT: MovieGenresAggregateInput
               OR: [MovieGenresAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -985,7 +987,8 @@ describe("Directive-preserve", () => {
               AND: [ActorActedInAggregateInput!]
               NOT: ActorActedInAggregateInput
               OR: [ActorActedInAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -1281,7 +1284,8 @@ describe("Directive-preserve", () => {
               AND: [MovieActorsAggregateInput!]
               NOT: MovieActorsAggregateInput
               OR: [MovieActorsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -1505,7 +1509,8 @@ describe("Directive-preserve", () => {
               AND: [ProductionActorsAggregateInput!]
               NOT: ProductionActorsAggregateInput
               OR: [ProductionActorsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -1810,7 +1815,8 @@ describe("Directive-preserve", () => {
               AND: [SeriesActorsAggregateInput!]
               NOT: SeriesActorsAggregateInput
               OR: [SeriesActorsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -2180,7 +2186,8 @@ describe("Directive-preserve", () => {
               AND: [ActorActedInAggregateInput!]
               NOT: ActorActedInAggregateInput
               OR: [ActorActedInAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -2473,7 +2480,8 @@ describe("Directive-preserve", () => {
               AND: [MovieActorsAggregateInput!]
               NOT: MovieActorsAggregateInput
               OR: [MovieActorsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -2831,7 +2839,8 @@ describe("Directive-preserve", () => {
               AND: [SeriesActorsAggregateInput!]
               NOT: SeriesActorsAggregateInput
               OR: [SeriesActorsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -3224,7 +3233,8 @@ describe("Directive-preserve", () => {
               AND: [ActorActedInAggregateInput!]
               NOT: ActorActedInAggregateInput
               OR: [ActorActedInAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -3517,7 +3527,8 @@ describe("Directive-preserve", () => {
               AND: [MovieActorsAggregateInput!]
               NOT: MovieActorsAggregateInput
               OR: [MovieActorsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -3875,7 +3886,8 @@ describe("Directive-preserve", () => {
               AND: [SeriesActorsAggregateInput!]
               NOT: SeriesActorsAggregateInput
               OR: [SeriesActorsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -4235,7 +4247,8 @@ describe("Directive-preserve", () => {
               AND: [BlogPostsAggregateInput!]
               NOT: BlogPostsAggregateInput
               OR: [BlogPostsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int

--- a/packages/graphql/tests/schema/directives/alias.test.ts
+++ b/packages/graphql/tests/schema/directives/alias.test.ts
@@ -62,7 +62,8 @@ describe("Alias", () => {
               AND: [ActorActedInAggregateInput!]
               NOT: ActorActedInAggregateInput
               OR: [ActorActedInAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int

--- a/packages/graphql/tests/schema/directives/filterable.test.ts
+++ b/packages/graphql/tests/schema/directives/filterable.test.ts
@@ -992,7 +992,8 @@ describe("@filterable directive", () => {
                       AND: [ActorMoviesAggregateInput!]
                       NOT: ActorMoviesAggregateInput
                       OR: [ActorMoviesAggregateInput!]
-                      count: Int
+                      count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                      count_EQ: Int
                       count_GT: Int
                       count_GTE: Int
                       count_LT: Int
@@ -1266,7 +1267,8 @@ describe("@filterable directive", () => {
                       AND: [MovieActorsAggregateInput!]
                       NOT: MovieActorsAggregateInput
                       OR: [MovieActorsAggregateInput!]
-                      count: Int
+                      count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                      count_EQ: Int
                       count_GT: Int
                       count_GTE: Int
                       count_LT: Int
@@ -1775,7 +1777,8 @@ describe("@filterable directive", () => {
                       AND: [ActorMoviesAggregateInput!]
                       NOT: ActorMoviesAggregateInput
                       OR: [ActorMoviesAggregateInput!]
-                      count: Int
+                      count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                      count_EQ: Int
                       count_GT: Int
                       count_GTE: Int
                       count_LT: Int
@@ -2091,7 +2094,8 @@ describe("@filterable directive", () => {
                       AND: [MovieActorsAggregateInput!]
                       NOT: MovieActorsAggregateInput
                       OR: [MovieActorsAggregateInput!]
-                      count: Int
+                      count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                      count_EQ: Int
                       count_GT: Int
                       count_GTE: Int
                       count_LT: Int
@@ -2600,7 +2604,8 @@ describe("@filterable directive", () => {
                       AND: [ActorMoviesAggregateInput!]
                       NOT: ActorMoviesAggregateInput
                       OR: [ActorMoviesAggregateInput!]
-                      count: Int
+                      count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                      count_EQ: Int
                       count_GT: Int
                       count_GTE: Int
                       count_LT: Int
@@ -2906,7 +2911,8 @@ describe("@filterable directive", () => {
                       AND: [MovieActorsAggregateInput!]
                       NOT: MovieActorsAggregateInput
                       OR: [MovieActorsAggregateInput!]
-                      count: Int
+                      count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                      count_EQ: Int
                       count_GT: Int
                       count_GTE: Int
                       count_LT: Int
@@ -3398,7 +3404,8 @@ describe("@filterable directive", () => {
                       AND: [ActorMoviesAggregateInput!]
                       NOT: ActorMoviesAggregateInput
                       OR: [ActorMoviesAggregateInput!]
-                      count: Int
+                      count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                      count_EQ: Int
                       count_GT: Int
                       count_GTE: Int
                       count_LT: Int
@@ -4136,7 +4143,8 @@ describe("@filterable directive", () => {
                       AND: [ActorMoviesAggregateInput!]
                       NOT: ActorMoviesAggregateInput
                       OR: [ActorMoviesAggregateInput!]
-                      count: Int
+                      count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                      count_EQ: Int
                       count_GT: Int
                       count_GTE: Int
                       count_LT: Int
@@ -4452,7 +4460,8 @@ describe("@filterable directive", () => {
                       AND: [MovieActorsAggregateInput!]
                       NOT: MovieActorsAggregateInput
                       OR: [MovieActorsAggregateInput!]
-                      count: Int
+                      count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                      count_EQ: Int
                       count_GT: Int
                       count_GTE: Int
                       count_LT: Int
@@ -4963,7 +4972,8 @@ describe("@filterable directive", () => {
                       AND: [ActorMoviesAggregateInput!]
                       NOT: ActorMoviesAggregateInput
                       OR: [ActorMoviesAggregateInput!]
-                      count: Int
+                      count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                      count_EQ: Int
                       count_GT: Int
                       count_GTE: Int
                       count_LT: Int
@@ -5279,7 +5289,8 @@ describe("@filterable directive", () => {
                       AND: [MovieActorsAggregateInput!]
                       NOT: MovieActorsAggregateInput
                       OR: [MovieActorsAggregateInput!]
-                      count: Int
+                      count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                      count_EQ: Int
                       count_GT: Int
                       count_GTE: Int
                       count_LT: Int
@@ -5764,7 +5775,8 @@ describe("@filterable directive", () => {
                       AND: [ActorMoviesAggregateInput!]
                       NOT: ActorMoviesAggregateInput
                       OR: [ActorMoviesAggregateInput!]
-                      count: Int
+                      count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                      count_EQ: Int
                       count_GT: Int
                       count_GTE: Int
                       count_LT: Int
@@ -6503,7 +6515,8 @@ describe("@filterable directive", () => {
                       AND: [ActorMoviesAggregateInput!]
                       NOT: ActorMoviesAggregateInput
                       OR: [ActorMoviesAggregateInput!]
-                      count: Int
+                      count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                      count_EQ: Int
                       count_GT: Int
                       count_GTE: Int
                       count_LT: Int
@@ -7319,7 +7332,8 @@ describe("@filterable directive", () => {
                       AND: [ActorMoviesAggregateInput!]
                       NOT: ActorMoviesAggregateInput
                       OR: [ActorMoviesAggregateInput!]
-                      count: Int
+                      count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                      count_EQ: Int
                       count_GT: Int
                       count_GTE: Int
                       count_LT: Int
@@ -7625,7 +7639,8 @@ describe("@filterable directive", () => {
                       AND: [MovieActorsAggregateInput!]
                       NOT: MovieActorsAggregateInput
                       OR: [MovieActorsAggregateInput!]
-                      count: Int
+                      count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                      count_EQ: Int
                       count_GT: Int
                       count_GTE: Int
                       count_LT: Int
@@ -8189,7 +8204,8 @@ describe("@filterable directive", () => {
                       AND: [ActorMoviesAggregateInput!]
                       NOT: ActorMoviesAggregateInput
                       OR: [ActorMoviesAggregateInput!]
-                      count: Int
+                      count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                      count_EQ: Int
                       count_GT: Int
                       count_GTE: Int
                       count_LT: Int
@@ -9013,7 +9029,8 @@ describe("@filterable directive", () => {
                       AND: [ActorMoviesAggregateInput!]
                       NOT: ActorMoviesAggregateInput
                       OR: [ActorMoviesAggregateInput!]
-                      count: Int
+                      count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                      count_EQ: Int
                       count_GT: Int
                       count_GTE: Int
                       count_LT: Int
@@ -9347,7 +9364,8 @@ describe("@filterable directive", () => {
                       AND: [AppearanceMoviesAggregateInput!]
                       NOT: AppearanceMoviesAggregateInput
                       OR: [AppearanceMoviesAggregateInput!]
-                      count: Int
+                      count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                      count_EQ: Int
                       count_GT: Int
                       count_GTE: Int
                       count_LT: Int
@@ -10200,7 +10218,8 @@ describe("@filterable directive", () => {
                       AND: [ActorMoviesAggregateInput!]
                       NOT: ActorMoviesAggregateInput
                       OR: [ActorMoviesAggregateInput!]
-                      count: Int
+                      count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                      count_EQ: Int
                       count_GT: Int
                       count_GTE: Int
                       count_LT: Int
@@ -10534,7 +10553,8 @@ describe("@filterable directive", () => {
                       AND: [AppearanceMoviesAggregateInput!]
                       NOT: AppearanceMoviesAggregateInput
                       OR: [AppearanceMoviesAggregateInput!]
-                      count: Int
+                      count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                      count_EQ: Int
                       count_GT: Int
                       count_GTE: Int
                       count_LT: Int
@@ -11387,7 +11407,8 @@ describe("@filterable directive", () => {
                       AND: [ActorMoviesAggregateInput!]
                       NOT: ActorMoviesAggregateInput
                       OR: [ActorMoviesAggregateInput!]
-                      count: Int
+                      count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                      count_EQ: Int
                       count_GT: Int
                       count_GTE: Int
                       count_LT: Int
@@ -11721,7 +11742,8 @@ describe("@filterable directive", () => {
                       AND: [AppearanceMoviesAggregateInput!]
                       NOT: AppearanceMoviesAggregateInput
                       OR: [AppearanceMoviesAggregateInput!]
-                      count: Int
+                      count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                      count_EQ: Int
                       count_GT: Int
                       count_GTE: Int
                       count_LT: Int

--- a/packages/graphql/tests/schema/directives/populatedBy.test.ts
+++ b/packages/graphql/tests/schema/directives/populatedBy.test.ts
@@ -859,7 +859,8 @@ describe("@populatedBy tests", () => {
                   AND: [MovieGenresAggregateInput!]
                   NOT: MovieGenresAggregateInput
                   OR: [MovieGenresAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int
@@ -1442,7 +1443,8 @@ describe("@populatedBy tests", () => {
                   AND: [MovieGenresAggregateInput!]
                   NOT: MovieGenresAggregateInput
                   OR: [MovieGenresAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int

--- a/packages/graphql/tests/schema/directives/relationship-aggregate.test.ts
+++ b/packages/graphql/tests/schema/directives/relationship-aggregate.test.ts
@@ -336,7 +336,8 @@ describe("@relationship directive, aggregate argument", () => {
                   AND: [MovieActorsAggregateInput!]
                   NOT: MovieActorsAggregateInput
                   OR: [MovieActorsAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int
@@ -781,7 +782,8 @@ describe("@relationship directive, aggregate argument", () => {
                   AND: [MovieActorsAggregateInput!]
                   NOT: MovieActorsAggregateInput
                   OR: [MovieActorsAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int
@@ -1217,7 +1219,8 @@ describe("@relationship directive, aggregate argument", () => {
                       AND: [MovieActorsAggregateInput!]
                       NOT: MovieActorsAggregateInput
                       OR: [MovieActorsAggregateInput!]
-                      count: Int
+                      count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                      count_EQ: Int
                       count_GT: Int
                       count_GTE: Int
                       count_LT: Int
@@ -1726,7 +1729,8 @@ describe("@relationship directive, aggregate argument", () => {
                       AND: [MovieActorsAggregateInput!]
                       NOT: MovieActorsAggregateInput
                       OR: [MovieActorsAggregateInput!]
-                      count: Int
+                      count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                      count_EQ: Int
                       count_GT: Int
                       count_GTE: Int
                       count_LT: Int

--- a/packages/graphql/tests/schema/directives/relationship-nested-operations.test.ts
+++ b/packages/graphql/tests/schema/directives/relationship-nested-operations.test.ts
@@ -94,7 +94,8 @@ describe("Relationship nested operations", () => {
                   AND: [MovieActorsAggregateInput!]
                   NOT: MovieActorsAggregateInput
                   OR: [MovieActorsAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int
@@ -435,7 +436,8 @@ describe("Relationship nested operations", () => {
                   AND: [MovieActorsAggregateInput!]
                   NOT: MovieActorsAggregateInput
                   OR: [MovieActorsAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int
@@ -795,7 +797,8 @@ describe("Relationship nested operations", () => {
                   AND: [MovieActorsAggregateInput!]
                   NOT: MovieActorsAggregateInput
                   OR: [MovieActorsAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int
@@ -1163,7 +1166,8 @@ describe("Relationship nested operations", () => {
                   AND: [MovieActorsAggregateInput!]
                   NOT: MovieActorsAggregateInput
                   OR: [MovieActorsAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int
@@ -1514,7 +1518,8 @@ describe("Relationship nested operations", () => {
                   AND: [MovieActorsAggregateInput!]
                   NOT: MovieActorsAggregateInput
                   OR: [MovieActorsAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int
@@ -1869,7 +1874,8 @@ describe("Relationship nested operations", () => {
                   AND: [MovieActorsAggregateInput!]
                   NOT: MovieActorsAggregateInput
                   OR: [MovieActorsAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int
@@ -2225,7 +2231,8 @@ describe("Relationship nested operations", () => {
                   AND: [MovieActorsAggregateInput!]
                   NOT: MovieActorsAggregateInput
                   OR: [MovieActorsAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int
@@ -2568,7 +2575,8 @@ describe("Relationship nested operations", () => {
                   AND: [MovieActorsAggregateInput!]
                   NOT: MovieActorsAggregateInput
                   OR: [MovieActorsAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int
@@ -2961,7 +2969,8 @@ describe("Relationship nested operations", () => {
                   AND: [MovieActorsAggregateInput!]
                   NOT: MovieActorsAggregateInput
                   OR: [MovieActorsAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int
@@ -3129,7 +3138,8 @@ describe("Relationship nested operations", () => {
                   AND: [MovieProducersAggregateInput!]
                   NOT: MovieProducersAggregateInput
                   OR: [MovieProducersAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int
@@ -3488,7 +3498,8 @@ describe("Relationship nested operations", () => {
                   AND: [MovieActorsAggregateInput!]
                   NOT: MovieActorsAggregateInput
                   OR: [MovieActorsAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int
@@ -3622,7 +3633,8 @@ describe("Relationship nested operations", () => {
                   AND: [MovieProducersAggregateInput!]
                   NOT: MovieProducersAggregateInput
                   OR: [MovieProducersAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int
@@ -8420,7 +8432,8 @@ describe("Relationship nested operations", () => {
                   AND: [MovieActorsAggregateInput!]
                   NOT: MovieActorsAggregateInput
                   OR: [MovieActorsAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int
@@ -8907,7 +8920,8 @@ describe("Relationship nested operations", () => {
                   AND: [MovieActorsAggregateInput!]
                   NOT: MovieActorsAggregateInput
                   OR: [MovieActorsAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int
@@ -9418,7 +9432,8 @@ describe("Relationship nested operations", () => {
                   AND: [MovieActorsAggregateInput!]
                   NOT: MovieActorsAggregateInput
                   OR: [MovieActorsAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int
@@ -9928,7 +9943,8 @@ describe("Relationship nested operations", () => {
                   AND: [MovieActorsAggregateInput!]
                   NOT: MovieActorsAggregateInput
                   OR: [MovieActorsAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int
@@ -10429,7 +10445,8 @@ describe("Relationship nested operations", () => {
                   AND: [MovieActorsAggregateInput!]
                   NOT: MovieActorsAggregateInput
                   OR: [MovieActorsAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int
@@ -10930,7 +10947,8 @@ describe("Relationship nested operations", () => {
                   AND: [MovieActorsAggregateInput!]
                   NOT: MovieActorsAggregateInput
                   OR: [MovieActorsAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int
@@ -11435,7 +11453,8 @@ describe("Relationship nested operations", () => {
                   AND: [MovieActorsAggregateInput!]
                   NOT: MovieActorsAggregateInput
                   OR: [MovieActorsAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int
@@ -11599,7 +11618,8 @@ describe("Relationship nested operations", () => {
                   AND: [MovieProducersAggregateInput!]
                   NOT: MovieProducersAggregateInput
                   OR: [MovieProducersAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int
@@ -12114,7 +12134,8 @@ describe("Relationship nested operations", () => {
                   AND: [MovieActorsAggregateInput!]
                   NOT: MovieActorsAggregateInput
                   OR: [MovieActorsAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int
@@ -12257,7 +12278,8 @@ describe("Relationship nested operations", () => {
                   AND: [MovieProducersAggregateInput!]
                   NOT: MovieProducersAggregateInput
                   OR: [MovieProducersAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int

--- a/packages/graphql/tests/schema/directives/relationship-properties.test.ts
+++ b/packages/graphql/tests/schema/directives/relationship-properties.test.ts
@@ -190,7 +190,8 @@ describe("Relationship-properties", () => {
               AND: [ActorMoviesAggregateInput!]
               NOT: ActorMoviesAggregateInput
               OR: [ActorMoviesAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -442,7 +443,8 @@ describe("Relationship-properties", () => {
               AND: [MovieActorsAggregateInput!]
               NOT: MovieActorsAggregateInput
               OR: [MovieActorsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -909,7 +911,8 @@ describe("Relationship-properties", () => {
               AND: [ActorMoviesAggregateInput!]
               NOT: ActorMoviesAggregateInput
               OR: [ActorMoviesAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -1173,7 +1176,8 @@ describe("Relationship-properties", () => {
               AND: [MovieActorsAggregateInput!]
               NOT: MovieActorsAggregateInput
               OR: [MovieActorsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -1594,7 +1598,8 @@ describe("Relationship-properties", () => {
               AND: [ActorMoviesAggregateInput!]
               NOT: ActorMoviesAggregateInput
               OR: [ActorMoviesAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -1847,7 +1852,8 @@ describe("Relationship-properties", () => {
               AND: [MovieActorsAggregateInput!]
               NOT: MovieActorsAggregateInput
               OR: [MovieActorsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int

--- a/packages/graphql/tests/schema/directives/relationship.test.ts
+++ b/packages/graphql/tests/schema/directives/relationship.test.ts
@@ -156,7 +156,8 @@ describe("Relationship", () => {
               AND: [MovieActorsAggregateInput!]
               NOT: MovieActorsAggregateInput
               OR: [MovieActorsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -496,7 +497,8 @@ describe("Relationship", () => {
               AND: [ActorMoviesAggregateInput!]
               NOT: ActorMoviesAggregateInput
               OR: [ActorMoviesAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -697,7 +699,8 @@ describe("Relationship", () => {
               AND: [MovieActorsAggregateInput!]
               NOT: MovieActorsAggregateInput
               OR: [MovieActorsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int

--- a/packages/graphql/tests/schema/directives/selectable.test.ts
+++ b/packages/graphql/tests/schema/directives/selectable.test.ts
@@ -737,7 +737,8 @@ describe("@selectable", () => {
                   AND: [ActorActedInAggregateInput!]
                   NOT: ActorActedInAggregateInput
                   OR: [ActorActedInAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int
@@ -1166,7 +1167,8 @@ describe("@selectable", () => {
                   AND: [ActorActedInAggregateInput!]
                   NOT: ActorActedInAggregateInput
                   OR: [ActorActedInAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int
@@ -2651,7 +2653,8 @@ describe("@selectable", () => {
                   AND: [ActorActedInAggregateInput!]
                   NOT: ActorActedInAggregateInput
                   OR: [ActorActedInAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int
@@ -3245,7 +3248,8 @@ describe("@selectable", () => {
                   AND: [ActorActedInAggregateInput!]
                   NOT: ActorActedInAggregateInput
                   OR: [ActorActedInAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int

--- a/packages/graphql/tests/schema/directives/settable.test.ts
+++ b/packages/graphql/tests/schema/directives/settable.test.ts
@@ -585,7 +585,8 @@ describe("@settable", () => {
                   AND: [ActorActedInAggregateInput!]
                   NOT: ActorActedInAggregateInput
                   OR: [ActorActedInAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int
@@ -1024,7 +1025,8 @@ describe("@settable", () => {
                   AND: [ActorActedInAggregateInput!]
                   NOT: ActorActedInAggregateInput
                   OR: [ActorActedInAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int
@@ -1454,7 +1456,8 @@ describe("@settable", () => {
                   AND: [ActorActedInAggregateInput!]
                   NOT: ActorActedInAggregateInput
                   OR: [ActorActedInAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int
@@ -1747,7 +1750,8 @@ describe("@settable", () => {
                   AND: [MovieActorsAggregateInput!]
                   NOT: MovieActorsAggregateInput
                   OR: [MovieActorsAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int
@@ -2064,7 +2068,8 @@ describe("@settable", () => {
                   AND: [ActorActedInAggregateInput!]
                   NOT: ActorActedInAggregateInput
                   OR: [ActorActedInAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int
@@ -2365,7 +2370,8 @@ describe("@settable", () => {
                   AND: [MovieActorsAggregateInput!]
                   NOT: MovieActorsAggregateInput
                   OR: [MovieActorsAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int
@@ -3932,7 +3938,8 @@ describe("@settable", () => {
                   AND: [MovieActorsAggregateInput!]
                   NOT: MovieActorsAggregateInput
                   OR: [MovieActorsAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int
@@ -4616,7 +4623,8 @@ describe("@settable", () => {
                   AND: [MovieActorsAggregateInput!]
                   NOT: MovieActorsAggregateInput
                   OR: [MovieActorsAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int
@@ -5042,7 +5050,8 @@ describe("@settable", () => {
                   AND: [ActorActedInAggregateInput!]
                   NOT: ActorActedInAggregateInput
                   OR: [ActorActedInAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int
@@ -5646,7 +5655,8 @@ describe("@settable", () => {
                   AND: [ActorActedInAggregateInput!]
                   NOT: ActorActedInAggregateInput
                   OR: [ActorActedInAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int
@@ -6238,7 +6248,8 @@ describe("@settable", () => {
                   AND: [ActorActedInAggregateInput!]
                   NOT: ActorActedInAggregateInput
                   OR: [ActorActedInAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int
@@ -6532,7 +6543,8 @@ describe("@settable", () => {
                   AND: [MovieActorsAggregateInput!]
                   NOT: MovieActorsAggregateInput
                   OR: [MovieActorsAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int
@@ -6750,7 +6762,8 @@ describe("@settable", () => {
                   AND: [ProductionActorsAggregateInput!]
                   NOT: ProductionActorsAggregateInput
                   OR: [ProductionActorsAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int
@@ -6982,7 +6995,8 @@ describe("@settable", () => {
                   AND: [SeriesActorsAggregateInput!]
                   NOT: SeriesActorsAggregateInput
                   OR: [SeriesActorsAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int
@@ -7254,7 +7268,8 @@ describe("@settable", () => {
                   AND: [ActorActedInAggregateInput!]
                   NOT: ActorActedInAggregateInput
                   OR: [ActorActedInAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int
@@ -7556,7 +7571,8 @@ describe("@settable", () => {
                   AND: [MovieActorsAggregateInput!]
                   NOT: MovieActorsAggregateInput
                   OR: [MovieActorsAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int
@@ -7774,7 +7790,8 @@ describe("@settable", () => {
                   AND: [ProductionActorsAggregateInput!]
                   NOT: ProductionActorsAggregateInput
                   OR: [ProductionActorsAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int
@@ -8029,7 +8046,8 @@ describe("@settable", () => {
                   AND: [SeriesActorsAggregateInput!]
                   NOT: SeriesActorsAggregateInput
                   OR: [SeriesActorsAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int

--- a/packages/graphql/tests/schema/federation.test.ts
+++ b/packages/graphql/tests/schema/federation.test.ts
@@ -130,7 +130,8 @@ describe("Apollo Federation", () => {
               AND: [PostAuthorAggregateInput!]
               NOT: PostAuthorAggregateInput
               OR: [PostAuthorAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -427,7 +428,8 @@ describe("Apollo Federation", () => {
               AND: [UserPostsAggregateInput!]
               NOT: UserPostsAggregateInput
               OR: [UserPostsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -729,7 +731,8 @@ describe("Apollo Federation", () => {
               AND: [PostAuthorAggregateInput!]
               NOT: PostAuthorAggregateInput
               OR: [PostAuthorAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int

--- a/packages/graphql/tests/schema/inheritance.test.ts
+++ b/packages/graphql/tests/schema/inheritance.test.ts
@@ -96,7 +96,8 @@ describe("inheritance", () => {
               AND: [ActorFriendsAggregateInput!]
               NOT: ActorFriendsAggregateInput
               OR: [ActorFriendsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -426,7 +427,8 @@ describe("inheritance", () => {
               AND: [PersonFriendsAggregateInput!]
               NOT: PersonFriendsAggregateInput
               OR: [PersonFriendsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int

--- a/packages/graphql/tests/schema/interface-relationships.test.ts
+++ b/packages/graphql/tests/schema/interface-relationships.test.ts
@@ -134,7 +134,8 @@ describe("Interface Relationships", () => {
               AND: [ActorActedInAggregateInput!]
               NOT: ActorActedInAggregateInput
               OR: [ActorActedInAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -802,7 +803,8 @@ describe("Interface Relationships", () => {
               AND: [ActorActedInAggregateInput!]
               NOT: ActorActedInAggregateInput
               OR: [ActorActedInAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -1125,7 +1127,8 @@ describe("Interface Relationships", () => {
               AND: [EpisodeSeriesAggregateInput!]
               NOT: EpisodeSeriesAggregateInput
               OR: [EpisodeSeriesAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -1341,7 +1344,8 @@ describe("Interface Relationships", () => {
               AND: [MovieActorsAggregateInput!]
               NOT: MovieActorsAggregateInput
               OR: [MovieActorsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -1568,7 +1572,8 @@ describe("Interface Relationships", () => {
               AND: [ProductionActorsAggregateInput!]
               NOT: ProductionActorsAggregateInput
               OR: [ProductionActorsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -1879,7 +1884,8 @@ describe("Interface Relationships", () => {
               AND: [SeriesActorsAggregateInput!]
               NOT: SeriesActorsAggregateInput
               OR: [SeriesActorsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -2019,7 +2025,8 @@ describe("Interface Relationships", () => {
               AND: [SeriesEpisodesAggregateInput!]
               NOT: SeriesEpisodesAggregateInput
               OR: [SeriesEpisodesAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -2396,7 +2403,8 @@ describe("Interface Relationships", () => {
               AND: [ActorActedInAggregateInput!]
               NOT: ActorActedInAggregateInput
               OR: [ActorActedInAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -2719,7 +2727,8 @@ describe("Interface Relationships", () => {
               AND: [EpisodeSeriesAggregateInput!]
               NOT: EpisodeSeriesAggregateInput
               OR: [EpisodeSeriesAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -2935,7 +2944,8 @@ describe("Interface Relationships", () => {
               AND: [MovieActorsAggregateInput!]
               NOT: MovieActorsAggregateInput
               OR: [MovieActorsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -3162,7 +3172,8 @@ describe("Interface Relationships", () => {
               AND: [ProductionActorsAggregateInput!]
               NOT: ProductionActorsAggregateInput
               OR: [ProductionActorsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -3493,7 +3504,8 @@ describe("Interface Relationships", () => {
               AND: [SeriesActorsAggregateInput!]
               NOT: SeriesActorsAggregateInput
               OR: [SeriesActorsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -3633,7 +3645,8 @@ describe("Interface Relationships", () => {
               AND: [SeriesEpisodesAggregateInput!]
               NOT: SeriesEpisodesAggregateInput
               OR: [SeriesEpisodesAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -4084,7 +4097,8 @@ describe("Interface Relationships", () => {
               AND: [Interface1Interface2AggregateInput!]
               NOT: Interface1Interface2AggregateInput
               OR: [Interface1Interface2AggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -4434,7 +4448,8 @@ describe("Interface Relationships", () => {
               AND: [Type1Interface1AggregateInput!]
               NOT: Type1Interface1AggregateInput
               OR: [Type1Interface1AggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -4523,7 +4538,8 @@ describe("Interface Relationships", () => {
               AND: [Type1Interface1Interface2AggregateInput!]
               NOT: Type1Interface1Interface2AggregateInput
               OR: [Type1Interface1Interface2AggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -4916,7 +4932,8 @@ describe("Interface Relationships", () => {
               AND: [Type2Interface1Interface2AggregateInput!]
               NOT: Type2Interface1Interface2AggregateInput
               OR: [Type2Interface1Interface2AggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -5329,7 +5346,8 @@ describe("Interface Relationships", () => {
               AND: [Interface1Interface2AggregateInput!]
               NOT: Interface1Interface2AggregateInput
               OR: [Interface1Interface2AggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -5800,7 +5818,8 @@ describe("Interface Relationships", () => {
               AND: [Type1Interface1AggregateInput!]
               NOT: Type1Interface1AggregateInput
               OR: [Type1Interface1AggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -5889,7 +5908,8 @@ describe("Interface Relationships", () => {
               AND: [Type1Interface1Interface2AggregateInput!]
               NOT: Type1Interface1Interface2AggregateInput
               OR: [Type1Interface1Interface2AggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -6291,7 +6311,8 @@ describe("Interface Relationships", () => {
               AND: [Type2Interface1Interface2AggregateInput!]
               NOT: Type2Interface1Interface2AggregateInput
               OR: [Type2Interface1Interface2AggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -6719,7 +6740,8 @@ describe("Interface Relationships", () => {
               AND: [Interface1Interface2AggregateInput!]
               NOT: Interface1Interface2AggregateInput
               OR: [Interface1Interface2AggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -7143,7 +7165,8 @@ describe("Interface Relationships", () => {
               AND: [Type1Interface1AggregateInput!]
               NOT: Type1Interface1AggregateInput
               OR: [Type1Interface1AggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -7232,7 +7255,8 @@ describe("Interface Relationships", () => {
               AND: [Type1Interface1Interface2AggregateInput!]
               NOT: Type1Interface1Interface2AggregateInput
               OR: [Type1Interface1Interface2AggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -7700,7 +7724,8 @@ describe("Interface Relationships", () => {
               AND: [Type2Interface1Interface2AggregateInput!]
               NOT: Type2Interface1Interface2AggregateInput
               OR: [Type2Interface1Interface2AggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -8119,7 +8144,8 @@ describe("Interface Relationships", () => {
               AND: [CommentCreatorAggregateInput!]
               NOT: CommentCreatorAggregateInput
               OR: [CommentCreatorAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -8228,7 +8254,8 @@ describe("Interface Relationships", () => {
               AND: [CommentPostAggregateInput!]
               NOT: CommentPostAggregateInput
               OR: [CommentPostAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -8441,7 +8468,8 @@ describe("Interface Relationships", () => {
               AND: [ContentCreatorAggregateInput!]
               NOT: ContentCreatorAggregateInput
               OR: [ContentCreatorAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -8707,7 +8735,8 @@ describe("Interface Relationships", () => {
               AND: [PostCommentsAggregateInput!]
               NOT: PostCommentsAggregateInput
               OR: [PostCommentsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -8840,7 +8869,8 @@ describe("Interface Relationships", () => {
               AND: [PostCreatorAggregateInput!]
               NOT: PostCreatorAggregateInput
               OR: [PostCreatorAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -9109,7 +9139,8 @@ describe("Interface Relationships", () => {
               AND: [UserContentAggregateInput!]
               NOT: UserContentAggregateInput
               OR: [UserContentAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -9452,7 +9483,8 @@ describe("Interface Relationships", () => {
               AND: [ActorActedInAggregateInput!]
               NOT: ActorActedInAggregateInput
               OR: [ActorActedInAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -9748,7 +9780,8 @@ describe("Interface Relationships", () => {
               AND: [MovieActorsAggregateInput!]
               NOT: MovieActorsAggregateInput
               OR: [MovieActorsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -10061,7 +10094,8 @@ describe("Interface Relationships", () => {
               AND: [SeriesActorsAggregateInput!]
               NOT: SeriesActorsAggregateInput
               OR: [SeriesActorsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -10265,7 +10299,8 @@ describe("Interface Relationships", () => {
               AND: [ShowActorsAggregateInput!]
               NOT: ShowActorsAggregateInput
               OR: [ShowActorsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int

--- a/packages/graphql/tests/schema/interfaces.test.ts
+++ b/packages/graphql/tests/schema/interfaces.test.ts
@@ -135,7 +135,8 @@ describe("Interfaces", () => {
               AND: [MovieMoviesAggregateInput!]
               NOT: MovieMoviesAggregateInput
               OR: [MovieMoviesAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -206,7 +207,8 @@ describe("Interfaces", () => {
               AND: [MovieNodeMoviesAggregateInput!]
               NOT: MovieNodeMoviesAggregateInput
               OR: [MovieNodeMoviesAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -549,7 +551,8 @@ describe("Interfaces", () => {
               AND: [MovieMoviesAggregateInput!]
               NOT: MovieMoviesAggregateInput
               OR: [MovieMoviesAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -620,7 +623,8 @@ describe("Interfaces", () => {
               AND: [MovieNodeMoviesAggregateInput!]
               NOT: MovieNodeMoviesAggregateInput
               OR: [MovieNodeMoviesAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int

--- a/packages/graphql/tests/schema/issues/1182.test.ts
+++ b/packages/graphql/tests/schema/issues/1182.test.ts
@@ -219,7 +219,8 @@ describe("https://github.com/neo4j/graphql/issues/1182", () => {
               AND: [MovieActorsAggregateInput!]
               NOT: MovieActorsAggregateInput
               OR: [MovieActorsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int

--- a/packages/graphql/tests/schema/issues/1614.test.ts
+++ b/packages/graphql/tests/schema/issues/1614.test.ts
@@ -116,7 +116,8 @@ describe("https://github.com/neo4j/graphql/issues/1614", () => {
               AND: [CrewMemberMoviesAggregateInput!]
               NOT: CrewMemberMoviesAggregateInput
               OR: [CrewMemberMoviesAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int

--- a/packages/graphql/tests/schema/issues/162.test.ts
+++ b/packages/graphql/tests/schema/issues/162.test.ts
@@ -209,7 +209,8 @@ describe("162", () => {
               AND: [TigerJawLevel2Part1AggregateInput!]
               NOT: TigerJawLevel2Part1AggregateInput
               OR: [TigerJawLevel2Part1AggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -329,7 +330,8 @@ describe("162", () => {
               AND: [TigerJawLevel2Part1TigerAggregateInput!]
               NOT: TigerJawLevel2Part1TigerAggregateInput
               OR: [TigerJawLevel2Part1TigerAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int

--- a/packages/graphql/tests/schema/issues/2187.test.ts
+++ b/packages/graphql/tests/schema/issues/2187.test.ts
@@ -136,7 +136,8 @@ describe("https://github.com/neo4j/graphql/issues/2187", () => {
               AND: [GenreMoviesAggregateInput!]
               NOT: GenreMoviesAggregateInput
               OR: [GenreMoviesAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -432,7 +433,8 @@ describe("https://github.com/neo4j/graphql/issues/2187", () => {
               AND: [MovieGenresAggregateInput!]
               NOT: MovieGenresAggregateInput
               OR: [MovieGenresAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int

--- a/packages/graphql/tests/schema/issues/2377.test.ts
+++ b/packages/graphql/tests/schema/issues/2377.test.ts
@@ -195,7 +195,8 @@ describe("https://github.com/neo4j/graphql/issues/2377", () => {
               AND: [ResourceContainedByAggregateInput!]
               NOT: ResourceContainedByAggregateInput
               OR: [ResourceContainedByAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int

--- a/packages/graphql/tests/schema/issues/2969.test.ts
+++ b/packages/graphql/tests/schema/issues/2969.test.ts
@@ -111,7 +111,8 @@ describe("https://github.com/neo4j/graphql/issues/2969", () => {
               AND: [PostAuthorAggregateInput!]
               NOT: PostAuthorAggregateInput
               OR: [PostAuthorAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -412,7 +413,8 @@ describe("https://github.com/neo4j/graphql/issues/2969", () => {
               AND: [UserPostsAggregateInput!]
               NOT: UserPostsAggregateInput
               OR: [UserPostsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int

--- a/packages/graphql/tests/schema/issues/2981.test.ts
+++ b/packages/graphql/tests/schema/issues/2981.test.ts
@@ -148,7 +148,8 @@ describe("https://github.com/neo4j/graphql/issues/2981", () => {
               AND: [BookTitle_ENBookAggregateInput!]
               NOT: BookTitle_ENBookAggregateInput
               OR: [BookTitle_ENBookAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -387,7 +388,8 @@ describe("https://github.com/neo4j/graphql/issues/2981", () => {
               AND: [BookTitle_SVBookAggregateInput!]
               NOT: BookTitle_SVBookAggregateInput
               OR: [BookTitle_SVBookAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int

--- a/packages/graphql/tests/schema/issues/2993.test.ts
+++ b/packages/graphql/tests/schema/issues/2993.test.ts
@@ -303,7 +303,8 @@ describe("https://github.com/neo4j/graphql/issues/2993", () => {
               AND: [UserFollowingAggregateInput!]
               NOT: UserFollowingAggregateInput
               OR: [UserFollowingAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int

--- a/packages/graphql/tests/schema/issues/3428.test.ts
+++ b/packages/graphql/tests/schema/issues/3428.test.ts
@@ -88,7 +88,8 @@ describe("Relationship nested operations", () => {
               AND: [MovieActorsAggregateInput!]
               NOT: MovieActorsAggregateInput
               OR: [MovieActorsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int

--- a/packages/graphql/tests/schema/issues/3439.test.ts
+++ b/packages/graphql/tests/schema/issues/3439.test.ts
@@ -204,7 +204,8 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               AND: [GenreProductAggregateInput!]
               NOT: GenreProductAggregateInput
               OR: [GenreProductAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -695,7 +696,8 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               AND: [MovieGenreAggregateInput!]
               NOT: MovieGenreAggregateInput
               OR: [MovieGenreAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -1060,7 +1062,8 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               AND: [SeriesGenreAggregateInput!]
               NOT: SeriesGenreAggregateInput
               OR: [SeriesGenreAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -1543,7 +1546,8 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               AND: [GenreProductAggregateInput!]
               NOT: GenreProductAggregateInput
               OR: [GenreProductAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -1980,7 +1984,8 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               AND: [MovieGenreAggregateInput!]
               NOT: MovieGenreAggregateInput
               OR: [MovieGenreAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -2342,7 +2347,8 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               AND: [SeriesGenreAggregateInput!]
               NOT: SeriesGenreAggregateInput
               OR: [SeriesGenreAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -2833,7 +2839,8 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               AND: [GenreProductAggregateInput!]
               NOT: GenreProductAggregateInput
               OR: [GenreProductAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -3153,7 +3160,8 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               AND: [IProductGenreAggregateInput!]
               NOT: IProductGenreAggregateInput
               OR: [IProductGenreAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -3493,7 +3501,8 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               AND: [MovieGenreAggregateInput!]
               NOT: MovieGenreAggregateInput
               OR: [MovieGenreAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -3914,7 +3923,8 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               AND: [SeriesGenreAggregateInput!]
               NOT: SeriesGenreAggregateInput
               OR: [SeriesGenreAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -4476,7 +4486,8 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               AND: [GenreProductAggregateInput!]
               NOT: GenreProductAggregateInput
               OR: [GenreProductAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -5575,7 +5586,8 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               AND: [RatingProductAggregateInput!]
               NOT: RatingProductAggregateInput
               OR: [RatingProductAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int

--- a/packages/graphql/tests/schema/issues/3541.test.ts
+++ b/packages/graphql/tests/schema/issues/3541.test.ts
@@ -133,7 +133,8 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
               AND: [MovieActorsAggregateInput!]
               NOT: MovieActorsAggregateInput
               OR: [MovieActorsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -485,7 +486,8 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
               AND: [MovieActorsAggregateInput!]
               NOT: MovieActorsAggregateInput
               OR: [MovieActorsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int

--- a/packages/graphql/tests/schema/issues/3698.test.ts
+++ b/packages/graphql/tests/schema/issues/3698.test.ts
@@ -198,7 +198,8 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
               AND: [GenreProductAggregateInput!]
               NOT: GenreProductAggregateInput
               OR: [GenreProductAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -685,7 +686,8 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
               AND: [MovieGenreAggregateInput!]
               NOT: MovieGenreAggregateInput
               OR: [MovieGenreAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -1191,7 +1193,8 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
               AND: [GenreProductAggregateInput!]
               NOT: GenreProductAggregateInput
               OR: [GenreProductAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -1547,7 +1550,8 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
               AND: [IProductGenreAggregateInput!]
               NOT: IProductGenreAggregateInput
               OR: [IProductGenreAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -1819,7 +1823,8 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
               AND: [MovieGenreAggregateInput!]
               NOT: MovieGenreAggregateInput
               OR: [MovieGenreAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -2306,7 +2311,8 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
               AND: [GenreProductAggregateInput!]
               NOT: GenreProductAggregateInput
               OR: [GenreProductAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -2663,7 +2669,8 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
               AND: [IProductGenreAggregateInput!]
               NOT: IProductGenreAggregateInput
               OR: [IProductGenreAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -2936,7 +2943,8 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
               AND: [MovieGenreAggregateInput!]
               NOT: MovieGenreAggregateInput
               OR: [MovieGenreAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -3270,7 +3278,8 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
               AND: [SeriesGenreAggregateInput!]
               NOT: SeriesGenreAggregateInput
               OR: [SeriesGenreAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int

--- a/packages/graphql/tests/schema/issues/3816.test.ts
+++ b/packages/graphql/tests/schema/issues/3816.test.ts
@@ -124,7 +124,8 @@ describe("https://github.com/neo4j/graphql/issues/3816", () => {
               AND: [GenreMoviesAggregateInput!]
               NOT: GenreMoviesAggregateInput
               OR: [GenreMoviesAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -343,7 +344,8 @@ describe("https://github.com/neo4j/graphql/issues/3816", () => {
               AND: [MovieGenreAggregateInput!]
               NOT: MovieGenreAggregateInput
               OR: [MovieGenreAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -648,7 +650,8 @@ describe("https://github.com/neo4j/graphql/issues/3816", () => {
               AND: [GenreMoviesAggregateInput!]
               NOT: GenreMoviesAggregateInput
               OR: [GenreMoviesAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -856,7 +859,8 @@ describe("https://github.com/neo4j/graphql/issues/3816", () => {
               AND: [MovieGenreAggregateInput!]
               NOT: MovieGenreAggregateInput
               OR: [MovieGenreAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int

--- a/packages/graphql/tests/schema/issues/3817.test.ts
+++ b/packages/graphql/tests/schema/issues/3817.test.ts
@@ -232,7 +232,8 @@ describe("3817", () => {
               AND: [PersonFriendsAggregateInput!]
               NOT: PersonFriendsAggregateInput
               OR: [PersonFriendsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int

--- a/packages/graphql/tests/schema/issues/4511.test.ts
+++ b/packages/graphql/tests/schema/issues/4511.test.ts
@@ -129,7 +129,8 @@ describe("https://github.com/neo4j/graphql/issues/4511", () => {
               AND: [CreatureMoviesAggregateInput!]
               NOT: CreatureMoviesAggregateInput
               OR: [CreatureMoviesAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -288,7 +289,8 @@ describe("https://github.com/neo4j/graphql/issues/4511", () => {
               AND: [MovieDirectorAggregateInput!]
               NOT: MovieDirectorAggregateInput
               OR: [MovieDirectorAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -470,7 +472,8 @@ describe("https://github.com/neo4j/graphql/issues/4511", () => {
               AND: [PersonMoviesAggregateInput!]
               NOT: PersonMoviesAggregateInput
               OR: [PersonMoviesAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -628,7 +631,8 @@ describe("https://github.com/neo4j/graphql/issues/4511", () => {
               AND: [ProductionDirectorAggregateInput!]
               NOT: ProductionDirectorAggregateInput
               OR: [ProductionDirectorAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -834,7 +838,8 @@ describe("https://github.com/neo4j/graphql/issues/4511", () => {
               AND: [SeriesDirectorAggregateInput!]
               NOT: SeriesDirectorAggregateInput
               OR: [SeriesDirectorAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int

--- a/packages/graphql/tests/schema/issues/4615.test.ts
+++ b/packages/graphql/tests/schema/issues/4615.test.ts
@@ -142,7 +142,8 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
               AND: [ActorActedInAggregateInput!]
               NOT: ActorActedInAggregateInput
               OR: [ActorActedInAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -447,7 +448,8 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
               AND: [MovieActorsAggregateInput!]
               NOT: MovieActorsAggregateInput
               OR: [MovieActorsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -713,7 +715,8 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
               AND: [SeriesActorsAggregateInput!]
               NOT: SeriesActorsAggregateInput
               OR: [SeriesActorsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -917,7 +920,8 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
               AND: [ShowActorsAggregateInput!]
               NOT: ShowActorsAggregateInput
               OR: [ShowActorsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int

--- a/packages/graphql/tests/schema/issues/5435.test.ts
+++ b/packages/graphql/tests/schema/issues/5435.test.ts
@@ -122,7 +122,8 @@ describe("https://github.com/neo4j/graphql/issues/5435", () => {
               AND: [PostAuthorAggregateInput!]
               NOT: PostAuthorAggregateInput
               OR: [PostAuthorAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int

--- a/packages/graphql/tests/schema/issues/872.test.ts
+++ b/packages/graphql/tests/schema/issues/872.test.ts
@@ -108,7 +108,8 @@ describe("https://github.com/neo4j/graphql/issues/872", () => {
               AND: [Actor2MoviesAggregateInput!]
               NOT: Actor2MoviesAggregateInput
               OR: [Actor2MoviesAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -344,7 +345,8 @@ describe("https://github.com/neo4j/graphql/issues/872", () => {
               AND: [ActorMoviesAggregateInput!]
               NOT: ActorMoviesAggregateInput
               OR: [ActorMoviesAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int

--- a/packages/graphql/tests/schema/lowercase-type-names.test.ts
+++ b/packages/graphql/tests/schema/lowercase-type-names.test.ts
@@ -213,7 +213,8 @@ describe("lower case type names", () => {
               AND: [actorMoviesAggregateInput!]
               NOT: actorMoviesAggregateInput
               OR: [actorMoviesAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -510,7 +511,8 @@ describe("lower case type names", () => {
               AND: [movieActorsAggregateInput!]
               NOT: movieActorsAggregateInput
               OR: [movieActorsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int

--- a/packages/graphql/tests/schema/math.test.ts
+++ b/packages/graphql/tests/schema/math.test.ts
@@ -611,7 +611,8 @@ describe("Algebraic", () => {
               AND: [DirectorDirectsAggregateInput!]
               NOT: DirectorDirectsAggregateInput
               OR: [DirectorDirectsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -851,7 +852,8 @@ describe("Algebraic", () => {
               AND: [MovieDirectedByAggregateInput!]
               NOT: MovieDirectedByAggregateInput
               OR: [MovieDirectedByAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -1290,7 +1292,8 @@ describe("Algebraic", () => {
               AND: [MovieWorkersAggregateInput!]
               NOT: MovieWorkersAggregateInput
               OR: [MovieWorkersAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -1546,7 +1549,8 @@ describe("Algebraic", () => {
               AND: [PersonWorksInProductionAggregateInput!]
               NOT: PersonWorksInProductionAggregateInput
               OR: [PersonWorksInProductionAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -1907,7 +1911,8 @@ describe("Algebraic", () => {
               AND: [MovieActorsAggregateInput!]
               NOT: MovieActorsAggregateInput
               OR: [MovieActorsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -2175,7 +2180,8 @@ describe("Algebraic", () => {
               AND: [PersonActedInMoviesAggregateInput!]
               NOT: PersonActedInMoviesAggregateInput
               OR: [PersonActedInMoviesAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int

--- a/packages/graphql/tests/schema/nested-aggregation-on-type.test.ts
+++ b/packages/graphql/tests/schema/nested-aggregation-on-type.test.ts
@@ -107,7 +107,8 @@ describe("nested aggregation on interface", () => {
               AND: [ActorActedInAggregateInput!]
               NOT: ActorActedInAggregateInput
               OR: [ActorActedInAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int

--- a/packages/graphql/tests/schema/pluralize-consistency.test.ts
+++ b/packages/graphql/tests/schema/pluralize-consistency.test.ts
@@ -235,7 +235,8 @@ describe("Pluralize consistency", () => {
               AND: [super_userMy_friendAggregateInput!]
               NOT: super_userMy_friendAggregateInput
               OR: [super_userMy_friendAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int

--- a/packages/graphql/tests/schema/query-direction.test.ts
+++ b/packages/graphql/tests/schema/query-direction.test.ts
@@ -154,7 +154,8 @@ describe("Query Direction", () => {
               AND: [UserFriendsAggregateInput!]
               NOT: UserFriendsAggregateInput
               OR: [UserFriendsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -477,7 +478,8 @@ describe("Query Direction", () => {
               AND: [UserFriendsAggregateInput!]
               NOT: UserFriendsAggregateInput
               OR: [UserFriendsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -800,7 +802,8 @@ describe("Query Direction", () => {
               AND: [UserFriendsAggregateInput!]
               NOT: UserFriendsAggregateInput
               OR: [UserFriendsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int

--- a/packages/graphql/tests/schema/remove-deprecated/aggregations.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/aggregations.test.ts
@@ -856,7 +856,8 @@ describe("Remove deprecated fields for aggregations", () => {
               AND: [PostLikesAggregateInput!]
               NOT: PostLikesAggregateInput
               OR: [PostLikesAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int

--- a/packages/graphql/tests/schema/remove-deprecated/array-methods.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/array-methods.test.ts
@@ -103,7 +103,8 @@ describe("Arrays Methods", () => {
               AND: [ActorActedInAggregateInput!]
               NOT: ActorActedInAggregateInput
               OR: [ActorActedInAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -375,7 +376,8 @@ describe("Arrays Methods", () => {
               AND: [MovieActorsAggregateInput!]
               NOT: MovieActorsAggregateInput
               OR: [MovieActorsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int

--- a/packages/graphql/tests/schema/remove-deprecated/comments.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/comments.test.ts
@@ -428,7 +428,8 @@ describe("Comments", () => {
                   AND: [MovieActorsAggregateInput!]
                   NOT: MovieActorsAggregateInput
                   OR: [MovieActorsAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int
@@ -791,7 +792,8 @@ describe("Comments", () => {
                   AND: [ActorActedInAggregateInput!]
                   NOT: ActorActedInAggregateInput
                   OR: [ActorActedInAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int

--- a/packages/graphql/tests/schema/remove-deprecated/implicit-equality.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/implicit-equality.test.ts
@@ -22,7 +22,7 @@ import { lexicographicSortSchema } from "graphql/utilities";
 import { Neo4jGraphQL } from "../../../src";
 
 describe("Implicit Equality filters", () => {
-    test("Should remove implicitEqualFilters if specified by the settings", async () => {
+    test("Should remove implicit filters if specified by the setting implicitEqualFilters", async () => {
         const typeDefs = /* GraphQL */ `
             type Actor @node {
                 name: String

--- a/packages/graphql/tests/schema/remove-deprecated/implicit-equality.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/implicit-equality.test.ts
@@ -516,7 +516,8 @@ describe("Implicit Equality filters", () => {
                   AND: [MovieActorsAggregateInput!]
                   NOT: MovieActorsAggregateInput
                   OR: [MovieActorsAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int
@@ -879,7 +880,8 @@ describe("Implicit Equality filters", () => {
                   AND: [ActorActedInAggregateInput!]
                   NOT: ActorActedInAggregateInput
                   OR: [ActorActedInAggregateInput!]
-                  count: Int
+                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+                  count_EQ: Int
                   count_GT: Int
                   count_GTE: Int
                   count_LT: Int

--- a/packages/graphql/tests/schema/remove-deprecated/implicit-equality.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/implicit-equality.test.ts
@@ -18,35 +18,36 @@
  */
 
 import { printSchemaWithDirectives } from "@graphql-tools/utils";
-import { gql } from "graphql-tag";
 import { lexicographicSortSchema } from "graphql/utilities";
 import { Neo4jGraphQL } from "../../../src";
 
 describe("Implicit Equality filters", () => {
     test("Should remove implicitEqualFilters if specified by the settings", async () => {
         const typeDefs = /* GraphQL */ `
+            type Actor @node {
+                name: String
+                movies: [Movie!]! @relationship(type: "ACTED_IN", direction: OUT, properties: "ActedIn")
+            }
             type Movie @node {
                 id: ID
-                title: String
-                actorCount: Int
-                averageRating: Float
-                isActive: Boolean
-                viewers: BigInt
-                location: Point
-                geoLocation: CartesianPoint
-                alternativeTitles: [String]
-                released: Date
+                actors: [Actor!]! @relationship(type: "ACTED_IN", direction: IN, properties: "ActedIn")
+            }
+
+            type ActedIn @relationshipProperties {
+                role: String
             }
         `;
         const neoSchema = new Neo4jGraphQL({
             typeDefs,
             features: {
                 excludeDeprecatedFields: {
-                    implicitEqualFilters: false,
+                    implicitEqualFilters: true,
                     bookmark: true,
                     arrayFilters: true,
                     stringAggregation: true,
                     aggregationFilters: true,
+                    deprecatedOptionsArgument: true,
+                    nestedUpdateOperationsFields: true,
                 },
             },
         });
@@ -59,39 +60,255 @@ describe("Implicit Equality filters", () => {
             }
 
             \\"\\"\\"
-            A BigInt value up to 64 bits in size, which can be a number or a string if used inline, or a string only if used as a variable. Always returned as a string.
+            The edge properties for the following fields:
+            * Actor.movies
+            * Movie.actors
             \\"\\"\\"
-            scalar BigInt
+            type ActedIn {
+              role: String
+            }
 
-            type BigIntAggregateSelection {
-              average: BigInt
-              max: BigInt
-              min: BigInt
-              sum: BigInt
+            input ActedInAggregationWhereInput {
+              AND: [ActedInAggregationWhereInput!]
+              NOT: ActedInAggregationWhereInput
+              OR: [ActedInAggregationWhereInput!]
+              role_AVERAGE_LENGTH_EQUAL: Float
+              role_AVERAGE_LENGTH_GT: Float
+              role_AVERAGE_LENGTH_GTE: Float
+              role_AVERAGE_LENGTH_LT: Float
+              role_AVERAGE_LENGTH_LTE: Float
+              role_LONGEST_LENGTH_EQUAL: Int
+              role_LONGEST_LENGTH_GT: Int
+              role_LONGEST_LENGTH_GTE: Int
+              role_LONGEST_LENGTH_LT: Int
+              role_LONGEST_LENGTH_LTE: Int
+              role_SHORTEST_LENGTH_EQUAL: Int
+              role_SHORTEST_LENGTH_GT: Int
+              role_SHORTEST_LENGTH_GTE: Int
+              role_SHORTEST_LENGTH_LT: Int
+              role_SHORTEST_LENGTH_LTE: Int
+            }
+
+            input ActedInCreateInput {
+              role: String
+            }
+
+            input ActedInSort {
+              role: SortDirection
+            }
+
+            input ActedInUpdateInput {
+              role: String
+            }
+
+            input ActedInWhere {
+              AND: [ActedInWhere!]
+              NOT: ActedInWhere
+              OR: [ActedInWhere!]
+              role_CONTAINS: String
+              role_ENDS_WITH: String
+              role_EQ: String
+              role_IN: [String]
+              role_STARTS_WITH: String
+            }
+
+            type Actor {
+              movies(directed: Boolean = true, limit: Int, offset: Int, sort: [MovieSort!], where: MovieWhere): [Movie!]!
+              moviesAggregate(directed: Boolean = true, where: MovieWhere): ActorMovieMoviesAggregationSelection
+              moviesConnection(after: String, directed: Boolean = true, first: Int, sort: [ActorMoviesConnectionSort!], where: ActorMoviesConnectionWhere): ActorMoviesConnection!
+              name: String
+            }
+
+            type ActorAggregateSelection {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
+            input ActorConnectInput {
+              movies: [ActorMoviesConnectFieldInput!]
+            }
+
+            input ActorConnectWhere {
+              node: ActorWhere!
+            }
+
+            input ActorCreateInput {
+              movies: ActorMoviesFieldInput
+              name: String
+            }
+
+            input ActorDeleteInput {
+              movies: [ActorMoviesDeleteFieldInput!]
+            }
+
+            input ActorDisconnectInput {
+              movies: [ActorMoviesDisconnectFieldInput!]
+            }
+
+            type ActorEdge {
+              cursor: String!
+              node: Actor!
+            }
+
+            type ActorMovieMoviesAggregationSelection {
+              count: Int!
+              edge: ActorMovieMoviesEdgeAggregateSelection
+              node: ActorMovieMoviesNodeAggregateSelection
+            }
+
+            type ActorMovieMoviesEdgeAggregateSelection {
+              role: StringAggregateSelection!
+            }
+
+            type ActorMovieMoviesNodeAggregateSelection {
+              id: IDAggregateSelection!
+            }
+
+            input ActorMoviesAggregateInput {
+              AND: [ActorMoviesAggregateInput!]
+              NOT: ActorMoviesAggregateInput
+              OR: [ActorMoviesAggregateInput!]
+              count_EQ: Int
+              count_GT: Int
+              count_GTE: Int
+              count_LT: Int
+              count_LTE: Int
+              edge: ActedInAggregationWhereInput
+              node: ActorMoviesNodeAggregationWhereInput
+            }
+
+            input ActorMoviesConnectFieldInput {
+              connect: [MovieConnectInput!]
+              edge: ActedInCreateInput
+              \\"\\"\\"
+              Whether or not to overwrite any matching relationship with the new properties.
+              \\"\\"\\"
+              overwrite: Boolean! = true
+              where: MovieConnectWhere
+            }
+
+            type ActorMoviesConnection {
+              edges: [ActorMoviesRelationship!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            input ActorMoviesConnectionSort {
+              edge: ActedInSort
+              node: MovieSort
+            }
+
+            input ActorMoviesConnectionWhere {
+              AND: [ActorMoviesConnectionWhere!]
+              NOT: ActorMoviesConnectionWhere
+              OR: [ActorMoviesConnectionWhere!]
+              edge: ActedInWhere
+              node: MovieWhere
+            }
+
+            input ActorMoviesCreateFieldInput {
+              edge: ActedInCreateInput
+              node: MovieCreateInput!
+            }
+
+            input ActorMoviesDeleteFieldInput {
+              delete: MovieDeleteInput
+              where: ActorMoviesConnectionWhere
+            }
+
+            input ActorMoviesDisconnectFieldInput {
+              disconnect: MovieDisconnectInput
+              where: ActorMoviesConnectionWhere
+            }
+
+            input ActorMoviesFieldInput {
+              connect: [ActorMoviesConnectFieldInput!]
+              create: [ActorMoviesCreateFieldInput!]
+            }
+
+            input ActorMoviesNodeAggregationWhereInput {
+              AND: [ActorMoviesNodeAggregationWhereInput!]
+              NOT: ActorMoviesNodeAggregationWhereInput
+              OR: [ActorMoviesNodeAggregationWhereInput!]
+            }
+
+            type ActorMoviesRelationship {
+              cursor: String!
+              node: Movie!
+              properties: ActedIn!
+            }
+
+            input ActorMoviesUpdateConnectionInput {
+              edge: ActedInUpdateInput
+              node: MovieUpdateInput
+            }
+
+            input ActorMoviesUpdateFieldInput {
+              connect: [ActorMoviesConnectFieldInput!]
+              create: [ActorMoviesCreateFieldInput!]
+              delete: [ActorMoviesDeleteFieldInput!]
+              disconnect: [ActorMoviesDisconnectFieldInput!]
+              update: ActorMoviesUpdateConnectionInput
+              where: ActorMoviesConnectionWhere
             }
 
             \\"\\"\\"
-            A point in a two- or three-dimensional Cartesian coordinate system or in a three-dimensional cylindrical coordinate system. For more information, see https://neo4j.com/docs/graphql/4/type-definitions/types/spatial/#cartesian-point
+            Fields to sort Actors by. The order in which sorts are applied is not guaranteed when specifying many fields in one ActorSort object.
             \\"\\"\\"
-            type CartesianPoint {
-              crs: String!
-              srid: Int!
-              x: Float!
-              y: Float!
-              z: Float
+            input ActorSort {
+              name: SortDirection
             }
 
-            \\"\\"\\"Input type for a cartesian point with a distance\\"\\"\\"
-            input CartesianPointDistance {
-              distance: Float!
-              point: CartesianPointInput!
+            input ActorUpdateInput {
+              movies: [ActorMoviesUpdateFieldInput!]
+              name: String
             }
 
-            \\"\\"\\"Input type for a cartesian point\\"\\"\\"
-            input CartesianPointInput {
-              x: Float!
-              y: Float!
-              z: Float
+            input ActorWhere {
+              AND: [ActorWhere!]
+              NOT: ActorWhere
+              OR: [ActorWhere!]
+              moviesAggregate: ActorMoviesAggregateInput
+              \\"\\"\\"
+              Return Actors where all of the related ActorMoviesConnections match this filter
+              \\"\\"\\"
+              moviesConnection_ALL: ActorMoviesConnectionWhere
+              \\"\\"\\"
+              Return Actors where none of the related ActorMoviesConnections match this filter
+              \\"\\"\\"
+              moviesConnection_NONE: ActorMoviesConnectionWhere
+              \\"\\"\\"
+              Return Actors where one of the related ActorMoviesConnections match this filter
+              \\"\\"\\"
+              moviesConnection_SINGLE: ActorMoviesConnectionWhere
+              \\"\\"\\"
+              Return Actors where some of the related ActorMoviesConnections match this filter
+              \\"\\"\\"
+              moviesConnection_SOME: ActorMoviesConnectionWhere
+              \\"\\"\\"Return Actors where all of the related Movies match this filter\\"\\"\\"
+              movies_ALL: MovieWhere
+              \\"\\"\\"Return Actors where none of the related Movies match this filter\\"\\"\\"
+              movies_NONE: MovieWhere
+              \\"\\"\\"Return Actors where one of the related Movies match this filter\\"\\"\\"
+              movies_SINGLE: MovieWhere
+              \\"\\"\\"Return Actors where some of the related Movies match this filter\\"\\"\\"
+              movies_SOME: MovieWhere
+              name_CONTAINS: String
+              name_ENDS_WITH: String
+              name_EQ: String
+              name_IN: [String]
+              name_STARTS_WITH: String
+            }
+
+            type ActorsConnection {
+              edges: [ActorEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type CreateActorsMutationResponse {
+              actors: [Actor!]!
+              info: CreateInfo!
             }
 
             \\"\\"\\"
@@ -107,9 +324,6 @@ describe("Implicit Equality filters", () => {
               movies: [Movie!]!
             }
 
-            \\"\\"\\"A date, represented as a 'yyyy-mm-dd' string\\"\\"\\"
-            scalar Date
-
             \\"\\"\\"
             Information about the number of nodes and relationships deleted during a delete mutation
             \\"\\"\\"
@@ -118,58 +332,159 @@ describe("Implicit Equality filters", () => {
               relationshipsDeleted: Int!
             }
 
-            type FloatAggregateSelection {
-              average: Float
-              max: Float
-              min: Float
-              sum: Float
-            }
-
             type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
 
-            type IntAggregateSelection {
-              average: Float
-              max: Int
-              min: Int
-              sum: Int
+            type Movie {
+              actors(directed: Boolean = true, limit: Int, offset: Int, sort: [ActorSort!], where: ActorWhere): [Actor!]!
+              actorsAggregate(directed: Boolean = true, where: ActorWhere): MovieActorActorsAggregationSelection
+              actorsConnection(after: String, directed: Boolean = true, first: Int, sort: [MovieActorsConnectionSort!], where: MovieActorsConnectionWhere): MovieActorsConnection!
+              id: ID
             }
 
-            type Movie {
-              actorCount: Int
-              alternativeTitles: [String]
-              averageRating: Float
-              geoLocation: CartesianPoint
-              id: ID
-              isActive: Boolean
-              location: Point
-              released: Date
-              title: String
-              viewers: BigInt
+            type MovieActorActorsAggregationSelection {
+              count: Int!
+              edge: MovieActorActorsEdgeAggregateSelection
+              node: MovieActorActorsNodeAggregateSelection
+            }
+
+            type MovieActorActorsEdgeAggregateSelection {
+              role: StringAggregateSelection!
+            }
+
+            type MovieActorActorsNodeAggregateSelection {
+              name: StringAggregateSelection!
+            }
+
+            input MovieActorsAggregateInput {
+              AND: [MovieActorsAggregateInput!]
+              NOT: MovieActorsAggregateInput
+              OR: [MovieActorsAggregateInput!]
+              count_EQ: Int
+              count_GT: Int
+              count_GTE: Int
+              count_LT: Int
+              count_LTE: Int
+              edge: ActedInAggregationWhereInput
+              node: MovieActorsNodeAggregationWhereInput
+            }
+
+            input MovieActorsConnectFieldInput {
+              connect: [ActorConnectInput!]
+              edge: ActedInCreateInput
+              \\"\\"\\"
+              Whether or not to overwrite any matching relationship with the new properties.
+              \\"\\"\\"
+              overwrite: Boolean! = true
+              where: ActorConnectWhere
+            }
+
+            type MovieActorsConnection {
+              edges: [MovieActorsRelationship!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            input MovieActorsConnectionSort {
+              edge: ActedInSort
+              node: ActorSort
+            }
+
+            input MovieActorsConnectionWhere {
+              AND: [MovieActorsConnectionWhere!]
+              NOT: MovieActorsConnectionWhere
+              OR: [MovieActorsConnectionWhere!]
+              edge: ActedInWhere
+              node: ActorWhere
+            }
+
+            input MovieActorsCreateFieldInput {
+              edge: ActedInCreateInput
+              node: ActorCreateInput!
+            }
+
+            input MovieActorsDeleteFieldInput {
+              delete: ActorDeleteInput
+              where: MovieActorsConnectionWhere
+            }
+
+            input MovieActorsDisconnectFieldInput {
+              disconnect: ActorDisconnectInput
+              where: MovieActorsConnectionWhere
+            }
+
+            input MovieActorsFieldInput {
+              connect: [MovieActorsConnectFieldInput!]
+              create: [MovieActorsCreateFieldInput!]
+            }
+
+            input MovieActorsNodeAggregationWhereInput {
+              AND: [MovieActorsNodeAggregationWhereInput!]
+              NOT: MovieActorsNodeAggregationWhereInput
+              OR: [MovieActorsNodeAggregationWhereInput!]
+              name_AVERAGE_LENGTH_EQUAL: Float
+              name_AVERAGE_LENGTH_GT: Float
+              name_AVERAGE_LENGTH_GTE: Float
+              name_AVERAGE_LENGTH_LT: Float
+              name_AVERAGE_LENGTH_LTE: Float
+              name_LONGEST_LENGTH_EQUAL: Int
+              name_LONGEST_LENGTH_GT: Int
+              name_LONGEST_LENGTH_GTE: Int
+              name_LONGEST_LENGTH_LT: Int
+              name_LONGEST_LENGTH_LTE: Int
+              name_SHORTEST_LENGTH_EQUAL: Int
+              name_SHORTEST_LENGTH_GT: Int
+              name_SHORTEST_LENGTH_GTE: Int
+              name_SHORTEST_LENGTH_LT: Int
+              name_SHORTEST_LENGTH_LTE: Int
+            }
+
+            type MovieActorsRelationship {
+              cursor: String!
+              node: Actor!
+              properties: ActedIn!
+            }
+
+            input MovieActorsUpdateConnectionInput {
+              edge: ActedInUpdateInput
+              node: ActorUpdateInput
+            }
+
+            input MovieActorsUpdateFieldInput {
+              connect: [MovieActorsConnectFieldInput!]
+              create: [MovieActorsCreateFieldInput!]
+              delete: [MovieActorsDeleteFieldInput!]
+              disconnect: [MovieActorsDisconnectFieldInput!]
+              update: MovieActorsUpdateConnectionInput
+              where: MovieActorsConnectionWhere
             }
 
             type MovieAggregateSelection {
-              actorCount: IntAggregateSelection!
-              averageRating: FloatAggregateSelection!
               count: Int!
               id: IDAggregateSelection!
-              title: StringAggregateSelection!
-              viewers: BigIntAggregateSelection!
+            }
+
+            input MovieConnectInput {
+              actors: [MovieActorsConnectFieldInput!]
+            }
+
+            input MovieConnectWhere {
+              node: MovieWhere!
             }
 
             input MovieCreateInput {
-              actorCount: Int
-              alternativeTitles: [String]
-              averageRating: Float
-              geoLocation: CartesianPointInput
+              actors: MovieActorsFieldInput
               id: ID
-              isActive: Boolean
-              location: PointInput
-              released: Date
-              title: String
-              viewers: BigInt
+            }
+
+            input MovieDeleteInput {
+              actors: [MovieActorsDeleteFieldInput!]
+            }
+
+            input MovieDisconnectInput {
+              actors: [MovieActorsDisconnectFieldInput!]
             }
 
             type MovieEdge {
@@ -177,118 +492,52 @@ describe("Implicit Equality filters", () => {
               node: Movie!
             }
 
-            input MovieOptions {
-              limit: Int
-              offset: Int
-              \\"\\"\\"
-              Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array.
-              \\"\\"\\"
-              sort: [MovieSort!]
-            }
-
             \\"\\"\\"
             Fields to sort Movies by. The order in which sorts are applied is not guaranteed when specifying many fields in one MovieSort object.
             \\"\\"\\"
             input MovieSort {
-              actorCount: SortDirection
-              averageRating: SortDirection
-              geoLocation: SortDirection
               id: SortDirection
-              isActive: SortDirection
-              location: SortDirection
-              released: SortDirection
-              title: SortDirection
-              viewers: SortDirection
             }
 
             input MovieUpdateInput {
-              actorCount: Int
-              actorCount_DECREMENT: Int
-              actorCount_INCREMENT: Int
-              alternativeTitles: [String]
-              alternativeTitles_POP: Int
-              alternativeTitles_PUSH: [String]
-              averageRating: Float
-              averageRating_ADD: Float
-              averageRating_DIVIDE: Float
-              averageRating_MULTIPLY: Float
-              averageRating_SUBTRACT: Float
-              geoLocation: CartesianPointInput
+              actors: [MovieActorsUpdateFieldInput!]
               id: ID
-              isActive: Boolean
-              location: PointInput
-              released: Date
-              title: String
-              viewers: BigInt
-              viewers_DECREMENT: BigInt
-              viewers_INCREMENT: BigInt
             }
 
             input MovieWhere {
               AND: [MovieWhere!]
               NOT: MovieWhere
               OR: [MovieWhere!]
-              actorCount: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
-              actorCount_EQ: Int
-              actorCount_GT: Int
-              actorCount_GTE: Int
-              actorCount_IN: [Int]
-              actorCount_LT: Int
-              actorCount_LTE: Int
-              alternativeTitles: [String] @deprecated(reason: \\"Please use the explicit _EQ version\\")
-              alternativeTitles_EQ: [String]
-              alternativeTitles_INCLUDES: String
-              averageRating: Float @deprecated(reason: \\"Please use the explicit _EQ version\\")
-              averageRating_EQ: Float
-              averageRating_GT: Float
-              averageRating_GTE: Float
-              averageRating_IN: [Float]
-              averageRating_LT: Float
-              averageRating_LTE: Float
-              geoLocation: CartesianPointInput @deprecated(reason: \\"Please use the explicit _EQ version\\")
-              geoLocation_DISTANCE: CartesianPointDistance
-              geoLocation_EQ: CartesianPointInput
-              geoLocation_GT: CartesianPointDistance
-              geoLocation_GTE: CartesianPointDistance
-              geoLocation_IN: [CartesianPointInput]
-              geoLocation_LT: CartesianPointDistance
-              geoLocation_LTE: CartesianPointDistance
-              id: ID @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              actorsAggregate: MovieActorsAggregateInput
+              \\"\\"\\"
+              Return Movies where all of the related MovieActorsConnections match this filter
+              \\"\\"\\"
+              actorsConnection_ALL: MovieActorsConnectionWhere
+              \\"\\"\\"
+              Return Movies where none of the related MovieActorsConnections match this filter
+              \\"\\"\\"
+              actorsConnection_NONE: MovieActorsConnectionWhere
+              \\"\\"\\"
+              Return Movies where one of the related MovieActorsConnections match this filter
+              \\"\\"\\"
+              actorsConnection_SINGLE: MovieActorsConnectionWhere
+              \\"\\"\\"
+              Return Movies where some of the related MovieActorsConnections match this filter
+              \\"\\"\\"
+              actorsConnection_SOME: MovieActorsConnectionWhere
+              \\"\\"\\"Return Movies where all of the related Actors match this filter\\"\\"\\"
+              actors_ALL: ActorWhere
+              \\"\\"\\"Return Movies where none of the related Actors match this filter\\"\\"\\"
+              actors_NONE: ActorWhere
+              \\"\\"\\"Return Movies where one of the related Actors match this filter\\"\\"\\"
+              actors_SINGLE: ActorWhere
+              \\"\\"\\"Return Movies where some of the related Actors match this filter\\"\\"\\"
+              actors_SOME: ActorWhere
               id_CONTAINS: ID
               id_ENDS_WITH: ID
               id_EQ: ID
               id_IN: [ID]
               id_STARTS_WITH: ID
-              isActive: Boolean @deprecated(reason: \\"Please use the explicit _EQ version\\")
-              isActive_EQ: Boolean
-              location: PointInput @deprecated(reason: \\"Please use the explicit _EQ version\\")
-              location_DISTANCE: PointDistance
-              location_EQ: PointInput
-              location_GT: PointDistance
-              location_GTE: PointDistance
-              location_IN: [PointInput]
-              location_LT: PointDistance
-              location_LTE: PointDistance
-              released: Date @deprecated(reason: \\"Please use the explicit _EQ version\\")
-              released_EQ: Date
-              released_GT: Date
-              released_GTE: Date
-              released_IN: [Date]
-              released_LT: Date
-              released_LTE: Date
-              title: String @deprecated(reason: \\"Please use the explicit _EQ version\\")
-              title_CONTAINS: String
-              title_ENDS_WITH: String
-              title_EQ: String
-              title_IN: [String]
-              title_STARTS_WITH: String
-              viewers: BigInt @deprecated(reason: \\"Please use the explicit _EQ version\\")
-              viewers_EQ: BigInt
-              viewers_GT: BigInt
-              viewers_GTE: BigInt
-              viewers_IN: [BigInt]
-              viewers_LT: BigInt
-              viewers_LTE: BigInt
             }
 
             type MoviesConnection {
@@ -298,8 +547,11 @@ describe("Implicit Equality filters", () => {
             }
 
             type Mutation {
+              createActors(input: [ActorCreateInput!]!): CreateActorsMutationResponse!
               createMovies(input: [MovieCreateInput!]!): CreateMoviesMutationResponse!
-              deleteMovies(where: MovieWhere): DeleteInfo!
+              deleteActors(delete: ActorDeleteInput, where: ActorWhere): DeleteInfo!
+              deleteMovies(delete: MovieDeleteInput, where: MovieWhere): DeleteInfo!
+              updateActors(update: ActorUpdateInput, where: ActorWhere): UpdateActorsMutationResponse!
               updateMovies(update: MovieUpdateInput, where: MovieWhere): UpdateMoviesMutationResponse!
             }
 
@@ -311,33 +563,11 @@ describe("Implicit Equality filters", () => {
               startCursor: String
             }
 
-            \\"\\"\\"
-            A point in a coordinate system. For more information, see https://neo4j.com/docs/graphql/4/type-definitions/types/spatial/#point
-            \\"\\"\\"
-            type Point {
-              crs: String!
-              height: Float
-              latitude: Float!
-              longitude: Float!
-              srid: Int!
-            }
-
-            \\"\\"\\"Input type for a point with a distance\\"\\"\\"
-            input PointDistance {
-              \\"\\"\\"The distance in metres to be used when comparing two points\\"\\"\\"
-              distance: Float!
-              point: PointInput!
-            }
-
-            \\"\\"\\"Input type for a point\\"\\"\\"
-            input PointInput {
-              height: Float
-              latitude: Float!
-              longitude: Float!
-            }
-
             type Query {
-              movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
+              actors(limit: Int, offset: Int, sort: [ActorSort!], where: ActorWhere): [Actor!]!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
+              movies(limit: Int, offset: Int, sort: [MovieSort!], where: MovieWhere): [Movie!]!
               moviesAggregate(where: MovieWhere): MovieAggregateSelection!
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
@@ -355,6 +585,11 @@ describe("Implicit Equality filters", () => {
               shortest: String
             }
 
+            type UpdateActorsMutationResponse {
+              actors: [Actor!]!
+              info: UpdateInfo!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created and deleted during an update mutation
             \\"\\"\\"
@@ -370,1466 +605,5 @@ describe("Implicit Equality filters", () => {
               movies: [Movie!]!
             }"
         `);
-    });
-
-    describe("Relationship", () => {
-        test("Simple", async () => {
-            const typeDefs = gql`
-                type Actor @node {
-                    name: String
-                }
-
-                type Movie @node {
-                    id: ID
-                    "Actors in Movie"
-                    actors: [Actor!]! @relationship(type: "ACTED_IN", direction: IN)
-                }
-            `;
-            const neoSchema = new Neo4jGraphQL({
-                typeDefs,
-                features: {
-                    excludeDeprecatedFields: {
-                        bookmark: true,
-                        arrayFilters: true,
-                        stringAggregation: true,
-                        aggregationFilters: true,
-                    },
-                },
-            });
-            const printedSchema = printSchemaWithDirectives(lexicographicSortSchema(await neoSchema.getSchema()));
-
-            expect(printedSchema).toMatchInlineSnapshot(`
-                "schema {
-                  query: Query
-                  mutation: Mutation
-                }
-
-                type Actor {
-                  name: String
-                }
-
-                type ActorAggregateSelection {
-                  count: Int!
-                  name: StringAggregateSelection!
-                }
-
-                input ActorConnectWhere {
-                  node: ActorWhere!
-                }
-
-                input ActorCreateInput {
-                  name: String
-                }
-
-                type ActorEdge {
-                  cursor: String!
-                  node: Actor!
-                }
-
-                input ActorOptions {
-                  limit: Int
-                  offset: Int
-                  \\"\\"\\"
-                  Specify one or more ActorSort objects to sort Actors by. The sorts will be applied in the order in which they are arranged in the array.
-                  \\"\\"\\"
-                  sort: [ActorSort!]
-                }
-
-                \\"\\"\\"
-                Fields to sort Actors by. The order in which sorts are applied is not guaranteed when specifying many fields in one ActorSort object.
-                \\"\\"\\"
-                input ActorSort {
-                  name: SortDirection
-                }
-
-                input ActorUpdateInput {
-                  name: String
-                }
-
-                input ActorWhere {
-                  AND: [ActorWhere!]
-                  NOT: ActorWhere
-                  OR: [ActorWhere!]
-                  name: String @deprecated(reason: \\"Please use the explicit _EQ version\\")
-                  name_CONTAINS: String
-                  name_ENDS_WITH: String
-                  name_EQ: String
-                  name_IN: [String]
-                  name_STARTS_WITH: String
-                }
-
-                type ActorsConnection {
-                  edges: [ActorEdge!]!
-                  pageInfo: PageInfo!
-                  totalCount: Int!
-                }
-
-                type CreateActorsMutationResponse {
-                  actors: [Actor!]!
-                  info: CreateInfo!
-                }
-
-                \\"\\"\\"
-                Information about the number of nodes and relationships created during a create mutation
-                \\"\\"\\"
-                type CreateInfo {
-                  nodesCreated: Int!
-                  relationshipsCreated: Int!
-                }
-
-                type CreateMoviesMutationResponse {
-                  info: CreateInfo!
-                  movies: [Movie!]!
-                }
-
-                \\"\\"\\"
-                Information about the number of nodes and relationships deleted during a delete mutation
-                \\"\\"\\"
-                type DeleteInfo {
-                  nodesDeleted: Int!
-                  relationshipsDeleted: Int!
-                }
-
-                type IDAggregateSelection {
-                  longest: ID
-                  shortest: ID
-                }
-
-                type Movie {
-                  \\"\\"\\"Actors in Movie\\"\\"\\"
-                  actors(directed: Boolean = true, limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-                  actorsAggregate(directed: Boolean = true, where: ActorWhere): MovieActorActorsAggregationSelection
-                  actorsConnection(after: String, directed: Boolean = true, first: Int, sort: [MovieActorsConnectionSort!], where: MovieActorsConnectionWhere): MovieActorsConnection!
-                  id: ID
-                }
-
-                type MovieActorActorsAggregationSelection {
-                  count: Int!
-                  node: MovieActorActorsNodeAggregateSelection
-                }
-
-                type MovieActorActorsNodeAggregateSelection {
-                  name: StringAggregateSelection!
-                }
-
-                input MovieActorsAggregateInput {
-                  AND: [MovieActorsAggregateInput!]
-                  NOT: MovieActorsAggregateInput
-                  OR: [MovieActorsAggregateInput!]
-                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
-                  count_EQ: Int
-                  count_GT: Int
-                  count_GTE: Int
-                  count_LT: Int
-                  count_LTE: Int
-                  node: MovieActorsNodeAggregationWhereInput
-                }
-
-                input MovieActorsConnectFieldInput {
-                  \\"\\"\\"
-                  Whether or not to overwrite any matching relationship with the new properties.
-                  \\"\\"\\"
-                  overwrite: Boolean! = true
-                  where: ActorConnectWhere
-                }
-
-                type MovieActorsConnection {
-                  edges: [MovieActorsRelationship!]!
-                  pageInfo: PageInfo!
-                  totalCount: Int!
-                }
-
-                input MovieActorsConnectionSort {
-                  node: ActorSort
-                }
-
-                input MovieActorsConnectionWhere {
-                  AND: [MovieActorsConnectionWhere!]
-                  NOT: MovieActorsConnectionWhere
-                  OR: [MovieActorsConnectionWhere!]
-                  node: ActorWhere
-                }
-
-                input MovieActorsCreateFieldInput {
-                  node: ActorCreateInput!
-                }
-
-                input MovieActorsDeleteFieldInput {
-                  where: MovieActorsConnectionWhere
-                }
-
-                input MovieActorsDisconnectFieldInput {
-                  where: MovieActorsConnectionWhere
-                }
-
-                input MovieActorsFieldInput {
-                  connect: [MovieActorsConnectFieldInput!]
-                  create: [MovieActorsCreateFieldInput!]
-                }
-
-                input MovieActorsNodeAggregationWhereInput {
-                  AND: [MovieActorsNodeAggregationWhereInput!]
-                  NOT: MovieActorsNodeAggregationWhereInput
-                  OR: [MovieActorsNodeAggregationWhereInput!]
-                  name_AVERAGE_LENGTH_EQUAL: Float
-                  name_AVERAGE_LENGTH_GT: Float
-                  name_AVERAGE_LENGTH_GTE: Float
-                  name_AVERAGE_LENGTH_LT: Float
-                  name_AVERAGE_LENGTH_LTE: Float
-                  name_LONGEST_LENGTH_EQUAL: Int
-                  name_LONGEST_LENGTH_GT: Int
-                  name_LONGEST_LENGTH_GTE: Int
-                  name_LONGEST_LENGTH_LT: Int
-                  name_LONGEST_LENGTH_LTE: Int
-                  name_SHORTEST_LENGTH_EQUAL: Int
-                  name_SHORTEST_LENGTH_GT: Int
-                  name_SHORTEST_LENGTH_GTE: Int
-                  name_SHORTEST_LENGTH_LT: Int
-                  name_SHORTEST_LENGTH_LTE: Int
-                }
-
-                type MovieActorsRelationship {
-                  cursor: String!
-                  node: Actor!
-                }
-
-                input MovieActorsUpdateConnectionInput {
-                  node: ActorUpdateInput
-                }
-
-                input MovieActorsUpdateFieldInput {
-                  connect: [MovieActorsConnectFieldInput!]
-                  create: [MovieActorsCreateFieldInput!]
-                  delete: [MovieActorsDeleteFieldInput!]
-                  disconnect: [MovieActorsDisconnectFieldInput!]
-                  update: MovieActorsUpdateConnectionInput
-                  where: MovieActorsConnectionWhere
-                }
-
-                type MovieAggregateSelection {
-                  count: Int!
-                  id: IDAggregateSelection!
-                }
-
-                input MovieConnectInput {
-                  actors: [MovieActorsConnectFieldInput!]
-                }
-
-                input MovieCreateInput {
-                  actors: MovieActorsFieldInput
-                  id: ID
-                }
-
-                input MovieDeleteInput {
-                  actors: [MovieActorsDeleteFieldInput!]
-                }
-
-                input MovieDisconnectInput {
-                  actors: [MovieActorsDisconnectFieldInput!]
-                }
-
-                type MovieEdge {
-                  cursor: String!
-                  node: Movie!
-                }
-
-                input MovieOptions {
-                  limit: Int
-                  offset: Int
-                  \\"\\"\\"
-                  Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array.
-                  \\"\\"\\"
-                  sort: [MovieSort!]
-                }
-
-                input MovieRelationInput {
-                  actors: [MovieActorsCreateFieldInput!]
-                }
-
-                \\"\\"\\"
-                Fields to sort Movies by. The order in which sorts are applied is not guaranteed when specifying many fields in one MovieSort object.
-                \\"\\"\\"
-                input MovieSort {
-                  id: SortDirection
-                }
-
-                input MovieUpdateInput {
-                  actors: [MovieActorsUpdateFieldInput!]
-                  id: ID
-                }
-
-                input MovieWhere {
-                  AND: [MovieWhere!]
-                  NOT: MovieWhere
-                  OR: [MovieWhere!]
-                  actorsAggregate: MovieActorsAggregateInput
-                  \\"\\"\\"
-                  Return Movies where all of the related MovieActorsConnections match this filter
-                  \\"\\"\\"
-                  actorsConnection_ALL: MovieActorsConnectionWhere
-                  \\"\\"\\"
-                  Return Movies where none of the related MovieActorsConnections match this filter
-                  \\"\\"\\"
-                  actorsConnection_NONE: MovieActorsConnectionWhere
-                  \\"\\"\\"
-                  Return Movies where one of the related MovieActorsConnections match this filter
-                  \\"\\"\\"
-                  actorsConnection_SINGLE: MovieActorsConnectionWhere
-                  \\"\\"\\"
-                  Return Movies where some of the related MovieActorsConnections match this filter
-                  \\"\\"\\"
-                  actorsConnection_SOME: MovieActorsConnectionWhere
-                  \\"\\"\\"Return Movies where all of the related Actors match this filter\\"\\"\\"
-                  actors_ALL: ActorWhere
-                  \\"\\"\\"Return Movies where none of the related Actors match this filter\\"\\"\\"
-                  actors_NONE: ActorWhere
-                  \\"\\"\\"Return Movies where one of the related Actors match this filter\\"\\"\\"
-                  actors_SINGLE: ActorWhere
-                  \\"\\"\\"Return Movies where some of the related Actors match this filter\\"\\"\\"
-                  actors_SOME: ActorWhere
-                  id: ID @deprecated(reason: \\"Please use the explicit _EQ version\\")
-                  id_CONTAINS: ID
-                  id_ENDS_WITH: ID
-                  id_EQ: ID
-                  id_IN: [ID]
-                  id_STARTS_WITH: ID
-                }
-
-                type MoviesConnection {
-                  edges: [MovieEdge!]!
-                  pageInfo: PageInfo!
-                  totalCount: Int!
-                }
-
-                type Mutation {
-                  createActors(input: [ActorCreateInput!]!): CreateActorsMutationResponse!
-                  createMovies(input: [MovieCreateInput!]!): CreateMoviesMutationResponse!
-                  deleteActors(where: ActorWhere): DeleteInfo!
-                  deleteMovies(delete: MovieDeleteInput, where: MovieWhere): DeleteInfo!
-                  updateActors(update: ActorUpdateInput, where: ActorWhere): UpdateActorsMutationResponse!
-                  updateMovies(connect: MovieConnectInput @deprecated(reason: \\"Top level connect input argument in update is deprecated. Use the nested connect field in the relationship within the update argument\\"), create: MovieRelationInput @deprecated(reason: \\"Top level create input argument in update is deprecated. Use the nested create field in the relationship within the update argument\\"), delete: MovieDeleteInput @deprecated(reason: \\"Top level delete input argument in update is deprecated. Use the nested delete field in the relationship within the update argument\\"), disconnect: MovieDisconnectInput @deprecated(reason: \\"Top level disconnect input argument in update is deprecated. Use the nested disconnect field in the relationship within the update argument\\"), update: MovieUpdateInput, where: MovieWhere): UpdateMoviesMutationResponse!
-                }
-
-                \\"\\"\\"Pagination information (Relay)\\"\\"\\"
-                type PageInfo {
-                  endCursor: String
-                  hasNextPage: Boolean!
-                  hasPreviousPage: Boolean!
-                  startCursor: String
-                }
-
-                type Query {
-                  actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-                  actorsAggregate(where: ActorWhere): ActorAggregateSelection!
-                  actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
-                  movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
-                  moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
-                }
-
-                \\"\\"\\"An enum for sorting in either ascending or descending order.\\"\\"\\"
-                enum SortDirection {
-                  \\"\\"\\"Sort by field values in ascending order.\\"\\"\\"
-                  ASC
-                  \\"\\"\\"Sort by field values in descending order.\\"\\"\\"
-                  DESC
-                }
-
-                type StringAggregateSelection {
-                  longest: String
-                  shortest: String
-                }
-
-                type UpdateActorsMutationResponse {
-                  actors: [Actor!]!
-                  info: UpdateInfo!
-                }
-
-                \\"\\"\\"
-                Information about the number of nodes and relationships created and deleted during an update mutation
-                \\"\\"\\"
-                type UpdateInfo {
-                  nodesCreated: Int!
-                  nodesDeleted: Int!
-                  relationshipsCreated: Int!
-                  relationshipsDeleted: Int!
-                }
-
-                type UpdateMoviesMutationResponse {
-                  info: UpdateInfo!
-                  movies: [Movie!]!
-                }"
-            `);
-        });
-
-        test("Interface", async () => {
-            const typeDefs = gql`
-                interface Production {
-                    title: String!
-                }
-
-                type Movie implements Production @node {
-                    title: String!
-                    runtime: Int!
-                }
-
-                type Series implements Production @node {
-                    title: String!
-                    episodes: Int!
-                }
-
-                type ActedIn @relationshipProperties {
-                    screenTime: Int!
-                }
-
-                type Actor @node {
-                    name: String!
-                    "Acted in Production"
-                    actedIn: [Production!]! @relationship(type: "ACTED_IN", direction: OUT, properties: "ActedIn")
-                }
-            `;
-            const neoSchema = new Neo4jGraphQL({
-                typeDefs,
-                features: {
-                    excludeDeprecatedFields: {
-                        bookmark: true,
-                        arrayFilters: true,
-                        stringAggregation: true,
-                        aggregationFilters: true,
-                    },
-                },
-            });
-            const printedSchema = printSchemaWithDirectives(lexicographicSortSchema(await neoSchema.getSchema()));
-
-            expect(printedSchema).toMatchInlineSnapshot(`
-                "schema {
-                  query: Query
-                  mutation: Mutation
-                }
-
-                \\"\\"\\"
-                The edge properties for the following fields:
-                * Actor.actedIn
-                \\"\\"\\"
-                type ActedIn {
-                  screenTime: Int!
-                }
-
-                input ActedInAggregationWhereInput {
-                  AND: [ActedInAggregationWhereInput!]
-                  NOT: ActedInAggregationWhereInput
-                  OR: [ActedInAggregationWhereInput!]
-                  screenTime_AVERAGE_EQUAL: Float
-                  screenTime_AVERAGE_GT: Float
-                  screenTime_AVERAGE_GTE: Float
-                  screenTime_AVERAGE_LT: Float
-                  screenTime_AVERAGE_LTE: Float
-                  screenTime_MAX_EQUAL: Int
-                  screenTime_MAX_GT: Int
-                  screenTime_MAX_GTE: Int
-                  screenTime_MAX_LT: Int
-                  screenTime_MAX_LTE: Int
-                  screenTime_MIN_EQUAL: Int
-                  screenTime_MIN_GT: Int
-                  screenTime_MIN_GTE: Int
-                  screenTime_MIN_LT: Int
-                  screenTime_MIN_LTE: Int
-                  screenTime_SUM_EQUAL: Int
-                  screenTime_SUM_GT: Int
-                  screenTime_SUM_GTE: Int
-                  screenTime_SUM_LT: Int
-                  screenTime_SUM_LTE: Int
-                }
-
-                input ActedInCreateInput {
-                  screenTime: Int!
-                }
-
-                input ActedInSort {
-                  screenTime: SortDirection
-                }
-
-                input ActedInUpdateInput {
-                  screenTime: Int
-                  screenTime_DECREMENT: Int
-                  screenTime_INCREMENT: Int
-                }
-
-                input ActedInWhere {
-                  AND: [ActedInWhere!]
-                  NOT: ActedInWhere
-                  OR: [ActedInWhere!]
-                  screenTime: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
-                  screenTime_EQ: Int
-                  screenTime_GT: Int
-                  screenTime_GTE: Int
-                  screenTime_IN: [Int!]
-                  screenTime_LT: Int
-                  screenTime_LTE: Int
-                }
-
-                type Actor {
-                  \\"\\"\\"Acted in Production\\"\\"\\"
-                  actedIn(directed: Boolean = true, limit: Int, offset: Int, options: ProductionOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ProductionSort!], where: ProductionWhere): [Production!]!
-                  actedInAggregate(directed: Boolean = true, where: ProductionWhere): ActorProductionActedInAggregationSelection
-                  actedInConnection(after: String, directed: Boolean = true, first: Int, sort: [ActorActedInConnectionSort!], where: ActorActedInConnectionWhere): ActorActedInConnection!
-                  name: String!
-                }
-
-                input ActorActedInAggregateInput {
-                  AND: [ActorActedInAggregateInput!]
-                  NOT: ActorActedInAggregateInput
-                  OR: [ActorActedInAggregateInput!]
-                  count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
-                  count_EQ: Int
-                  count_GT: Int
-                  count_GTE: Int
-                  count_LT: Int
-                  count_LTE: Int
-                  edge: ActedInAggregationWhereInput
-                  node: ActorActedInNodeAggregationWhereInput
-                }
-
-                input ActorActedInConnectFieldInput {
-                  edge: ActedInCreateInput!
-                  where: ProductionConnectWhere
-                }
-
-                type ActorActedInConnection {
-                  edges: [ActorActedInRelationship!]!
-                  pageInfo: PageInfo!
-                  totalCount: Int!
-                }
-
-                input ActorActedInConnectionSort {
-                  edge: ActedInSort
-                  node: ProductionSort
-                }
-
-                input ActorActedInConnectionWhere {
-                  AND: [ActorActedInConnectionWhere!]
-                  NOT: ActorActedInConnectionWhere
-                  OR: [ActorActedInConnectionWhere!]
-                  edge: ActedInWhere
-                  node: ProductionWhere
-                }
-
-                input ActorActedInCreateFieldInput {
-                  edge: ActedInCreateInput!
-                  node: ProductionCreateInput!
-                }
-
-                input ActorActedInDeleteFieldInput {
-                  where: ActorActedInConnectionWhere
-                }
-
-                input ActorActedInDisconnectFieldInput {
-                  where: ActorActedInConnectionWhere
-                }
-
-                input ActorActedInFieldInput {
-                  connect: [ActorActedInConnectFieldInput!]
-                  create: [ActorActedInCreateFieldInput!]
-                }
-
-                input ActorActedInNodeAggregationWhereInput {
-                  AND: [ActorActedInNodeAggregationWhereInput!]
-                  NOT: ActorActedInNodeAggregationWhereInput
-                  OR: [ActorActedInNodeAggregationWhereInput!]
-                  title_AVERAGE_LENGTH_EQUAL: Float
-                  title_AVERAGE_LENGTH_GT: Float
-                  title_AVERAGE_LENGTH_GTE: Float
-                  title_AVERAGE_LENGTH_LT: Float
-                  title_AVERAGE_LENGTH_LTE: Float
-                  title_LONGEST_LENGTH_EQUAL: Int
-                  title_LONGEST_LENGTH_GT: Int
-                  title_LONGEST_LENGTH_GTE: Int
-                  title_LONGEST_LENGTH_LT: Int
-                  title_LONGEST_LENGTH_LTE: Int
-                  title_SHORTEST_LENGTH_EQUAL: Int
-                  title_SHORTEST_LENGTH_GT: Int
-                  title_SHORTEST_LENGTH_GTE: Int
-                  title_SHORTEST_LENGTH_LT: Int
-                  title_SHORTEST_LENGTH_LTE: Int
-                }
-
-                type ActorActedInRelationship {
-                  cursor: String!
-                  node: Production!
-                  properties: ActedIn!
-                }
-
-                input ActorActedInUpdateConnectionInput {
-                  edge: ActedInUpdateInput
-                  node: ProductionUpdateInput
-                }
-
-                input ActorActedInUpdateFieldInput {
-                  connect: [ActorActedInConnectFieldInput!]
-                  create: [ActorActedInCreateFieldInput!]
-                  delete: [ActorActedInDeleteFieldInput!]
-                  disconnect: [ActorActedInDisconnectFieldInput!]
-                  update: ActorActedInUpdateConnectionInput
-                  where: ActorActedInConnectionWhere
-                }
-
-                type ActorAggregateSelection {
-                  count: Int!
-                  name: StringAggregateSelection!
-                }
-
-                input ActorConnectInput {
-                  actedIn: [ActorActedInConnectFieldInput!]
-                }
-
-                input ActorCreateInput {
-                  actedIn: ActorActedInFieldInput
-                  name: String!
-                }
-
-                input ActorDeleteInput {
-                  actedIn: [ActorActedInDeleteFieldInput!]
-                }
-
-                input ActorDisconnectInput {
-                  actedIn: [ActorActedInDisconnectFieldInput!]
-                }
-
-                type ActorEdge {
-                  cursor: String!
-                  node: Actor!
-                }
-
-                input ActorOptions {
-                  limit: Int
-                  offset: Int
-                  \\"\\"\\"
-                  Specify one or more ActorSort objects to sort Actors by. The sorts will be applied in the order in which they are arranged in the array.
-                  \\"\\"\\"
-                  sort: [ActorSort!]
-                }
-
-                type ActorProductionActedInAggregationSelection {
-                  count: Int!
-                  edge: ActorProductionActedInEdgeAggregateSelection
-                  node: ActorProductionActedInNodeAggregateSelection
-                }
-
-                type ActorProductionActedInEdgeAggregateSelection {
-                  screenTime: IntAggregateSelection!
-                }
-
-                type ActorProductionActedInNodeAggregateSelection {
-                  title: StringAggregateSelection!
-                }
-
-                input ActorRelationInput {
-                  actedIn: [ActorActedInCreateFieldInput!]
-                }
-
-                \\"\\"\\"
-                Fields to sort Actors by. The order in which sorts are applied is not guaranteed when specifying many fields in one ActorSort object.
-                \\"\\"\\"
-                input ActorSort {
-                  name: SortDirection
-                }
-
-                input ActorUpdateInput {
-                  actedIn: [ActorActedInUpdateFieldInput!]
-                  name: String
-                }
-
-                input ActorWhere {
-                  AND: [ActorWhere!]
-                  NOT: ActorWhere
-                  OR: [ActorWhere!]
-                  actedInAggregate: ActorActedInAggregateInput
-                  \\"\\"\\"
-                  Return Actors where all of the related ActorActedInConnections match this filter
-                  \\"\\"\\"
-                  actedInConnection_ALL: ActorActedInConnectionWhere
-                  \\"\\"\\"
-                  Return Actors where none of the related ActorActedInConnections match this filter
-                  \\"\\"\\"
-                  actedInConnection_NONE: ActorActedInConnectionWhere
-                  \\"\\"\\"
-                  Return Actors where one of the related ActorActedInConnections match this filter
-                  \\"\\"\\"
-                  actedInConnection_SINGLE: ActorActedInConnectionWhere
-                  \\"\\"\\"
-                  Return Actors where some of the related ActorActedInConnections match this filter
-                  \\"\\"\\"
-                  actedInConnection_SOME: ActorActedInConnectionWhere
-                  \\"\\"\\"Return Actors where all of the related Productions match this filter\\"\\"\\"
-                  actedIn_ALL: ProductionWhere
-                  \\"\\"\\"Return Actors where none of the related Productions match this filter\\"\\"\\"
-                  actedIn_NONE: ProductionWhere
-                  \\"\\"\\"Return Actors where one of the related Productions match this filter\\"\\"\\"
-                  actedIn_SINGLE: ProductionWhere
-                  \\"\\"\\"Return Actors where some of the related Productions match this filter\\"\\"\\"
-                  actedIn_SOME: ProductionWhere
-                  name: String @deprecated(reason: \\"Please use the explicit _EQ version\\")
-                  name_CONTAINS: String
-                  name_ENDS_WITH: String
-                  name_EQ: String
-                  name_IN: [String!]
-                  name_STARTS_WITH: String
-                }
-
-                type ActorsConnection {
-                  edges: [ActorEdge!]!
-                  pageInfo: PageInfo!
-                  totalCount: Int!
-                }
-
-                type CreateActorsMutationResponse {
-                  actors: [Actor!]!
-                  info: CreateInfo!
-                }
-
-                \\"\\"\\"
-                Information about the number of nodes and relationships created during a create mutation
-                \\"\\"\\"
-                type CreateInfo {
-                  nodesCreated: Int!
-                  relationshipsCreated: Int!
-                }
-
-                type CreateMoviesMutationResponse {
-                  info: CreateInfo!
-                  movies: [Movie!]!
-                }
-
-                type CreateSeriesMutationResponse {
-                  info: CreateInfo!
-                  series: [Series!]!
-                }
-
-                \\"\\"\\"
-                Information about the number of nodes and relationships deleted during a delete mutation
-                \\"\\"\\"
-                type DeleteInfo {
-                  nodesDeleted: Int!
-                  relationshipsDeleted: Int!
-                }
-
-                type IntAggregateSelection {
-                  average: Float
-                  max: Int
-                  min: Int
-                  sum: Int
-                }
-
-                type Movie implements Production {
-                  runtime: Int!
-                  title: String!
-                }
-
-                type MovieAggregateSelection {
-                  count: Int!
-                  runtime: IntAggregateSelection!
-                  title: StringAggregateSelection!
-                }
-
-                input MovieCreateInput {
-                  runtime: Int!
-                  title: String!
-                }
-
-                type MovieEdge {
-                  cursor: String!
-                  node: Movie!
-                }
-
-                input MovieOptions {
-                  limit: Int
-                  offset: Int
-                  \\"\\"\\"
-                  Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array.
-                  \\"\\"\\"
-                  sort: [MovieSort!]
-                }
-
-                \\"\\"\\"
-                Fields to sort Movies by. The order in which sorts are applied is not guaranteed when specifying many fields in one MovieSort object.
-                \\"\\"\\"
-                input MovieSort {
-                  runtime: SortDirection
-                  title: SortDirection
-                }
-
-                input MovieUpdateInput {
-                  runtime: Int
-                  runtime_DECREMENT: Int
-                  runtime_INCREMENT: Int
-                  title: String
-                }
-
-                input MovieWhere {
-                  AND: [MovieWhere!]
-                  NOT: MovieWhere
-                  OR: [MovieWhere!]
-                  runtime: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
-                  runtime_EQ: Int
-                  runtime_GT: Int
-                  runtime_GTE: Int
-                  runtime_IN: [Int!]
-                  runtime_LT: Int
-                  runtime_LTE: Int
-                  title: String @deprecated(reason: \\"Please use the explicit _EQ version\\")
-                  title_CONTAINS: String
-                  title_ENDS_WITH: String
-                  title_EQ: String
-                  title_IN: [String!]
-                  title_STARTS_WITH: String
-                }
-
-                type MoviesConnection {
-                  edges: [MovieEdge!]!
-                  pageInfo: PageInfo!
-                  totalCount: Int!
-                }
-
-                type Mutation {
-                  createActors(input: [ActorCreateInput!]!): CreateActorsMutationResponse!
-                  createMovies(input: [MovieCreateInput!]!): CreateMoviesMutationResponse!
-                  createSeries(input: [SeriesCreateInput!]!): CreateSeriesMutationResponse!
-                  deleteActors(delete: ActorDeleteInput, where: ActorWhere): DeleteInfo!
-                  deleteMovies(where: MovieWhere): DeleteInfo!
-                  deleteSeries(where: SeriesWhere): DeleteInfo!
-                  updateActors(connect: ActorConnectInput @deprecated(reason: \\"Top level connect input argument in update is deprecated. Use the nested connect field in the relationship within the update argument\\"), create: ActorRelationInput @deprecated(reason: \\"Top level create input argument in update is deprecated. Use the nested create field in the relationship within the update argument\\"), delete: ActorDeleteInput @deprecated(reason: \\"Top level delete input argument in update is deprecated. Use the nested delete field in the relationship within the update argument\\"), disconnect: ActorDisconnectInput @deprecated(reason: \\"Top level disconnect input argument in update is deprecated. Use the nested disconnect field in the relationship within the update argument\\"), update: ActorUpdateInput, where: ActorWhere): UpdateActorsMutationResponse!
-                  updateMovies(update: MovieUpdateInput, where: MovieWhere): UpdateMoviesMutationResponse!
-                  updateSeries(update: SeriesUpdateInput, where: SeriesWhere): UpdateSeriesMutationResponse!
-                }
-
-                \\"\\"\\"Pagination information (Relay)\\"\\"\\"
-                type PageInfo {
-                  endCursor: String
-                  hasNextPage: Boolean!
-                  hasPreviousPage: Boolean!
-                  startCursor: String
-                }
-
-                interface Production {
-                  title: String!
-                }
-
-                type ProductionAggregateSelection {
-                  count: Int!
-                  title: StringAggregateSelection!
-                }
-
-                input ProductionConnectWhere {
-                  node: ProductionWhere!
-                }
-
-                input ProductionCreateInput {
-                  Movie: MovieCreateInput
-                  Series: SeriesCreateInput
-                }
-
-                type ProductionEdge {
-                  cursor: String!
-                  node: Production!
-                }
-
-                enum ProductionImplementation {
-                  Movie
-                  Series
-                }
-
-                input ProductionOptions {
-                  limit: Int
-                  offset: Int
-                  \\"\\"\\"
-                  Specify one or more ProductionSort objects to sort Productions by. The sorts will be applied in the order in which they are arranged in the array.
-                  \\"\\"\\"
-                  sort: [ProductionSort!]
-                }
-
-                \\"\\"\\"
-                Fields to sort Productions by. The order in which sorts are applied is not guaranteed when specifying many fields in one ProductionSort object.
-                \\"\\"\\"
-                input ProductionSort {
-                  title: SortDirection
-                }
-
-                input ProductionUpdateInput {
-                  title: String
-                }
-
-                input ProductionWhere {
-                  AND: [ProductionWhere!]
-                  NOT: ProductionWhere
-                  OR: [ProductionWhere!]
-                  title: String @deprecated(reason: \\"Please use the explicit _EQ version\\")
-                  title_CONTAINS: String
-                  title_ENDS_WITH: String
-                  title_EQ: String
-                  title_IN: [String!]
-                  title_STARTS_WITH: String
-                  typename_IN: [ProductionImplementation!]
-                }
-
-                type ProductionsConnection {
-                  edges: [ProductionEdge!]!
-                  pageInfo: PageInfo!
-                  totalCount: Int!
-                }
-
-                type Query {
-                  actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-                  actorsAggregate(where: ActorWhere): ActorAggregateSelection!
-                  actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
-                  movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
-                  moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
-                  productions(limit: Int, offset: Int, options: ProductionOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ProductionSort!], where: ProductionWhere): [Production!]!
-                  productionsAggregate(where: ProductionWhere): ProductionAggregateSelection!
-                  productionsConnection(after: String, first: Int, sort: [ProductionSort!], where: ProductionWhere): ProductionsConnection!
-                  series(limit: Int, offset: Int, options: SeriesOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [SeriesSort!], where: SeriesWhere): [Series!]!
-                  seriesAggregate(where: SeriesWhere): SeriesAggregateSelection!
-                  seriesConnection(after: String, first: Int, sort: [SeriesSort!], where: SeriesWhere): SeriesConnection!
-                }
-
-                type Series implements Production {
-                  episodes: Int!
-                  title: String!
-                }
-
-                type SeriesAggregateSelection {
-                  count: Int!
-                  episodes: IntAggregateSelection!
-                  title: StringAggregateSelection!
-                }
-
-                type SeriesConnection {
-                  edges: [SeriesEdge!]!
-                  pageInfo: PageInfo!
-                  totalCount: Int!
-                }
-
-                input SeriesCreateInput {
-                  episodes: Int!
-                  title: String!
-                }
-
-                type SeriesEdge {
-                  cursor: String!
-                  node: Series!
-                }
-
-                input SeriesOptions {
-                  limit: Int
-                  offset: Int
-                  \\"\\"\\"
-                  Specify one or more SeriesSort objects to sort Series by. The sorts will be applied in the order in which they are arranged in the array.
-                  \\"\\"\\"
-                  sort: [SeriesSort!]
-                }
-
-                \\"\\"\\"
-                Fields to sort Series by. The order in which sorts are applied is not guaranteed when specifying many fields in one SeriesSort object.
-                \\"\\"\\"
-                input SeriesSort {
-                  episodes: SortDirection
-                  title: SortDirection
-                }
-
-                input SeriesUpdateInput {
-                  episodes: Int
-                  episodes_DECREMENT: Int
-                  episodes_INCREMENT: Int
-                  title: String
-                }
-
-                input SeriesWhere {
-                  AND: [SeriesWhere!]
-                  NOT: SeriesWhere
-                  OR: [SeriesWhere!]
-                  episodes: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
-                  episodes_EQ: Int
-                  episodes_GT: Int
-                  episodes_GTE: Int
-                  episodes_IN: [Int!]
-                  episodes_LT: Int
-                  episodes_LTE: Int
-                  title: String @deprecated(reason: \\"Please use the explicit _EQ version\\")
-                  title_CONTAINS: String
-                  title_ENDS_WITH: String
-                  title_EQ: String
-                  title_IN: [String!]
-                  title_STARTS_WITH: String
-                }
-
-                \\"\\"\\"An enum for sorting in either ascending or descending order.\\"\\"\\"
-                enum SortDirection {
-                  \\"\\"\\"Sort by field values in ascending order.\\"\\"\\"
-                  ASC
-                  \\"\\"\\"Sort by field values in descending order.\\"\\"\\"
-                  DESC
-                }
-
-                type StringAggregateSelection {
-                  longest: String
-                  shortest: String
-                }
-
-                type UpdateActorsMutationResponse {
-                  actors: [Actor!]!
-                  info: UpdateInfo!
-                }
-
-                \\"\\"\\"
-                Information about the number of nodes and relationships created and deleted during an update mutation
-                \\"\\"\\"
-                type UpdateInfo {
-                  nodesCreated: Int!
-                  nodesDeleted: Int!
-                  relationshipsCreated: Int!
-                  relationshipsDeleted: Int!
-                }
-
-                type UpdateMoviesMutationResponse {
-                  info: UpdateInfo!
-                  movies: [Movie!]!
-                }
-
-                type UpdateSeriesMutationResponse {
-                  info: UpdateInfo!
-                  series: [Series!]!
-                }"
-            `);
-        });
-
-        test("Unions", async () => {
-            const typeDefs = gql`
-                union Search = Movie | Genre
-
-                type Genre @node {
-                    id: ID
-                }
-
-                type Movie @node {
-                    id: ID
-                    search: [Search!]! @relationship(type: "SEARCH", direction: OUT)
-                    searchNoDirective: Search
-                }
-            `;
-            const neoSchema = new Neo4jGraphQL({
-                typeDefs,
-                features: {
-                    excludeDeprecatedFields: {
-                        bookmark: true,
-                        arrayFilters: true,
-                        stringAggregation: true,
-                        aggregationFilters: true,
-                    },
-                },
-            });
-            const printedSchema = printSchemaWithDirectives(lexicographicSortSchema(await neoSchema.getSchema()));
-
-            expect(printedSchema).toMatchInlineSnapshot(`
-                "schema {
-                  query: Query
-                  mutation: Mutation
-                }
-
-                type CreateGenresMutationResponse {
-                  genres: [Genre!]!
-                  info: CreateInfo!
-                }
-
-                \\"\\"\\"
-                Information about the number of nodes and relationships created during a create mutation
-                \\"\\"\\"
-                type CreateInfo {
-                  nodesCreated: Int!
-                  relationshipsCreated: Int!
-                }
-
-                type CreateMoviesMutationResponse {
-                  info: CreateInfo!
-                  movies: [Movie!]!
-                }
-
-                \\"\\"\\"
-                Information about the number of nodes and relationships deleted during a delete mutation
-                \\"\\"\\"
-                type DeleteInfo {
-                  nodesDeleted: Int!
-                  relationshipsDeleted: Int!
-                }
-
-                type Genre {
-                  id: ID
-                }
-
-                type GenreAggregateSelection {
-                  count: Int!
-                  id: IDAggregateSelection!
-                }
-
-                input GenreConnectWhere {
-                  node: GenreWhere!
-                }
-
-                input GenreCreateInput {
-                  id: ID
-                }
-
-                type GenreEdge {
-                  cursor: String!
-                  node: Genre!
-                }
-
-                input GenreOptions {
-                  limit: Int
-                  offset: Int
-                  \\"\\"\\"
-                  Specify one or more GenreSort objects to sort Genres by. The sorts will be applied in the order in which they are arranged in the array.
-                  \\"\\"\\"
-                  sort: [GenreSort!]
-                }
-
-                \\"\\"\\"
-                Fields to sort Genres by. The order in which sorts are applied is not guaranteed when specifying many fields in one GenreSort object.
-                \\"\\"\\"
-                input GenreSort {
-                  id: SortDirection
-                }
-
-                input GenreUpdateInput {
-                  id: ID
-                }
-
-                input GenreWhere {
-                  AND: [GenreWhere!]
-                  NOT: GenreWhere
-                  OR: [GenreWhere!]
-                  id: ID @deprecated(reason: \\"Please use the explicit _EQ version\\")
-                  id_CONTAINS: ID
-                  id_ENDS_WITH: ID
-                  id_EQ: ID
-                  id_IN: [ID]
-                  id_STARTS_WITH: ID
-                }
-
-                type GenresConnection {
-                  edges: [GenreEdge!]!
-                  pageInfo: PageInfo!
-                  totalCount: Int!
-                }
-
-                type IDAggregateSelection {
-                  longest: ID
-                  shortest: ID
-                }
-
-                type Movie {
-                  id: ID
-                  search(directed: Boolean = true, limit: Int, offset: Int, options: QueryOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: SearchWhere): [Search!]!
-                  searchConnection(after: String, directed: Boolean = true, first: Int, where: MovieSearchConnectionWhere): MovieSearchConnection!
-                  searchNoDirective: Search
-                }
-
-                type MovieAggregateSelection {
-                  count: Int!
-                  id: IDAggregateSelection!
-                }
-
-                input MovieConnectInput {
-                  search: MovieSearchConnectInput
-                }
-
-                input MovieConnectWhere {
-                  node: MovieWhere!
-                }
-
-                input MovieCreateInput {
-                  id: ID
-                  search: MovieSearchCreateInput
-                }
-
-                input MovieDeleteInput {
-                  search: MovieSearchDeleteInput
-                }
-
-                input MovieDisconnectInput {
-                  search: MovieSearchDisconnectInput
-                }
-
-                type MovieEdge {
-                  cursor: String!
-                  node: Movie!
-                }
-
-                input MovieOptions {
-                  limit: Int
-                  offset: Int
-                  \\"\\"\\"
-                  Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array.
-                  \\"\\"\\"
-                  sort: [MovieSort!]
-                }
-
-                input MovieRelationInput {
-                  search: MovieSearchCreateFieldInput
-                }
-
-                input MovieSearchConnectInput {
-                  Genre: [MovieSearchGenreConnectFieldInput!]
-                  Movie: [MovieSearchMovieConnectFieldInput!]
-                }
-
-                type MovieSearchConnection {
-                  edges: [MovieSearchRelationship!]!
-                  pageInfo: PageInfo!
-                  totalCount: Int!
-                }
-
-                input MovieSearchConnectionWhere {
-                  Genre: MovieSearchGenreConnectionWhere
-                  Movie: MovieSearchMovieConnectionWhere
-                }
-
-                input MovieSearchCreateFieldInput {
-                  Genre: [MovieSearchGenreCreateFieldInput!]
-                  Movie: [MovieSearchMovieCreateFieldInput!]
-                }
-
-                input MovieSearchCreateInput {
-                  Genre: MovieSearchGenreFieldInput
-                  Movie: MovieSearchMovieFieldInput
-                }
-
-                input MovieSearchDeleteInput {
-                  Genre: [MovieSearchGenreDeleteFieldInput!]
-                  Movie: [MovieSearchMovieDeleteFieldInput!]
-                }
-
-                input MovieSearchDisconnectInput {
-                  Genre: [MovieSearchGenreDisconnectFieldInput!]
-                  Movie: [MovieSearchMovieDisconnectFieldInput!]
-                }
-
-                input MovieSearchGenreConnectFieldInput {
-                  where: GenreConnectWhere
-                }
-
-                input MovieSearchGenreConnectionWhere {
-                  AND: [MovieSearchGenreConnectionWhere!]
-                  NOT: MovieSearchGenreConnectionWhere
-                  OR: [MovieSearchGenreConnectionWhere!]
-                  node: GenreWhere
-                }
-
-                input MovieSearchGenreCreateFieldInput {
-                  node: GenreCreateInput!
-                }
-
-                input MovieSearchGenreDeleteFieldInput {
-                  where: MovieSearchGenreConnectionWhere
-                }
-
-                input MovieSearchGenreDisconnectFieldInput {
-                  where: MovieSearchGenreConnectionWhere
-                }
-
-                input MovieSearchGenreFieldInput {
-                  connect: [MovieSearchGenreConnectFieldInput!]
-                  create: [MovieSearchGenreCreateFieldInput!]
-                }
-
-                input MovieSearchGenreUpdateConnectionInput {
-                  node: GenreUpdateInput
-                }
-
-                input MovieSearchGenreUpdateFieldInput {
-                  connect: [MovieSearchGenreConnectFieldInput!]
-                  create: [MovieSearchGenreCreateFieldInput!]
-                  delete: [MovieSearchGenreDeleteFieldInput!]
-                  disconnect: [MovieSearchGenreDisconnectFieldInput!]
-                  update: MovieSearchGenreUpdateConnectionInput
-                  where: MovieSearchGenreConnectionWhere
-                }
-
-                input MovieSearchMovieConnectFieldInput {
-                  connect: [MovieConnectInput!]
-                  where: MovieConnectWhere
-                }
-
-                input MovieSearchMovieConnectionWhere {
-                  AND: [MovieSearchMovieConnectionWhere!]
-                  NOT: MovieSearchMovieConnectionWhere
-                  OR: [MovieSearchMovieConnectionWhere!]
-                  node: MovieWhere
-                }
-
-                input MovieSearchMovieCreateFieldInput {
-                  node: MovieCreateInput!
-                }
-
-                input MovieSearchMovieDeleteFieldInput {
-                  delete: MovieDeleteInput
-                  where: MovieSearchMovieConnectionWhere
-                }
-
-                input MovieSearchMovieDisconnectFieldInput {
-                  disconnect: MovieDisconnectInput
-                  where: MovieSearchMovieConnectionWhere
-                }
-
-                input MovieSearchMovieFieldInput {
-                  connect: [MovieSearchMovieConnectFieldInput!]
-                  create: [MovieSearchMovieCreateFieldInput!]
-                }
-
-                input MovieSearchMovieUpdateConnectionInput {
-                  node: MovieUpdateInput
-                }
-
-                input MovieSearchMovieUpdateFieldInput {
-                  connect: [MovieSearchMovieConnectFieldInput!]
-                  create: [MovieSearchMovieCreateFieldInput!]
-                  delete: [MovieSearchMovieDeleteFieldInput!]
-                  disconnect: [MovieSearchMovieDisconnectFieldInput!]
-                  update: MovieSearchMovieUpdateConnectionInput
-                  where: MovieSearchMovieConnectionWhere
-                }
-
-                type MovieSearchRelationship {
-                  cursor: String!
-                  node: Search!
-                }
-
-                input MovieSearchUpdateInput {
-                  Genre: [MovieSearchGenreUpdateFieldInput!]
-                  Movie: [MovieSearchMovieUpdateFieldInput!]
-                }
-
-                \\"\\"\\"
-                Fields to sort Movies by. The order in which sorts are applied is not guaranteed when specifying many fields in one MovieSort object.
-                \\"\\"\\"
-                input MovieSort {
-                  id: SortDirection
-                }
-
-                input MovieUpdateInput {
-                  id: ID
-                  search: MovieSearchUpdateInput
-                }
-
-                input MovieWhere {
-                  AND: [MovieWhere!]
-                  NOT: MovieWhere
-                  OR: [MovieWhere!]
-                  id: ID @deprecated(reason: \\"Please use the explicit _EQ version\\")
-                  id_CONTAINS: ID
-                  id_ENDS_WITH: ID
-                  id_EQ: ID
-                  id_IN: [ID]
-                  id_STARTS_WITH: ID
-                  \\"\\"\\"
-                  Return Movies where all of the related MovieSearchConnections match this filter
-                  \\"\\"\\"
-                  searchConnection_ALL: MovieSearchConnectionWhere
-                  \\"\\"\\"
-                  Return Movies where none of the related MovieSearchConnections match this filter
-                  \\"\\"\\"
-                  searchConnection_NONE: MovieSearchConnectionWhere
-                  \\"\\"\\"
-                  Return Movies where one of the related MovieSearchConnections match this filter
-                  \\"\\"\\"
-                  searchConnection_SINGLE: MovieSearchConnectionWhere
-                  \\"\\"\\"
-                  Return Movies where some of the related MovieSearchConnections match this filter
-                  \\"\\"\\"
-                  searchConnection_SOME: MovieSearchConnectionWhere
-                  \\"\\"\\"Return Movies where all of the related Searches match this filter\\"\\"\\"
-                  search_ALL: SearchWhere
-                  \\"\\"\\"Return Movies where none of the related Searches match this filter\\"\\"\\"
-                  search_NONE: SearchWhere
-                  \\"\\"\\"Return Movies where one of the related Searches match this filter\\"\\"\\"
-                  search_SINGLE: SearchWhere
-                  \\"\\"\\"Return Movies where some of the related Searches match this filter\\"\\"\\"
-                  search_SOME: SearchWhere
-                }
-
-                type MoviesConnection {
-                  edges: [MovieEdge!]!
-                  pageInfo: PageInfo!
-                  totalCount: Int!
-                }
-
-                type Mutation {
-                  createGenres(input: [GenreCreateInput!]!): CreateGenresMutationResponse!
-                  createMovies(input: [MovieCreateInput!]!): CreateMoviesMutationResponse!
-                  deleteGenres(where: GenreWhere): DeleteInfo!
-                  deleteMovies(delete: MovieDeleteInput, where: MovieWhere): DeleteInfo!
-                  updateGenres(update: GenreUpdateInput, where: GenreWhere): UpdateGenresMutationResponse!
-                  updateMovies(connect: MovieConnectInput @deprecated(reason: \\"Top level connect input argument in update is deprecated. Use the nested connect field in the relationship within the update argument\\"), create: MovieRelationInput @deprecated(reason: \\"Top level create input argument in update is deprecated. Use the nested create field in the relationship within the update argument\\"), delete: MovieDeleteInput @deprecated(reason: \\"Top level delete input argument in update is deprecated. Use the nested delete field in the relationship within the update argument\\"), disconnect: MovieDisconnectInput @deprecated(reason: \\"Top level disconnect input argument in update is deprecated. Use the nested disconnect field in the relationship within the update argument\\"), update: MovieUpdateInput, where: MovieWhere): UpdateMoviesMutationResponse!
-                }
-
-                \\"\\"\\"Pagination information (Relay)\\"\\"\\"
-                type PageInfo {
-                  endCursor: String
-                  hasNextPage: Boolean!
-                  hasPreviousPage: Boolean!
-                  startCursor: String
-                }
-
-                type Query {
-                  genres(limit: Int, offset: Int, options: GenreOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [GenreSort!], where: GenreWhere): [Genre!]!
-                  genresAggregate(where: GenreWhere): GenreAggregateSelection!
-                  genresConnection(after: String, first: Int, sort: [GenreSort!], where: GenreWhere): GenresConnection!
-                  movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
-                  moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
-                  searches(limit: Int, offset: Int, options: QueryOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: SearchWhere): [Search!]!
-                }
-
-                \\"\\"\\"Input type for options that can be specified on a query operation.\\"\\"\\"
-                input QueryOptions {
-                  limit: Int
-                  offset: Int
-                }
-
-                union Search = Genre | Movie
-
-                input SearchWhere {
-                  Genre: GenreWhere
-                  Movie: MovieWhere
-                }
-
-                \\"\\"\\"An enum for sorting in either ascending or descending order.\\"\\"\\"
-                enum SortDirection {
-                  \\"\\"\\"Sort by field values in ascending order.\\"\\"\\"
-                  ASC
-                  \\"\\"\\"Sort by field values in descending order.\\"\\"\\"
-                  DESC
-                }
-
-                type UpdateGenresMutationResponse {
-                  genres: [Genre!]!
-                  info: UpdateInfo!
-                }
-
-                \\"\\"\\"
-                Information about the number of nodes and relationships created and deleted during an update mutation
-                \\"\\"\\"
-                type UpdateInfo {
-                  nodesCreated: Int!
-                  nodesDeleted: Int!
-                  relationshipsCreated: Int!
-                  relationshipsDeleted: Int!
-                }
-
-                type UpdateMoviesMutationResponse {
-                  info: UpdateInfo!
-                  movies: [Movie!]!
-                }"
-            `);
-        });
     });
 });

--- a/packages/graphql/tests/schema/remove-deprecated/options-argument.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/options-argument.test.ts
@@ -205,7 +205,8 @@ describe("Deprecated options argument", () => {
               AND: [ActorMoviesAggregateInput!]
               NOT: ActorMoviesAggregateInput
               OR: [ActorMoviesAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -481,7 +482,8 @@ describe("Deprecated options argument", () => {
               AND: [MovieActorsAggregateInput!]
               NOT: MovieActorsAggregateInput
               OR: [MovieActorsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int

--- a/packages/graphql/tests/schema/remove-deprecated/update-operations.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/update-operations.test.ts
@@ -163,7 +163,8 @@ describe("Nested operations in update", () => {
               AND: [MovieActorsAggregateInput!]
               NOT: MovieActorsAggregateInput
               OR: [MovieActorsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int

--- a/packages/graphql/tests/schema/string-comparators.test.ts
+++ b/packages/graphql/tests/schema/string-comparators.test.ts
@@ -616,7 +616,8 @@ describe("String Comparators", () => {
               AND: [ActorActedInAggregateInput!]
               NOT: ActorActedInAggregateInput
               OR: [ActorActedInAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -907,7 +908,8 @@ describe("String Comparators", () => {
               AND: [MovieActorsAggregateInput!]
               NOT: MovieActorsAggregateInput
               OR: [MovieActorsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int

--- a/packages/graphql/tests/schema/subscriptions.test.ts
+++ b/packages/graphql/tests/schema/subscriptions.test.ts
@@ -232,7 +232,8 @@ describe("Subscriptions", () => {
               AND: [MovieActorsAggregateInput!]
               NOT: MovieActorsAggregateInput
               OR: [MovieActorsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -741,7 +742,8 @@ describe("Subscriptions", () => {
               AND: [ActorMoviesAggregateInput!]
               NOT: ActorMoviesAggregateInput
               OR: [ActorMoviesAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -1037,7 +1039,8 @@ describe("Subscriptions", () => {
               AND: [MovieActorsAggregateInput!]
               NOT: MovieActorsAggregateInput
               OR: [MovieActorsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -1940,7 +1943,8 @@ describe("Subscriptions", () => {
               AND: [PersonMoviesAggregateInput!]
               NOT: PersonMoviesAggregateInput
               OR: [PersonMoviesAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -2248,7 +2252,8 @@ describe("Subscriptions", () => {
               AND: [StarMoviesAggregateInput!]
               NOT: StarMoviesAggregateInput
               OR: [StarMoviesAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -2695,7 +2700,8 @@ describe("Subscriptions", () => {
               AND: [ActorMoviesAggregateInput!]
               NOT: ActorMoviesAggregateInput
               OR: [ActorMoviesAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -2996,7 +3002,8 @@ describe("Subscriptions", () => {
               AND: [MovieActorsAggregateInput!]
               NOT: MovieActorsAggregateInput
               OR: [MovieActorsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -3580,7 +3587,8 @@ describe("Subscriptions", () => {
               AND: [MovieActorsAggregateInput!]
               NOT: MovieActorsAggregateInput
               OR: [MovieActorsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -3985,7 +3993,8 @@ describe("Subscriptions", () => {
               AND: [AgreementOwnerAggregateInput!]
               NOT: AgreementOwnerAggregateInput
               OR: [AgreementOwnerAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -5002,7 +5011,8 @@ describe("Subscriptions", () => {
               AND: [PersonMoviesAggregateInput!]
               NOT: PersonMoviesAggregateInput
               OR: [PersonMoviesAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -5296,7 +5306,8 @@ describe("Subscriptions", () => {
               AND: [StarMoviesAggregateInput!]
               NOT: StarMoviesAggregateInput
               OR: [StarMoviesAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -5628,7 +5639,8 @@ describe("Subscriptions", () => {
               AND: [CreatureMoviesAggregateInput!]
               NOT: CreatureMoviesAggregateInput
               OR: [CreatureMoviesAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -5787,7 +5799,8 @@ describe("Subscriptions", () => {
               AND: [MovieDirectorAggregateInput!]
               NOT: MovieDirectorAggregateInput
               OR: [MovieDirectorAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -5969,7 +5982,8 @@ describe("Subscriptions", () => {
               AND: [PersonMoviesAggregateInput!]
               NOT: PersonMoviesAggregateInput
               OR: [PersonMoviesAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -6127,7 +6141,8 @@ describe("Subscriptions", () => {
               AND: [ProductionDirectorAggregateInput!]
               NOT: ProductionDirectorAggregateInput
               OR: [ProductionDirectorAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -6333,7 +6348,8 @@ describe("Subscriptions", () => {
               AND: [SeriesDirectorAggregateInput!]
               NOT: SeriesDirectorAggregateInput
               OR: [SeriesDirectorAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int

--- a/packages/graphql/tests/schema/union-interface-relationship.test.ts
+++ b/packages/graphql/tests/schema/union-interface-relationship.test.ts
@@ -215,7 +215,8 @@ describe("Union Interface Relationships", () => {
               AND: [ActorMoviesAggregateInput!]
               NOT: ActorMoviesAggregateInput
               OR: [ActorMoviesAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -665,7 +666,8 @@ describe("Union Interface Relationships", () => {
               AND: [MovieActorsAggregateInput!]
               NOT: MovieActorsAggregateInput
               OR: [MovieActorsAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -1086,7 +1088,8 @@ describe("Union Interface Relationships", () => {
               AND: [MovieReviewersAggregateInput!]
               NOT: MovieReviewersAggregateInput
               OR: [MovieReviewersAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int
@@ -1444,7 +1447,8 @@ describe("Union Interface Relationships", () => {
               AND: [PersonMoviesAggregateInput!]
               NOT: PersonMoviesAggregateInput
               OR: [PersonMoviesAggregateInput!]
-              count: Int
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
               count_GT: Int
               count_GTE: Int
               count_LT: Int

--- a/packages/graphql/tests/tck/aggregations/where/composite.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/composite.test.ts
@@ -48,7 +48,7 @@ describe("Cypher Aggregations where with count and node", () => {
     test("Equality Count and node", async () => {
         const query = /* GraphQL */ `
             {
-                posts(where: { likesAggregate: { count: 10, node: { name_EQUAL: "potato" } } }) {
+                posts(where: { likesAggregate: { count_EQ: 10, node: { name_EQUAL: "potato" } } }) {
                     content
                 }
             }
@@ -84,7 +84,11 @@ describe("Cypher Aggregations where with count and node", () => {
             {
                 posts(
                     where: {
-                        likesAggregate: { count: 10, node: { name_EQUAL: "potato" }, edge: { someString_EQUAL: "10" } }
+                        likesAggregate: {
+                            count_EQ: 10
+                            node: { name_EQUAL: "potato" }
+                            edge: { someString_EQUAL: "10" }
+                        }
                     }
                 ) {
                     content
@@ -124,7 +128,7 @@ describe("Cypher Aggregations where with count and node", () => {
                 posts(
                     where: {
                         likesAggregate: {
-                            count: 10
+                            count_EQ: 10
                             node: { name_EQUAL: "potato" }
                             edge: { someString_EQUAL: "10" }
                             AND: [{ count_GT: 10 }, { count_LT: 20 }]

--- a/packages/graphql/tests/tck/aggregations/where/count.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/count.test.ts
@@ -44,7 +44,7 @@ describe("Cypher Aggregations where with count", () => {
     test("Equality Count", async () => {
         const query = /* GraphQL */ `
             {
-                posts(where: { likesAggregate: { count: 10 } }) {
+                posts(where: { likesAggregate: { count_EQ: 10 } }) {
                     content
                 }
             }

--- a/packages/graphql/tests/tck/issues/1751.test.ts
+++ b/packages/graphql/tests/tck/issues/1751.test.ts
@@ -66,7 +66,7 @@ describe("https://github.com/neo4j/graphql/issues/1751", () => {
                         where: {
                             node: {
                                 organizationsAggregate: {
-                                    count: 1,
+                                    count_EQ: 1,
                                 },
                             },
                         },

--- a/packages/graphql/tests/tck/issues/2670.test.ts
+++ b/packages/graphql/tests/tck/issues/2670.test.ts
@@ -54,7 +54,7 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
     test("should find where moviesAggregate count equal", async () => {
         const query = /* GraphQL */ `
             {
-                movies(where: { genresConnection: { node: { moviesAggregate: { count: 2 } } } }) {
+                movies(where: { genresConnection: { node: { moviesAggregate: { count_EQ: 2 } } } }) {
                     title
                 }
             }
@@ -337,7 +337,7 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
     test("should find where genresConnection_SOME", async () => {
         const query = /* GraphQL */ `
             {
-                movies(where: { genresConnection_SOME: { node: { moviesAggregate: { count: 2 } } } }) {
+                movies(where: { genresConnection_SOME: { node: { moviesAggregate: { count_EQ: 2 } } } }) {
                     title
                 }
             }
@@ -377,7 +377,7 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
     test("should find where genresConnection_NONE", async () => {
         const query = /* GraphQL */ `
             {
-                movies(where: { genresConnection_NONE: { node: { moviesAggregate: { count: 2 } } } }) {
+                movies(where: { genresConnection_NONE: { node: { moviesAggregate: { count_EQ: 2 } } } }) {
                     title
                 }
             }
@@ -417,7 +417,7 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
     test("should find where genresConnection_ALL", async () => {
         const query = /* GraphQL */ `
             {
-                movies(where: { genresConnection_ALL: { node: { moviesAggregate: { count: 2 } } } }) {
+                movies(where: { genresConnection_ALL: { node: { moviesAggregate: { count_EQ: 2 } } } }) {
                     title
                 }
             }
@@ -473,7 +473,7 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
     test("should find where genresConnection_SINGLE", async () => {
         const query = /* GraphQL */ `
             {
-                movies(where: { genresConnection_SINGLE: { node: { moviesAggregate: { count: 2 } } } }) {
+                movies(where: { genresConnection_SINGLE: { node: { moviesAggregate: { count_EQ: 2 } } } }) {
                     title
                 }
             }
@@ -510,7 +510,6 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
         `);
     });
 
-  
     test("should find genresConnection with multiple AND aggregates", async () => {
         const query = /* GraphQL */ `
             {
@@ -518,7 +517,7 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
                     where: {
                         genresConnection: {
                             AND: [
-                                { node: { moviesAggregate: { count: 2 } } }
+                                { node: { moviesAggregate: { count_EQ: 2 } } }
                                 { node: { seriesAggregate: { node: { name_SHORTEST_EQUAL: 1 } } } }
                             ]
                         }
@@ -576,7 +575,7 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
                     where: {
                         genresConnection: {
                             OR: [
-                                { node: { moviesAggregate: { count: 3 } } }
+                                { node: { moviesAggregate: { count_EQ: 3 } } }
                                 { node: { seriesAggregate: { node: { name_SHORTEST_EQUAL: 983 } } } }
                             ]
                         }
@@ -634,7 +633,7 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
                     where: {
                         genresConnection: {
                             node: {
-                                moviesAggregate: { count: 2 }
+                                moviesAggregate: { count_EQ: 2 }
                                 seriesAggregate: { node: { name_SHORTEST_EQUAL: 983 } }
                             }
                         }
@@ -690,8 +689,8 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
             {
                 movies(
                     where: {
-                        genresConnection: { node: { moviesAggregate: { count: 3 } } }
-                        genresAggregate: { count: 1 }
+                        genresConnection: { node: { moviesAggregate: { count_EQ: 3 } } }
+                        genresAggregate: { count_EQ: 1 }
                     }
                 ) {
                     title

--- a/packages/graphql/tests/tck/issues/2708.test.ts
+++ b/packages/graphql/tests/tck/issues/2708.test.ts
@@ -54,7 +54,7 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
     test("should find where moviesAggregate count equal", async () => {
         const query = /* GraphQL */ `
             {
-                movies(where: { genres: { moviesAggregate: { count: 2 } } }) {
+                movies(where: { genres: { moviesAggregate: { count_EQ: 2 } } }) {
                     title
                 }
             }
@@ -331,7 +331,7 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
     test("should find where genres_SOME", async () => {
         const query = /* GraphQL */ `
             {
-                movies(where: { genres_SOME: { moviesAggregate: { count: 2 } } }) {
+                movies(where: { genres_SOME: { moviesAggregate: { count_EQ: 2 } } }) {
                     title
                 }
             }
@@ -371,7 +371,7 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
     test("should find where genres_NONE", async () => {
         const query = /* GraphQL */ `
             {
-                movies(where: { genres_NONE: { moviesAggregate: { count: 2 } } }) {
+                movies(where: { genres_NONE: { moviesAggregate: { count_EQ: 2 } } }) {
                     title
                 }
             }
@@ -411,7 +411,7 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
     test("should find where genres_ALL", async () => {
         const query = /* GraphQL */ `
             {
-                movies(where: { genres_ALL: { moviesAggregate: { count: 2 } } }) {
+                movies(where: { genres_ALL: { moviesAggregate: { count_EQ: 2 } } }) {
                     title
                 }
             }
@@ -467,7 +467,7 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
     test("should find where genres_SINGLE", async () => {
         const query = /* GraphQL */ `
             {
-                movies(where: { genres_SINGLE: { moviesAggregate: { count: 2 } } }) {
+                movies(where: { genres_SINGLE: { moviesAggregate: { count_EQ: 2 } } }) {
                     title
                 }
             }
@@ -504,11 +504,10 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
         `);
     });
 
-    
     test("should not find genres_ALL where NONE true", async () => {
         const query = /* GraphQL */ `
             {
-                movies(where: { genres_ALL: { moviesAggregate: { count: 0 } } }) {
+                movies(where: { genres_ALL: { moviesAggregate: { count_EQ: 0 } } }) {
                     title
                 }
             }
@@ -568,7 +567,7 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
                     where: {
                         genres: {
                             AND: [
-                                { moviesAggregate: { count: 2 } }
+                                { moviesAggregate: { count_EQ: 2 } }
                                 { seriesAggregate: { node: { name_SHORTEST_EQUAL: 1 } } }
                             ]
                         }
@@ -626,7 +625,7 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
                     where: {
                         genres: {
                             OR: [
-                                { moviesAggregate: { count: 3 } }
+                                { moviesAggregate: { count_EQ: 3 } }
                                 { seriesAggregate: { node: { name_SHORTEST_EQUAL: 1 } } }
                             ]
                         }
@@ -682,7 +681,10 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
             {
                 movies(
                     where: {
-                        genres: { moviesAggregate: { count: 2 }, seriesAggregate: { node: { name_SHORTEST_EQUAL: 1 } } }
+                        genres: {
+                            moviesAggregate: { count_EQ: 2 }
+                            seriesAggregate: { node: { name_SHORTEST_EQUAL: 1 } }
+                        }
                     }
                 ) {
                     title
@@ -733,7 +735,7 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
     test("should find genres with aggregation at the same level", async () => {
         const query = /* GraphQL */ `
             {
-                movies(where: { genres: { moviesAggregate: { count: 3 } }, genresAggregate: { count: 1 } }) {
+                movies(where: { genres: { moviesAggregate: { count_EQ: 3 } }, genresAggregate: { count_EQ: 1 } }) {
                     title
                 }
             }
@@ -784,7 +786,7 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
             {
                 movies(
                     where: {
-                        genres_ALL: { OR: [{ moviesAggregate: { count: 0 } }, { seriesAggregate: { count: 1 } }] }
+                        genres_ALL: { OR: [{ moviesAggregate: { count_EQ: 0 } }, { seriesAggregate: { count_EQ: 1 } }] }
                     }
                 ) {
                     title
@@ -863,8 +865,8 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
                 movies(
                     where: {
                         genres_ALL: {
-                            OR: [{ moviesAggregate: { count: 0 } }, { name_EQ: "Thriller" }]
-                            seriesAggregate: { count: 1 }
+                            OR: [{ moviesAggregate: { count_EQ: 0 } }, { name_EQ: "Thriller" }]
+                            seriesAggregate: { count_EQ: 1 }
                         }
                     }
                 ) {

--- a/packages/graphql/tests/tck/issues/2713.test.ts
+++ b/packages/graphql/tests/tck/issues/2713.test.ts
@@ -54,7 +54,7 @@ describe("https://github.com/neo4j/graphql/issues/2713", () => {
     test("should not find genresConnection_ALL where NONE true", async () => {
         const query = /* GraphQL */ `
             {
-                movies(where: { genresConnection_ALL: { node: { moviesAggregate: { count: 0 } } } }) {
+                movies(where: { genresConnection_ALL: { node: { moviesAggregate: { count_EQ: 0 } } } }) {
                     title
                 }
             }
@@ -110,7 +110,9 @@ describe("https://github.com/neo4j/graphql/issues/2713", () => {
     test("should not find genresConnection_ALL where NONE true and filter by genre title", async () => {
         const query = /* GraphQL */ `
             {
-                movies(where: { genresConnection_ALL: { node: { moviesAggregate: { count: 0 }, name_EQ: "Thriller" } } }) {
+                movies(
+                    where: { genresConnection_ALL: { node: { moviesAggregate: { count_EQ: 0 }, name_EQ: "Thriller" } } }
+                ) {
                     title
                 }
             }

--- a/packages/graphql/tests/tck/issues/2803.test.ts
+++ b/packages/graphql/tests/tck/issues/2803.test.ts
@@ -114,7 +114,10 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
             {
                 actors(
                     where: {
-                        movies_SOME: { actors_ALL: { moviesAggregate: { count_GT: 1 } }, actorsAggregate: { count: 1 } }
+                        movies_SOME: {
+                            actors_ALL: { moviesAggregate: { count_GT: 1 } }
+                            actorsAggregate: { count_EQ: 1 }
+                        }
                     }
                 ) {
                     name
@@ -430,7 +433,7 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
                     where: {
                         movies_SOME: {
                             actorsConnection_ALL: { node: { moviesAggregate: { count_GT: 1 } } }
-                            actorsAggregate: { count: 1 }
+                            actorsAggregate: { count_EQ: 1 }
                         }
                     }
                 ) {
@@ -1058,7 +1061,9 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
     test("should be able to filter by node properties and aggregations in nested relationships", async () => {
         const query = /* GraphQL */ `
             {
-                actors(where: { movies_ALL: { actors_SOME: { name_EQ: "a name", moviesAggregate: { count_GT: 1 } } } }) {
+                actors(
+                    where: { movies_ALL: { actors_SOME: { name_EQ: "a name", moviesAggregate: { count_GT: 1 } } } }
+                ) {
                     name
                 }
             }

--- a/packages/graphql/tests/tck/issues/4477.test.ts
+++ b/packages/graphql/tests/tck/issues/4477.test.ts
@@ -43,7 +43,7 @@ describe("https://github.com/neo4j/graphql/issues/4477", () => {
             query {
                 brands {
                     name
-                    services(where: { collectionAggregate: { count: 0 } }) {
+                    services(where: { collectionAggregate: { count_EQ: 0 } }) {
                         collectionAggregate {
                             count
                         }

--- a/packages/ogm/src/generate.test.ts
+++ b/packages/ogm/src/generate.test.ts
@@ -1317,11 +1317,13 @@ describe("generate", () => {
             };
 
             export type MovieActorsAggregateInput = {
-              count?: InputMaybe<Scalars[\\"Int\\"][\\"input\\"]>;
+              count_EQ?: InputMaybe<Scalars[\\"Int\\"][\\"input\\"]>;
               count_LT?: InputMaybe<Scalars[\\"Int\\"][\\"input\\"]>;
               count_LTE?: InputMaybe<Scalars[\\"Int\\"][\\"input\\"]>;
               count_GT?: InputMaybe<Scalars[\\"Int\\"][\\"input\\"]>;
               count_GTE?: InputMaybe<Scalars[\\"Int\\"][\\"input\\"]>;
+              /** @deprecated Please use the explicit _EQ version */
+              count?: InputMaybe<Scalars[\\"Int\\"][\\"input\\"]>;
               AND?: InputMaybe<Array<MovieActorsAggregateInput>>;
               OR?: InputMaybe<Array<MovieActorsAggregateInput>>;
               NOT?: InputMaybe<MovieActorsAggregateInput>;
@@ -2140,11 +2142,13 @@ describe("generate", () => {
             };
 
             export type FaqEntriesAggregateInput = {
-              count?: InputMaybe<Scalars[\\"Int\\"][\\"input\\"]>;
+              count_EQ?: InputMaybe<Scalars[\\"Int\\"][\\"input\\"]>;
               count_LT?: InputMaybe<Scalars[\\"Int\\"][\\"input\\"]>;
               count_LTE?: InputMaybe<Scalars[\\"Int\\"][\\"input\\"]>;
               count_GT?: InputMaybe<Scalars[\\"Int\\"][\\"input\\"]>;
               count_GTE?: InputMaybe<Scalars[\\"Int\\"][\\"input\\"]>;
+              /** @deprecated Please use the explicit _EQ version */
+              count?: InputMaybe<Scalars[\\"Int\\"][\\"input\\"]>;
               AND?: InputMaybe<Array<FaqEntriesAggregateInput>>;
               OR?: InputMaybe<Array<FaqEntriesAggregateInput>>;
               NOT?: InputMaybe<FaqEntriesAggregateInput>;
@@ -2408,11 +2412,13 @@ describe("generate", () => {
             };
 
             export type FaqEntryInFaQsAggregateInput = {
-              count?: InputMaybe<Scalars[\\"Int\\"][\\"input\\"]>;
+              count_EQ?: InputMaybe<Scalars[\\"Int\\"][\\"input\\"]>;
               count_LT?: InputMaybe<Scalars[\\"Int\\"][\\"input\\"]>;
               count_LTE?: InputMaybe<Scalars[\\"Int\\"][\\"input\\"]>;
               count_GT?: InputMaybe<Scalars[\\"Int\\"][\\"input\\"]>;
               count_GTE?: InputMaybe<Scalars[\\"Int\\"][\\"input\\"]>;
+              /** @deprecated Please use the explicit _EQ version */
+              count?: InputMaybe<Scalars[\\"Int\\"][\\"input\\"]>;
               AND?: InputMaybe<Array<FaqEntryInFaQsAggregateInput>>;
               OR?: InputMaybe<Array<FaqEntryInFaQsAggregateInput>>;
               NOT?: InputMaybe<FaqEntryInFaQsAggregateInput>;

--- a/packages/ogm/tests/issues/3591.test.ts
+++ b/packages/ogm/tests/issues/3591.test.ts
@@ -588,11 +588,13 @@ describe("issues/3591", () => {
             };
 
             export type UserCompanyAggregateInput = {
-              count?: InputMaybe<Scalars[\\"Int\\"][\\"input\\"]>;
+              count_EQ?: InputMaybe<Scalars[\\"Int\\"][\\"input\\"]>;
               count_LT?: InputMaybe<Scalars[\\"Int\\"][\\"input\\"]>;
               count_LTE?: InputMaybe<Scalars[\\"Int\\"][\\"input\\"]>;
               count_GT?: InputMaybe<Scalars[\\"Int\\"][\\"input\\"]>;
               count_GTE?: InputMaybe<Scalars[\\"Int\\"][\\"input\\"]>;
+              /** @deprecated Please use the explicit _EQ version */
+              count?: InputMaybe<Scalars[\\"Int\\"][\\"input\\"]>;
               AND?: InputMaybe<Array<UserCompanyAggregateInput>>;
               OR?: InputMaybe<Array<UserCompanyAggregateInput>>;
               NOT?: InputMaybe<UserCompanyAggregateInput>;
@@ -846,11 +848,13 @@ describe("issues/3591", () => {
             };
 
             export type UserFavoriteRestaurantsAggregateInput = {
-              count?: InputMaybe<Scalars[\\"Int\\"][\\"input\\"]>;
+              count_EQ?: InputMaybe<Scalars[\\"Int\\"][\\"input\\"]>;
               count_LT?: InputMaybe<Scalars[\\"Int\\"][\\"input\\"]>;
               count_LTE?: InputMaybe<Scalars[\\"Int\\"][\\"input\\"]>;
               count_GT?: InputMaybe<Scalars[\\"Int\\"][\\"input\\"]>;
               count_GTE?: InputMaybe<Scalars[\\"Int\\"][\\"input\\"]>;
+              /** @deprecated Please use the explicit _EQ version */
+              count?: InputMaybe<Scalars[\\"Int\\"][\\"input\\"]>;
               AND?: InputMaybe<Array<UserFavoriteRestaurantsAggregateInput>>;
               OR?: InputMaybe<Array<UserFavoriteRestaurantsAggregateInput>>;
               NOT?: InputMaybe<UserFavoriteRestaurantsAggregateInput>;


### PR DESCRIPTION
# Description

This PR introduced the explicit `count_EQ` filter and deprecate the implicit version `count`.  The deprecated version could be disabled with the already present `implicitEqualFilters` setting.