### PR TITLE
Fix #5671

### DIFF
--- a/.changeset/thin-guests-fail.md
+++ b/.changeset/thin-guests-fail.md
@@ -1,0 +1,18 @@
+---
+"@neo4j/graphql": major
+---
+
+Throws an error when the same field is updated multiple times on same update operation.
+
+For example:
+
+```graphql
+mutation {
+    updateMovies(update: { tags_POP: 1, tags_PUSH: "d" }) {
+        movies {
+            title
+            tags
+        }
+    }
+}
+```

--- a/packages/graphql/src/translate/queryAST/factory/parsers/parse-mutation-field.test.ts
+++ b/packages/graphql/src/translate/queryAST/factory/parsers/parse-mutation-field.test.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { parseMutationField } from "./parse-mutation-field";
+
+describe("parseMutationField", () => {
+    test("title", () => {
+        expect(parseMutationField("title")).toEqual({
+            fieldName: "title",
+            operator: undefined,
+        });
+    });
+
+    test("invalid operator", () => {
+        expect(parseMutationField("title_SOMETHING")).toEqual({
+            fieldName: "title_SOMETHING",
+            operator: undefined,
+        });
+    });
+
+    test.each(["PUSH", "POP", "ADD", "SUBTRACT", "MULTIPLY", "DIVIDE", "INCREMENT", "DECREMENT"])(
+        "title_%s",
+        (operator) => {
+            expect(parseMutationField(`title_${operator}`)).toEqual({
+                fieldName: "title",
+                operator: operator,
+            });
+        }
+    );
+});

--- a/packages/graphql/src/translate/queryAST/factory/parsers/parse-mutation-field.ts
+++ b/packages/graphql/src/translate/queryAST/factory/parsers/parse-mutation-field.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+type MutationOperation = "PUSH" | "POP" | "ADD" | "SUBTRACT" | "MULTIPLY" | "DIVIDE" | "INCREMENT" | "DECREMENT";
+
+export type MutationRegexGroups = {
+    fieldName: string;
+    operator: MutationOperation | undefined;
+};
+
+const mutationRegEx =
+    /(?<fieldName>[_A-Za-z]\w*?)(?:_(?<operator>PUSH|POP|ADD|SUBTRACT|MULTIPLY|DIVIDE|INCREMENT|DECREMENT))?$/;
+
+export function parseMutationField(field: string): MutationRegexGroups {
+    const match = mutationRegEx.exec(field);
+
+    return match?.groups as MutationRegexGroups;
+}

--- a/packages/graphql/src/utils/find-conflicting-properties.ts
+++ b/packages/graphql/src/utils/find-conflicting-properties.ts
@@ -18,6 +18,7 @@
  */
 
 import type { Node } from "../classes";
+import { parseMutationField } from "../translate/queryAST/factory/parsers/parse-mutation-field";
 import mapToDbProperty from "./map-to-db-property";
 
 /* returns conflicting mutation input properties */
