### PR TITLE
Bump minimum versions - Neo4j 5.s and Node.js 20.x

### DIFF
--- a/.changeset/blue-sloths-enjoy.md
+++ b/.changeset/blue-sloths-enjoy.md
@@ -1,0 +1,6 @@
+---
+"@neo4j/graphql": major
+"@neo4j/graphql-ogm": major
+---
+
+The Neo4j GraphQL Library now requires a Neo4j 5.x database.

--- a/.changeset/blue-sloths-enjoy.md
+++ b/.changeset/blue-sloths-enjoy.md
@@ -1,6 +1,7 @@
 ---
 "@neo4j/graphql": major
 "@neo4j/graphql-ogm": major
+"@neo4j/introspector": major
 ---
 
 The Neo4j GraphQL Library now requires a Neo4j 5.x database.

--- a/.changeset/wild-knives-yawn.md
+++ b/.changeset/wild-knives-yawn.md
@@ -1,0 +1,6 @@
+---
+"@neo4j/graphql": major
+"@neo4j/graphql-ogm": major
+---
+
+The Neo4j GraphQL Library now requires Node.js 20 or greater.

--- a/.github/workflows/reusable-api-library-tests.yml
+++ b/.github/workflows/reusable-api-library-tests.yml
@@ -24,8 +24,6 @@ jobs:
           - "^15.0.0"
           - "^16.0.0"
         neo4j-version:
-          - 4.4-community
-          - 4.4-enterprise
           - 5-community
           - 5-enterprise
 

--- a/.github/workflows/reusable-integration-tests-on-prem.yml
+++ b/.github/workflows/reusable-integration-tests-on-prem.yml
@@ -23,8 +23,6 @@ jobs:
             { package: "graphql", shard: 4/4, coverage_name: 6 },
           ]
         neo4j-version:
-          #   - 4.4-community
-          - 4.4-enterprise
           #   - 5-community
           - 5-enterprise
         graphql-version: [

--- a/.github/workflows/reusable-subscriptions-plugin-amqp-e2e-test.yml
+++ b/.github/workflows/reusable-subscriptions-plugin-amqp-e2e-test.yml
@@ -12,8 +12,6 @@ jobs:
           - "^15.0.0"
           - "^16.0.0"
         neo4j-version:
-          #   - 4.4-community
-          - 4.4-enterprise
           #   - 5-community
           - 5-enterprise
     services:

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -22,7 +22,7 @@
         "dist/**/*.js.map"
     ],
     "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
     },
     "scripts": {
         "build": "tsc --build src/tsconfig.production.json",

--- a/packages/graphql/src/classes/utils/verify-database.test.ts
+++ b/packages/graphql/src/classes/utils/verify-database.test.ts
@@ -18,10 +18,10 @@
  */
 
 import type { Driver, Session } from "neo4j-driver";
-import checkNeo4jCompat from "./verify-database";
-import { REQUIRED_APOC_FUNCTIONS, MIN_NEO4J_VERSION } from "../../constants";
-import { Neo4jDatabaseInfo } from "../Neo4jDatabaseInfo";
+import { MIN_NEO4J_VERSION, REQUIRED_APOC_FUNCTIONS } from "../../constants";
 import type { Neo4jGraphQLSessionConfig } from "../Executor";
+import { Neo4jDatabaseInfo } from "../Neo4jDatabaseInfo";
+import checkNeo4jCompat from "./verify-database";
 
 describe("checkNeo4jCompat", () => {
     test("should add driver config to session", async () => {
@@ -270,7 +270,7 @@ describe("checkNeo4jCompat", () => {
         ).resolves.not.toThrow();
     });
 
-    test("should not throw Error that 4.2 is minimum", async () => {
+    test("should throw Error for Neo4j 4.4", async () => {
         // @ts-ignore
         const fakeSession: Session = {
             // @ts-ignore
@@ -278,7 +278,7 @@ describe("checkNeo4jCompat", () => {
                 records: [
                     {
                         toObject: () => ({
-                            version: "4.1.10",
+                            version: "4.4.37",
                             functions: REQUIRED_APOC_FUNCTIONS,
                         }),
                     },
@@ -296,8 +296,8 @@ describe("checkNeo4jCompat", () => {
             verifyConnectivity: () => undefined,
         };
 
-        await expect(checkNeo4jCompat({ driver: fakeDriver, dbInfo: new Neo4jDatabaseInfo("4.1.10") })).rejects.toThrow(
-            `Encountered the following DBMS compatiblility issues:\nExpected minimum Neo4j version: '${MIN_NEO4J_VERSION}', received: '4.1.10'`
+        await expect(checkNeo4jCompat({ driver: fakeDriver, dbInfo: new Neo4jDatabaseInfo("4.4.37") })).rejects.toThrow(
+            `Encountered the following DBMS compatiblility issues:\nExpected minimum Neo4j version: '${MIN_NEO4J_VERSION}', received: '4.4.37'`
         );
     });
 });

--- a/packages/graphql/src/constants.ts
+++ b/packages/graphql/src/constants.ts
@@ -21,7 +21,7 @@ const DEBUG_PREFIX = "@neo4j/graphql";
 
 export const AUTH_FORBIDDEN_ERROR = "@neo4j/graphql/FORBIDDEN";
 export const AUTH_UNAUTHENTICATED_ERROR = "@neo4j/graphql/UNAUTHENTICATED";
-export const MIN_NEO4J_VERSION = "4.4";
+export const MIN_NEO4J_VERSION = "5.0";
 export const REQUIRED_APOC_FUNCTIONS = ["apoc.util.validatePredicate", "apoc.date.convertFormat"];
 export const AUTHORIZATION_UNAUTHENTICATED = "Unauthenticated";
 export const DEBUG_ALL = `${DEBUG_PREFIX}:*`;

--- a/packages/introspector/package.json
+++ b/packages/introspector/package.json
@@ -22,7 +22,7 @@
         "dist/**/*.js.map"
     ],
     "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
     },
     "scripts": {
         "build:clean": "yarn clean && yarn build",

--- a/packages/ogm/package.json
+++ b/packages/ogm/package.json
@@ -22,7 +22,7 @@
         "dist/**/*.js.map"
     ],
     "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
     },
     "scripts": {
         "build": "tsc --build tsconfig.production.json",


### PR DESCRIPTION
# Description

The Neo4j GraphQL Library now requires Neo4j 5.x and Node.js >=20.

## Complexity

Complexity: Low
