### PR TITLE
Fix cypher sort be included 

### DIFF
--- a/.changeset/five-seals-itch.md
+++ b/.changeset/five-seals-itch.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": major
+---
+
+Fixed a bug that caused `@cypher` field to be added as sortable fields in the schema even for not supported cases

--- a/packages/graphql/src/schema-model/attribute/model-adapters/AttributeAdapter.ts
+++ b/packages/graphql/src/schema-model/attribute/model-adapters/AttributeAdapter.ts
@@ -23,7 +23,7 @@ import type { Attribute } from "../Attribute";
 import type { AttributeType } from "../AttributeType";
 import { ListType } from "../AttributeType";
 import { AttributeTypeHelper } from "../AttributeTypeHelper";
-import { AggregationAdapter } from "./AggregationAdapter";
+import type { AggregationAdapter } from "./AggregationAdapter";
 import { ListAdapter } from "./ListAdapter";
 import { MathAdapter } from "./MathAdapter";
 
@@ -68,13 +68,6 @@ export class AttributeAdapter {
             this._mathModel = new MathAdapter(this);
         }
         return this._mathModel;
-    }
-
-    get aggregationModel(): AggregationAdapter {
-        if (!this._aggregationModel) {
-            this._aggregationModel = new AggregationAdapter(this);
-        }
-        return this._aggregationModel;
     }
 
     /**
@@ -127,7 +120,8 @@ export class AttributeAdapter {
         return (
             !this.typeHelper.isList() &&
             !this.isCustomResolvable() &&
-            (this.typeHelper.isScalar() || this.typeHelper.isEnum() || this.typeHelper.isSpatial() || this.isCypher())
+            (this.typeHelper.isScalar() || this.typeHelper.isEnum() || this.typeHelper.isSpatial()) &&
+            (!this.isCypher() || !this.args.some((arg) => arg.type.isRequired))
         );
     }
 

--- a/packages/graphql/src/schema-model/attribute/model-adapters/AttributeAdapter.ts
+++ b/packages/graphql/src/schema-model/attribute/model-adapters/AttributeAdapter.ts
@@ -23,7 +23,7 @@ import type { Attribute } from "../Attribute";
 import type { AttributeType } from "../AttributeType";
 import { ListType } from "../AttributeType";
 import { AttributeTypeHelper } from "../AttributeTypeHelper";
-import type { AggregationAdapter } from "./AggregationAdapter";
+import { AggregationAdapter } from "./AggregationAdapter";
 import { ListAdapter } from "./ListAdapter";
 import { MathAdapter } from "./MathAdapter";
 
@@ -68,6 +68,13 @@ export class AttributeAdapter {
             this._mathModel = new MathAdapter(this);
         }
         return this._mathModel;
+    }
+
+    get aggregationModel(): AggregationAdapter {
+        if (!this._aggregationModel) {
+            this._aggregationModel = new AggregationAdapter(this);
+        }
+        return this._aggregationModel;
     }
 
     /**

--- a/packages/graphql/tests/schema/directives/cypher.test.ts
+++ b/packages/graphql/tests/schema/directives/cypher.test.ts
@@ -18,14 +18,13 @@
  */
 
 import { printSchemaWithDirectives } from "@graphql-tools/utils";
