### PR TITLE
Filter cdc events skipping nodes not present in the schema

### DIFF
--- a/.changeset/tasty-onions-laugh.md
+++ b/.changeset/tasty-onions-laugh.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+CDC subscription optimization. Only node events with labels present in the GraphQL schema will be queried. This will reduce the number of subscription events queried by skipping events to nodes that cannot be subscribed through GraphQL


### PR DESCRIPTION
# Description

CDC subscription optimization. Only node events with labels present in the GraphQL schema will be queried. This will reduce the number of subscription events queried by skipping events to nodes that cannot be subscribed through GraphQL
