### PR TITLE
Deprecate `connectOrCreate`

### DIFF
--- a/.changeset/quiet-frogs-reflect.md
+++ b/.changeset/quiet-frogs-reflect.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+The `connectOrCreate` operation has been deprecated and will be removed in the next major version of the Neo4j GraphQL Library. Its implementation has always been more limited than the other operations, so the decision has been taken to remove it for the time being with a view of potentially refocussing on it again in the future.

--- a/packages/graphql/src/schema/constants.ts
+++ b/packages/graphql/src/schema/constants.ts
@@ -39,3 +39,10 @@ export const DEPRECATE_DIRECTED_ARGUMENT = {
         reason: "The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server",
     },
 };
+
+export const DEPRECATE_CONNECT_OR_CREATE = {
+    name: DEPRECATED,
+    args: {
+        reason: "The connectOrCreate operation is deprecated and will be removed",
+    },
+};

--- a/packages/graphql/src/schema/create-relationship-fields/create-relationship-fields.ts
+++ b/packages/graphql/src/schema/create-relationship-fields/create-relationship-fields.ts
@@ -314,7 +314,7 @@ function createRelationshipFieldsForTarget({
     });
 
     if (relationshipAdapter.target instanceof InterfaceEntityAdapter) {
-        withFieldInputType({ relationshipAdapter, composer, userDefinedFieldDirectives });
+        withFieldInputType({ relationshipAdapter, composer, userDefinedFieldDirectives, features });
     } else {
         withConnectOrCreateInputType({
             relationshipAdapter,
@@ -355,6 +355,7 @@ function createRelationshipFieldsForTarget({
         composer,
         deprecatedDirectives,
         userDefinedFieldDirectives,
+        features,
     });
 
     augmentConnectInputTypeWithConnectFieldInput({

--- a/packages/graphql/src/schema/generation/update-input.ts
+++ b/packages/graphql/src/schema/generation/update-input.ts
@@ -40,6 +40,7 @@ import { withConnectionWhereInputType } from "./connection-where-input";
 import { withDeleteFieldInputType } from "./delete-input";
 import { withDisconnectFieldInputType } from "./disconnect-input";
 import { withCreateFieldInputType } from "./relation-input";
+import { shouldAddDeprecatedFields } from "./utils";
 
 export function withUpdateInputType({
     entityAdapter,
@@ -224,6 +225,7 @@ function makeUpdateFieldInputTypeFields({
     features: Neo4jFeaturesSettings | undefined;
 }): InputTypeComposerFieldConfigMapDefinition {
     const fields = {};
+
     let connectOrCreateFieldInputType: InputTypeComposer | undefined;
     let connectionWhereInputType: InputTypeComposer | string | undefined;
     const relationshipTarget = relationshipAdapter.target;
@@ -259,7 +261,7 @@ function makeUpdateFieldInputTypeFields({
             directives: [],
         };
     }
-    if (connectOrCreateFieldInputType) {
+    if (connectOrCreateFieldInputType && shouldAddDeprecatedFields(features, "connectOrCreate")) {
         fields["connectOrCreate"] = {
             type: relationshipAdapter.isList
                 ? connectOrCreateFieldInputType.NonNull.List

--- a/packages/graphql/src/types/index.ts
+++ b/packages/graphql/src/types/index.ts
@@ -451,6 +451,7 @@ export type Neo4jFeaturesSettings = {
         implicitEqualFilters?: boolean;
         deprecatedOptionsArgument?: boolean;
         directedArgument?: boolean;
+        connectOrCreate?: boolean;
     };
     vector?: Neo4jVectorSettings;
 };

--- a/packages/graphql/tests/schema/connect-or-create-id.test.ts
+++ b/packages/graphql/tests/schema/connect-or-create-id.test.ts
@@ -141,7 +141,7 @@ describe("connect or create with id", () => {
 
             input ActorMoviesFieldInput {
               connect: [ActorMoviesConnectFieldInput!]
-              connectOrCreate: [ActorMoviesConnectOrCreateFieldInput!]
+              connectOrCreate: [ActorMoviesConnectOrCreateFieldInput!] @deprecated(reason: \\"The connectOrCreate operation is deprecated and will be removed\\")
               create: [ActorMoviesCreateFieldInput!]
             }
 
@@ -612,7 +612,7 @@ describe("connect or create with id", () => {
 
             input PostCreatorFieldInput {
               connect: PostCreatorConnectFieldInput
-              connectOrCreate: PostCreatorConnectOrCreateFieldInput
+              connectOrCreate: PostCreatorConnectOrCreateFieldInput @deprecated(reason: \\"The connectOrCreate operation is deprecated and will be removed\\")
               create: PostCreatorCreateFieldInput
             }
 
@@ -933,7 +933,7 @@ describe("connect or create with id", () => {
 
             input UserPostsFieldInput {
               connect: [UserPostsConnectFieldInput!]
-              connectOrCreate: [UserPostsConnectOrCreateFieldInput!]
+              connectOrCreate: [UserPostsConnectOrCreateFieldInput!] @deprecated(reason: \\"The connectOrCreate operation is deprecated and will be removed\\")
               create: [UserPostsCreateFieldInput!]
             }
 

--- a/packages/graphql/tests/schema/connect-or-create-unions.test.ts
+++ b/packages/graphql/tests/schema/connect-or-create-unions.test.ts
@@ -159,7 +159,7 @@ describe("Connect Or Create", () => {
 
             input ActorActedInMovieFieldInput {
               connect: [ActorActedInMovieConnectFieldInput!]
-              connectOrCreate: [ActorActedInMovieConnectOrCreateFieldInput!]
+              connectOrCreate: [ActorActedInMovieConnectOrCreateFieldInput!] @deprecated(reason: \\"The connectOrCreate operation is deprecated and will be removed\\")
               create: [ActorActedInMovieCreateFieldInput!]
             }
 
@@ -222,7 +222,7 @@ describe("Connect Or Create", () => {
 
             input ActorActedInSeriesFieldInput {
               connect: [ActorActedInSeriesConnectFieldInput!]
-              connectOrCreate: [ActorActedInSeriesConnectOrCreateFieldInput!]
+              connectOrCreate: [ActorActedInSeriesConnectOrCreateFieldInput!] @deprecated(reason: \\"The connectOrCreate operation is deprecated and will be removed\\")
               create: [ActorActedInSeriesCreateFieldInput!]
             }
 

--- a/packages/graphql/tests/schema/connect-or-create.test.ts
+++ b/packages/graphql/tests/schema/connect-or-create.test.ts
@@ -141,7 +141,7 @@ describe("Connect Or Create", () => {
 
             input ActorMoviesFieldInput {
               connect: [ActorMoviesConnectFieldInput!]
-              connectOrCreate: [ActorMoviesConnectOrCreateFieldInput!]
+              connectOrCreate: [ActorMoviesConnectOrCreateFieldInput!] @deprecated(reason: \\"The connectOrCreate operation is deprecated and will be removed\\")
               create: [ActorMoviesCreateFieldInput!]
             }
 
@@ -657,7 +657,7 @@ describe("Connect Or Create", () => {
 
             input ActorMoviesFieldInput {
               connect: [ActorMoviesConnectFieldInput!]
-              connectOrCreate: [ActorMoviesConnectOrCreateFieldInput!]
+              connectOrCreate: [ActorMoviesConnectOrCreateFieldInput!] @deprecated(reason: \\"The connectOrCreate operation is deprecated and will be removed\\")
               create: [ActorMoviesCreateFieldInput!]
             }
 

--- a/packages/graphql/tests/schema/directives/relationship-nested-operations.test.ts
+++ b/packages/graphql/tests/schema/directives/relationship-nested-operations.test.ts
@@ -2422,7 +2422,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 input MovieActorsFieldInput {
-                  connectOrCreate: [MovieActorsConnectOrCreateFieldInput!]
+                  connectOrCreate: [MovieActorsConnectOrCreateFieldInput!] @deprecated(reason: \\"The connectOrCreate operation is deprecated and will be removed\\")
                 }
 
                 input MovieActorsNodeAggregationWhereInput {
@@ -6480,7 +6480,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 input MovieActorsPersonOneFieldInput {
-                  connectOrCreate: [MovieActorsPersonOneConnectOrCreateFieldInput!]
+                  connectOrCreate: [MovieActorsPersonOneConnectOrCreateFieldInput!] @deprecated(reason: \\"The connectOrCreate operation is deprecated and will be removed\\")
                 }
 
                 input MovieActorsPersonOneUpdateFieldInput {
@@ -6505,7 +6505,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 input MovieActorsPersonTwoFieldInput {
-                  connectOrCreate: [MovieActorsPersonTwoConnectOrCreateFieldInput!]
+                  connectOrCreate: [MovieActorsPersonTwoConnectOrCreateFieldInput!] @deprecated(reason: \\"The connectOrCreate operation is deprecated and will be removed\\")
                 }
 
                 input MovieActorsPersonTwoUpdateFieldInput {

--- a/packages/graphql/tests/schema/issues/1182.test.ts
+++ b/packages/graphql/tests/schema/issues/1182.test.ts
@@ -274,7 +274,7 @@ describe("https://github.com/neo4j/graphql/issues/1182", () => {
 
             input MovieActorsFieldInput {
               connect: [MovieActorsConnectFieldInput!]
-              connectOrCreate: [MovieActorsConnectOrCreateFieldInput!]
+              connectOrCreate: [MovieActorsConnectOrCreateFieldInput!] @deprecated(reason: \\"The connectOrCreate operation is deprecated and will be removed\\")
               create: [MovieActorsCreateFieldInput!]
             }
 

--- a/packages/graphql/tests/schema/issues/2377.test.ts
+++ b/packages/graphql/tests/schema/issues/2377.test.ts
@@ -249,7 +249,7 @@ describe("https://github.com/neo4j/graphql/issues/2377", () => {
 
             input ResourceContainedByFieldInput {
               connect: [ResourceContainedByConnectFieldInput!]
-              connectOrCreate: [ResourceContainedByConnectOrCreateFieldInput!]
+              connectOrCreate: [ResourceContainedByConnectOrCreateFieldInput!] @deprecated(reason: \\"The connectOrCreate operation is deprecated and will be removed\\")
               create: [ResourceContainedByCreateFieldInput!]
             }
 

--- a/packages/graphql/tests/schema/issues/3439.test.ts
+++ b/packages/graphql/tests/schema/issues/3439.test.ts
@@ -619,7 +619,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
 
             input MovieGenreFieldInput {
               connect: MovieGenreConnectFieldInput
-              connectOrCreate: MovieGenreConnectOrCreateFieldInput
+              connectOrCreate: MovieGenreConnectOrCreateFieldInput @deprecated(reason: \\"The connectOrCreate operation is deprecated and will be removed\\")
               create: MovieGenreCreateFieldInput
             }
 
@@ -901,7 +901,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
 
             input SeriesGenreFieldInput {
               connect: SeriesGenreConnectFieldInput
-              connectOrCreate: SeriesGenreConnectOrCreateFieldInput
+              connectOrCreate: SeriesGenreConnectOrCreateFieldInput @deprecated(reason: \\"The connectOrCreate operation is deprecated and will be removed\\")
               create: SeriesGenreCreateFieldInput
             }
 
@@ -1611,7 +1611,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
 
             input MovieGenreFieldInput {
               connect: MovieGenreConnectFieldInput
-              connectOrCreate: MovieGenreConnectOrCreateFieldInput
+              connectOrCreate: MovieGenreConnectOrCreateFieldInput @deprecated(reason: \\"The connectOrCreate operation is deprecated and will be removed\\")
               create: MovieGenreCreateFieldInput
             }
 
@@ -1890,7 +1890,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
 
             input SeriesGenreFieldInput {
               connect: SeriesGenreConnectFieldInput
-              connectOrCreate: SeriesGenreConnectOrCreateFieldInput
+              connectOrCreate: SeriesGenreConnectOrCreateFieldInput @deprecated(reason: \\"The connectOrCreate operation is deprecated and will be removed\\")
               create: SeriesGenreCreateFieldInput
             }
 
@@ -2789,7 +2789,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
 
             input MovieGenreFieldInput {
               connect: MovieGenreConnectFieldInput
-              connectOrCreate: MovieGenreConnectOrCreateFieldInput
+              connectOrCreate: MovieGenreConnectOrCreateFieldInput @deprecated(reason: \\"The connectOrCreate operation is deprecated and will be removed\\")
               create: MovieGenreCreateFieldInput
             }
 
@@ -3107,7 +3107,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
 
             input SeriesGenreFieldInput {
               connect: SeriesGenreConnectFieldInput
-              connectOrCreate: SeriesGenreConnectOrCreateFieldInput
+              connectOrCreate: SeriesGenreConnectOrCreateFieldInput @deprecated(reason: \\"The connectOrCreate operation is deprecated and will be removed\\")
               create: SeriesGenreCreateFieldInput
             }
 
@@ -4096,7 +4096,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
 
             input MovieGenreGenreFieldInput {
               connect: MovieGenreGenreConnectFieldInput
-              connectOrCreate: MovieGenreGenreConnectOrCreateFieldInput
+              connectOrCreate: MovieGenreGenreConnectOrCreateFieldInput @deprecated(reason: \\"The connectOrCreate operation is deprecated and will be removed\\")
               create: MovieGenreGenreCreateFieldInput
             }
 
@@ -4138,7 +4138,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
 
             input MovieGenreRatingFieldInput {
               connect: MovieGenreRatingConnectFieldInput
-              connectOrCreate: MovieGenreRatingConnectOrCreateFieldInput
+              connectOrCreate: MovieGenreRatingConnectOrCreateFieldInput @deprecated(reason: \\"The connectOrCreate operation is deprecated and will be removed\\")
               create: MovieGenreRatingCreateFieldInput
             }
 
@@ -4675,7 +4675,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
 
             input SeriesGenreGenreFieldInput {
               connect: SeriesGenreGenreConnectFieldInput
-              connectOrCreate: SeriesGenreGenreConnectOrCreateFieldInput
+              connectOrCreate: SeriesGenreGenreConnectOrCreateFieldInput @deprecated(reason: \\"The connectOrCreate operation is deprecated and will be removed\\")
               create: SeriesGenreGenreCreateFieldInput
             }
 
@@ -4717,7 +4717,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
 
             input SeriesGenreRatingFieldInput {
               connect: SeriesGenreRatingConnectFieldInput
-              connectOrCreate: SeriesGenreRatingConnectOrCreateFieldInput
+              connectOrCreate: SeriesGenreRatingConnectOrCreateFieldInput @deprecated(reason: \\"The connectOrCreate operation is deprecated and will be removed\\")
               create: SeriesGenreRatingCreateFieldInput
             }
 

--- a/packages/graphql/tests/schema/issues/3698.test.ts
+++ b/packages/graphql/tests/schema/issues/3698.test.ts
@@ -583,7 +583,7 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
 
             input MovieGenreFieldInput {
               connect: MovieGenreConnectFieldInput
-              connectOrCreate: MovieGenreConnectOrCreateFieldInput
+              connectOrCreate: MovieGenreConnectOrCreateFieldInput @deprecated(reason: \\"The connectOrCreate operation is deprecated and will be removed\\")
               create: MovieGenreCreateFieldInput
             }
 
@@ -1437,7 +1437,7 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
 
             input MovieGenreFieldInput {
               connect: MovieGenreConnectFieldInput
-              connectOrCreate: MovieGenreConnectOrCreateFieldInput
+              connectOrCreate: MovieGenreConnectOrCreateFieldInput @deprecated(reason: \\"The connectOrCreate operation is deprecated and will be removed\\")
               create: MovieGenreCreateFieldInput
             }
 
@@ -2301,7 +2301,7 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
 
             input MovieGenreFieldInput {
               connect: MovieGenreConnectFieldInput
-              connectOrCreate: MovieGenreConnectOrCreateFieldInput
+              connectOrCreate: MovieGenreConnectOrCreateFieldInput @deprecated(reason: \\"The connectOrCreate operation is deprecated and will be removed\\")
               create: MovieGenreCreateFieldInput
             }
 
@@ -2552,7 +2552,7 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
 
             input SeriesGenreFieldInput {
               connect: SeriesGenreConnectFieldInput
-              connectOrCreate: SeriesGenreConnectOrCreateFieldInput
+              connectOrCreate: SeriesGenreConnectOrCreateFieldInput @deprecated(reason: \\"The connectOrCreate operation is deprecated and will be removed\\")
               create: SeriesGenreCreateFieldInput
             }
 

--- a/packages/graphql/tests/schema/issues/3817.test.ts
+++ b/packages/graphql/tests/schema/issues/3817.test.ts
@@ -269,7 +269,7 @@ describe("3817", () => {
 
             input PersonFriendsFieldInput {
               connect: [PersonFriendsConnectFieldInput!]
-              connectOrCreate: [PersonFriendsConnectOrCreateFieldInput!]
+              connectOrCreate: [PersonFriendsConnectOrCreateFieldInput!] @deprecated(reason: \\"The connectOrCreate operation is deprecated and will be removed\\")
               create: [PersonFriendsCreateFieldInput!]
             }
 

--- a/packages/graphql/tests/schema/issues/872.test.ts
+++ b/packages/graphql/tests/schema/issues/872.test.ts
@@ -153,7 +153,7 @@ describe("https://github.com/neo4j/graphql/issues/872", () => {
 
             input Actor2MoviesFieldInput {
               connect: [Actor2MoviesConnectFieldInput!]
-              connectOrCreate: [Actor2MoviesConnectOrCreateFieldInput!]
+              connectOrCreate: [Actor2MoviesConnectOrCreateFieldInput!] @deprecated(reason: \\"The connectOrCreate operation is deprecated and will be removed\\")
               create: [Actor2MoviesCreateFieldInput!]
             }
 
@@ -361,7 +361,7 @@ describe("https://github.com/neo4j/graphql/issues/872", () => {
 
             input ActorMoviesFieldInput {
               connect: [ActorMoviesConnectFieldInput!]
-              connectOrCreate: [ActorMoviesConnectOrCreateFieldInput!]
+              connectOrCreate: [ActorMoviesConnectOrCreateFieldInput!] @deprecated(reason: \\"The connectOrCreate operation is deprecated and will be removed\\")
               create: [ActorMoviesCreateFieldInput!]
             }
 

--- a/packages/graphql/tests/schema/remove-deprecated/connect-or-create.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/connect-or-create.test.ts
@@ -1,0 +1,416 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { printSchemaWithDirectives } from "@graphql-tools/utils";
+import { gql } from "graphql-tag";
+import { lexicographicSortSchema } from "graphql/utilities";
+import { Neo4jGraphQL } from "../../../src";
+
+describe("Connect Or Create", () => {
+    test("Connect Or Create", async () => {
+        const typeDefs = gql`
+            type Movie @node {
+                title: String!
+                isan: String! @unique
+            }
+
+            type Actor @node {
+                name: String!
+                movies: [Movie!]! @relationship(type: "ACTED_IN", direction: OUT)
+            }
+        `;
+        const neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            features: { excludeDeprecatedFields: { connectOrCreate: true } },
+        });
+        const printedSchema = printSchemaWithDirectives(lexicographicSortSchema(await neoSchema.getSchema()));
+
+        expect(printedSchema).toMatchInlineSnapshot(`
+            "schema {
+              query: Query
+              mutation: Mutation
+            }
+
+            type Actor {
+              movies(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
+              moviesAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: MovieWhere): ActorMovieMoviesAggregationSelection
+              moviesConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [ActorMoviesConnectionSort!], where: ActorMoviesConnectionWhere): ActorMoviesConnection!
+              name: String!
+            }
+
+            type ActorAggregateSelection {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
+            input ActorCreateInput {
+              movies: ActorMoviesFieldInput
+              name: String!
+            }
+
+            input ActorDeleteInput {
+              movies: [ActorMoviesDeleteFieldInput!]
+            }
+
+            type ActorEdge {
+              cursor: String!
+              node: Actor!
+            }
+
+            type ActorMovieMoviesAggregationSelection {
+              count: Int!
+              node: ActorMovieMoviesNodeAggregateSelection
+            }
+
+            type ActorMovieMoviesNodeAggregateSelection {
+              isan: StringAggregateSelection!
+              title: StringAggregateSelection!
+            }
+
+            input ActorMoviesAggregateInput {
+              AND: [ActorMoviesAggregateInput!]
+              NOT: ActorMoviesAggregateInput
+              OR: [ActorMoviesAggregateInput!]
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
+              count_GT: Int
+              count_GTE: Int
+              count_LT: Int
+              count_LTE: Int
+              node: ActorMoviesNodeAggregationWhereInput
+            }
+
+            input ActorMoviesConnectFieldInput {
+              \\"\\"\\"
+              Whether or not to overwrite any matching relationship with the new properties.
+              \\"\\"\\"
+              overwrite: Boolean! = true
+              where: MovieConnectWhere
+            }
+
+            type ActorMoviesConnection {
+              edges: [ActorMoviesRelationship!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            input ActorMoviesConnectionSort {
+              node: MovieSort
+            }
+
+            input ActorMoviesConnectionWhere {
+              AND: [ActorMoviesConnectionWhere!]
+              NOT: ActorMoviesConnectionWhere
+              OR: [ActorMoviesConnectionWhere!]
+              node: MovieWhere
+            }
+
+            input ActorMoviesCreateFieldInput {
+              node: MovieCreateInput!
+            }
+
+            input ActorMoviesDeleteFieldInput {
+              where: ActorMoviesConnectionWhere
+            }
+
+            input ActorMoviesDisconnectFieldInput {
+              where: ActorMoviesConnectionWhere
+            }
+
+            input ActorMoviesFieldInput {
+              connect: [ActorMoviesConnectFieldInput!]
+              create: [ActorMoviesCreateFieldInput!]
+            }
+
+            input ActorMoviesNodeAggregationWhereInput {
+              AND: [ActorMoviesNodeAggregationWhereInput!]
+              NOT: ActorMoviesNodeAggregationWhereInput
+              OR: [ActorMoviesNodeAggregationWhereInput!]
+              isan_AVERAGE_LENGTH_EQUAL: Float
+              isan_AVERAGE_LENGTH_GT: Float
+              isan_AVERAGE_LENGTH_GTE: Float
+              isan_AVERAGE_LENGTH_LT: Float
+              isan_AVERAGE_LENGTH_LTE: Float
+              isan_LONGEST_LENGTH_EQUAL: Int
+              isan_LONGEST_LENGTH_GT: Int
+              isan_LONGEST_LENGTH_GTE: Int
+              isan_LONGEST_LENGTH_LT: Int
+              isan_LONGEST_LENGTH_LTE: Int
+              isan_SHORTEST_LENGTH_EQUAL: Int
+              isan_SHORTEST_LENGTH_GT: Int
+              isan_SHORTEST_LENGTH_GTE: Int
+              isan_SHORTEST_LENGTH_LT: Int
+              isan_SHORTEST_LENGTH_LTE: Int
+              title_AVERAGE_LENGTH_EQUAL: Float
+              title_AVERAGE_LENGTH_GT: Float
+              title_AVERAGE_LENGTH_GTE: Float
+              title_AVERAGE_LENGTH_LT: Float
+              title_AVERAGE_LENGTH_LTE: Float
+              title_LONGEST_LENGTH_EQUAL: Int
+              title_LONGEST_LENGTH_GT: Int
+              title_LONGEST_LENGTH_GTE: Int
+              title_LONGEST_LENGTH_LT: Int
+              title_LONGEST_LENGTH_LTE: Int
+              title_SHORTEST_LENGTH_EQUAL: Int
+              title_SHORTEST_LENGTH_GT: Int
+              title_SHORTEST_LENGTH_GTE: Int
+              title_SHORTEST_LENGTH_LT: Int
+              title_SHORTEST_LENGTH_LTE: Int
+            }
+
+            type ActorMoviesRelationship {
+              cursor: String!
+              node: Movie!
+            }
+
+            input ActorMoviesUpdateConnectionInput {
+              node: MovieUpdateInput
+            }
+
+            input ActorMoviesUpdateFieldInput {
+              connect: [ActorMoviesConnectFieldInput!]
+              create: [ActorMoviesCreateFieldInput!]
+              delete: [ActorMoviesDeleteFieldInput!]
+              disconnect: [ActorMoviesDisconnectFieldInput!]
+              update: ActorMoviesUpdateConnectionInput
+              where: ActorMoviesConnectionWhere
+            }
+
+            input ActorOptions {
+              limit: Int
+              offset: Int
+              \\"\\"\\"
+              Specify one or more ActorSort objects to sort Actors by. The sorts will be applied in the order in which they are arranged in the array.
+              \\"\\"\\"
+              sort: [ActorSort!]
+            }
+
+            \\"\\"\\"
+            Fields to sort Actors by. The order in which sorts are applied is not guaranteed when specifying many fields in one ActorSort object.
+            \\"\\"\\"
+            input ActorSort {
+              name: SortDirection
+            }
+
+            input ActorUpdateInput {
+              movies: [ActorMoviesUpdateFieldInput!]
+              name: String
+            }
+
+            input ActorWhere {
+              AND: [ActorWhere!]
+              NOT: ActorWhere
+              OR: [ActorWhere!]
+              moviesAggregate: ActorMoviesAggregateInput
+              \\"\\"\\"
+              Return Actors where all of the related ActorMoviesConnections match this filter
+              \\"\\"\\"
+              moviesConnection_ALL: ActorMoviesConnectionWhere
+              \\"\\"\\"
+              Return Actors where none of the related ActorMoviesConnections match this filter
+              \\"\\"\\"
+              moviesConnection_NONE: ActorMoviesConnectionWhere
+              \\"\\"\\"
+              Return Actors where one of the related ActorMoviesConnections match this filter
+              \\"\\"\\"
+              moviesConnection_SINGLE: ActorMoviesConnectionWhere
+              \\"\\"\\"
+              Return Actors where some of the related ActorMoviesConnections match this filter
+              \\"\\"\\"
+              moviesConnection_SOME: ActorMoviesConnectionWhere
+              \\"\\"\\"Return Actors where all of the related Movies match this filter\\"\\"\\"
+              movies_ALL: MovieWhere
+              \\"\\"\\"Return Actors where none of the related Movies match this filter\\"\\"\\"
+              movies_NONE: MovieWhere
+              \\"\\"\\"Return Actors where one of the related Movies match this filter\\"\\"\\"
+              movies_SINGLE: MovieWhere
+              \\"\\"\\"Return Actors where some of the related Movies match this filter\\"\\"\\"
+              movies_SOME: MovieWhere
+              name: String @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              name_CONTAINS: String
+              name_ENDS_WITH: String
+              name_EQ: String
+              name_IN: [String!]
+              name_STARTS_WITH: String
+            }
+
+            type ActorsConnection {
+              edges: [ActorEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type CreateActorsMutationResponse {
+              actors: [Actor!]!
+              info: CreateInfo!
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships created during a create mutation
+            \\"\\"\\"
+            type CreateInfo {
+              nodesCreated: Int!
+              relationshipsCreated: Int!
+            }
+
+            type CreateMoviesMutationResponse {
+              info: CreateInfo!
+              movies: [Movie!]!
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships deleted during a delete mutation
+            \\"\\"\\"
+            type DeleteInfo {
+              nodesDeleted: Int!
+              relationshipsDeleted: Int!
+            }
+
+            type Movie {
+              isan: String!
+              title: String!
+            }
+
+            type MovieAggregateSelection {
+              count: Int!
+              isan: StringAggregateSelection!
+              title: StringAggregateSelection!
+            }
+
+            input MovieConnectWhere {
+              node: MovieWhere!
+            }
+
+            input MovieCreateInput {
+              isan: String!
+              title: String!
+            }
+
+            type MovieEdge {
+              cursor: String!
+              node: Movie!
+            }
+
+            input MovieOptions {
+              limit: Int
+              offset: Int
+              \\"\\"\\"
+              Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array.
+              \\"\\"\\"
+              sort: [MovieSort!]
+            }
+
+            \\"\\"\\"
+            Fields to sort Movies by. The order in which sorts are applied is not guaranteed when specifying many fields in one MovieSort object.
+            \\"\\"\\"
+            input MovieSort {
+              isan: SortDirection
+              title: SortDirection
+            }
+
+            input MovieUpdateInput {
+              isan: String
+              title: String
+            }
+
+            input MovieWhere {
+              AND: [MovieWhere!]
+              NOT: MovieWhere
+              OR: [MovieWhere!]
+              isan: String @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              isan_CONTAINS: String
+              isan_ENDS_WITH: String
+              isan_EQ: String
+              isan_IN: [String!]
+              isan_STARTS_WITH: String
+              title: String @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              title_CONTAINS: String
+              title_ENDS_WITH: String
+              title_EQ: String
+              title_IN: [String!]
+              title_STARTS_WITH: String
+            }
+
+            type MoviesConnection {
+              edges: [MovieEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type Mutation {
+              createActors(input: [ActorCreateInput!]!): CreateActorsMutationResponse!
+              createMovies(input: [MovieCreateInput!]!): CreateMoviesMutationResponse!
+              deleteActors(delete: ActorDeleteInput, where: ActorWhere): DeleteInfo!
+              deleteMovies(where: MovieWhere): DeleteInfo!
+              updateActors(update: ActorUpdateInput, where: ActorWhere): UpdateActorsMutationResponse!
+              updateMovies(update: MovieUpdateInput, where: MovieWhere): UpdateMoviesMutationResponse!
+            }
+
+            \\"\\"\\"Pagination information (Relay)\\"\\"\\"
+            type PageInfo {
+              endCursor: String
+              hasNextPage: Boolean!
+              hasPreviousPage: Boolean!
+              startCursor: String
+            }
+
+            type Query {
+              actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
+              movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
+            }
+
+            \\"\\"\\"An enum for sorting in either ascending or descending order.\\"\\"\\"
+            enum SortDirection {
+              \\"\\"\\"Sort by field values in ascending order.\\"\\"\\"
+              ASC
+              \\"\\"\\"Sort by field values in descending order.\\"\\"\\"
+              DESC
+            }
+
+            type StringAggregateSelection {
+              longest: String
+              shortest: String
+            }
+
+            type UpdateActorsMutationResponse {
+              actors: [Actor!]!
+              info: UpdateInfo!
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships created and deleted during an update mutation
+            \\"\\"\\"
+            type UpdateInfo {
+              nodesCreated: Int!
+              nodesDeleted: Int!
+              relationshipsCreated: Int!
+              relationshipsDeleted: Int!
+            }
+
+            type UpdateMoviesMutationResponse {
+              info: UpdateInfo!
+              movies: [Movie!]!
+            }"
+        `);
+    });
+});

--- a/packages/graphql/tests/schema/union-interface-relationship.test.ts
+++ b/packages/graphql/tests/schema/union-interface-relationship.test.ts
@@ -272,7 +272,7 @@ describe("Union Interface Relationships", () => {
 
             input ActorMoviesFieldInput {
               connect: [ActorMoviesConnectFieldInput!]
-              connectOrCreate: [ActorMoviesConnectOrCreateFieldInput!]
+              connectOrCreate: [ActorMoviesConnectOrCreateFieldInput!] @deprecated(reason: \\"The connectOrCreate operation is deprecated and will be removed\\")
               create: [ActorMoviesCreateFieldInput!]
             }
 
@@ -690,7 +690,7 @@ describe("Union Interface Relationships", () => {
 
             input MovieActorsFieldInput {
               connect: [MovieActorsConnectFieldInput!]
-              connectOrCreate: [MovieActorsConnectOrCreateFieldInput!]
+              connectOrCreate: [MovieActorsConnectOrCreateFieldInput!] @deprecated(reason: \\"The connectOrCreate operation is deprecated and will be removed\\")
               create: [MovieActorsCreateFieldInput!]
             }
 
@@ -831,7 +831,7 @@ describe("Union Interface Relationships", () => {
 
             input MovieDirectorsActorFieldInput {
               connect: [MovieDirectorsActorConnectFieldInput!]
-              connectOrCreate: [MovieDirectorsActorConnectOrCreateFieldInput!]
+              connectOrCreate: [MovieDirectorsActorConnectOrCreateFieldInput!] @deprecated(reason: \\"The connectOrCreate operation is deprecated and will be removed\\")
               create: [MovieDirectorsActorCreateFieldInput!]
             }
 
@@ -926,7 +926,7 @@ describe("Union Interface Relationships", () => {
 
             input MovieDirectorsPersonFieldInput {
               connect: [MovieDirectorsPersonConnectFieldInput!]
-              connectOrCreate: [MovieDirectorsPersonConnectOrCreateFieldInput!]
+              connectOrCreate: [MovieDirectorsPersonConnectOrCreateFieldInput!] @deprecated(reason: \\"The connectOrCreate operation is deprecated and will be removed\\")
               create: [MovieDirectorsPersonCreateFieldInput!]
             }
 
@@ -1405,7 +1405,7 @@ describe("Union Interface Relationships", () => {
 
             input PersonMoviesFieldInput {
               connect: [PersonMoviesConnectFieldInput!]
-              connectOrCreate: [PersonMoviesConnectOrCreateFieldInput!]
+              connectOrCreate: [PersonMoviesConnectOrCreateFieldInput!] @deprecated(reason: \\"The connectOrCreate operation is deprecated and will be removed\\")
               create: [PersonMoviesCreateFieldInput!]
             }
 


### PR DESCRIPTION
# Description

The `connectOrCreate` operation has been deprecated and will be removed in the next major version of the Neo4j GraphQL Library. Its implementation has always been more limited than the other operations, so the decision has been taken to remove it for the time being with a view of potentially refocussing on it again in the future.

## Complexity

Complexity: Low
