### PR TITLE
Remove unused `stringAggregation` option from `excludeDeprecatedFields`

### DIFF
--- a/.changeset/dry-dots-scream.md
+++ b/.changeset/dry-dots-scream.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": major
+---
+
+Remove no-op option to remove `stringAggregation` deprecated fields.

--- a/packages/graphql/src/types/index.ts
+++ b/packages/graphql/src/types/index.ts
@@ -479,7 +479,6 @@ export type Neo4jFeaturesSettings = {
         bookmark?: boolean;
         implicitEqualFilters?: boolean;
         arrayFilters?: boolean;
-        stringAggregation?: boolean;
         aggregationFilters?: boolean;
         deprecatedOptionsArgument?: boolean;
         nestedUpdateOperationsFields?: boolean;

--- a/packages/graphql/tests/schema/remove-deprecated/aggregations.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/aggregations.test.ts
@@ -45,7 +45,6 @@ describe("Remove deprecated fields for aggregations", () => {
                 excludeDeprecatedFields: {
                     bookmark: true,
                     arrayFilters: true,
-                    stringAggregation: true,
                     aggregationFilters: true,
                 },
             },
@@ -423,7 +422,6 @@ describe("Remove deprecated fields for aggregations", () => {
                 excludeDeprecatedFields: {
                     bookmark: true,
                     arrayFilters: true,
-                    stringAggregation: true,
                     aggregationFilters: true,
                 },
             },

--- a/packages/graphql/tests/schema/remove-deprecated/array-methods.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/array-methods.test.ts
@@ -47,7 +47,6 @@ describe("Arrays Methods", () => {
                 excludeDeprecatedFields: {
                     bookmark: true,
                     arrayFilters: true,
-                    stringAggregation: true,
                     aggregationFilters: true,
                 },
             },

--- a/packages/graphql/tests/schema/remove-deprecated/comments.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/comments.test.ts
@@ -62,7 +62,6 @@ describe("Comments", () => {
                 excludeDeprecatedFields: {
                     bookmark: true,
                     arrayFilters: true,
-                    stringAggregation: true,
                     aggregationFilters: true,
                 },
             },
@@ -303,7 +302,6 @@ describe("Comments", () => {
                     excludeDeprecatedFields: {
                         bookmark: true,
                         arrayFilters: true,
-                        stringAggregation: true,
                         aggregationFilters: true,
                     },
                 },
@@ -705,7 +703,6 @@ describe("Comments", () => {
                     excludeDeprecatedFields: {
                         bookmark: true,
                         arrayFilters: true,
-                        stringAggregation: true,
                         aggregationFilters: true,
                     },
                 },
@@ -1332,7 +1329,6 @@ describe("Comments", () => {
                     excludeDeprecatedFields: {
                         bookmark: true,
                         arrayFilters: true,
-                        stringAggregation: true,
                         aggregationFilters: true,
                     },
                 },

--- a/packages/graphql/tests/schema/remove-deprecated/implicit-equality.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/implicit-equality.test.ts
@@ -45,7 +45,6 @@ describe("Implicit Equality filters", () => {
                     implicitEqualFilters: false,
                     bookmark: true,
                     arrayFilters: true,
-                    stringAggregation: true,
                     aggregationFilters: true,
                 },
             },
@@ -391,7 +390,6 @@ describe("Implicit Equality filters", () => {
                     excludeDeprecatedFields: {
                         bookmark: true,
                         arrayFilters: true,
-                        stringAggregation: true,
                         aggregationFilters: true,
                     },
                 },
@@ -793,7 +791,6 @@ describe("Implicit Equality filters", () => {
                     excludeDeprecatedFields: {
                         bookmark: true,
                         arrayFilters: true,
-                        stringAggregation: true,
                         aggregationFilters: true,
                     },
                 },
@@ -1420,7 +1417,6 @@ describe("Implicit Equality filters", () => {
                     excludeDeprecatedFields: {
                         bookmark: true,
                         arrayFilters: true,
-                        stringAggregation: true,
                         aggregationFilters: true,
                     },
                 },

--- a/packages/graphql/tests/schema/remove-deprecated/options-argument.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/options-argument.test.ts
@@ -56,7 +56,6 @@ describe("Deprecated options argument", () => {
                 excludeDeprecatedFields: {
                     bookmark: true,
                     arrayFilters: true,
-                    stringAggregation: true,
                     aggregationFilters: true,
                     deprecatedOptionsArgument: true,
                 },


### PR DESCRIPTION
# Description

Remove unused `stringAggregation` option in `excludeDeprecatedFields`.

## Complexity

Complexity: Low