-import { gql } from "graphql-tag";
 import { lexicographicSortSchema } from "graphql/utilities";
 import { Neo4jGraphQL } from "../../../src";
 import { TestCDCEngine } from "../../utils/builders/TestCDCEngine";
 
 describe("Cypher", () => {
     test("Custom Directive Simple", async () => {
-        const typeDefs = gql`
+        const typeDefs = /* GraphQL */ `
             type Actor @node {
                 name: String
             }
@@ -327,7 +326,6 @@ describe("Cypher", () => {
             Fields to sort Movies by. The order in which sorts are applied is not guaranteed when specifying many fields in one MovieSort object.
             \\"\\"\\"
             input MovieSort {
-              actor: SortDirection
               custom_big_int: SortDirection
               custom_boolean: SortDirection
               custom_cartesian_point: SortDirection
@@ -591,7 +589,7 @@ describe("Cypher", () => {
     });
 
     test("Filters should not be generated on list custom cypher fields", async () => {
-        const typeDefs = gql`
+        const typeDefs = /* GraphQL */ `
             type Movie {
                 custom_cypher_string_list: [String]
                     @cypher(statement: "RETURN ['a','b','c'] as list", columnName: "list")
@@ -712,7 +710,7 @@ describe("Cypher", () => {
     });
 
     test("Filters should not be generated on custom cypher fields with arguments", async () => {
-        const typeDefs = gql`
+        const typeDefs = /* GraphQL */ `
             type Movie {
                 custom_string_with_param(param: String): String
                     @cypher(statement: "RETURN $param as c", columnName: "c")
@@ -849,7 +847,7 @@ describe("Cypher", () => {
     });
 
     test("Filters should not be generated on Relationship/Object custom cypher fields", async () => {
-        const typeDefs = gql`
+        const typeDefs = /* GraphQL */ `
             type Movie {
                 actors: [Actor]
                     @cypher(
@@ -1071,7 +1069,7 @@ describe("Cypher", () => {
     });
 
     test("Sort On Primitive Field", async () => {
-        const typeDefs = gql`
+        const typeDefs = /* GraphQL */ `
             type Actor @node {
                 name: String
                 totalScreenTime: Int!
@@ -1321,7 +1319,7 @@ describe("Cypher", () => {
     });
 
     test("Filters should not be generated on custom cypher fields for subscriptions", async () => {
-        const typeDefs = gql`
+        const typeDefs = /* GraphQL */ `
             type Movie {
                 title: String
                 custom_title: String @cypher(statement: "RETURN 'hello' as t", columnName: "t")

--- a/packages/graphql/tests/schema/issues/5631.test.ts
+++ b/packages/graphql/tests/schema/issues/5631.test.ts
@@ -1,0 +1,251 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { printSchemaWithDirectives } from "@graphql-tools/utils";
+import { lexicographicSortSchema } from "graphql/utilities";
+import { Neo4jGraphQL } from "../../../src";
+
+describe("https://github.com/neo4j/graphql/issues/5631", () => {
+    test("sorting input should not be generated for cypher fields with NonNullable arguments", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Movie @node {
+                custom_actors_with_params(title: String): [Actor]
+                    @cypher(
+                        statement: """
+                        MATCH (a:Actor {title: $title})
+                        RETURN a
+                        """
+                        columnName: "a"
+                    )
+                custom_actor_with_zero_param: Actor
+                    @cypher(statement: "MATCH (this)-[:ACTED_IN]->(a:Actor) RETURN head(a)", columnName: "a")
+                custom_string_with_non_nullable_param(param: String!): String!
+                    @cypher(statement: "RETURN $param as c", columnName: "c")
+            }
+
+            type Actor @node {
+                custom_string_with_zero_param: String! @cypher(statement: "RETURN 'a' as c", columnName: "c")
+                custom_string_with_nullable_param(param: String): String!
+                    @cypher(statement: "RETURN $param as c", columnName: "c")
+            }
+        `;
+
+        const neoSchema = new Neo4jGraphQL({
+            typeDefs,
+        });
+
+        const printedSchema = printSchemaWithDirectives(lexicographicSortSchema(await neoSchema.getSchema()));
+
+        expect(printedSchema).toMatchInlineSnapshot(`
+            "schema {
+              query: Query
+              mutation: Mutation
+            }
+
+            type Actor {
+              custom_string_with_nullable_param(param: String): String!
+              custom_string_with_zero_param: String!
+            }
+
+            type ActorAggregateSelection {
+              count: Int!
+            }
+
+            input ActorCreateInput {
+              \\"\\"\\"
+              Appears because this input type would be empty otherwise because this type is composed of just generated and/or relationship properties. See https://neo4j.com/docs/graphql-manual/current/troubleshooting/faqs/
+              \\"\\"\\"
+              _emptyInput: Boolean
+            }
+
+            type ActorEdge {
+              cursor: String!
+              node: Actor!
+            }
+
+            input ActorOptions {
+              limit: Int
+              offset: Int
+              \\"\\"\\"
+              Specify one or more ActorSort objects to sort Actors by. The sorts will be applied in the order in which they are arranged in the array.
+              \\"\\"\\"
+              sort: [ActorSort!]
+            }
+
+            \\"\\"\\"
+            Fields to sort Actors by. The order in which sorts are applied is not guaranteed when specifying many fields in one ActorSort object.
+            \\"\\"\\"
+            input ActorSort {
+              custom_string_with_nullable_param: SortDirection
+              custom_string_with_zero_param: SortDirection
+            }
+
+            input ActorUpdateInput {
+              \\"\\"\\"
+              Appears because this input type would be empty otherwise because this type is composed of just generated and/or relationship properties. See https://neo4j.com/docs/graphql-manual/current/troubleshooting/faqs/
+              \\"\\"\\"
+              _emptyInput: Boolean
+            }
+
+            input ActorWhere {
+              AND: [ActorWhere!]
+              NOT: ActorWhere
+              OR: [ActorWhere!]
+              custom_string_with_zero_param: String @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              custom_string_with_zero_param_CONTAINS: String
+              custom_string_with_zero_param_ENDS_WITH: String
+              custom_string_with_zero_param_EQ: String
+              custom_string_with_zero_param_IN: [String!]
+              custom_string_with_zero_param_STARTS_WITH: String
+            }
+
+            type ActorsConnection {
+              edges: [ActorEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type CreateActorsMutationResponse {
+              actors: [Actor!]!
+              info: CreateInfo!
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships created during a create mutation
+            \\"\\"\\"
+            type CreateInfo {
+              nodesCreated: Int!
+              relationshipsCreated: Int!
+            }
+
+            type CreateMoviesMutationResponse {
+              info: CreateInfo!
+              movies: [Movie!]!
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships deleted during a delete mutation
+            \\"\\"\\"
+            type DeleteInfo {
+              nodesDeleted: Int!
+              relationshipsDeleted: Int!
+            }
+
+            type Movie {
+              custom_actor_with_zero_param: Actor
+              custom_actors_with_params(title: String): [Actor]
+              custom_string_with_non_nullable_param(param: String!): String!
+            }
+
+            type MovieAggregateSelection {
+              count: Int!
+            }
+
+            input MovieCreateInput {
+              \\"\\"\\"
+              Appears because this input type would be empty otherwise because this type is composed of just generated and/or relationship properties. See https://neo4j.com/docs/graphql-manual/current/troubleshooting/faqs/
+              \\"\\"\\"
+              _emptyInput: Boolean
+            }
+
+            type MovieEdge {
+              cursor: String!
+              node: Movie!
+            }
+
+            input MovieOptions {
+              limit: Int
+              offset: Int
+            }
+
+            input MovieUpdateInput {
+              \\"\\"\\"
+              Appears because this input type would be empty otherwise because this type is composed of just generated and/or relationship properties. See https://neo4j.com/docs/graphql-manual/current/troubleshooting/faqs/
+              \\"\\"\\"
+              _emptyInput: Boolean
+            }
+
+            input MovieWhere {
+              AND: [MovieWhere!]
+              NOT: MovieWhere
+              OR: [MovieWhere!]
+            }
+
+            type MoviesConnection {
+              edges: [MovieEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type Mutation {
+              createActors(input: [ActorCreateInput!]!): CreateActorsMutationResponse!
+              createMovies(input: [MovieCreateInput!]!): CreateMoviesMutationResponse!
+              deleteActors(where: ActorWhere): DeleteInfo!
+              deleteMovies(where: MovieWhere): DeleteInfo!
+              updateActors(update: ActorUpdateInput, where: ActorWhere): UpdateActorsMutationResponse!
+              updateMovies(update: MovieUpdateInput, where: MovieWhere): UpdateMoviesMutationResponse!
+            }
+
+            \\"\\"\\"Pagination information (Relay)\\"\\"\\"
+            type PageInfo {
+              endCursor: String
+              hasNextPage: Boolean!
+              hasPreviousPage: Boolean!
+              startCursor: String
+            }
+
+            type Query {
+              actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
+              movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: MovieWhere): [Movie!]!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesConnection(after: String, first: Int, where: MovieWhere): MoviesConnection!
+            }
+
+            \\"\\"\\"An enum for sorting in either ascending or descending order.\\"\\"\\"
+            enum SortDirection {
+              \\"\\"\\"Sort by field values in ascending order.\\"\\"\\"
+              ASC
+              \\"\\"\\"Sort by field values in descending order.\\"\\"\\"
+              DESC
+            }
+
+            type UpdateActorsMutationResponse {
+              actors: [Actor!]!
+              info: UpdateInfo!
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships created and deleted during an update mutation
+            \\"\\"\\"
+            type UpdateInfo {
+              nodesCreated: Int!
+              nodesDeleted: Int!
+              relationshipsCreated: Int!
+              relationshipsDeleted: Int!
+            }
+
+            type UpdateMoviesMutationResponse {
+              info: UpdateInfo!
+              movies: [Movie!]!
+            }"
+        `);
+    });
+});


### PR DESCRIPTION
Fixed a bug that caused `@cypher` fields to be included as sortable fields in the generated even when this is not supported.

Fixes: #5631 