@@ -31,16 +32,18 @@ export function findConflictingProperties({
     if (!input) {
         return [];
     }
-    const dbPropertiesToInputFieldNames: Record<string, string[]> = Object.keys(input).reduce((acc, fieldName) => {
+    const dbPropertiesToInputFieldNames: Record<string, string[]> = Object.keys(input).reduce((acc, rawField) => {
+        const { fieldName } = parseMutationField(rawField);
+
         const dbName = mapToDbProperty(node, fieldName);
         // some input fields (eg relation fields) have no corresponding db name in the map
         if (!dbName) {
             return acc;
         }
         if (acc[dbName]) {
-            acc[dbName].push(fieldName);
+            acc[dbName].push(rawField);
         } else {
-            acc[dbName] = [fieldName];
+            acc[dbName] = [rawField];
         }
         return acc;
     }, {});

--- a/packages/graphql/tests/integration/array-methods/array-pop-errors.int.test.ts
+++ b/packages/graphql/tests/integration/array-methods/array-pop-errors.int.test.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import type { GraphQLError } from "graphql";
+import { GraphQLError } from "graphql";
 import { gql } from "graphql-tag";
 import { IncomingMessage } from "http";
 import { Socket } from "net";
@@ -253,12 +253,9 @@ describe("array-pop-errors", () => {
 
         const gqlResult = await testHelper.executeGraphQL(update);
 
-        expect(gqlResult.errors).toBeDefined();
-        expect(
-            (gqlResult.errors as GraphQLError[]).some((el) =>
-                el.message.includes("Cannot mutate the same field multiple times in one Mutation")
-            )
-        ).toBeTruthy();
+        expect(gqlResult.errors).toEqual([
+            new GraphQLError(`Conflicting modification of [[tags]], [[tags_POP]] on type ${typeMovie}`),
+        ]);
         expect(gqlResult.data).toBeNull();
     });
 

--- a/packages/graphql/tests/integration/array-methods/array-push-errors.int.test.ts
+++ b/packages/graphql/tests/integration/array-methods/array-push-errors.int.test.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import type { GraphQLError } from "graphql";
+import { GraphQLError } from "graphql";
 import { gql } from "graphql-tag";
 import { IncomingMessage } from "http";
 import { Socket } from "net";
@@ -206,12 +206,9 @@ describe("array-push", () => {
 
         const gqlResult = await testHelper.executeGraphQL(update);
 
-        expect(gqlResult.errors).toBeDefined();
-        expect(
-            (gqlResult.errors as GraphQLError[]).some((el) =>
-                el.message.includes("Cannot mutate the same field multiple times in one Mutation")
-            )
-        ).toBeTruthy();
+        expect(gqlResult.errors).toEqual([
+            new GraphQLError(`Conflicting modification of [[tags]], [[tags_PUSH]] on type ${typeMovie}`),
+        ]);
         expect(gqlResult.data).toBeNull();
     });
 

--- a/packages/graphql/tests/integration/issues/5671.int.test.ts
+++ b/packages/graphql/tests/integration/issues/5671.int.test.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { GraphQLError } from "graphql";
+import type { UniqueType } from "../../utils/graphql-types";
+import { TestHelper } from "../../utils/tests-helper";
+
+describe("https://github.com/neo4j/graphql/issues/5671", () => {
+    let Movie: UniqueType;
+
+    const testHelper = new TestHelper();
+
+    beforeEach(async () => {
+        Movie = testHelper.createUniqueType("Movie");
+
+        const typeDefs = /* GraphQL */ `
+            type ${Movie} @node {
+                title: String!
+                tags: [String!]!
+                rating: Int
+            }
+        `;
+        await testHelper.initNeo4jGraphQL({
+            typeDefs,
+        });
+    });
+
+    afterEach(async () => {
+        await testHelper.close();
+    });
+
+    test("should fail to update an array in the same update", async () => {
+        const mutation = /* GraphQL */ `
+            mutation {
+                ${Movie.operations.update}(update: { tags_POP: 1, tags_PUSH: "d" }) {
+                    ${Movie.plural} {
+                        title
+                        tags
+                    }
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(mutation);
+        expect(result.errors).toEqual([
+            new GraphQLError(`Conflicting modification of [[tags_POP]], [[tags_PUSH]] on type ${Movie}`),
+        ]);
+    });
+
+    test("should fail to update an int in the same update", async () => {
+        const mutation = /* GraphQL */ `
+            mutation UpdateMovies {
+                ${Movie.operations.update}(update: { rating_INCREMENT: 5, rating_DECREMENT: 2 }) {
+                    ${Movie.plural} {
+                        title
+                    }
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(mutation);
+        expect(result.errors).toEqual([
+            new GraphQLError(`Conflicting modification of [[rating_INCREMENT]], [[rating_DECREMENT]] on type ${Movie}`),
+        ]);
+    });
+});

--- a/packages/graphql/tests/integration/math.int.test.ts
+++ b/packages/graphql/tests/integration/math.int.test.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import type { GraphQLError } from "graphql";
+import { GraphQLError } from "graphql";
 import { int } from "neo4j-driver";
 import { generate } from "randomstring";
 import { TestHelper } from "../utils/tests-helper";
@@ -215,12 +215,9 @@ describe("Mathematical operations tests", () => {
         const gqlResult = await testHelper.executeGraphQL(query, {
             variableValues: { id, value: 10 },
         });
-        expect(gqlResult.errors).toBeDefined();
-        expect(
-            (gqlResult.errors as GraphQLError[]).some((el) =>
-                el.message.includes("Cannot mutate the same field multiple times in one Mutation")
-            )
-        ).toBeTruthy();
+        expect(gqlResult.errors).toEqual([
+            new GraphQLError(`Conflicting modification of [[viewers]], [[viewers_INCREMENT]] on type ${movie}`),
+        ]);
         const storedValue = await testHelper.executeCypher(
             `
                 MATCH (n:${movie.name} {id: $id}) RETURN n.viewers AS viewers


### PR DESCRIPTION
# Description

Throws an error when the same field is updated multiple times on same update operation.

For example:

```graphql
mutation {
    updateMovies(update: { tags_POP: 1, tags_PUSH: "d" }) {
        movies {
            title
            tags
        }
    }
}
```