### PR TITLE
Add legacy trailing comma configuration to Prettier

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -9,5 +9,6 @@
                 "tabWidth": 2
             }
         }
-    ]
+    ],
+    "trailingComma": "es5"
 }


### PR DESCRIPTION
Set the "trailingComma" to the value. "es5" to match "ESLint" and previous formatting configuration