### PR TITLE
Remove aura 4 tests

### DIFF
--- a/.github/workflows/aura-tests.yml
+++ b/.github/workflows/aura-tests.yml
@@ -29,19 +29,6 @@ jobs:
       PASSWORD: ${{ secrets.AURA_FREE_PASSWORD }}
     concurrency: aura-free
 
-  aura-professional-4-tests:
-    if: |
-      github.event_name != 'pull_request_target' ||
-      github.event.pull_request.user.login == 'neo4j-team-graphql' &&
-      startsWith(github.head_ref, 'changeset-release/')
-    uses: ./.github/workflows/reusable-aura-tests.yml
-    with:
-      BRANCH: ${{ github.head_ref || github.ref }}
-    secrets:
-      URI: ${{ secrets.AURA_PROFESSIONAL_4_URI }}
-      PASSWORD: ${{ secrets.AURA_PROFESSIONAL_4_PASSWORD }}
-    concurrency: aura-professional-4
-
   aura-professional-5-tests:
     if: |
       github.event_name != 'pull_request_target' ||


### PR DESCRIPTION
# Description

Since version 6. Neo4j 4 is no longer supported in the GraphQL library. This PR remove tests on aura using neo4j 4
