### PR TITLE
Cypher filtering 1 to 1 relationships

### DIFF
--- a/.changeset/seven-bobcats-carry.md
+++ b/.changeset/seven-bobcats-carry.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": minor
+---
+
+Add filtering on 1 to 1 relationship custom cypher fields

--- a/packages/graphql/src/schema-model/Neo4jGraphQLSchemaModel.ts
+++ b/packages/graphql/src/schema-model/Neo4jGraphQLSchemaModel.ts
@@ -69,6 +69,11 @@ export class Neo4jGraphQLSchemaModel {
         return concreteEntity ? new ConcreteEntityAdapter(concreteEntity) : undefined;
     }
 
+    public getConcreteEntity(name: string): ConcreteEntity | undefined {
+        const concreteEntity = this.concreteEntities.find((entity) => entity.name === name);
+        return concreteEntity;
+    }
+
     public getEntitiesByLabels(labels: string[]): ConcreteEntity[] {
         return this.concreteEntities.filter((entity) => entity.matchLabels(labels));
     }

--- a/packages/graphql/src/schema-model/annotation/CypherAnnotation.ts
+++ b/packages/graphql/src/schema-model/annotation/CypherAnnotation.ts
@@ -17,12 +17,14 @@
  * limitations under the License.
  */
 
+import type { ConcreteEntity } from "../entity/ConcreteEntity";
 import type { Annotation } from "./Annotation";
 
 export class CypherAnnotation implements Annotation {
     readonly name = "cypher";
     public statement: string;
     public columnName: string;
+    public targetEntity?: ConcreteEntity;
 
     constructor({ statement, columnName }: { statement: string; columnName: string }) {
         this.statement = statement;

--- a/packages/graphql/src/schema-model/attribute/model-adapters/AttributeAdapter.ts
+++ b/packages/graphql/src/schema-model/attribute/model-adapters/AttributeAdapter.ts
@@ -132,9 +132,16 @@ export class AttributeAdapter {
         );
     }
 
+    isCypherRelationshipField(): boolean {
+        return this.isCypher() && Boolean(this.annotations.cypher?.targetEntity);
+    }
+
     isWhereField(): boolean {
         return (
-            (this.typeHelper.isEnum() || this.typeHelper.isSpatial() || this.typeHelper.isScalar()) &&
+            (this.typeHelper.isEnum() ||
+                this.typeHelper.isSpatial() ||
+                this.typeHelper.isScalar() ||
+                this.isCypherRelationshipField()) &&
             this.isFilterable() &&
             !this.isCustomResolvable()
         );

--- a/packages/graphql/src/schema-model/parser/annotations-parser/cypher-annotation.ts
+++ b/packages/graphql/src/schema-model/parser/annotations-parser/cypher-annotation.ts
@@ -18,9 +18,9 @@
  */
 import type { DirectiveNode } from "graphql";
 import { Neo4jGraphQLSchemaValidationError } from "../../../classes";
+import { cypherDirective } from "../../../graphql/directives";
 import { CypherAnnotation } from "../../annotation/CypherAnnotation";
 import { parseArguments } from "../parse-arguments";
-import { cypherDirective } from "../../../graphql/directives";
 
 export function parseCypherAnnotation(directive: DirectiveNode): CypherAnnotation {
     const { statement, columnName } = parseArguments(cypherDirective, directive);

--- a/packages/graphql/src/schema/generation/augment-where-input.ts
+++ b/packages/graphql/src/schema/generation/augment-where-input.ts
@@ -21,7 +21,7 @@ import type { Directive, InputTypeComposerFieldConfigMapDefinition } from "graph
 import type { RelationshipAdapter } from "../../schema-model/relationship/model-adapters/RelationshipAdapter";
 import type { RelationshipDeclarationAdapter } from "../../schema-model/relationship/model-adapters/RelationshipDeclarationAdapter";
 
-function augmentWhereInputType({
+function augmentRelationshipWhereInputType({
     whereType,
     fieldName,
     filters,
@@ -69,7 +69,7 @@ export function augmentWhereInputTypeWithRelationshipFields(
     deprecatedDirectives: Directive[]
 ): InputTypeComposerFieldConfigMapDefinition {
     const filters = relationshipAdapter.listFiltersModel?.filters;
-    return augmentWhereInputType({
+    return augmentRelationshipWhereInputType({
         whereType: relationshipAdapter.target.operations.whereInputTypeName,
         fieldName: relationshipAdapter.name,
         filters,
@@ -83,7 +83,7 @@ export function augmentWhereInputTypeWithConnectionFields(
     deprecatedDirectives: Directive[]
 ): InputTypeComposerFieldConfigMapDefinition {
     const filters = relationshipAdapter.listFiltersModel?.connectionFilters;
-    return augmentWhereInputType({
+    return augmentRelationshipWhereInputType({
         whereType: relationshipAdapter.operations.getConnectionWhereTypename(),
         fieldName: relationshipAdapter.operations.connectionFieldName,
         filters,

--- a/packages/graphql/src/schema/get-where-fields.ts
+++ b/packages/graphql/src/schema/get-where-fields.ts
@@ -77,13 +77,6 @@ export function getWhereFieldsForAttributes({
                     type: targetEntityAdapter.operations.whereInputTypeName,
                     directives: deprecatedDirectives,
                 };
-
-                if (shouldAddDeprecatedFields(features, "negationFilters")) {
-                    result[`${field.name}_NOT`] = {
-                        type: targetEntityAdapter.operations.whereInputTypeName,
-                        directives: deprecatedDirectives.length ? deprecatedDirectives : [DEPRECATE_NOT],
-                    };
-                }
                 continue;
             }
         }

--- a/packages/graphql/src/schema/get-where-fields.ts
+++ b/packages/graphql/src/schema/get-where-fields.ts
@@ -21,6 +21,7 @@ import type { DirectiveNode } from "graphql";
 import type { Directive } from "graphql-compose";
 import { DEPRECATED } from "../constants";
 import type { AttributeAdapter } from "../schema-model/attribute/model-adapters/AttributeAdapter";
+import { ConcreteEntityAdapter } from "../schema-model/entity/model-adapters/ConcreteEntityAdapter";
 import type { Neo4jFeaturesSettings } from "../types";
 import { DEPRECATE_IMPLICIT_EQUAL_FILTERS } from "./constants";
 import { shouldAddDeprecatedFields } from "./generation/utils";
@@ -67,6 +68,22 @@ export function getWhereFieldsForAttributes({
 
             // If the field is a cypher field with arguments, skip it
             if (field.args.length > 0) {
+                continue;
+            }
+
+            if (field.annotations.cypher.targetEntity) {
+                const targetEntityAdapter = new ConcreteEntityAdapter(field.annotations.cypher.targetEntity);
+                result[field.name] = {
+                    type: targetEntityAdapter.operations.whereInputTypeName,
+                    directives: deprecatedDirectives,
+                };
+
+                if (shouldAddDeprecatedFields(features, "negationFilters")) {
+                    result[`${field.name}_NOT`] = {
+                        type: targetEntityAdapter.operations.whereInputTypeName,
+                        directives: deprecatedDirectives.length ? deprecatedDirectives : [DEPRECATE_NOT],
+                    };
+                }
                 continue;
             }
         }

--- a/packages/graphql/src/translate/queryAST/ast/QueryASTContext.ts
+++ b/packages/graphql/src/translate/queryAST/ast/QueryASTContext.ts
@@ -49,7 +49,6 @@ export class QueryASTContext<T extends Cypher.Node | undefined = Cypher.Node | u
     public readonly shouldCollect: boolean; // temporary hack to describe if we should collect the return variable (used for mutation response)
     public readonly shouldDistinct: boolean; // temporary hack to describe if we should distinct the return variable (used for mutation response)
 
-
     public env: QueryASTEnv;
     public neo4jGraphQLContext: Neo4jGraphQLTranslationContext;
 
@@ -141,6 +140,16 @@ export class QueryASTContext<T extends Cypher.Node | undefined = Cypher.Node | u
             env: this.env,
             neo4jGraphQLContext: this.neo4jGraphQLContext,
             returnVariable: variable,
+        });
+    }
+
+    public setTarget(target: Cypher.Node): QueryASTContext<Cypher.Node> {
+        return new QueryASTContext({
+            source: this.target,
+            target,
+            env: this.env,
+            neo4jGraphQLContext: this.neo4jGraphQLContext,
+            returnVariable: this.returnVariable,
         });
     }
 }

--- a/packages/graphql/src/translate/queryAST/ast/filters/CypherOneToOneRelationshipFilter.ts
+++ b/packages/graphql/src/translate/queryAST/ast/filters/CypherOneToOneRelationshipFilter.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Cypher from "@neo4j/cypher-builder";
+import type { AttributeAdapter } from "../../../../schema-model/attribute/model-adapters/AttributeAdapter";
+import type { RelationshipWhereOperator } from "../../../where/types";
+import type { QueryASTContext } from "../QueryASTContext";
+import type { QueryASTNode } from "../QueryASTNode";
+import type { CustomCypherSelection } from "../selection/CustomCypherSelection";
+import { Filter } from "./Filter";
+
+export class CypherOneToOneRelationshipFilter extends Filter {
+    private returnVariable: Cypher.Node;
+    private attribute: AttributeAdapter;
+    private selection: CustomCypherSelection;
+    private operator: RelationshipWhereOperator;
+    private targetNodeFilters: Filter[] = [];
+    private isNot: boolean;
+    private isNull: boolean;
+
+    constructor({
+        selection,
+        attribute,
+        operator,
+        isNot,
+        isNull,
+        returnVariable,
+    }: {
+        selection: CustomCypherSelection;
+        attribute: AttributeAdapter;
+        operator: RelationshipWhereOperator;
+        isNot: boolean;
+        isNull: boolean;
+        returnVariable: Cypher.Node;
+    }) {
+        super();
+        this.selection = selection;
+        this.attribute = attribute;
+        this.isNot = isNot;
+        this.isNull = isNull;
+        this.operator = operator;
+        this.returnVariable = returnVariable;
+    }
+
+    public getChildren(): QueryASTNode[] {
+        return [...this.targetNodeFilters, this.selection];
+    }
+
+    public addTargetNodeFilter(...filter: Filter[]): void {
+        this.targetNodeFilters.push(...filter);
+    }
+
+    public print(): string {
+        return `${super.print()} [${this.attribute.name}] <${this.isNot ? "NOT " : ""}${this.operator}>`;
+    }
+
+    public getSubqueries(context: QueryASTContext): Cypher.Clause[] {
+        const { selection, nestedContext } = this.selection.apply(context);
+
+        const cypherSubquery = selection.return([
+            Cypher.head(Cypher.collect(nestedContext.returnVariable)),
+            this.returnVariable,
+        ]);
+
+        return [cypherSubquery];
+    }
+
+    public getPredicate(queryASTContext: QueryASTContext): Cypher.Predicate | undefined {
+        const context = queryASTContext.setTarget(this.returnVariable);
+
+        const predicate = this.createRelationshipOperation(context);
+        if (predicate) {
+            return this.wrapInNotIfNeeded(predicate);
+        }
+    }
+
+    private createRelationshipOperation(queryASTContext: QueryASTContext): Cypher.Predicate | undefined {
+        const targetNodePredicates = this.targetNodeFilters.map((c) => c.getPredicate(queryASTContext));
+        const innerPredicate = Cypher.and(...targetNodePredicates);
+
+        if (this.isNull) {
+            return Cypher.and(innerPredicate, Cypher.isNull(this.returnVariable));
+        }
+
+        return innerPredicate;
+    }
+
+    private wrapInNotIfNeeded(predicate: Cypher.Predicate): Cypher.Predicate {
+        if (this.isNot) {
+            return Cypher.not(predicate);
+        }
+
+        return predicate;
+    }
+}

--- a/packages/graphql/src/translate/queryAST/ast/filters/CypherOneToOneRelationshipFilter.ts
+++ b/packages/graphql/src/translate/queryAST/ast/filters/CypherOneToOneRelationshipFilter.ts
@@ -19,17 +19,17 @@
 
 import Cypher from "@neo4j/cypher-builder";
 import type { AttributeAdapter } from "../../../../schema-model/attribute/model-adapters/AttributeAdapter";
-import type { RelationshipWhereOperator } from "../../../where/types";
 import type { QueryASTContext } from "../QueryASTContext";
 import type { QueryASTNode } from "../QueryASTNode";
 import type { CustomCypherSelection } from "../selection/CustomCypherSelection";
+import type { FilterOperator, RelationshipWhereOperator } from "./Filter";
 import { Filter } from "./Filter";
 
 export class CypherOneToOneRelationshipFilter extends Filter {
     private returnVariable: Cypher.Node;
     private attribute: AttributeAdapter;
     private selection: CustomCypherSelection;
-    private operator: RelationshipWhereOperator;
+    private operator: FilterOperator;
     private targetNodeFilters: Filter[] = [];
     private isNot: boolean;
     private isNull: boolean;

--- a/packages/graphql/src/translate/queryAST/factory/AuthFilterFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/AuthFilterFactory.ts
@@ -29,11 +29,8 @@ import type { Neo4jGraphQLTranslationContext } from "../../../types/neo4j-graphq
 import { asArray } from "../../../utils/utils";
 import { isLogicalOperator } from "../../utils/logical-operators";
 import type { ConnectionFilter } from "../ast/filters/ConnectionFilter";
-<<<<<<< HEAD
 import type { Filter, FilterOperator, RelationshipWhereOperator } from "../ast/filters/Filter";
-=======
-import { isRelationshipOperator, type Filter } from "../ast/filters/Filter";
->>>>>>> d40590e36 (Merge pull request #5723 from mjfwebb/cypher-filtering-1-to-1-relationships)
+import { isRelationshipOperator } from "../ast/filters/Filter";
 import { LogicalFilter } from "../ast/filters/LogicalFilter";
 import type { RelationshipFilter } from "../ast/filters/RelationshipFilter";
 import { AuthConnectionFilter } from "../ast/filters/authorization-filters/AuthConnectionFilter";
@@ -145,13 +142,8 @@ export class AuthFilterFactory extends FilterFactory {
         isNot: boolean;
         attachedTo?: "node" | "relationship";
         relationship?: RelationshipAdapter;
-<<<<<<< HEAD
-    }): CypherFilter | PropertyFilter {
-        const filterOperator = operator ?? "EQ";
-=======
     }): Filter {
         const filterOperator = operator || "EQ";
->>>>>>> d40590e36 (Merge pull request #5723 from mjfwebb/cypher-filtering-1-to-1-relationships)
 
         const isCypherVariable =
             comparisonValue instanceof Cypher.Variable ||

--- a/packages/graphql/src/translate/queryAST/factory/FilterFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/FilterFactory.ts
@@ -29,12 +29,8 @@ import { fromGlobalId } from "../../../utils/global-ids";
 import { asArray, filterTruthy } from "../../../utils/utils";
 import { isLogicalOperator } from "../../utils/logical-operators";
 import { ConnectionFilter } from "../ast/filters/ConnectionFilter";
-<<<<<<< HEAD
-import type { Filter, FilterOperator, RelationshipWhereOperator } from "../ast/filters/Filter";
-=======
 import { CypherOneToOneRelationshipFilter } from "../ast/filters/CypherOneToOneRelationshipFilter";
-import type { Filter } from "../ast/filters/Filter";
->>>>>>> d40590e36 (Merge pull request #5723 from mjfwebb/cypher-filtering-1-to-1-relationships)
+import type { Filter, FilterOperator, RelationshipWhereOperator } from "../ast/filters/Filter";
 import { isRelationshipOperator } from "../ast/filters/Filter";
 import { LogicalFilter } from "../ast/filters/LogicalFilter";
 import { RelationshipFilter } from "../ast/filters/RelationshipFilter";
@@ -179,7 +175,7 @@ export class FilterFactory {
     }: {
         attribute: AttributeAdapter;
         comparisonValue: GraphQLWhereArg;
-        operator: WhereOperator | undefined;
+        operator: FilterOperator | undefined;
         isNot: boolean;
     }): Filter | Filter[] {
         const filterOperator = operator || "EQ";
@@ -229,22 +225,13 @@ export class FilterFactory {
     }: {
         attribute: AttributeAdapter;
         relationship?: RelationshipAdapter;
-<<<<<<< HEAD
-        comparisonValue: unknown;
-        operator: FilterOperator | undefined;
-        isNot: boolean;
-        attachedTo?: "node" | "relationship";
-    }): PropertyFilter | CypherFilter {
-        const filterOperator = operator ?? "EQ";
-=======
         comparisonValue: GraphQLWhereArg;
-        operator: WhereOperator | undefined;
+        operator: FilterOperator | undefined;
         isNot: boolean;
         attachedTo?: "node" | "relationship";
     }): Filter | Filter[] {
         const filterOperator = operator || "EQ";
 
->>>>>>> d40590e36 (Merge pull request #5723 from mjfwebb/cypher-filtering-1-to-1-relationships)
         if (attribute.annotations.cypher) {
             return this.createCypherFilter({
                 attribute,

--- a/packages/graphql/src/translate/queryAST/factory/OperationFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/OperationFactory.ts
@@ -332,7 +332,7 @@ export class OperationsFactory {
             });
             operation.addFilters(...filters);
         } else {
-            const filters = this.filterFactory.createNodeFilters(entity, whereArgs, context);
+            const filters = this.filterFactory.createNodeFilters(entity, whereArgs);
             operation.addFilters(...filters);
         }
 

--- a/packages/graphql/src/translate/queryAST/factory/Operations/ConnectionFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/Operations/ConnectionFactory.ts
@@ -381,7 +381,6 @@ export class ConnectionFactory {
             rel: relationship,
             entity: target,
             where: whereArgs,
-            context,
         });
 
         operation.setNodeFields(nodeFields);

--- a/packages/graphql/tests/integration/directives/cypher/filtering/cypher-filtering-one-to-one-relationship.int.test.ts
+++ b/packages/graphql/tests/integration/directives/cypher/filtering/cypher-filtering-one-to-one-relationship.int.test.ts
@@ -75,7 +75,7 @@ describe("cypher directive filtering - One To One Relationship", () => {
                 ${Movie.plural}(
                     where: {
                         actor: {
-                            name: "Keanu Reeves"
+                            name_EQ: "Keanu Reeves"
                         } 
                     }
                 ) {
@@ -239,7 +239,7 @@ describe("cypher directive filtering - One To One Relationship", () => {
             query {
                 ${Movie.plural}(
                     where: {
-                        released: 2003,
+                        released_EQ: 2003,
                         actor: null 
                     }
                 ) {
@@ -336,7 +336,7 @@ describe("cypher directive filtering - One To One Relationship", () => {
         const Person = testHelper.createUniqueType("Person");
 
         const typeDefs = /* GraphQL */ `
-            type ${Movie} @node @authorization(filter: [{ where: { node: { directed_by: { name: "$jwt.custom_value" } } } }]) {
+            type ${Movie} @node @authorization(filter: [{ where: { node: { directed_by: { name_EQ: "$jwt.custom_value" } } } }]) {
                 title: String
                 released: Int
                 directed_by: ${Person}!
@@ -387,7 +387,7 @@ describe("cypher directive filtering - One To One Relationship", () => {
 
         const query = /* GraphQL */ `
             query {
-                ${Person.plural}(where: { directed: { title: "The Matrix" } }) {
+                ${Person.plural}(where: { directed: { title_EQ: "The Matrix" } }) {
                     directed {
                         title
                         directed_by {
@@ -420,7 +420,7 @@ describe("cypher directive filtering - One To One Relationship", () => {
         const Person = testHelper.createUniqueType("Person");
 
         const typeDefs = /* GraphQL */ `
-            type ${Movie} @node @authorization(filter: [{ where: { node: { directed_by: { name: "$jwt.custom_value" } } } }]) {
+            type ${Movie} @node @authorization(filter: [{ where: { node: { directed_by: { name_EQ: "$jwt.custom_value" } } } }]) {
                 title: String
                 released: Int
                 directed_by: ${Person}!
@@ -471,7 +471,7 @@ describe("cypher directive filtering - One To One Relationship", () => {
 
         const query = /* GraphQL */ `
             query {
-                ${Person.plural}(where: { directed: { title: "The Matrix" } }) {
+                ${Person.plural}(where: { directed: { title_EQ: "The Matrix" } }) {
                     directed {
                         title
                         directed_by {
@@ -495,7 +495,7 @@ describe("cypher directive filtering - One To One Relationship", () => {
             type ${Movie} @node {
                 title: String
                 released: Int
-                directed_by: ${Person}! @authorization(filter: [{ where: { node: { directed_by: { name: "$jwt.custom_value" } } } }])
+                directed_by: ${Person}! @authorization(filter: [{ where: { node: { directed_by: { name_EQ: "$jwt.custom_value" } } } }])
                     @cypher(
                         statement: """
                         MATCH (this)<-[:DIRECTED]-(director:${Person})
@@ -543,7 +543,7 @@ describe("cypher directive filtering - One To One Relationship", () => {
 
         const query = /* GraphQL */ `
             query {
-                ${Person.plural}(where: { directed: { title: "The Matrix" } }) {
+                ${Person.plural}(where: { directed: { title_EQ: "The Matrix" } }) {
                     directed {
                         title
                         directed_by {
@@ -579,7 +579,7 @@ describe("cypher directive filtering - One To One Relationship", () => {
             type ${Movie} @node {
                 title: String
                 released: Int
-                directed_by: ${Person}! @authorization(filter: [{ where: { node: { directed_by: { name: "$jwt.custom_value" } } } }])
+                directed_by: ${Person}! @authorization(filter: [{ where: { node: { directed_by: { name_EQ: "$jwt.custom_value" } } } }])
                     @cypher(
                         statement: """
                         MATCH (this)<-[:DIRECTED]-(director:${Person})
@@ -627,7 +627,7 @@ describe("cypher directive filtering - One To One Relationship", () => {
 
         const query = /* GraphQL */ `
             query {
-                ${Person.plural}(where: { directed: { title: "The Matrix" } }) {
+                ${Person.plural}(where: { directed: { title_EQ: "The Matrix" } }) {
                     directed {
                         title
                         directed_by {
@@ -648,7 +648,7 @@ describe("cypher directive filtering - One To One Relationship", () => {
         const Person = testHelper.createUniqueType("Person");
 
         const typeDefs = /* GraphQL */ `
-            type ${Movie} @node @authorization(validate: [{ where: { node: { directed_by: { name: "$jwt.custom_value" } } } }]) {
+            type ${Movie} @node @authorization(validate: [{ where: { node: { directed_by: { name_EQ: "$jwt.custom_value" } } } }]) {
                 title: String
                 released: Int
                 directed_by: ${Person}!
@@ -699,7 +699,7 @@ describe("cypher directive filtering - One To One Relationship", () => {
 
         const query = /* GraphQL */ `
             query {
-                ${Person.plural}(where: { directed: { title: "The Matrix" } }) {
+                ${Person.plural}(where: { directed: { title_EQ: "The Matrix" } }) {
                     directed {
                         title
                         directed_by {
@@ -732,7 +732,7 @@ describe("cypher directive filtering - One To One Relationship", () => {
         const Person = testHelper.createUniqueType("Person");
 
         const typeDefs = /* GraphQL */ `
-            type ${Movie} @node @authorization(validate: [{ where: { node: { directed_by: { name: "$jwt.custom_value" } } } }]) {
+            type ${Movie} @node @authorization(validate: [{ where: { node: { directed_by: { name_EQ: "$jwt.custom_value" } } } }]) {
                 title: String
                 released: Int
                 directed_by: ${Person}!
@@ -783,7 +783,7 @@ describe("cypher directive filtering - One To One Relationship", () => {
 
         const query = /* GraphQL */ `
             query {
-                ${Person.plural}(where: { directed: { title: "The Matrix" } }) {
+                ${Person.plural}(where: { directed: { title_EQ: "The Matrix" } }) {
                     directed {
                         title
                         directed_by {
@@ -856,7 +856,7 @@ describe("cypher directive filtering - One To One Relationship", () => {
 
         const query = /* GraphQL */ `
             query {
-                ${Person.plural}(where: { directed: { title: "The Matrix" } }) {
+                ${Person.plural}(where: { directed: { title_EQ: "The Matrix" } }) {
                     directed {
                         title
                         directed_by {
@@ -892,7 +892,7 @@ describe("cypher directive filtering - One To One Relationship", () => {
             type ${Movie} @node {
                 title: String
                 released: Int
-                directed_by: ${Person}! @authorization(validate: [{ where: { node: { directed_by: { name: "$jwt.custom_value" } } } }])
+                directed_by: ${Person}! @authorization(validate: [{ where: { node: { directed_by: { name_EQ: "$jwt.custom_value" } } } }])
                     @cypher(
                         statement: """
                         MATCH (this)<-[:DIRECTED]-(director:${Person})
@@ -940,7 +940,7 @@ describe("cypher directive filtering - One To One Relationship", () => {
 
         const query = /* GraphQL */ `
             query {
-                ${Person.plural}(where: { directed: { title: "The Matrix" } }) {
+                ${Person.plural}(where: { directed: { title_EQ: "The Matrix" } }) {
                     directed {
                         title
                         directed_by {
@@ -1015,7 +1015,7 @@ describe("cypher directive filtering - One To One Relationship", () => {
 
         const query = /* GraphQL */ `
             query {
-                ${Person.plural}(where: { directed: { title: "The Matrix" } }) {
+                ${Person.plural}(where: { directed: { title_EQ: "The Matrix" } }) {
                     directed {
                         title
                         directed_by {
@@ -1133,7 +1133,7 @@ describe("cypher directive filtering - One To One Relationship", () => {
 
         const query = /* GraphQL */ `
             query {
-                ${Movie.plural}(where: { directed_by: { name: "Lilly Wachowski"}, title_ENDS_WITH: "Matrix" }) {
+                ${Movie.plural}(where: { directed_by: { name_EQ: "Lilly Wachowski"}, title_ENDS_WITH: "Matrix" }) {
                     actorsConnection {
                         totalCount
                         edges {

--- a/packages/graphql/tests/integration/directives/cypher/filtering/cypher-filtering-one-to-one-relationship.int.test.ts
+++ b/packages/graphql/tests/integration/directives/cypher/filtering/cypher-filtering-one-to-one-relationship.int.test.ts
@@ -1,0 +1,1169 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TestHelper } from "../../../../utils/tests-helper";
+
+describe("cypher directive filtering - One To One Relationship", () => {
+    const testHelper = new TestHelper();
+
+    afterEach(async () => {
+        await testHelper.close();
+    });
+
+    test("1 to 1 relationship with single property filter", async () => {
+        const Movie = testHelper.createUniqueType("Movie");
+        const Actor = testHelper.createUniqueType("Actor");
+
+        const typeDefs = /* GraphQL */ `
+            type ${Movie} @node {
+                title: String
+                actor: ${Actor}!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:ACTED_IN]-(actor:${Actor})
+                        RETURN actor
+                        """
+                        columnName: "actor"
+                    )
+            }
+
+            type ${Actor} @node {
+                name: String
+                movie: ${Movie}!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(movie:${Movie})
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        await testHelper.initNeo4jGraphQL({ typeDefs });
+        await testHelper.executeCypher(
+            `
+            CREATE (m:${Movie} { title: "The Matrix" })
+            CREATE (m2:${Movie} { title: "The Matrix Reloaded" })
+            CREATE (m3:${Movie} { title: "The Matrix Revolutions" })
+            CREATE (a:${Actor} { name: "Keanu Reeves" })
+            CREATE (a)-[:ACTED_IN]->(m)
+            CREATE (a)-[:ACTED_IN]->(m2)
+            CREATE (a)-[:ACTED_IN]->(m3)
+            `,
+            {}
+        );
+
+        const query = /* GraphQL */ `
+            query {
+                ${Movie.plural}(
+                    where: {
+                        actor: {
+                            name: "Keanu Reeves"
+                        } 
+                    }
+                ) {
+                    title
+                    actor {
+                        name
+                    }
+                }
+            }
+        `;
+
+        const gqlResult = await testHelper.executeGraphQL(query);
+
+        expect(gqlResult.errors).toBeFalsy();
+        expect(gqlResult?.data).toEqual({
+            [Movie.plural]: expect.toIncludeSameMembers([
+                {
+                    title: "The Matrix",
+                    actor: {
+                        name: "Keanu Reeves",
+                    },
+                },
+                {
+                    title: "The Matrix Reloaded",
+                    actor: {
+                        name: "Keanu Reeves",
+                    },
+                },
+                {
+                    title: "The Matrix Revolutions",
+                    actor: {
+                        name: "Keanu Reeves",
+                    },
+                },
+            ]),
+        });
+    });
+
+    test("1 to 1 relationship with single property filter with non-deterministic result", async () => {
+        const Movie = testHelper.createUniqueType("Movie");
+        const Actor = testHelper.createUniqueType("Actor");
+
+        const typeDefs = /* GraphQL */ `
+            type ${Movie} @node {
+                title: String
+                actor: ${Actor}!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:ACTED_IN]-(actor:${Actor})
+                        RETURN actor
+                        """
+                        columnName: "actor"
+                    )
+            }
+
+            type ${Actor} @node {
+                name: String
+                movie: ${Movie}!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(movie:${Movie})
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        await testHelper.initNeo4jGraphQL({ typeDefs });
+        await testHelper.executeCypher(
+            `
+            CREATE (m:${Movie} { title: "The Matrix" })
+            CREATE (m2:${Movie} { title: "The Matrix Reloaded" })
+            CREATE (m3:${Movie} { title: "The Matrix Revolutions" })
+            CREATE (a:${Actor} { name: "Keanu Reeves" })
+            CREATE (a)-[:ACTED_IN]->(m)
+            CREATE (a)-[:ACTED_IN]->(m2)
+            CREATE (a)-[:ACTED_IN]->(m3)
+            `,
+            {}
+        );
+
+        const query = /* GraphQL */ `
+            query {
+                ${Actor.plural}(
+                    where: {
+                        movie: {
+                            title_STARTS_WITH: "The Matrix"
+                        } 
+                    }
+                ) {
+                    name
+                    movie {
+                        title
+                    }
+                }
+            }
+        `;
+
+        const gqlResult = await testHelper.executeGraphQL(query);
+
+        expect(gqlResult.errors).toBeFalsy();
+        expect(gqlResult?.data).toEqual({
+            [Actor.plural]: expect.toIncludeSameMembers([
+                {
+                    name: "Keanu Reeves",
+                    movie: {
+                        // The result is non-deterministic, so we can potentially match any of the movies
+                        title: expect.toStartWith("The Matrix"),
+                    },
+                },
+            ]),
+        });
+    });
+
+    test("1 to 1 relationship with null filter", async () => {
+        const Movie = testHelper.createUniqueType("Movie");
+        const Actor = testHelper.createUniqueType("Actor");
+
+        const typeDefs = /* GraphQL */ `
+            type ${Movie} @node {
+                title: String
+                released: Int
+                actor: ${Actor}
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:ACTED_IN]-(actor:${Actor})
+                        RETURN actor
+                        """
+                        columnName: "actor"
+                    )
+            }
+
+            type ${Actor} @node {
+                name: String
+                movie: ${Movie}
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(movie:${Movie})
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        await testHelper.initNeo4jGraphQL({ typeDefs });
+        await testHelper.executeCypher(
+            `
+            CREATE (m:${Movie} { title: "The Matrix", released: 1999 })
+            CREATE (m2:${Movie} { title: "The Matrix Reloaded", released: 2003 })
+            CREATE (m3:${Movie} { title: "The Matrix Revolutions", released: 2003 })
+            CREATE (a:${Actor} { name: "Keanu Reeves" })
+            CREATE (a)-[:ACTED_IN]->(m)
+            CREATE (a)-[:ACTED_IN]->(m2)
+            `,
+            {}
+        );
+
+        const query = /* GraphQL */ `
+            query {
+                ${Movie.plural}(
+                    where: {
+                        released: 2003,
+                        actor: null 
+                    }
+                ) {
+                    title
+                }
+            }
+        `;
+
+        const gqlResult = await testHelper.executeGraphQL(query);
+
+        expect(gqlResult.errors).toBeFalsy();
+        expect(gqlResult?.data).toEqual({
+            [Movie.plural]: expect.toIncludeSameMembers([
+                {
+                    title: "The Matrix Revolutions",
+                },
+            ]),
+        });
+    });
+
+    test("1 to 1 relationship with NOT null filter", async () => {
+        const Movie = testHelper.createUniqueType("Movie");
+        const Actor = testHelper.createUniqueType("Actor");
+
+        const typeDefs = /* GraphQL */ `
+            type ${Movie} @node {
+                title: String
+                released: Int
+                actor: ${Actor}
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:ACTED_IN]-(actor:${Actor})
+                        RETURN actor
+                        """
+                        columnName: "actor"
+                    )
+            }
+
+            type ${Actor} @node {
+                name: String
+                movie: ${Movie}
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(movie:${Movie})
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        await testHelper.initNeo4jGraphQL({ typeDefs });
+        await testHelper.executeCypher(
+            `
+            CREATE (m:${Movie} { title: "The Matrix", released: 1999 })
+            CREATE (m2:${Movie} { title: "The Matrix Reloaded", released: 2003 })
+            CREATE (m3:${Movie} { title: "The Matrix Revolutions", released: 2003 })
+            CREATE (a:${Actor} { name: "Keanu Reeves" })
+            CREATE (a2:${Actor} { name: "Jada Pinkett Smith" })
+            CREATE (a2)-[:ACTED_IN]->(m3)
+            CREATE (a)-[:ACTED_IN]->(m)
+            CREATE (a)-[:ACTED_IN]->(m2)
+            `,
+            {}
+        );
+
+        const query = /* GraphQL */ `
+            query {
+                ${Movie.plural}(
+                    where: { AND: [{ released_IN: [2003], NOT: { actor: null } }] }
+                ) {
+                    title
+                }
+            }
+        `;
+
+        const gqlResult = await testHelper.executeGraphQL(query);
+
+        expect(gqlResult.errors).toBeFalsy();
+        expect(gqlResult?.data).toEqual({
+            [Movie.plural]: expect.toIncludeSameMembers([
+                {
+                    title: "The Matrix Reloaded",
+                },
+                {
+                    title: "The Matrix Revolutions",
+                },
+            ]),
+        });
+    });
+
+    test("1 to 1 relationship with auth filter on type PASS", async () => {
+        const Movie = testHelper.createUniqueType("Movie");
+        const Person = testHelper.createUniqueType("Person");
+
+        const typeDefs = /* GraphQL */ `
+            type ${Movie} @node @authorization(filter: [{ where: { node: { directed_by: { name: "$jwt.custom_value" } } } }]) {
+                title: String
+                released: Int
+                directed_by: ${Person}!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:DIRECTED]-(director:${Person})
+                        RETURN director
+                        """
+                        columnName: "director"
+                    )
+            }
+
+            type ${Person} @node {
+                name: String
+                directed: ${Movie}!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:DIRECTED]->(movie:${Movie})
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        const token = testHelper.createBearerToken("secret", { custom_value: "Lilly Wachowski" });
+
+        await testHelper.initNeo4jGraphQL({
+            typeDefs,
+            features: {
+                authorization: {
+                    key: "secret",
+                },
+            },
+        });
+        await testHelper.executeCypher(
+            `
+            CREATE (m:${Movie} { title: "The Matrix", released: 1999 })
+            CREATE (m2:${Movie} { title: "The Matrix Reloaded", released: 2003 })
+            CREATE (a:${Person} { name: "Keanu Reeves" })
+            CREATE (a)-[:ACTED_IN]->(m)
+            CREATE (a)-[:ACTED_IN]->(m2)
+            CREATE (a5:${Person} { name: "Lilly Wachowski" })
+            CREATE (a5)-[:DIRECTED]->(m)
+            `,
+            {}
+        );
+
+        const query = /* GraphQL */ `
+            query {
+                ${Person.plural}(where: { directed: { title: "The Matrix" } }) {
+                    directed {
+                        title
+                        directed_by {
+                            name
+                        }
+                    }
+                }
+            }
+        `;
+
+        const gqlResult = await testHelper.executeGraphQLWithToken(query, token);
+
+        expect(gqlResult.errors).toBeFalsy();
+        expect(gqlResult?.data).toEqual({
+            [Person.plural]: [
+                {
+                    directed: {
+                        title: "The Matrix",
+                        directed_by: {
+                            name: "Lilly Wachowski",
+                        },
+                    },
+                },
+            ],
+        });
+    });
+
+    test("1 to 1 relationship with auth filter on type FAIL", async () => {
+        const Movie = testHelper.createUniqueType("Movie");
+        const Person = testHelper.createUniqueType("Person");
+
+        const typeDefs = /* GraphQL */ `
+            type ${Movie} @node @authorization(filter: [{ where: { node: { directed_by: { name: "$jwt.custom_value" } } } }]) {
+                title: String
+                released: Int
+                directed_by: ${Person}!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:DIRECTED]-(director:${Person})
+                        RETURN director
+                        """
+                        columnName: "director"
+                    )
+            }
+
+            type ${Person} @node {
+                name: String
+                directed: ${Movie}!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:DIRECTED]->(movie:${Movie})
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        const token = testHelper.createBearerToken("secret", { custom_value: "Something Incorrect" });
+
+        await testHelper.initNeo4jGraphQL({
+            typeDefs,
+            features: {
+                authorization: {
+                    key: "secret",
+                },
+            },
+        });
+        await testHelper.executeCypher(
+            `
+            CREATE (m:${Movie} { title: "The Matrix", released: 1999 })
+            CREATE (m2:${Movie} { title: "The Matrix Reloaded", released: 2003 })
+            CREATE (a:${Person} { name: "Keanu Reeves" })
+            CREATE (a)-[:ACTED_IN]->(m)
+            CREATE (a)-[:ACTED_IN]->(m2)
+            CREATE (a5:${Person} { name: "Lilly Wachowski" })
+            CREATE (a5)-[:DIRECTED]->(m)
+            `,
+            {}
+        );
+
+        const query = /* GraphQL */ `
+            query {
+                ${Person.plural}(where: { directed: { title: "The Matrix" } }) {
+                    directed {
+                        title
+                        directed_by {
+                            name
+                        }
+                    }
+                }
+            }
+        `;
+
+        const gqlResult = await testHelper.executeGraphQLWithToken(query, token);
+
+        expect(gqlResult.errors).toBeTruthy();
+    });
+
+    test("1 to 1 relationship with auth filter on field PASS", async () => {
+        const Movie = testHelper.createUniqueType("Movie");
+        const Person = testHelper.createUniqueType("Person");
+
+        const typeDefs = /* GraphQL */ `
+            type ${Movie} @node {
+                title: String
+                released: Int
+                directed_by: ${Person}! @authorization(filter: [{ where: { node: { directed_by: { name: "$jwt.custom_value" } } } }])
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:DIRECTED]-(director:${Person})
+                        RETURN director
+                        """
+                        columnName: "director"
+                    )
+            }
+
+            type ${Person} @node {
+                name: String
+                directed: ${Movie}!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:DIRECTED]->(movie:${Movie})
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        const token = testHelper.createBearerToken("secret", { custom_value: "Lilly Wachowski" });
+
+        await testHelper.initNeo4jGraphQL({
+            typeDefs,
+            features: {
+                authorization: {
+                    key: "secret",
+                },
+            },
+        });
+        await testHelper.executeCypher(
+            `
+            CREATE (m:${Movie} { title: "The Matrix", released: 1999 })
+            CREATE (m2:${Movie} { title: "The Matrix Reloaded", released: 2003 })
+            CREATE (a:${Person} { name: "Keanu Reeves" })
+            CREATE (a)-[:ACTED_IN]->(m)
+            CREATE (a)-[:ACTED_IN]->(m2)
+            CREATE (a5:${Person} { name: "Lilly Wachowski" })
+            CREATE (a5)-[:DIRECTED]->(m)
+            `,
+            {}
+        );
+
+        const query = /* GraphQL */ `
+            query {
+                ${Person.plural}(where: { directed: { title: "The Matrix" } }) {
+                    directed {
+                        title
+                        directed_by {
+                            name
+                        }
+                    }
+                }
+            }
+        `;
+
+        const gqlResult = await testHelper.executeGraphQLWithToken(query, token);
+
+        expect(gqlResult.errors).toBeFalsy();
+        expect(gqlResult?.data).toEqual({
+            [Person.plural]: [
+                {
+                    directed: {
+                        title: "The Matrix",
+                        directed_by: {
+                            name: "Lilly Wachowski",
+                        },
+                    },
+                },
+            ],
+        });
+    });
+
+    test("1 to 1 relationship with auth filter on field FAIL", async () => {
+        const Movie = testHelper.createUniqueType("Movie");
+        const Person = testHelper.createUniqueType("Person");
+
+        const typeDefs = /* GraphQL */ `
+            type ${Movie} @node {
+                title: String
+                released: Int
+                directed_by: ${Person}! @authorization(filter: [{ where: { node: { directed_by: { name: "$jwt.custom_value" } } } }])
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:DIRECTED]-(director:${Person})
+                        RETURN director
+                        """
+                        columnName: "director"
+                    )
+            }
+
+            type ${Person} @node {
+                name: String
+                directed: ${Movie}!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:DIRECTED]->(movie:${Movie})
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        const token = testHelper.createBearerToken("secret", { custom_value: "Something Incorrect" });
+
+        await testHelper.initNeo4jGraphQL({
+            typeDefs,
+            features: {
+                authorization: {
+                    key: "secret",
+                },
+            },
+        });
+        await testHelper.executeCypher(
+            `
+            CREATE (m:${Movie} { title: "The Matrix", released: 1999 })
+            CREATE (m2:${Movie} { title: "The Matrix Reloaded", released: 2003 })
+            CREATE (a:${Person} { name: "Keanu Reeves" })
+            CREATE (a)-[:ACTED_IN]->(m)
+            CREATE (a)-[:ACTED_IN]->(m2)
+            CREATE (a5:${Person} { name: "Lilly Wachowski" })
+            CREATE (a5)-[:DIRECTED]->(m)
+            `,
+            {}
+        );
+
+        const query = /* GraphQL */ `
+            query {
+                ${Person.plural}(where: { directed: { title: "The Matrix" } }) {
+                    directed {
+                        title
+                        directed_by {
+                            name
+                        }
+                    }
+                }
+            }
+        `;
+
+        const gqlResult = await testHelper.executeGraphQLWithToken(query, token);
+
+        expect(gqlResult.errors).toBeTruthy();
+    });
+
+    test("1 to 1 relationship with auth validate type PASS", async () => {
+        const Movie = testHelper.createUniqueType("Movie");
+        const Person = testHelper.createUniqueType("Person");
+
+        const typeDefs = /* GraphQL */ `
+            type ${Movie} @node @authorization(validate: [{ where: { node: { directed_by: { name: "$jwt.custom_value" } } } }]) {
+                title: String
+                released: Int
+                directed_by: ${Person}!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:DIRECTED]-(director:${Person})
+                        RETURN director
+                        """
+                        columnName: "director"
+                    )
+            }
+
+            type ${Person} @node {
+                name: String
+                directed: ${Movie}!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:DIRECTED]->(movie:${Movie})
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        const token = testHelper.createBearerToken("secret", { custom_value: "Lilly Wachowski" });
+
+        await testHelper.initNeo4jGraphQL({
+            typeDefs,
+            features: {
+                authorization: {
+                    key: "secret",
+                },
+            },
+        });
+        await testHelper.executeCypher(
+            `
+            CREATE (m:${Movie} { title: "The Matrix", released: 1999 })
+            CREATE (m2:${Movie} { title: "The Matrix Reloaded", released: 2003 })
+            CREATE (a:${Person} { name: "Keanu Reeves" })
+            CREATE (a)-[:ACTED_IN]->(m)
+            CREATE (a)-[:ACTED_IN]->(m2)
+            CREATE (a5:${Person} { name: "Lilly Wachowski" })
+            CREATE (a5)-[:DIRECTED]->(m)
+            `,
+            {}
+        );
+
+        const query = /* GraphQL */ `
+            query {
+                ${Person.plural}(where: { directed: { title: "The Matrix" } }) {
+                    directed {
+                        title
+                        directed_by {
+                            name
+                        }
+                    }
+                }
+            }
+        `;
+
+        const gqlResult = await testHelper.executeGraphQLWithToken(query, token);
+
+        expect(gqlResult.errors).toBeFalsy();
+        expect(gqlResult?.data).toEqual({
+            [Person.plural]: [
+                {
+                    directed: {
+                        title: "The Matrix",
+                        directed_by: {
+                            name: "Lilly Wachowski",
+                        },
+                    },
+                },
+            ],
+        });
+    });
+
+    test("1 to 1 relationship with auth validate type FAIL", async () => {
+        const Movie = testHelper.createUniqueType("Movie");
+        const Person = testHelper.createUniqueType("Person");
+
+        const typeDefs = /* GraphQL */ `
+            type ${Movie} @node @authorization(validate: [{ where: { node: { directed_by: { name: "$jwt.custom_value" } } } }]) {
+                title: String
+                released: Int
+                directed_by: ${Person}!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:DIRECTED]-(director:${Person})
+                        RETURN director
+                        """
+                        columnName: "director"
+                    )
+            }
+
+            type ${Person} @node {
+                name: String
+                directed: ${Movie}!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:DIRECTED]->(movie:${Movie})
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        const token = testHelper.createBearerToken("secret", { custom_value: "Something Wrong" });
+
+        await testHelper.initNeo4jGraphQL({
+            typeDefs,
+            features: {
+                authorization: {
+                    key: "secret",
+                },
+            },
+        });
+        await testHelper.executeCypher(
+            `
+            CREATE (m:${Movie} { title: "The Matrix", released: 1999 })
+            CREATE (m2:${Movie} { title: "The Matrix Reloaded", released: 2003 })
+            CREATE (a:${Person} { name: "Keanu Reeves" })
+            CREATE (a)-[:ACTED_IN]->(m)
+            CREATE (a)-[:ACTED_IN]->(m2)
+            CREATE (a5:${Person} { name: "Lilly Wachowski" })
+            CREATE (a5)-[:DIRECTED]->(m)
+            `,
+            {}
+        );
+
+        const query = /* GraphQL */ `
+            query {
+                ${Person.plural}(where: { directed: { title: "The Matrix" } }) {
+                    directed {
+                        title
+                        directed_by {
+                            name
+                        }
+                    }
+                }
+            }
+        `;
+
+        const gqlResult = await testHelper.executeGraphQLWithToken(query, token);
+
+        expect(gqlResult.errors).toHaveLength(1);
+        expect(gqlResult.errors?.[0]?.message).toBe("Forbidden");
+    });
+
+    test("1 to 1 relationship with auth validate field PASS", async () => {
+        const Movie = testHelper.createUniqueType("Movie");
+        const Person = testHelper.createUniqueType("Person");
+
+        const typeDefs = /* GraphQL */ `
+            type ${Movie} @node {
+                title: String
+                released: Int
+                directed_by: ${Person}! @authorization(validate: [{ where: { node: { directed_by: { name: "$jwt.custom_value" } } } }])
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:DIRECTED]-(director:${Person})
+                        RETURN director
+                        """
+                        columnName: "director"
+                    )
+            }
+
+            type ${Person} @node {
+                name: String
+                directed: ${Movie}!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:DIRECTED]->(movie:${Movie})
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        const token = testHelper.createBearerToken("secret", { custom_value: "Lilly Wachowski" });
+
+        await testHelper.initNeo4jGraphQL({
+            typeDefs,
+            features: {
+                authorization: {
+                    key: "secret",
+                },
+            },
+        });
+        await testHelper.executeCypher(
+            `
+            CREATE (m:${Movie} { title: "The Matrix", released: 1999 })
+            CREATE (m2:${Movie} { title: "The Matrix Reloaded", released: 2003 })
+            CREATE (a:${Person} { name: "Keanu Reeves" })
+            CREATE (a)-[:ACTED_IN]->(m)
+            CREATE (a)-[:ACTED_IN]->(m2)
+            CREATE (a5:${Person} { name: "Lilly Wachowski" })
+            CREATE (a5)-[:DIRECTED]->(m)
+            `,
+            {}
+        );
+
+        const query = /* GraphQL */ `
+            query {
+                ${Person.plural}(where: { directed: { title: "The Matrix" } }) {
+                    directed {
+                        title
+                        directed_by {
+                            name
+                        }
+                    }
+                }
+            }
+        `;
+
+        const gqlResult = await testHelper.executeGraphQLWithToken(query, token);
+
+        expect(gqlResult.errors).toBeFalsy();
+        expect(gqlResult?.data).toEqual({
+            [Person.plural]: [
+                {
+                    directed: {
+                        title: "The Matrix",
+                        directed_by: {
+                            name: "Lilly Wachowski",
+                        },
+                    },
+                },
+            ],
+        });
+    });
+
+    test("1 to 1 relationship with auth validate field FAIL", async () => {
+        const Movie = testHelper.createUniqueType("Movie");
+        const Person = testHelper.createUniqueType("Person");
+
+        const typeDefs = /* GraphQL */ `
+            type ${Movie} @node {
+                title: String
+                released: Int
+                directed_by: ${Person}! @authorization(validate: [{ where: { node: { directed_by: { name: "$jwt.custom_value" } } } }])
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:DIRECTED]-(director:${Person})
+                        RETURN director
+                        """
+                        columnName: "director"
+                    )
+            }
+
+            type ${Person} @node {
+                name: String
+                directed: ${Movie}!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:DIRECTED]->(movie:${Movie})
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        const token = testHelper.createBearerToken("secret", { custom_value: "Something Wrong" });
+
+        await testHelper.initNeo4jGraphQL({
+            typeDefs,
+            features: {
+                authorization: {
+                    key: "secret",
+                },
+            },
+        });
+        await testHelper.executeCypher(
+            `
+            CREATE (m:${Movie} { title: "The Matrix", released: 1999 })
+            CREATE (m2:${Movie} { title: "The Matrix Reloaded", released: 2003 })
+            CREATE (a:${Person} { name: "Keanu Reeves" })
+            CREATE (a)-[:ACTED_IN]->(m)
+            CREATE (a)-[:ACTED_IN]->(m2)
+            CREATE (a5:${Person} { name: "Lilly Wachowski" })
+            CREATE (a5)-[:DIRECTED]->(m)
+            `,
+            {}
+        );
+
+        const query = /* GraphQL */ `
+            query {
+                ${Person.plural}(where: { directed: { title: "The Matrix" } }) {
+                    directed {
+                        title
+                        directed_by {
+                            name
+                        }
+                    }
+                }
+            }
+        `;
+
+        const gqlResult = await testHelper.executeGraphQLWithToken(query, token);
+
+        expect(gqlResult.errors).toHaveLength(1);
+        expect(gqlResult.errors?.[0]?.message).toBe("Forbidden");
+    });
+
+    test("1 to 1 relationship with nested selection", async () => {
+        const Movie = testHelper.createUniqueType("Movie");
+        const Person = testHelper.createUniqueType("Person");
+
+        const typeDefs = /* GraphQL */ `
+            type ${Movie} @node {
+                title: String
+                released: Int
+                actors: [${Person}!]! @relationship(type: "ACTED_IN", direction: IN)
+                directed_by: ${Person}!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:DIRECTED]-(director:${Person})
+                        RETURN director
+                        """
+                        columnName: "director"
+                    )
+            }
+
+            type ${Person} @node {
+                name: String
+                movies: [${Movie}!]! @relationship(type: "ACTED_IN", direction: OUT)
+                directed: ${Movie}!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:DIRECTED]->(movie:${Movie})
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        await testHelper.initNeo4jGraphQL({ typeDefs });
+        await testHelper.executeCypher(
+            `
+            CREATE (m:${Movie} { title: "The Matrix", released: 1999 })
+            CREATE (m2:${Movie} { title: "The Matrix Reloaded", released: 2003 })
+            CREATE (m3:${Movie} { title: "The Matrix Revolutions", released: 2003 })
+            CREATE (a:${Person} { name: "Keanu Reeves" })
+            CREATE (a)-[:ACTED_IN]->(m)
+            CREATE (a)-[:ACTED_IN]->(m2)
+            CREATE (a)-[:ACTED_IN]->(m3)
+            CREATE (a2:${Person} { name: "Jada Pinkett Smith" })
+            CREATE (a2)-[:ACTED_IN]->(m2)
+            CREATE (a2)-[:ACTED_IN]->(m3)
+            CREATE (a3:${Person} { name: "Director Person" })
+            CREATE (a3)-[:DIRECTED]->(m)
+            CREATE (a4:${Person} { name: "Lana Wachowski" })
+            CREATE (a4)-[:DIRECTED]->(m2)
+            CREATE (a5:${Person} { name: "Lilly Wachowski" })
+            CREATE (a5)-[:DIRECTED]->(m3)
+            `,
+            {}
+        );
+
+        const query = /* GraphQL */ `
+            query {
+                ${Person.plural}(where: { directed: { title: "The Matrix" } }) {
+                    directed {
+                        title
+                        directed_by {
+                            name
+                        }
+                        actors {
+                            name
+                            movies {
+                                directed_by {
+                                    name
+                                }
+                                title
+                            }
+                        }
+                    }
+                }
+            }
+        `;
+
+        const gqlResult = await testHelper.executeGraphQL(query);
+
+        expect(gqlResult.errors).toBeFalsy();
+        expect(gqlResult?.data).toEqual({
+            [Person.plural]: [
+                {
+                    directed: {
+                        title: "The Matrix",
+                        directed_by: {
+                            name: "Director Person",
+                        },
+                        actors: expect.toIncludeSameMembers([
+                            {
+                                name: "Keanu Reeves",
+                                movies: expect.toIncludeSameMembers([
+                                    {
+                                        directed_by: {
+                                            name: "Director Person",
+                                        },
+                                        title: "The Matrix",
+                                    },
+                                    {
+                                        directed_by: {
+                                            name: "Lana Wachowski",
+                                        },
+                                        title: "The Matrix Reloaded",
+                                    },
+                                    {
+                                        directed_by: {
+                                            name: "Lilly Wachowski",
+                                        },
+                                        title: "The Matrix Revolutions",
+                                    },
+                                ]),
+                            },
+                        ]),
+                    },
+                },
+            ],
+        });
+    });
+
+    test("1 to 1 relationship with connection", async () => {
+        const Movie = testHelper.createUniqueType("Movie");
+        const Person = testHelper.createUniqueType("Person");
+
+        const typeDefs = /* GraphQL */ `
+            type ${Movie} @node {
+                title: String
+                released: Int
+                actors: [${Person}!]! @relationship(type: "ACTED_IN", direction: IN)
+                directed_by: ${Person}!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:DIRECTED]-(director:${Person})
+                        RETURN director
+                        """
+                        columnName: "director"
+                    )
+            }
+
+            type ${Person} @node {
+                name: String
+                movies: [${Movie}!]! @relationship(type: "ACTED_IN", direction: OUT)
+                directed: ${Movie}!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:DIRECTED]->(movie:${Movie})
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        await testHelper.initNeo4jGraphQL({ typeDefs });
+        await testHelper.executeCypher(
+            `
+            CREATE (m:${Movie} { title: "The Matrix", released: 1999 })
+            CREATE (m2:${Movie} { title: "The Matrix Reloaded", released: 2003 })
+            CREATE (m3:${Movie} { title: "The Matrix Revolutions", released: 2003 })
+            CREATE (a:${Person} { name: "Keanu Reeves" })
+            CREATE (a)-[:ACTED_IN]->(m)
+            CREATE (a)-[:ACTED_IN]->(m2)
+            CREATE (a)-[:ACTED_IN]->(m3)
+            CREATE (a2:${Person} { name: "Jada Pinkett Smith" })
+            CREATE (a2)-[:ACTED_IN]->(m2)
+            CREATE (a2)-[:ACTED_IN]->(m3)
+            CREATE (a5:${Person} { name: "Lilly Wachowski" })
+            CREATE (a5)-[:DIRECTED]->(m)
+            CREATE (a5)-[:DIRECTED]->(m2)
+            CREATE (a5)-[:DIRECTED]->(m3)
+            `,
+            {}
+        );
+
+        const query = /* GraphQL */ `
+            query {
+                ${Movie.plural}(where: { directed_by: { name: "Lilly Wachowski"}, title_ENDS_WITH: "Matrix" }) {
+                    actorsConnection {
+                        totalCount
+                        edges {
+                            node {
+                                name
+                            }
+                        }
+                    }
+                }
+            }
+        `;
+
+        const gqlResult = await testHelper.executeGraphQL(query);
+
+        expect(gqlResult.errors).toBeFalsy();
+        expect(gqlResult?.data).toEqual({
+            [Movie.plural]: [
+                {
+                    ["actorsConnection"]: {
+                        totalCount: 1,
+                        edges: [
+                            {
+                                node: {
+                                    name: "Keanu Reeves",
+                                },
+                            },
+                        ],
+                    },
+                },
+            ],
+        });
+    });
+});

--- a/packages/graphql/tests/schema/directives/cypher.test.ts
+++ b/packages/graphql/tests/schema/directives/cypher.test.ts
@@ -351,14 +351,9 @@ describe("Cypher", () => {
               AND: [MovieWhere!]
               NOT: MovieWhere
               OR: [MovieWhere!]
-<<<<<<< HEAD
+              actor: ActorWhere
               custom_big_int: BigInt @deprecated(reason: \\"Please use the explicit _EQ version\\")
               custom_big_int_EQ: BigInt
-=======
-              actor: ActorWhere
-              actor_NOT: ActorWhere @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
-              custom_big_int: BigInt
->>>>>>> d40590e36 (Merge pull request #5723 from mjfwebb/cypher-filtering-1-to-1-relationships)
               custom_big_int_GT: BigInt
               custom_big_int_GTE: BigInt
               custom_big_int_IN: [BigInt]
@@ -596,7 +591,7 @@ describe("Cypher", () => {
 
     test("Filters should not be generated on list custom cypher fields", async () => {
         const typeDefs = /* GraphQL */ `
-            type Movie {
+            type Movie @node {
                 custom_cypher_string_list: [String]
                     @cypher(statement: "RETURN ['a','b','c'] as list", columnName: "list")
             }
@@ -717,11 +712,7 @@ describe("Cypher", () => {
 
     test("Filters should not be generated on custom cypher fields with arguments", async () => {
         const typeDefs = /* GraphQL */ `
-<<<<<<< HEAD
-            type Movie {
-=======
             type Movie @node {
->>>>>>> d40590e36 (Merge pull request #5723 from mjfwebb/cypher-filtering-1-to-1-relationships)
                 custom_string_with_param(param: String): String
                     @cypher(statement: "RETURN $param as c", columnName: "c")
             }
@@ -856,11 +847,6 @@ describe("Cypher", () => {
         `);
     });
 
-<<<<<<< HEAD
-    test("Filters should not be generated on Relationship/Object custom cypher fields", async () => {
-        const typeDefs = /* GraphQL */ `
-            type Movie {
-=======
     test("Union: Filters should not be generated for Relationship/Object custom cypher fields", async () => {
         const typeDefs = /* GraphQL */ `
             union Content = Blog | Post
@@ -933,7 +919,6 @@ describe("Cypher", () => {
             Fields to sort Blogs by. The order in which sorts are applied is not guaranteed when specifying many fields in one BlogSort object.
             \\"\\"\\"
             input BlogSort {
-              post: SortDirection
               title: SortDirection
             }
 
@@ -946,16 +931,11 @@ describe("Cypher", () => {
               NOT: BlogWhere
               OR: [BlogWhere!]
               post: PostWhere
-              post_NOT: PostWhere @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
-              title: String
+              title: String @deprecated(reason: \\"Please use the explicit _EQ version\\")
               title_CONTAINS: String
               title_ENDS_WITH: String
+              title_EQ: String
               title_IN: [String]
-              title_NOT: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
-              title_NOT_CONTAINS: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
-              title_NOT_ENDS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
-              title_NOT_IN: [String] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
-              title_NOT_STARTS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
               title_STARTS_WITH: String
             }
 
@@ -981,7 +961,6 @@ describe("Cypher", () => {
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
             type CreateInfo {
-              bookmark: String @deprecated(reason: \\"This field has been deprecated because bookmarks are now handled by the driver.\\")
               nodesCreated: Int!
               relationshipsCreated: Int!
             }
@@ -995,7 +974,6 @@ describe("Cypher", () => {
             Information about the number of nodes and relationships deleted during a delete mutation
             \\"\\"\\"
             type DeleteInfo {
-              bookmark: String @deprecated(reason: \\"This field has been deprecated because bookmarks are now handled by the driver.\\")
               nodesDeleted: Int!
               relationshipsDeleted: Int!
             }
@@ -1059,15 +1037,11 @@ describe("Cypher", () => {
               AND: [PostWhere!]
               NOT: PostWhere
               OR: [PostWhere!]
-              content: String
+              content: String @deprecated(reason: \\"Please use the explicit _EQ version\\")
               content_CONTAINS: String
               content_ENDS_WITH: String
+              content_EQ: String
               content_IN: [String]
-              content_NOT: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
-              content_NOT_CONTAINS: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
-              content_NOT_ENDS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
-              content_NOT_IN: [String] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
-              content_NOT_STARTS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
               content_STARTS_WITH: String
             }
 
@@ -1078,13 +1052,13 @@ describe("Cypher", () => {
             }
 
             type Query {
-              blogs(options: BlogOptions, where: BlogWhere): [Blog!]!
+              blogs(limit: Int, offset: Int, options: BlogOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [BlogSort!], where: BlogWhere): [Blog!]!
               blogsAggregate(where: BlogWhere): BlogAggregateSelection!
-              blogsConnection(after: String, first: Int, sort: [BlogSort], where: BlogWhere): BlogsConnection!
-              contents(options: QueryOptions, where: ContentWhere): [Content!]!
-              posts(options: PostOptions, where: PostWhere): [Post!]!
+              blogsConnection(after: String, first: Int, sort: [BlogSort!], where: BlogWhere): BlogsConnection!
+              contents(limit: Int, offset: Int, options: QueryOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: ContentWhere): [Content!]!
+              posts(limit: Int, offset: Int, options: PostOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PostSort!], where: PostWhere): [Post!]!
               postsAggregate(where: PostWhere): PostAggregateSelection!
-              postsConnection(after: String, first: Int, sort: [PostSort], where: PostWhere): PostsConnection!
+              postsConnection(after: String, first: Int, sort: [PostSort!], where: PostWhere): PostsConnection!
             }
 
             \\"\\"\\"Input type for options that can be specified on a query operation.\\"\\"\\"
@@ -1115,7 +1089,6 @@ describe("Cypher", () => {
             Information about the number of nodes and relationships created and deleted during an update mutation
             \\"\\"\\"
             type UpdateInfo {
-              bookmark: String @deprecated(reason: \\"This field has been deprecated because bookmarks are now handled by the driver.\\")
               nodesCreated: Int!
               nodesDeleted: Int!
               relationshipsCreated: Int!
@@ -1137,7 +1110,6 @@ describe("Cypher", () => {
             }
 
             type Movie implements Production @node {
->>>>>>> d40590e36 (Merge pull request #5723 from mjfwebb/cypher-filtering-1-to-1-relationships)
                 actors: [Actor]
                     @cypher(
                         statement: """
@@ -1220,7 +1192,6 @@ describe("Cypher", () => {
             Fields to sort Actors by. The order in which sorts are applied is not guaranteed when specifying many fields in one ActorSort object.
             \\"\\"\\"
             input ActorSort {
-              movie: SortDirection
               name: SortDirection
             }
 
@@ -1232,20 +1203,12 @@ describe("Cypher", () => {
               AND: [ActorWhere!]
               NOT: ActorWhere
               OR: [ActorWhere!]
-<<<<<<< HEAD
-              name: String @deprecated(reason: \\"Please use the explicit _EQ version\\")
-=======
               movie: MovieWhere
-              movie_NOT: MovieWhere @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
-              name: String
+              name: String @deprecated(reason: \\"Please use the explicit _EQ version\\")
               name_CONTAINS: String
               name_ENDS_WITH: String
+              name_EQ: String
               name_IN: [String]
-              name_NOT: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
-              name_NOT_CONTAINS: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
-              name_NOT_ENDS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
-              name_NOT_IN: [String] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
-              name_NOT_STARTS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
               name_STARTS_WITH: String
             }
 
@@ -1264,7 +1227,6 @@ describe("Cypher", () => {
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
             type CreateInfo {
-              bookmark: String @deprecated(reason: \\"This field has been deprecated because bookmarks are now handled by the driver.\\")
               nodesCreated: Int!
               relationshipsCreated: Int!
             }
@@ -1278,7 +1240,6 @@ describe("Cypher", () => {
             Information about the number of nodes and relationships deleted during a delete mutation
             \\"\\"\\"
             type DeleteInfo {
-              bookmark: String @deprecated(reason: \\"This field has been deprecated because bookmarks are now handled by the driver.\\")
               nodesDeleted: Int!
               relationshipsDeleted: Int!
             }
@@ -1307,17 +1268,6 @@ describe("Cypher", () => {
             input MovieOptions {
               limit: Int
               offset: Int
-              \\"\\"\\"
-              Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array.
-              \\"\\"\\"
-              sort: [MovieSort!]
-            }
-
-            \\"\\"\\"
-            Fields to sort Movies by. The order in which sorts are applied is not guaranteed when specifying many fields in one MovieSort object.
-            \\"\\"\\"
-            input MovieSort {
-              actor: SortDirection
             }
 
             input MovieUpdateInput {
@@ -1332,7 +1282,6 @@ describe("Cypher", () => {
               NOT: MovieWhere
               OR: [MovieWhere!]
               actor: ActorWhere
-              actor_NOT: ActorWhere @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
             }
 
             type MoviesConnection {
@@ -1395,13 +1344,13 @@ describe("Cypher", () => {
             }
 
             type Query {
-              actors(options: ActorOptions, where: ActorWhere): [Actor!]!
+              actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
               actorsAggregate(where: ActorWhere): ActorAggregateSelection!
-              actorsConnection(after: String, first: Int, sort: [ActorSort], where: ActorWhere): ActorsConnection!
-              movies(options: MovieOptions, where: MovieWhere): [Movie!]!
+              actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
+              movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: MovieWhere): [Movie!]!
               moviesAggregate(where: MovieWhere): MovieAggregateSelection!
-              moviesConnection(after: String, first: Int, sort: [MovieSort], where: MovieWhere): MoviesConnection!
-              productions(options: ProductionOptions, where: ProductionWhere): [Production!]!
+              moviesConnection(after: String, first: Int, where: MovieWhere): MoviesConnection!
+              productions(limit: Int, offset: Int, options: ProductionOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: ProductionWhere): [Production!]!
               productionsAggregate(where: ProductionWhere): ProductionAggregateSelection!
               productionsConnection(after: String, first: Int, where: ProductionWhere): ProductionsConnection!
             }
@@ -1428,7 +1377,6 @@ describe("Cypher", () => {
             Information about the number of nodes and relationships created and deleted during an update mutation
             \\"\\"\\"
             type UpdateInfo {
-              bookmark: String @deprecated(reason: \\"This field has been deprecated because bookmarks are now handled by the driver.\\")
               nodesCreated: Int!
               nodesDeleted: Int!
               relationshipsCreated: Int!
@@ -1527,7 +1475,6 @@ describe("Cypher", () => {
             Fields to sort Actors by. The order in which sorts are applied is not guaranteed when specifying many fields in one ActorSort object.
             \\"\\"\\"
             input ActorSort {
-              movie: SortDirection
               name: SortDirection
             }
 
@@ -1540,9 +1487,7 @@ describe("Cypher", () => {
               NOT: ActorWhere
               OR: [ActorWhere!]
               movie: MovieWhere
-              movie_NOT: MovieWhere @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
-              name: String
->>>>>>> d40590e36 (Merge pull request #5723 from mjfwebb/cypher-filtering-1-to-1-relationships)
+              name: String @deprecated(reason: \\"Please use the explicit _EQ version\\")
               name_CONTAINS: String
               name_ENDS_WITH: String
               name_EQ: String
@@ -1606,17 +1551,6 @@ describe("Cypher", () => {
             input MovieOptions {
               limit: Int
               offset: Int
-              \\"\\"\\"
-              Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array.
-              \\"\\"\\"
-              sort: [MovieSort!]
-            }
-
-            \\"\\"\\"
-            Fields to sort Movies by. The order in which sorts are applied is not guaranteed when specifying many fields in one MovieSort object.
-            \\"\\"\\"
-            input MovieSort {
-              actor: SortDirection
             }
 
             input MovieUpdateInput {
@@ -1631,7 +1565,6 @@ describe("Cypher", () => {
               NOT: MovieWhere
               OR: [MovieWhere!]
               actor: ActorWhere
-              actor_NOT: ActorWhere @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
             }
 
             type MoviesConnection {
@@ -1663,7 +1596,7 @@ describe("Cypher", () => {
               actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: MovieWhere): [Movie!]!
               moviesAggregate(where: MovieWhere): MovieAggregateSelection!
-              moviesConnection(after: String, first: Int, sort: [MovieSort], where: MovieWhere): MoviesConnection!
+              moviesConnection(after: String, first: Int, where: MovieWhere): MoviesConnection!
             }
 
             \\"\\"\\"An enum for sorting in either ascending or descending order.\\"\\"\\"
@@ -1953,11 +1886,7 @@ describe("Cypher", () => {
 
     test("Filters should not be generated on custom cypher fields for subscriptions", async () => {
         const typeDefs = /* GraphQL */ `
-<<<<<<< HEAD
-            type Movie {
-=======
             type Movie @node {
->>>>>>> d40590e36 (Merge pull request #5723 from mjfwebb/cypher-filtering-1-to-1-relationships)
                 title: String
                 custom_title: String @cypher(statement: "RETURN 'hello' as t", columnName: "t")
             }

--- a/packages/graphql/tests/schema/directives/cypher.test.ts
+++ b/packages/graphql/tests/schema/directives/cypher.test.ts
@@ -351,8 +351,14 @@ describe("Cypher", () => {
               AND: [MovieWhere!]
               NOT: MovieWhere
               OR: [MovieWhere!]
+<<<<<<< HEAD
               custom_big_int: BigInt @deprecated(reason: \\"Please use the explicit _EQ version\\")
               custom_big_int_EQ: BigInt
+=======
+              actor: ActorWhere
+              actor_NOT: ActorWhere @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              custom_big_int: BigInt
+>>>>>>> d40590e36 (Merge pull request #5723 from mjfwebb/cypher-filtering-1-to-1-relationships)
               custom_big_int_GT: BigInt
               custom_big_int_GTE: BigInt
               custom_big_int_IN: [BigInt]
@@ -711,7 +717,11 @@ describe("Cypher", () => {
 
     test("Filters should not be generated on custom cypher fields with arguments", async () => {
         const typeDefs = /* GraphQL */ `
+<<<<<<< HEAD
             type Movie {
+=======
+            type Movie @node {
+>>>>>>> d40590e36 (Merge pull request #5723 from mjfwebb/cypher-filtering-1-to-1-relationships)
                 custom_string_with_param(param: String): String
                     @cypher(statement: "RETURN $param as c", columnName: "c")
             }
@@ -846,9 +856,288 @@ describe("Cypher", () => {
         `);
     });
 
+<<<<<<< HEAD
     test("Filters should not be generated on Relationship/Object custom cypher fields", async () => {
         const typeDefs = /* GraphQL */ `
             type Movie {
+=======
+    test("Union: Filters should not be generated for Relationship/Object custom cypher fields", async () => {
+        const typeDefs = /* GraphQL */ `
+            union Content = Blog | Post
+
+            type Blog @node {
+                title: String
+                posts: [Post!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:HAS_POST]->(post)
+                        RETURN post
+                        """
+                        columnName: "post"
+                    )
+                post: Post
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:HAS_POST]->(post)
+                        RETURN post
+                        LIMIT 1
+                        """
+                        columnName: "post"
+                    )
+            }
+
+            type Post @node {
+                content: String
+            }
+        `;
+
+        const neoSchema = new Neo4jGraphQL({ typeDefs });
+        const printedSchema = printSchemaWithDirectives(lexicographicSortSchema(await neoSchema.getSchema()));
+
+        expect(printedSchema).toMatchInlineSnapshot(`
+            "schema {
+              query: Query
+              mutation: Mutation
+            }
+
+            type Blog {
+              post: Post
+              posts: [Post!]!
+              title: String
+            }
+
+            type BlogAggregateSelection {
+              count: Int!
+              title: StringAggregateSelection!
+            }
+
+            input BlogCreateInput {
+              title: String
+            }
+
+            type BlogEdge {
+              cursor: String!
+              node: Blog!
+            }
+
+            input BlogOptions {
+              limit: Int
+              offset: Int
+              \\"\\"\\"
+              Specify one or more BlogSort objects to sort Blogs by. The sorts will be applied in the order in which they are arranged in the array.
+              \\"\\"\\"
+              sort: [BlogSort!]
+            }
+
+            \\"\\"\\"
+            Fields to sort Blogs by. The order in which sorts are applied is not guaranteed when specifying many fields in one BlogSort object.
+            \\"\\"\\"
+            input BlogSort {
+              post: SortDirection
+              title: SortDirection
+            }
+
+            input BlogUpdateInput {
+              title: String
+            }
+
+            input BlogWhere {
+              AND: [BlogWhere!]
+              NOT: BlogWhere
+              OR: [BlogWhere!]
+              post: PostWhere
+              post_NOT: PostWhere @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              title: String
+              title_CONTAINS: String
+              title_ENDS_WITH: String
+              title_IN: [String]
+              title_NOT: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              title_NOT_CONTAINS: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              title_NOT_ENDS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              title_NOT_IN: [String] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              title_NOT_STARTS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              title_STARTS_WITH: String
+            }
+
+            type BlogsConnection {
+              edges: [BlogEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            union Content = Blog | Post
+
+            input ContentWhere {
+              Blog: BlogWhere
+              Post: PostWhere
+            }
+
+            type CreateBlogsMutationResponse {
+              blogs: [Blog!]!
+              info: CreateInfo!
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships created during a create mutation
+            \\"\\"\\"
+            type CreateInfo {
+              bookmark: String @deprecated(reason: \\"This field has been deprecated because bookmarks are now handled by the driver.\\")
+              nodesCreated: Int!
+              relationshipsCreated: Int!
+            }
+
+            type CreatePostsMutationResponse {
+              info: CreateInfo!
+              posts: [Post!]!
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships deleted during a delete mutation
+            \\"\\"\\"
+            type DeleteInfo {
+              bookmark: String @deprecated(reason: \\"This field has been deprecated because bookmarks are now handled by the driver.\\")
+              nodesDeleted: Int!
+              relationshipsDeleted: Int!
+            }
+
+            type Mutation {
+              createBlogs(input: [BlogCreateInput!]!): CreateBlogsMutationResponse!
+              createPosts(input: [PostCreateInput!]!): CreatePostsMutationResponse!
+              deleteBlogs(where: BlogWhere): DeleteInfo!
+              deletePosts(where: PostWhere): DeleteInfo!
+              updateBlogs(update: BlogUpdateInput, where: BlogWhere): UpdateBlogsMutationResponse!
+              updatePosts(update: PostUpdateInput, where: PostWhere): UpdatePostsMutationResponse!
+            }
+
+            \\"\\"\\"Pagination information (Relay)\\"\\"\\"
+            type PageInfo {
+              endCursor: String
+              hasNextPage: Boolean!
+              hasPreviousPage: Boolean!
+              startCursor: String
+            }
+
+            type Post {
+              content: String
+            }
+
+            type PostAggregateSelection {
+              content: StringAggregateSelection!
+              count: Int!
+            }
+
+            input PostCreateInput {
+              content: String
+            }
+
+            type PostEdge {
+              cursor: String!
+              node: Post!
+            }
+
+            input PostOptions {
+              limit: Int
+              offset: Int
+              \\"\\"\\"
+              Specify one or more PostSort objects to sort Posts by. The sorts will be applied in the order in which they are arranged in the array.
+              \\"\\"\\"
+              sort: [PostSort!]
+            }
+
+            \\"\\"\\"
+            Fields to sort Posts by. The order in which sorts are applied is not guaranteed when specifying many fields in one PostSort object.
+            \\"\\"\\"
+            input PostSort {
+              content: SortDirection
+            }
+
+            input PostUpdateInput {
+              content: String
+            }
+
+            input PostWhere {
+              AND: [PostWhere!]
+              NOT: PostWhere
+              OR: [PostWhere!]
+              content: String
+              content_CONTAINS: String
+              content_ENDS_WITH: String
+              content_IN: [String]
+              content_NOT: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              content_NOT_CONTAINS: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              content_NOT_ENDS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              content_NOT_IN: [String] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              content_NOT_STARTS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              content_STARTS_WITH: String
+            }
+
+            type PostsConnection {
+              edges: [PostEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type Query {
+              blogs(options: BlogOptions, where: BlogWhere): [Blog!]!
+              blogsAggregate(where: BlogWhere): BlogAggregateSelection!
+              blogsConnection(after: String, first: Int, sort: [BlogSort], where: BlogWhere): BlogsConnection!
+              contents(options: QueryOptions, where: ContentWhere): [Content!]!
+              posts(options: PostOptions, where: PostWhere): [Post!]!
+              postsAggregate(where: PostWhere): PostAggregateSelection!
+              postsConnection(after: String, first: Int, sort: [PostSort], where: PostWhere): PostsConnection!
+            }
+
+            \\"\\"\\"Input type for options that can be specified on a query operation.\\"\\"\\"
+            input QueryOptions {
+              limit: Int
+              offset: Int
+            }
+
+            \\"\\"\\"An enum for sorting in either ascending or descending order.\\"\\"\\"
+            enum SortDirection {
+              \\"\\"\\"Sort by field values in ascending order.\\"\\"\\"
+              ASC
+              \\"\\"\\"Sort by field values in descending order.\\"\\"\\"
+              DESC
+            }
+
+            type StringAggregateSelection {
+              longest: String
+              shortest: String
+            }
+
+            type UpdateBlogsMutationResponse {
+              blogs: [Blog!]!
+              info: UpdateInfo!
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships created and deleted during an update mutation
+            \\"\\"\\"
+            type UpdateInfo {
+              bookmark: String @deprecated(reason: \\"This field has been deprecated because bookmarks are now handled by the driver.\\")
+              nodesCreated: Int!
+              nodesDeleted: Int!
+              relationshipsCreated: Int!
+              relationshipsDeleted: Int!
+            }
+
+            type UpdatePostsMutationResponse {
+              info: UpdateInfo!
+              posts: [Post!]!
+            }"
+        `);
+    });
+
+    test("Interface: Filters should not be generated for Relationship/Object custom cypher fields", async () => {
+        const typeDefs = /* GraphQL */ `
+            interface Production {
+                actor: Actor
+                actors: [Actor]
+            }
+
+            type Movie implements Production @node {
+>>>>>>> d40590e36 (Merge pull request #5723 from mjfwebb/cypher-filtering-1-to-1-relationships)
                 actors: [Actor]
                     @cypher(
                         statement: """
@@ -857,15 +1146,33 @@ describe("Cypher", () => {
                         """
                         columnName: "actor"
                     )
+                actor: Actor
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(actor:Actor)
+                        RETURN actor
+                        LIMIT 1
+                        """
+                        columnName: "actor"
+                    )
             }
 
-            type Actor {
+            type Actor @node {
                 name: String
                 movies: [Movie]
                     @cypher(
                         statement: """
                         MATCH (this)-[:ACTED_IN]->(movie:Movie)
                         RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+                movie: Movie
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(movie:Movie)
+                        RETURN movie
+                        LIMIT 1
                         """
                         columnName: "movie"
                     )
@@ -881,6 +1188,7 @@ describe("Cypher", () => {
             }
 
             type Actor {
+              movie: Movie
               movies: [Movie]
               name: String
             }
@@ -912,6 +1220,7 @@ describe("Cypher", () => {
             Fields to sort Actors by. The order in which sorts are applied is not guaranteed when specifying many fields in one ActorSort object.
             \\"\\"\\"
             input ActorSort {
+              movie: SortDirection
               name: SortDirection
             }
 
@@ -923,7 +1232,317 @@ describe("Cypher", () => {
               AND: [ActorWhere!]
               NOT: ActorWhere
               OR: [ActorWhere!]
+<<<<<<< HEAD
               name: String @deprecated(reason: \\"Please use the explicit _EQ version\\")
+=======
+              movie: MovieWhere
+              movie_NOT: MovieWhere @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              name: String
+              name_CONTAINS: String
+              name_ENDS_WITH: String
+              name_IN: [String]
+              name_NOT: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              name_NOT_CONTAINS: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              name_NOT_ENDS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              name_NOT_IN: [String] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              name_NOT_STARTS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              name_STARTS_WITH: String
+            }
+
+            type ActorsConnection {
+              edges: [ActorEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type CreateActorsMutationResponse {
+              actors: [Actor!]!
+              info: CreateInfo!
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships created during a create mutation
+            \\"\\"\\"
+            type CreateInfo {
+              bookmark: String @deprecated(reason: \\"This field has been deprecated because bookmarks are now handled by the driver.\\")
+              nodesCreated: Int!
+              relationshipsCreated: Int!
+            }
+
+            type CreateMoviesMutationResponse {
+              info: CreateInfo!
+              movies: [Movie!]!
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships deleted during a delete mutation
+            \\"\\"\\"
+            type DeleteInfo {
+              bookmark: String @deprecated(reason: \\"This field has been deprecated because bookmarks are now handled by the driver.\\")
+              nodesDeleted: Int!
+              relationshipsDeleted: Int!
+            }
+
+            type Movie implements Production {
+              actor: Actor
+              actors: [Actor]
+            }
+
+            type MovieAggregateSelection {
+              count: Int!
+            }
+
+            input MovieCreateInput {
+              \\"\\"\\"
+              Appears because this input type would be empty otherwise because this type is composed of just generated and/or relationship properties. See https://neo4j.com/docs/graphql-manual/current/troubleshooting/faqs/
+              \\"\\"\\"
+              _emptyInput: Boolean
+            }
+
+            type MovieEdge {
+              cursor: String!
+              node: Movie!
+            }
+
+            input MovieOptions {
+              limit: Int
+              offset: Int
+              \\"\\"\\"
+              Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array.
+              \\"\\"\\"
+              sort: [MovieSort!]
+            }
+
+            \\"\\"\\"
+            Fields to sort Movies by. The order in which sorts are applied is not guaranteed when specifying many fields in one MovieSort object.
+            \\"\\"\\"
+            input MovieSort {
+              actor: SortDirection
+            }
+
+            input MovieUpdateInput {
+              \\"\\"\\"
+              Appears because this input type would be empty otherwise because this type is composed of just generated and/or relationship properties. See https://neo4j.com/docs/graphql-manual/current/troubleshooting/faqs/
+              \\"\\"\\"
+              _emptyInput: Boolean
+            }
+
+            input MovieWhere {
+              AND: [MovieWhere!]
+              NOT: MovieWhere
+              OR: [MovieWhere!]
+              actor: ActorWhere
+              actor_NOT: ActorWhere @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+            }
+
+            type MoviesConnection {
+              edges: [MovieEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type Mutation {
+              createActors(input: [ActorCreateInput!]!): CreateActorsMutationResponse!
+              createMovies(input: [MovieCreateInput!]!): CreateMoviesMutationResponse!
+              deleteActors(where: ActorWhere): DeleteInfo!
+              deleteMovies(where: MovieWhere): DeleteInfo!
+              updateActors(update: ActorUpdateInput, where: ActorWhere): UpdateActorsMutationResponse!
+              updateMovies(update: MovieUpdateInput, where: MovieWhere): UpdateMoviesMutationResponse!
+            }
+
+            \\"\\"\\"Pagination information (Relay)\\"\\"\\"
+            type PageInfo {
+              endCursor: String
+              hasNextPage: Boolean!
+              hasPreviousPage: Boolean!
+              startCursor: String
+            }
+
+            interface Production {
+              actor: Actor
+              actors: [Actor]
+            }
+
+            type ProductionAggregateSelection {
+              count: Int!
+            }
+
+            type ProductionEdge {
+              cursor: String!
+              node: Production!
+            }
+
+            enum ProductionImplementation {
+              Movie
+            }
+
+            input ProductionOptions {
+              limit: Int
+              offset: Int
+            }
+
+            input ProductionWhere {
+              AND: [ProductionWhere!]
+              NOT: ProductionWhere
+              OR: [ProductionWhere!]
+              typename_IN: [ProductionImplementation!]
+            }
+
+            type ProductionsConnection {
+              edges: [ProductionEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type Query {
+              actors(options: ActorOptions, where: ActorWhere): [Actor!]!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsConnection(after: String, first: Int, sort: [ActorSort], where: ActorWhere): ActorsConnection!
+              movies(options: MovieOptions, where: MovieWhere): [Movie!]!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesConnection(after: String, first: Int, sort: [MovieSort], where: MovieWhere): MoviesConnection!
+              productions(options: ProductionOptions, where: ProductionWhere): [Production!]!
+              productionsAggregate(where: ProductionWhere): ProductionAggregateSelection!
+              productionsConnection(after: String, first: Int, where: ProductionWhere): ProductionsConnection!
+            }
+
+            \\"\\"\\"An enum for sorting in either ascending or descending order.\\"\\"\\"
+            enum SortDirection {
+              \\"\\"\\"Sort by field values in ascending order.\\"\\"\\"
+              ASC
+              \\"\\"\\"Sort by field values in descending order.\\"\\"\\"
+              DESC
+            }
+
+            type StringAggregateSelection {
+              longest: String
+              shortest: String
+            }
+
+            type UpdateActorsMutationResponse {
+              actors: [Actor!]!
+              info: UpdateInfo!
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships created and deleted during an update mutation
+            \\"\\"\\"
+            type UpdateInfo {
+              bookmark: String @deprecated(reason: \\"This field has been deprecated because bookmarks are now handled by the driver.\\")
+              nodesCreated: Int!
+              nodesDeleted: Int!
+              relationshipsCreated: Int!
+              relationshipsDeleted: Int!
+            }
+
+            type UpdateMoviesMutationResponse {
+              info: UpdateInfo!
+              movies: [Movie!]!
+            }"
+        `);
+    });
+
+    test("Filters should be generated only on 1:1 Relationship/Object custom cypher fields", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Movie @node {
+                actors: [Actor]
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(actor:Actor)
+                        RETURN actor
+                        """
+                        columnName: "actor"
+                    )
+                actor: Actor
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(actor:Actor)
+                        RETURN actor
+                        LIMIT 1
+                        """
+                        columnName: "actor"
+                    )
+            }
+
+            type Actor @node {
+                name: String
+                movies: [Movie]
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(movie:Movie)
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+                movie: Movie
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(movie:Movie)
+                        RETURN movie
+                        LIMIT 1
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+        const neoSchema = new Neo4jGraphQL({ typeDefs });
+        const printedSchema = printSchemaWithDirectives(lexicographicSortSchema(await neoSchema.getSchema()));
+
+        expect(printedSchema).toMatchInlineSnapshot(`
+            "schema {
+              query: Query
+              mutation: Mutation
+            }
+
+            type Actor {
+              movie: Movie
+              movies: [Movie]
+              name: String
+            }
+
+            type ActorAggregateSelection {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
+            input ActorCreateInput {
+              name: String
+            }
+
+            type ActorEdge {
+              cursor: String!
+              node: Actor!
+            }
+
+            input ActorOptions {
+              limit: Int
+              offset: Int
+              \\"\\"\\"
+              Specify one or more ActorSort objects to sort Actors by. The sorts will be applied in the order in which they are arranged in the array.
+              \\"\\"\\"
+              sort: [ActorSort!]
+            }
+
+            \\"\\"\\"
+            Fields to sort Actors by. The order in which sorts are applied is not guaranteed when specifying many fields in one ActorSort object.
+            \\"\\"\\"
+            input ActorSort {
+              movie: SortDirection
+              name: SortDirection
+            }
+
+            input ActorUpdateInput {
+              name: String
+            }
+
+            input ActorWhere {
+              AND: [ActorWhere!]
+              NOT: ActorWhere
+              OR: [ActorWhere!]
+              movie: MovieWhere
+              movie_NOT: MovieWhere @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              name: String
+>>>>>>> d40590e36 (Merge pull request #5723 from mjfwebb/cypher-filtering-1-to-1-relationships)
               name_CONTAINS: String
               name_ENDS_WITH: String
               name_EQ: String
@@ -964,6 +1583,7 @@ describe("Cypher", () => {
             }
 
             type Movie {
+              actor: Actor
               actors: [Actor]
             }
 
@@ -986,6 +1606,17 @@ describe("Cypher", () => {
             input MovieOptions {
               limit: Int
               offset: Int
+              \\"\\"\\"
+              Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array.
+              \\"\\"\\"
+              sort: [MovieSort!]
+            }
+
+            \\"\\"\\"
+            Fields to sort Movies by. The order in which sorts are applied is not guaranteed when specifying many fields in one MovieSort object.
+            \\"\\"\\"
+            input MovieSort {
+              actor: SortDirection
             }
 
             input MovieUpdateInput {
@@ -999,6 +1630,8 @@ describe("Cypher", () => {
               AND: [MovieWhere!]
               NOT: MovieWhere
               OR: [MovieWhere!]
+              actor: ActorWhere
+              actor_NOT: ActorWhere @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
             }
 
             type MoviesConnection {
@@ -1030,7 +1663,7 @@ describe("Cypher", () => {
               actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: MovieWhere): [Movie!]!
               moviesAggregate(where: MovieWhere): MovieAggregateSelection!
-              moviesConnection(after: String, first: Int, where: MovieWhere): MoviesConnection!
+              moviesConnection(after: String, first: Int, sort: [MovieSort], where: MovieWhere): MoviesConnection!
             }
 
             \\"\\"\\"An enum for sorting in either ascending or descending order.\\"\\"\\"
@@ -1320,7 +1953,11 @@ describe("Cypher", () => {
 
     test("Filters should not be generated on custom cypher fields for subscriptions", async () => {
         const typeDefs = /* GraphQL */ `
+<<<<<<< HEAD
             type Movie {
+=======
+            type Movie @node {
+>>>>>>> d40590e36 (Merge pull request #5723 from mjfwebb/cypher-filtering-1-to-1-relationships)
                 title: String
                 custom_title: String @cypher(statement: "RETURN 'hello' as t", columnName: "t")
             }

--- a/packages/graphql/tests/schema/issues/5631.test.ts
+++ b/packages/graphql/tests/schema/issues/5631.test.ts
@@ -185,6 +185,7 @@ describe("https://github.com/neo4j/graphql/issues/5631", () => {
               AND: [MovieWhere!]
               NOT: MovieWhere
               OR: [MovieWhere!]
+              custom_actor_with_zero_param: ActorWhere
             }
 
             type MoviesConnection {

--- a/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-one-to-one-relationship.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-one-to-one-relationship.test.ts
@@ -50,9 +50,9 @@ describe("cypher directive filtering - One To One Relationship", () => {
             }
         `;
 
-        const query = `
+        const query = /* GraphQL */ `
             query {
-                movies(where: { actor: { name: "Keanu Reeves" } }) {
+                movies(where: { actor: { name_EQ: "Keanu Reeves" } }) {
                     title
                 }
             }
@@ -118,9 +118,9 @@ describe("cypher directive filtering - One To One Relationship", () => {
             }
         `;
 
-        const query = `
+        const query = /* GraphQL */ `
             query {
-                movies(where: { released: 2003, actor: { name: "Keanu Reeves", age_GT: 30 } }) {
+                movies(where: { released: 2003, actor: { name_EQ: "Keanu Reeves", age_GT: 30 } }) {
                     title
                 }
             }
@@ -198,7 +198,7 @@ describe("cypher directive filtering - One To One Relationship", () => {
 
         const query = /* GraphQL */ `
             query {
-                movies(where: { actor: { name: "Keanu Reeves" } }) {
+                movies(where: { actor: { name_EQ: "Keanu Reeves" } }) {
                     title
                     actor {
                         name
@@ -280,7 +280,7 @@ describe("cypher directive filtering - One To One Relationship", () => {
 
         const query = /* GraphQL */ `
             query {
-                movies(where: { released: 2003, actor: null }) {
+                movies(where: { released_EQ: 2003, actor: null }) {
                     title
                 }
             }
@@ -392,7 +392,7 @@ describe("cypher directive filtering - One To One Relationship", () => {
         const typeDefs = /* GraphQL */ `
             type Movie
                 @node
-                @authorization(filter: [{ where: { node: { directed_by: { name: "$jwt.custom_value" } } } }]) {
+                @authorization(filter: [{ where: { node: { directed_by: { name_EQ: "$jwt.custom_value" } } } }]) {
                 title: String
                 released: Int
                 directed_by: Person!
@@ -431,7 +431,7 @@ describe("cypher directive filtering - One To One Relationship", () => {
 
         const query = /* GraphQL */ `
             query {
-                people(where: { directed: { title: "The Matrix" } }) {
+                people(where: { directed: { title_EQ: "The Matrix" } }) {
                     directed {
                         title
                         directed_by {
@@ -515,7 +515,7 @@ describe("cypher directive filtering - One To One Relationship", () => {
         const typeDefs = /* GraphQL */ `
             type Movie
                 @node
-                @authorization(filter: [{ where: { node: { directed_by: { name: "$jwt.custom_value" } } } }]) {
+                @authorization(filter: [{ where: { node: { directed_by: { name_EQ: "$jwt.custom_value" } } } }]) {
                 title: String
                 released: Int
                 directed_by: Person!
@@ -554,7 +554,7 @@ describe("cypher directive filtering - One To One Relationship", () => {
 
         const query = /* GraphQL */ `
             query {
-                people(where: { directed: { title: "The Matrix" } }) {
+                people(where: { directed: { title_EQ: "The Matrix" } }) {
                     directed {
                         title
                         directed_by {
@@ -640,7 +640,7 @@ describe("cypher directive filtering - One To One Relationship", () => {
                 title: String
                 released: Int
                 directed_by: Person!
-                    @authorization(filter: [{ where: { node: { directed_by: { name: "$jwt.custom_value" } } } }])
+                    @authorization(filter: [{ where: { node: { directed_by: { name_EQ: "$jwt.custom_value" } } } }])
                     @cypher(
                         statement: """
                         MATCH (this)<-[:DIRECTED]-(director:Person)
@@ -676,7 +676,7 @@ describe("cypher directive filtering - One To One Relationship", () => {
 
         const query = /* GraphQL */ `
             query {
-                people(where: { directed: { title: "The Matrix" } }) {
+                people(where: { directed: { title_EQ: "The Matrix" } }) {
                     directed {
                         title
                         directed_by {
@@ -762,7 +762,7 @@ describe("cypher directive filtering - One To One Relationship", () => {
                 title: String
                 released: Int
                 directed_by: Person!
-                    @authorization(filter: [{ where: { node: { directed_by: { name: "$jwt.custom_value" } } } }])
+                    @authorization(filter: [{ where: { node: { directed_by: { name_EQ: "$jwt.custom_value" } } } }])
                     @cypher(
                         statement: """
                         MATCH (this)<-[:DIRECTED]-(director:Person)
@@ -798,7 +798,7 @@ describe("cypher directive filtering - One To One Relationship", () => {
 
         const query = /* GraphQL */ `
             query {
-                people(where: { directed: { title: "The Matrix" } }) {
+                people(where: { directed: { title_EQ: "The Matrix" } }) {
                     directed {
                         title
                         directed_by {
@@ -882,7 +882,7 @@ describe("cypher directive filtering - One To One Relationship", () => {
         const typeDefs = /* GraphQL */ `
             type Movie
                 @node
-                @authorization(validate: [{ where: { node: { directed_by: { name: "$jwt.custom_value" } } } }]) {
+                @authorization(validate: [{ where: { node: { directed_by: { name_EQ: "$jwt.custom_value" } } } }]) {
                 title: String
                 released: Int
                 directed_by: Person!
@@ -1005,7 +1005,7 @@ describe("cypher directive filtering - One To One Relationship", () => {
         const typeDefs = /* GraphQL */ `
             type Movie
                 @node
-                @authorization(validate: [{ where: { node: { directed_by: { name: "$jwt.custom_value" } } } }]) {
+                @authorization(validate: [{ where: { node: { directed_by: { name_EQ: "$jwt.custom_value" } } } }]) {
                 title: String
                 released: Int
                 directed_by: Person!
@@ -1044,7 +1044,7 @@ describe("cypher directive filtering - One To One Relationship", () => {
 
         const query = /* GraphQL */ `
             query {
-                people(where: { directed: { title: "The Matrix" } }) {
+                people(where: { directed: { title_EQ: "The Matrix" } }) {
                     directed {
                         title
                         directed_by {
@@ -1130,7 +1130,7 @@ describe("cypher directive filtering - One To One Relationship", () => {
                 title: String
                 released: Int
                 directed_by: Person!
-                    @authorization(validate: [{ where: { node: { directed_by: { name: "$jwt.custom_value" } } } }])
+                    @authorization(validate: [{ where: { node: { directed_by: { name_EQ: "$jwt.custom_value" } } } }])
                     @cypher(
                         statement: """
                         MATCH (this)<-[:DIRECTED]-(director:Person)
@@ -1166,7 +1166,7 @@ describe("cypher directive filtering - One To One Relationship", () => {
 
         const query = /* GraphQL */ `
             query {
-                people(where: { directed: { title: "The Matrix" } }) {
+                people(where: { directed: { title_EQ: "The Matrix" } }) {
                     directed {
                         title
                         directed_by {
@@ -1252,7 +1252,7 @@ describe("cypher directive filtering - One To One Relationship", () => {
                 title: String
                 released: Int
                 directed_by: Person!
-                    @authorization(validate: [{ where: { node: { directed_by: { name: "$jwt.custom_value" } } } }])
+                    @authorization(validate: [{ where: { node: { directed_by: { name_EQ: "$jwt.custom_value" } } } }])
                     @cypher(
                         statement: """
                         MATCH (this)<-[:DIRECTED]-(director:Person)
@@ -1288,7 +1288,7 @@ describe("cypher directive filtering - One To One Relationship", () => {
 
         const query = /* GraphQL */ `
             query {
-                people(where: { directed: { title: "The Matrix" } }) {
+                people(where: { directed: { title_EQ: "The Matrix" } }) {
                     directed {
                         title
                         directed_by {
@@ -1404,7 +1404,7 @@ describe("cypher directive filtering - One To One Relationship", () => {
 
         const query = /* GraphQL */ `
             query {
-                people(where: { directed: { title: "The Matrix" } }) {
+                people(where: { directed: { title_EQ: "The Matrix" } }) {
                     directed {
                         title
                         directed_by {
@@ -1535,7 +1535,7 @@ describe("cypher directive filtering - One To One Relationship", () => {
 
         const query = /* GraphQL */ `
             query {
-                movies(where: { directed_by: { name: "Lilly Wachowski" }, title_ENDS_WITH: "Matrix" }) {
+                movies(where: { directed_by: { name_EQ: "Lilly Wachowski" }, title_ENDS_WITH: "Matrix" }) {
                     actorsConnection {
                         totalCount
                         edges {

--- a/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-one-to-one-relationship.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-one-to-one-relationship.test.ts
@@ -1,0 +1,1591 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Neo4jGraphQL } from "../../../../../src";
+import { createBearerToken } from "../../../../utils/create-bearer-token";
+import { formatCypher, formatParams, translateQuery } from "../../../utils/tck-test-utils";
+
+describe("cypher directive filtering - One To One Relationship", () => {
+    test("1 to 1 relationship", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Movie @node {
+                title: String
+                released: Int
+                actor: Actor!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(actor:Actor)
+                        RETURN actor
+                        """
+                        columnName: "actor"
+                    )
+            }
+
+            type Actor @node {
+                name: String
+                movie: Movie!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(movie:Movie)
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        const query = `
+            query {
+                movies(where: { actor: { name: "Keanu Reeves" } }) {
+                    title
+                }
+            }
+        `;
+
+        const neoSchema: Neo4jGraphQL = new Neo4jGraphQL({
+            typeDefs,
+        });
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:Movie)
+            CALL {
+                WITH this
+                CALL {
+                    WITH this
+                    WITH this AS this
+                    MATCH (this)-[:ACTED_IN]->(actor:Actor)
+                    RETURN actor
+                }
+                WITH actor AS this0
+                RETURN head(collect(this0)) AS this1
+            }
+            WITH *
+            WHERE this1.name = $param0
+            RETURN this { .title } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"Keanu Reeves\\"
+            }"
+        `);
+    });
+
+    test("1 to 1 relationship with multiple filters", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Movie @node {
+                title: String
+                released: Int
+                actor: Actor!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(actor:Actor)
+                        RETURN actor
+                        """
+                        columnName: "actor"
+                    )
+            }
+
+            type Actor @node {
+                name: String
+                age: Int
+                movie: Movie!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(movie:Movie)
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        const query = `
+            query {
+                movies(where: { released: 2003, actor: { name: "Keanu Reeves", age_GT: 30 } }) {
+                    title
+                }
+            }
+        `;
+
+        const neoSchema: Neo4jGraphQL = new Neo4jGraphQL({
+            typeDefs,
+        });
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:Movie)
+            CALL {
+                WITH this
+                CALL {
+                    WITH this
+                    WITH this AS this
+                    MATCH (this)-[:ACTED_IN]->(actor:Actor)
+                    RETURN actor
+                }
+                WITH actor AS this0
+                RETURN head(collect(this0)) AS this1
+            }
+            WITH *
+            WHERE (this.released = $param0 AND (this1.name = $param1 AND this1.age > $param2))
+            RETURN this { .title } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": {
+                    \\"low\\": 2003,
+                    \\"high\\": 0
+                },
+                \\"param1\\": \\"Keanu Reeves\\",
+                \\"param2\\": {
+                    \\"low\\": 30,
+                    \\"high\\": 0
+                }
+            }"
+        `);
+    });
+
+    test("1 to 1 relationship with single property filter", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Movie @node {
+                title: String
+                actor: Actor!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                        RETURN actor
+                        """
+                        columnName: "actor"
+                    )
+            }
+
+            type Actor @node {
+                name: String
+                movie: Movie!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(movie:Movie)
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        const neoSchema: Neo4jGraphQL = new Neo4jGraphQL({
+            typeDefs,
+        });
+
+        const query = /* GraphQL */ `
+            query {
+                movies(where: { actor: { name: "Keanu Reeves" } }) {
+                    title
+                    actor {
+                        name
+                    }
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:Movie)
+            CALL {
+                WITH this
+                CALL {
+                    WITH this
+                    WITH this AS this
+                    MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                    RETURN actor
+                }
+                WITH actor AS this0
+                RETURN head(collect(this0)) AS this1
+            }
+            WITH *
+            WHERE this1.name = $param0
+            CALL {
+                WITH this
+                CALL {
+                    WITH this
+                    WITH this AS this
+                    MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                    RETURN actor
+                }
+                WITH actor AS this2
+                WITH this2 { .name } AS this2
+                RETURN head(collect(this2)) AS var3
+            }
+            RETURN this { .title, actor: var3 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"Keanu Reeves\\"
+            }"
+        `);
+    });
+
+    test("1 to 1 relationship with null filter", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Movie @node {
+                title: String
+                released: Int
+                actor: Actor
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                        RETURN actor
+                        """
+                        columnName: "actor"
+                    )
+            }
+
+            type Actor @node {
+                name: String
+                movie: Movie
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(movie:Movie)
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        const neoSchema: Neo4jGraphQL = new Neo4jGraphQL({
+            typeDefs,
+        });
+
+        const query = /* GraphQL */ `
+            query {
+                movies(where: { released: 2003, actor: null }) {
+                    title
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:Movie)
+            CALL {
+                WITH this
+                CALL {
+                    WITH this
+                    WITH this AS this
+                    MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                    RETURN actor
+                }
+                WITH actor AS this0
+                RETURN head(collect(this0)) AS this1
+            }
+            WITH *
+            WHERE (this.released = $param0 AND this1 IS NULL)
+            RETURN this { .title } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": {
+                    \\"low\\": 2003,
+                    \\"high\\": 0
+                }
+            }"
+        `);
+    });
+
+    test("1 to 1 relationship with NOT null filter", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Movie @node {
+                title: String
+                released: Int
+                actor: Actor
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                        RETURN actor
+                        """
+                        columnName: "actor"
+                    )
+            }
+
+            type Actor @node {
+                name: String
+                movie: Movie
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(movie:Movie)
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        const neoSchema: Neo4jGraphQL = new Neo4jGraphQL({
+            typeDefs,
+        });
+
+        const query = /* GraphQL */ `
+            query {
+                movies(where: { AND: [{ released_IN: [2003], NOT: { actor: null } }] }) {
+                    title
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:Movie)
+            CALL {
+                WITH this
+                CALL {
+                    WITH this
+                    WITH this AS this
+                    MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                    RETURN actor
+                }
+                WITH actor AS this0
+                RETURN head(collect(this0)) AS this1
+            }
+            WITH *
+            WHERE (this.released IN $param0 AND NOT (this1 IS NULL))
+            RETURN this { .title } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": [
+                    {
+                        \\"low\\": 2003,
+                        \\"high\\": 0
+                    }
+                ]
+            }"
+        `);
+    });
+
+    test("1 to 1 relationship with auth filter on type PASS", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Movie
+                @node
+                @authorization(filter: [{ where: { node: { directed_by: { name: "$jwt.custom_value" } } } }]) {
+                title: String
+                released: Int
+                directed_by: Person!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:DIRECTED]-(director:Person)
+                        RETURN director
+                        """
+                        columnName: "director"
+                    )
+            }
+
+            type Person @node {
+                name: String
+                directed: Movie!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:DIRECTED]->(movie:Movie)
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        const token = createBearerToken("secret", { custom_value: "Lilly Wachowski" });
+
+        const neoSchema: Neo4jGraphQL = new Neo4jGraphQL({
+            typeDefs,
+            features: {
+                authorization: {
+                    key: "secret",
+                },
+            },
+        });
+
+        const query = /* GraphQL */ `
+            query {
+                people(where: { directed: { title: "The Matrix" } }) {
+                    directed {
+                        title
+                        directed_by {
+                            name
+                        }
+                    }
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query, { token });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:Person)
+            CALL {
+                WITH this
+                CALL {
+                    WITH this
+                    WITH this AS this
+                    MATCH (this)-[:DIRECTED]->(movie:Movie)
+                    RETURN movie
+                }
+                WITH movie AS this0
+                RETURN head(collect(this0)) AS this1
+            }
+            WITH *
+            WHERE this1.title = $param0
+            CALL {
+                WITH this
+                CALL {
+                    WITH this
+                    WITH this AS this
+                    MATCH (this)-[:DIRECTED]->(movie:Movie)
+                    RETURN movie
+                }
+                WITH movie AS this2
+                CALL {
+                    WITH this2
+                    CALL {
+                        WITH this2
+                        WITH this2 AS this
+                        MATCH (this)<-[:DIRECTED]-(director:Person)
+                        RETURN director
+                    }
+                    WITH director AS this3
+                    WITH this3 { .name } AS this3
+                    RETURN head(collect(this3)) AS var4
+                }
+                CALL {
+                    WITH this2
+                    CALL {
+                        WITH this2
+                        WITH this2 AS this
+                        MATCH (this)<-[:DIRECTED]-(director:Person)
+                        RETURN director
+                    }
+                    WITH director AS this5
+                    RETURN head(collect(this5)) AS this6
+                }
+                WITH *
+                WHERE ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND this6.name = $jwt.custom_value))
+                WITH this2 { .title, directed_by: var4 } AS this2
+                RETURN head(collect(this2)) AS var7
+            }
+            RETURN this { directed: var7 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"The Matrix\\",
+                \\"isAuthenticated\\": true,
+                \\"jwt\\": {
+                    \\"roles\\": [],
+                    \\"custom_value\\": \\"Lilly Wachowski\\"
+                }
+            }"
+        `);
+    });
+
+    test("1 to 1 relationship with auth filter on type FAIL", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Movie
+                @node
+                @authorization(filter: [{ where: { node: { directed_by: { name: "$jwt.custom_value" } } } }]) {
+                title: String
+                released: Int
+                directed_by: Person!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:DIRECTED]-(director:Person)
+                        RETURN director
+                        """
+                        columnName: "director"
+                    )
+            }
+
+            type Person @node {
+                name: String
+                directed: Movie!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:DIRECTED]->(movie:Movie)
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        const token = createBearerToken("secret", { custom_value: "Something Incorrect" });
+
+        const neoSchema: Neo4jGraphQL = new Neo4jGraphQL({
+            typeDefs,
+            features: {
+                authorization: {
+                    key: "secret",
+                },
+            },
+        });
+
+        const query = /* GraphQL */ `
+            query {
+                people(where: { directed: { title: "The Matrix" } }) {
+                    directed {
+                        title
+                        directed_by {
+                            name
+                        }
+                    }
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query, { token });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:Person)
+            CALL {
+                WITH this
+                CALL {
+                    WITH this
+                    WITH this AS this
+                    MATCH (this)-[:DIRECTED]->(movie:Movie)
+                    RETURN movie
+                }
+                WITH movie AS this0
+                RETURN head(collect(this0)) AS this1
+            }
+            WITH *
+            WHERE this1.title = $param0
+            CALL {
+                WITH this
+                CALL {
+                    WITH this
+                    WITH this AS this
+                    MATCH (this)-[:DIRECTED]->(movie:Movie)
+                    RETURN movie
+                }
+                WITH movie AS this2
+                CALL {
+                    WITH this2
+                    CALL {
+                        WITH this2
+                        WITH this2 AS this
+                        MATCH (this)<-[:DIRECTED]-(director:Person)
+                        RETURN director
+                    }
+                    WITH director AS this3
+                    WITH this3 { .name } AS this3
+                    RETURN head(collect(this3)) AS var4
+                }
+                CALL {
+                    WITH this2
+                    CALL {
+                        WITH this2
+                        WITH this2 AS this
+                        MATCH (this)<-[:DIRECTED]-(director:Person)
+                        RETURN director
+                    }
+                    WITH director AS this5
+                    RETURN head(collect(this5)) AS this6
+                }
+                WITH *
+                WHERE ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND this6.name = $jwt.custom_value))
+                WITH this2 { .title, directed_by: var4 } AS this2
+                RETURN head(collect(this2)) AS var7
+            }
+            RETURN this { directed: var7 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"The Matrix\\",
+                \\"isAuthenticated\\": true,
+                \\"jwt\\": {
+                    \\"roles\\": [],
+                    \\"custom_value\\": \\"Something Incorrect\\"
+                }
+            }"
+        `);
+    });
+
+    test("1 to 1 relationship with auth filter on field PASS", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Movie @node {
+                title: String
+                released: Int
+                directed_by: Person!
+                    @authorization(filter: [{ where: { node: { directed_by: { name: "$jwt.custom_value" } } } }])
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:DIRECTED]-(director:Person)
+                        RETURN director
+                        """
+                        columnName: "director"
+                    )
+            }
+
+            type Person @node {
+                name: String
+                directed: Movie!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:DIRECTED]->(movie:Movie)
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        const token = createBearerToken("secret", { custom_value: "Lilly Wachowski" });
+
+        const neoSchema: Neo4jGraphQL = new Neo4jGraphQL({
+            typeDefs,
+            features: {
+                authorization: {
+                    key: "secret",
+                },
+            },
+        });
+
+        const query = /* GraphQL */ `
+            query {
+                people(where: { directed: { title: "The Matrix" } }) {
+                    directed {
+                        title
+                        directed_by {
+                            name
+                        }
+                    }
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query, { token });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:Person)
+            CALL {
+                WITH this
+                CALL {
+                    WITH this
+                    WITH this AS this
+                    MATCH (this)-[:DIRECTED]->(movie:Movie)
+                    RETURN movie
+                }
+                WITH movie AS this0
+                RETURN head(collect(this0)) AS this1
+            }
+            WITH *
+            WHERE this1.title = $param0
+            CALL {
+                WITH this
+                CALL {
+                    WITH this
+                    WITH this AS this
+                    MATCH (this)-[:DIRECTED]->(movie:Movie)
+                    RETURN movie
+                }
+                WITH movie AS this2
+                CALL {
+                    WITH this2
+                    CALL {
+                        WITH this2
+                        WITH this2 AS this
+                        MATCH (this)<-[:DIRECTED]-(director:Person)
+                        RETURN director
+                    }
+                    WITH director AS this3
+                    WITH this3 { .name } AS this3
+                    RETURN head(collect(this3)) AS var4
+                }
+                CALL {
+                    WITH this2
+                    CALL {
+                        WITH this2
+                        WITH this2 AS this
+                        MATCH (this)<-[:DIRECTED]-(director:Person)
+                        RETURN director
+                    }
+                    WITH director AS this5
+                    RETURN head(collect(this5)) AS this6
+                }
+                WITH *
+                WHERE ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND this6.name = $jwt.custom_value))
+                WITH this2 { .title, directed_by: var4 } AS this2
+                RETURN head(collect(this2)) AS var7
+            }
+            RETURN this { directed: var7 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"The Matrix\\",
+                \\"isAuthenticated\\": true,
+                \\"jwt\\": {
+                    \\"roles\\": [],
+                    \\"custom_value\\": \\"Lilly Wachowski\\"
+                }
+            }"
+        `);
+    });
+
+    test("1 to 1 relationship with auth filter on field FAIL", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Movie @node {
+                title: String
+                released: Int
+                directed_by: Person!
+                    @authorization(filter: [{ where: { node: { directed_by: { name: "$jwt.custom_value" } } } }])
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:DIRECTED]-(director:Person)
+                        RETURN director
+                        """
+                        columnName: "director"
+                    )
+            }
+
+            type Person @node {
+                name: String
+                directed: Movie!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:DIRECTED]->(movie:Movie)
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        const token = createBearerToken("secret", { custom_value: "Something Incorrect" });
+
+        const neoSchema: Neo4jGraphQL = new Neo4jGraphQL({
+            typeDefs,
+            features: {
+                authorization: {
+                    key: "secret",
+                },
+            },
+        });
+
+        const query = /* GraphQL */ `
+            query {
+                people(where: { directed: { title: "The Matrix" } }) {
+                    directed {
+                        title
+                        directed_by {
+                            name
+                        }
+                    }
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query, { token });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:Person)
+            CALL {
+                WITH this
+                CALL {
+                    WITH this
+                    WITH this AS this
+                    MATCH (this)-[:DIRECTED]->(movie:Movie)
+                    RETURN movie
+                }
+                WITH movie AS this0
+                RETURN head(collect(this0)) AS this1
+            }
+            WITH *
+            WHERE this1.title = $param0
+            CALL {
+                WITH this
+                CALL {
+                    WITH this
+                    WITH this AS this
+                    MATCH (this)-[:DIRECTED]->(movie:Movie)
+                    RETURN movie
+                }
+                WITH movie AS this2
+                CALL {
+                    WITH this2
+                    CALL {
+                        WITH this2
+                        WITH this2 AS this
+                        MATCH (this)<-[:DIRECTED]-(director:Person)
+                        RETURN director
+                    }
+                    WITH director AS this3
+                    WITH this3 { .name } AS this3
+                    RETURN head(collect(this3)) AS var4
+                }
+                CALL {
+                    WITH this2
+                    CALL {
+                        WITH this2
+                        WITH this2 AS this
+                        MATCH (this)<-[:DIRECTED]-(director:Person)
+                        RETURN director
+                    }
+                    WITH director AS this5
+                    RETURN head(collect(this5)) AS this6
+                }
+                WITH *
+                WHERE ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND this6.name = $jwt.custom_value))
+                WITH this2 { .title, directed_by: var4 } AS this2
+                RETURN head(collect(this2)) AS var7
+            }
+            RETURN this { directed: var7 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"The Matrix\\",
+                \\"isAuthenticated\\": true,
+                \\"jwt\\": {
+                    \\"roles\\": [],
+                    \\"custom_value\\": \\"Something Incorrect\\"
+                }
+            }"
+        `);
+    });
+
+    test("1 to 1 relationship with auth validate type PASS", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Movie
+                @node
+                @authorization(validate: [{ where: { node: { directed_by: { name: "$jwt.custom_value" } } } }]) {
+                title: String
+                released: Int
+                directed_by: Person!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:DIRECTED]-(director:Person)
+                        RETURN director
+                        """
+                        columnName: "director"
+                    )
+            }
+
+            type Person @node {
+                name: String
+                directed: Movie!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:DIRECTED]->(movie:Movie)
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        const token = createBearerToken("secret", { custom_value: "Lilly Wachowski" });
+
+        const neoSchema: Neo4jGraphQL = new Neo4jGraphQL({
+            typeDefs,
+            features: {
+                authorization: {
+                    key: "secret",
+                },
+            },
+        });
+
+        const query = /* GraphQL */ `
+            query {
+                people(where: { directed: { title: "The Matrix" } }) {
+                    directed {
+                        title
+                        directed_by {
+                            name
+                        }
+                    }
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query, { token });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:Person)
+            CALL {
+                WITH this
+                CALL {
+                    WITH this
+                    WITH this AS this
+                    MATCH (this)-[:DIRECTED]->(movie:Movie)
+                    RETURN movie
+                }
+                WITH movie AS this0
+                RETURN head(collect(this0)) AS this1
+            }
+            WITH *
+            WHERE this1.title = $param0
+            CALL {
+                WITH this
+                CALL {
+                    WITH this
+                    WITH this AS this
+                    MATCH (this)-[:DIRECTED]->(movie:Movie)
+                    RETURN movie
+                }
+                WITH movie AS this2
+                CALL {
+                    WITH this2
+                    CALL {
+                        WITH this2
+                        WITH this2 AS this
+                        MATCH (this)<-[:DIRECTED]-(director:Person)
+                        RETURN director
+                    }
+                    WITH director AS this3
+                    WITH this3 { .name } AS this3
+                    RETURN head(collect(this3)) AS var4
+                }
+                CALL {
+                    WITH this2
+                    CALL {
+                        WITH this2
+                        WITH this2 AS this
+                        MATCH (this)<-[:DIRECTED]-(director:Person)
+                        RETURN director
+                    }
+                    WITH director AS this5
+                    RETURN head(collect(this5)) AS this6
+                }
+                WITH *
+                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND this6.name = $jwt.custom_value)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                WITH this2 { .title, directed_by: var4 } AS this2
+                RETURN head(collect(this2)) AS var7
+            }
+            RETURN this { directed: var7 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"The Matrix\\",
+                \\"isAuthenticated\\": true,
+                \\"jwt\\": {
+                    \\"roles\\": [],
+                    \\"custom_value\\": \\"Lilly Wachowski\\"
+                }
+            }"
+        `);
+    });
+
+    test("1 to 1 relationship with auth validate type FAIL", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Movie
+                @node
+                @authorization(validate: [{ where: { node: { directed_by: { name: "$jwt.custom_value" } } } }]) {
+                title: String
+                released: Int
+                directed_by: Person!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:DIRECTED]-(director:Person)
+                        RETURN director
+                        """
+                        columnName: "director"
+                    )
+            }
+
+            type Person @node {
+                name: String
+                directed: Movie!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:DIRECTED]->(movie:Movie)
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        const token = createBearerToken("secret", { custom_value: "Something Wrong" });
+
+        const neoSchema: Neo4jGraphQL = new Neo4jGraphQL({
+            typeDefs,
+            features: {
+                authorization: {
+                    key: "secret",
+                },
+            },
+        });
+
+        const query = /* GraphQL */ `
+            query {
+                people(where: { directed: { title: "The Matrix" } }) {
+                    directed {
+                        title
+                        directed_by {
+                            name
+                        }
+                    }
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query, { token });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:Person)
+            CALL {
+                WITH this
+                CALL {
+                    WITH this
+                    WITH this AS this
+                    MATCH (this)-[:DIRECTED]->(movie:Movie)
+                    RETURN movie
+                }
+                WITH movie AS this0
+                RETURN head(collect(this0)) AS this1
+            }
+            WITH *
+            WHERE this1.title = $param0
+            CALL {
+                WITH this
+                CALL {
+                    WITH this
+                    WITH this AS this
+                    MATCH (this)-[:DIRECTED]->(movie:Movie)
+                    RETURN movie
+                }
+                WITH movie AS this2
+                CALL {
+                    WITH this2
+                    CALL {
+                        WITH this2
+                        WITH this2 AS this
+                        MATCH (this)<-[:DIRECTED]-(director:Person)
+                        RETURN director
+                    }
+                    WITH director AS this3
+                    WITH this3 { .name } AS this3
+                    RETURN head(collect(this3)) AS var4
+                }
+                CALL {
+                    WITH this2
+                    CALL {
+                        WITH this2
+                        WITH this2 AS this
+                        MATCH (this)<-[:DIRECTED]-(director:Person)
+                        RETURN director
+                    }
+                    WITH director AS this5
+                    RETURN head(collect(this5)) AS this6
+                }
+                WITH *
+                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND this6.name = $jwt.custom_value)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                WITH this2 { .title, directed_by: var4 } AS this2
+                RETURN head(collect(this2)) AS var7
+            }
+            RETURN this { directed: var7 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"The Matrix\\",
+                \\"isAuthenticated\\": true,
+                \\"jwt\\": {
+                    \\"roles\\": [],
+                    \\"custom_value\\": \\"Something Wrong\\"
+                }
+            }"
+        `);
+    });
+
+    test("1 to 1 relationship with auth validate field PASS", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Movie @node {
+                title: String
+                released: Int
+                directed_by: Person!
+                    @authorization(validate: [{ where: { node: { directed_by: { name: "$jwt.custom_value" } } } }])
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:DIRECTED]-(director:Person)
+                        RETURN director
+                        """
+                        columnName: "director"
+                    )
+            }
+
+            type Person @node {
+                name: String
+                directed: Movie!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:DIRECTED]->(movie:Movie)
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        const token = createBearerToken("secret", { custom_value: "Lilly Wachowski" });
+
+        const neoSchema: Neo4jGraphQL = new Neo4jGraphQL({
+            typeDefs,
+            features: {
+                authorization: {
+                    key: "secret",
+                },
+            },
+        });
+
+        const query = /* GraphQL */ `
+            query {
+                people(where: { directed: { title: "The Matrix" } }) {
+                    directed {
+                        title
+                        directed_by {
+                            name
+                        }
+                    }
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query, { token });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:Person)
+            CALL {
+                WITH this
+                CALL {
+                    WITH this
+                    WITH this AS this
+                    MATCH (this)-[:DIRECTED]->(movie:Movie)
+                    RETURN movie
+                }
+                WITH movie AS this0
+                RETURN head(collect(this0)) AS this1
+            }
+            WITH *
+            WHERE this1.title = $param0
+            CALL {
+                WITH this
+                CALL {
+                    WITH this
+                    WITH this AS this
+                    MATCH (this)-[:DIRECTED]->(movie:Movie)
+                    RETURN movie
+                }
+                WITH movie AS this2
+                CALL {
+                    WITH this2
+                    CALL {
+                        WITH this2
+                        WITH this2 AS this
+                        MATCH (this)<-[:DIRECTED]-(director:Person)
+                        RETURN director
+                    }
+                    WITH director AS this3
+                    WITH this3 { .name } AS this3
+                    RETURN head(collect(this3)) AS var4
+                }
+                CALL {
+                    WITH this2
+                    CALL {
+                        WITH this2
+                        WITH this2 AS this
+                        MATCH (this)<-[:DIRECTED]-(director:Person)
+                        RETURN director
+                    }
+                    WITH director AS this5
+                    RETURN head(collect(this5)) AS this6
+                }
+                WITH *
+                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND this6.name = $jwt.custom_value)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                WITH this2 { .title, directed_by: var4 } AS this2
+                RETURN head(collect(this2)) AS var7
+            }
+            RETURN this { directed: var7 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"The Matrix\\",
+                \\"isAuthenticated\\": true,
+                \\"jwt\\": {
+                    \\"roles\\": [],
+                    \\"custom_value\\": \\"Lilly Wachowski\\"
+                }
+            }"
+        `);
+    });
+
+    test("1 to 1 relationship with auth validate field FAIL", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Movie @node {
+                title: String
+                released: Int
+                directed_by: Person!
+                    @authorization(validate: [{ where: { node: { directed_by: { name: "$jwt.custom_value" } } } }])
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:DIRECTED]-(director:Person)
+                        RETURN director
+                        """
+                        columnName: "director"
+                    )
+            }
+
+            type Person @node {
+                name: String
+                directed: Movie!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:DIRECTED]->(movie:Movie)
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        const token = createBearerToken("secret", { custom_value: "Something Wrong" });
+
+        const neoSchema: Neo4jGraphQL = new Neo4jGraphQL({
+            typeDefs,
+            features: {
+                authorization: {
+                    key: "secret",
+                },
+            },
+        });
+
+        const query = /* GraphQL */ `
+            query {
+                people(where: { directed: { title: "The Matrix" } }) {
+                    directed {
+                        title
+                        directed_by {
+                            name
+                        }
+                    }
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query, { token });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:Person)
+            CALL {
+                WITH this
+                CALL {
+                    WITH this
+                    WITH this AS this
+                    MATCH (this)-[:DIRECTED]->(movie:Movie)
+                    RETURN movie
+                }
+                WITH movie AS this0
+                RETURN head(collect(this0)) AS this1
+            }
+            WITH *
+            WHERE this1.title = $param0
+            CALL {
+                WITH this
+                CALL {
+                    WITH this
+                    WITH this AS this
+                    MATCH (this)-[:DIRECTED]->(movie:Movie)
+                    RETURN movie
+                }
+                WITH movie AS this2
+                CALL {
+                    WITH this2
+                    CALL {
+                        WITH this2
+                        WITH this2 AS this
+                        MATCH (this)<-[:DIRECTED]-(director:Person)
+                        RETURN director
+                    }
+                    WITH director AS this3
+                    WITH this3 { .name } AS this3
+                    RETURN head(collect(this3)) AS var4
+                }
+                CALL {
+                    WITH this2
+                    CALL {
+                        WITH this2
+                        WITH this2 AS this
+                        MATCH (this)<-[:DIRECTED]-(director:Person)
+                        RETURN director
+                    }
+                    WITH director AS this5
+                    RETURN head(collect(this5)) AS this6
+                }
+                WITH *
+                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND this6.name = $jwt.custom_value)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                WITH this2 { .title, directed_by: var4 } AS this2
+                RETURN head(collect(this2)) AS var7
+            }
+            RETURN this { directed: var7 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"The Matrix\\",
+                \\"isAuthenticated\\": true,
+                \\"jwt\\": {
+                    \\"roles\\": [],
+                    \\"custom_value\\": \\"Something Wrong\\"
+                }
+            }"
+        `);
+    });
+
+    test("1 to 1 relationship with nested selection", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Movie @node {
+                title: String
+                released: Int
+                actors: [Person!]! @relationship(type: "ACTED_IN", direction: IN)
+                directed_by: Person!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:DIRECTED]-(director:Person)
+                        RETURN director
+                        """
+                        columnName: "director"
+                    )
+            }
+
+            type Person @node {
+                name: String
+                movies: [Movie!]! @relationship(type: "ACTED_IN", direction: OUT)
+                directed: Movie!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:DIRECTED]->(movie:Movie)
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        const neoSchema: Neo4jGraphQL = new Neo4jGraphQL({
+            typeDefs,
+        });
+
+        const query = /* GraphQL */ `
+            query {
+                people(where: { directed: { title: "The Matrix" } }) {
+                    directed {
+                        title
+                        directed_by {
+                            name
+                        }
+                        actors {
+                            name
+                            movies {
+                                directed_by {
+                                    name
+                                }
+                                title
+                            }
+                        }
+                    }
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:Person)
+            CALL {
+                WITH this
+                CALL {
+                    WITH this
+                    WITH this AS this
+                    MATCH (this)-[:DIRECTED]->(movie:Movie)
+                    RETURN movie
+                }
+                WITH movie AS this0
+                RETURN head(collect(this0)) AS this1
+            }
+            WITH *
+            WHERE this1.title = $param0
+            CALL {
+                WITH this
+                CALL {
+                    WITH this
+                    WITH this AS this
+                    MATCH (this)-[:DIRECTED]->(movie:Movie)
+                    RETURN movie
+                }
+                WITH movie AS this2
+                CALL {
+                    WITH this2
+                    MATCH (this2)<-[this3:ACTED_IN]-(this4:Person)
+                    CALL {
+                        WITH this4
+                        MATCH (this4)-[this5:ACTED_IN]->(this6:Movie)
+                        CALL {
+                            WITH this6
+                            CALL {
+                                WITH this6
+                                WITH this6 AS this
+                                MATCH (this)<-[:DIRECTED]-(director:Person)
+                                RETURN director
+                            }
+                            WITH director AS this7
+                            WITH this7 { .name } AS this7
+                            RETURN head(collect(this7)) AS var8
+                        }
+                        WITH this6 { .title, directed_by: var8 } AS this6
+                        RETURN collect(this6) AS var9
+                    }
+                    WITH this4 { .name, movies: var9 } AS this4
+                    RETURN collect(this4) AS var10
+                }
+                CALL {
+                    WITH this2
+                    CALL {
+                        WITH this2
+                        WITH this2 AS this
+                        MATCH (this)<-[:DIRECTED]-(director:Person)
+                        RETURN director
+                    }
+                    WITH director AS this11
+                    WITH this11 { .name } AS this11
+                    RETURN head(collect(this11)) AS var12
+                }
+                WITH this2 { .title, directed_by: var12, actors: var10 } AS this2
+                RETURN head(collect(this2)) AS var13
+            }
+            RETURN this { directed: var13 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"The Matrix\\"
+            }"
+        `);
+    });
+
+    test("1 to 1 relationship with connection", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Movie @node {
+                title: String
+                released: Int
+                actors: [Person!]! @relationship(type: "ACTED_IN", direction: IN)
+                directed_by: Person!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:DIRECTED]-(director:Person)
+                        RETURN director
+                        """
+                        columnName: "director"
+                    )
+            }
+
+            type Person @node {
+                name: String
+                movies: [Movie!]! @relationship(type: "ACTED_IN", direction: OUT)
+                directed: Movie!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:DIRECTED]->(movie:Movie)
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        const neoSchema: Neo4jGraphQL = new Neo4jGraphQL({
+            typeDefs,
+        });
+
+        const query = /* GraphQL */ `
+            query {
+                movies(where: { directed_by: { name: "Lilly Wachowski" }, title_ENDS_WITH: "Matrix" }) {
+                    actorsConnection {
+                        totalCount
+                        edges {
+                            node {
+                                name
+                            }
+                        }
+                    }
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:Movie)
+            CALL {
+                WITH this
+                CALL {
+                    WITH this
+                    WITH this AS this
+                    MATCH (this)<-[:DIRECTED]-(director:Person)
+                    RETURN director
+                }
+                WITH director AS this0
+                RETURN head(collect(this0)) AS this1
+            }
+            WITH *
+            WHERE (this.title ENDS WITH $param0 AND this1.name = $param1)
+            CALL {
+                WITH this
+                MATCH (this)<-[this2:ACTED_IN]-(this3:Person)
+                WITH collect({ node: this3, relationship: this2 }) AS edges
+                WITH edges, size(edges) AS totalCount
+                CALL {
+                    WITH edges
+                    UNWIND edges AS edge
+                    WITH edge.node AS this3, edge.relationship AS this2
+                    RETURN collect({ node: { name: this3.name, __resolveType: \\"Person\\" } }) AS var4
+                }
+                RETURN { edges: var4, totalCount: totalCount } AS var5
+            }
+            RETURN this { actorsConnection: var5 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"Matrix\\",
+                \\"param1\\": \\"Lilly Wachowski\\"
+            }"
+        `);
+    });
+});


### PR DESCRIPTION
This PR is essentially the same as #5723 except it does not include the deprecated _NOT syntax, and updates types to match 6.0.0

# Description

This PR adds the ability to filter on 1 to 1 relationship cypher fields. A contrived example:

Type definitions:
```gql
type Movie
    @node
    @authorization(validate: [{ where: { node: { directed_by: { name: "$jwt.custom_value" } } } }]) {
    title: String
    released: Int
    directed_by: Person!
        @cypher(
            statement: """
            MATCH (this)<-[:DIRECTED]-(director:Person)
            RETURN director
            """
            columnName: "director"
        )
}

type Person @node {
    name: String
    directed: Movie!
        @cypher(
            statement: """
            MATCH (this)-[:DIRECTED]->(movie:Movie)
            RETURN movie
            """
            columnName: "movie"
        )
}
```

You can now query with a filter based on the `directed` field:
```gql
query {
    people(where: { directed: { title: "The Matrix" } }) {
        directed {
            title
            directed_by {
                name
            }
        }
    }
}
```

## Complexity

Medium

# Issue

Relates to #554, but not fully closing as this does not n to n relationship fields.

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [x] TCK tests have been updated
- [x] Integration tests have been updated
- [ ] Example applications have been updated
- [x] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
