### PR TITLE
Add option`onlyGraphQLEvents` for subscriptions

### DIFF
--- a/.changeset/curvy-rabbits-notice.md
+++ b/.changeset/curvy-rabbits-notice.md
@@ -2,12 +2,12 @@
 "@neo4j/graphql": patch
 ---
 
-Add support for filtering GraphQL only events in CDC subscriptions with the option `filterGraphQLEvents` passed to `Neo4jGraphQLSubscriptionsCDCEngine`
+Add support for filtering GraphQL only events in CDC subscriptions with the option `onlyGraphQLEvents` passed to `Neo4jGraphQLSubscriptionsCDCEngine`
 
 ```ts
 const engine = new Neo4jGraphQLSubscriptionsCDCEngine({
     driver,
-    filterGraphQLEvents: true,
+    onlyGraphQLEvents: true,
 });
 
 const neoSchema = new Neo4jGraphQL({

--- a/.changeset/curvy-rabbits-notice.md
+++ b/.changeset/curvy-rabbits-notice.md
@@ -1,0 +1,20 @@
+---
+"@neo4j/graphql": patch
+---
+
+Add support for filtering GraphQL only events in CDC subscriptions with the option `filterGraphQLEvents` passed to `Neo4jGraphQLSubscriptionsCDCEngine`
+
+```ts
+const engine = new Neo4jGraphQLSubscriptionsCDCEngine({
+    driver,
+    filterGraphQLEvents: true,
+});
+
+const neoSchema = new Neo4jGraphQL({
+    typeDefs,
+    driver,
+    features: {
+        subscriptions: engine,
+    },
+});
+```

--- a/packages/graphql/src/classes/Executor.ts
+++ b/packages/graphql/src/classes/Executor.ts
@@ -32,13 +32,13 @@ import type {
 } from "neo4j-driver";
 import { Neo4jError } from "neo4j-driver";
 import {
+    APP_ID,
     AUTH_FORBIDDEN_ERROR,
     AUTH_UNAUTHENTICATED_ERROR,
     DEBUG_EXECUTE,
     RELATIONSHIP_REQUIREMENT_PREFIX,
 } from "../constants";
 import { debugCypherAndParams } from "../debug/debug-cypher-and-params";
-import environment from "../environment";
 import type { CypherQueryOptions } from "../types";
 import {
     Neo4jGraphQLAuthenticationError,
@@ -186,12 +186,10 @@ export class Executor {
     }
 
     private getTransactionConfig(info?: GraphQLResolveInfo): TransactionConfig {
-        const app = `${environment.NPM_PACKAGE_NAME}@${environment.NPM_PACKAGE_VERSION}`;
-
         const transactionConfig: TransactionConfig = {
             metadata: {
                 ...this.transactionMetadata,
-                app,
+                app: APP_ID,
                 type: "user-transpiled",
             },
         };

--- a/packages/graphql/src/classes/subscription/Neo4jGraphQLSubscriptionsCDCEngine.ts
+++ b/packages/graphql/src/classes/subscription/Neo4jGraphQLSubscriptionsCDCEngine.ts
@@ -17,9 +17,11 @@
  * limitations under the License.
  */
 
+import Cypher from "@neo4j/cypher-builder";
 import { EventEmitter } from "events";
 import type { Driver, QueryConfig } from "neo4j-driver";
 import { Memoize } from "typescript-memoize";
+import environment from "../../environment";
 import type { Neo4jGraphQLSchemaModel } from "../../schema-model/Neo4jGraphQLSchemaModel";
 import type { Neo4jGraphQLSubscriptionsEngine, SubscriptionEngineContext, SubscriptionsEvent } from "../../types";
 import { CDCApi } from "./cdc/cdc-api";
@@ -35,18 +37,22 @@ export class Neo4jGraphQLSubscriptionsCDCEngine implements Neo4jGraphQLSubscript
     private closed = false;
 
     private subscribeToLabels: string[] | undefined;
+    private filterGraphQLEvents: boolean;
 
     constructor({
         driver,
         pollTime = 1000,
         queryConfig,
+        filterGraphQLEvents = false,
     }: {
         driver: Driver;
         pollTime?: number;
         queryConfig?: QueryConfig;
+        filterGraphQLEvents?: boolean;
     }) {
         this.cdcApi = new CDCApi(driver, queryConfig);
         this.pollTime = pollTime;
+        this.filterGraphQLEvents = filterGraphQLEvents;
     }
 
     // This memoize is done to keep typings correct whilst avoiding the performance ir of the throw
@@ -97,7 +103,16 @@ export class Neo4jGraphQLSubscriptionsCDCEngine implements Neo4jGraphQLSubscript
     }
 
     private async pollEvents(): Promise<void> {
-        const cdcEvents = await this.cdcApi.queryEvents(this.subscribeToLabels);
+        let txFilter: Cypher.Map | undefined;
+        if (this.filterGraphQLEvents) {
+            const app = `${environment.NPM_PACKAGE_NAME}@${environment.NPM_PACKAGE_VERSION}`;
+
+            const appMetadata = new Cypher.Param(app);
+            txFilter = new Cypher.Map({
+                app: appMetadata,
+            });
+        }
+        const cdcEvents = await this.cdcApi.queryEvents(this.subscribeToLabels, txFilter);
         for (const cdcEvent of cdcEvents) {
             const parsedEvent = this.parser.parseCDCEvent(cdcEvent);
             if (parsedEvent) {

--- a/packages/graphql/src/constants.ts
+++ b/packages/graphql/src/constants.ts
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+import environment from "./environment";
+
 const DEBUG_PREFIX = "@neo4j/graphql";
 
 export const AUTH_FORBIDDEN_ERROR = "@neo4j/graphql/FORBIDDEN";
@@ -100,3 +102,5 @@ export const DEPRECATED = "deprecated";
 export const SHAREABLE = "shareable";
 export const PROPAGATED_DIRECTIVES = [SHAREABLE, DEPRECATED] as const;
 export const SCORE_FIELD = "score";
+
+export const APP_ID = `${environment.NPM_PACKAGE_NAME}@${environment.NPM_PACKAGE_VERSION}`;

--- a/packages/graphql/tests/e2e/subscriptions/create.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/create.e2e.test.ts
@@ -109,6 +109,7 @@ describe("Create Subscription", () => {
             },
         ]);
     });
+
     test("create subscription with where", async () => {
         await wsClient.subscribe(`
             subscription {

--- a/packages/graphql/tests/e2e/subscriptions/issues/5787.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/issues/5787.e2e.test.ts
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Response } from "supertest";
+import supertest from "supertest";
+import type { UniqueType } from "../../../utils/graphql-types";
+import { TestHelper } from "../../../utils/tests-helper";
+import type { TestGraphQLServer } from "../../setup/apollo-server";
+import { ApolloTestServer } from "../../setup/apollo-server";
+import { WebSocketTestClient } from "../../setup/ws-client";
+
+describe("https://github.com/neo4j/graphql/issues/5787", () => {
+    describe("With filterGraphQLEvents", () => {
+        const testHelper = new TestHelper({ cdc: true, filterGraphQLEvents: true });
+        let server: TestGraphQLServer;
+        let wsClient: WebSocketTestClient;
+        let typeMovie: UniqueType;
+
+        beforeAll(async () => {
+            await testHelper.assertCDCEnabled();
+        });
+
+        beforeEach(async () => {
+            typeMovie = testHelper.createUniqueType("Movie");
+
+            const typeDefs = `
+         type ${typeMovie} @node {
+             title: String
+         }
+
+         `;
+
+            const neoSchema = await testHelper.initNeo4jGraphQL({
+                typeDefs,
+                features: {
+                    subscriptions: await testHelper.getSubscriptionEngine(),
+                },
+            });
+            // eslint-disable-next-line @typescript-eslint/require-await
+            server = new ApolloTestServer(neoSchema, async ({ req }) => ({
+                sessionConfig: {
+                    database: testHelper.database,
+                },
+                token: req.headers.authorization,
+            }));
+            await server.start();
+
+            wsClient = new WebSocketTestClient(server.wsPath);
+        });
+
+        afterEach(async () => {
+            await wsClient.close();
+            await server.close();
+            await testHelper.close();
+        });
+
+        test("non-graphql subscriptions are not filtered by default", async () => {
+            await wsClient.subscribe(`
+                            subscription {
+                                ${typeMovie.operations.subscribe.created} {
+                                    ${typeMovie.operations.subscribe.payload.created} {
+                                        title
+                                    }
+                                    event
+                                    timestamp
+                                }
+                            }
+                            `);
+
+            await createMovie("movie1");
+            await createMovieWithCypher("movie2");
+
+            await wsClient.waitForEvents(1);
+
+            expect(wsClient.errors).toEqual([]);
+            expect(wsClient.events).toEqual([
+                {
+                    [typeMovie.operations.subscribe.created]: {
+                        [typeMovie.operations.subscribe.payload.created]: { title: "movie1" },
+                        event: "CREATE",
+                        timestamp: expect.any(Number),
+                    },
+                },
+            ]);
+        });
+
+        async function createMovie(title: string): Promise<Response> {
+            const result = await supertest(server.path)
+                .post("")
+                .send({
+                    query: `
+                    mutation {
+                        ${typeMovie.operations.create}(input: [{ title: "${title}" }]) {
+                            ${typeMovie.plural} {
+                                title
+                            }
+                        }
+                    }
+                `,
+                })
+                .expect(200);
+            return result;
+        }
+
+        async function createMovieWithCypher(title: string): Promise<void> {
+            await testHelper.executeCypher(`CREATE(:${typeMovie} {title: "${title}"})`);
+        }
+    });
+
+    describe("Without filterGraphQLEvents", () => {
+        const testHelper = new TestHelper({ cdc: true, filterTxMeta: false });
+        let server: TestGraphQLServer;
+        let wsClient: WebSocketTestClient;
+        let typeMovie: UniqueType;
+
+        beforeAll(async () => {
+            await testHelper.assertCDCEnabled();
+        });
+
+        beforeEach(async () => {
+            typeMovie = testHelper.createUniqueType("Movie");
+
+            const typeDefs = `
+         type ${typeMovie} @node {
+             title: String
+         }
+
+         `;
+
+            const neoSchema = await testHelper.initNeo4jGraphQL({
+                typeDefs,
+                features: {
+                    subscriptions: await testHelper.getSubscriptionEngine(),
+                },
+            });
+            // eslint-disable-next-line @typescript-eslint/require-await
+            server = new ApolloTestServer(neoSchema, async ({ req }) => ({
+                sessionConfig: {
+                    database: testHelper.database,
+                },
+                token: req.headers.authorization,
+            }));
+            await server.start();
+
+            wsClient = new WebSocketTestClient(server.wsPath);
+        });
+
+        afterEach(async () => {
+            await wsClient.close();
+            await server.close();
+            await testHelper.close();
+        });
+
+        test("non-graphql subscriptions are not filtered by default", async () => {
+            await wsClient.subscribe(`
+                            subscription {
+                                ${typeMovie.operations.subscribe.created} {
+                                    ${typeMovie.operations.subscribe.payload.created} {
+                                        title
+                                    }
+                                    event
+                                    timestamp
+                                }
+                            }
+                            `);
+
+            await createMovie("movie1");
+            await createMovieWithCypher("movie2");
+
+            await wsClient.waitForEvents(2);
+
+            expect(wsClient.errors).toEqual([]);
+            expect(wsClient.events).toEqual([
+                {
+                    [typeMovie.operations.subscribe.created]: {
+                        [typeMovie.operations.subscribe.payload.created]: { title: "movie1" },
+                        event: "CREATE",
+                        timestamp: expect.any(Number),
+                    },
+                },
+                {
+                    [typeMovie.operations.subscribe.created]: {
+                        [typeMovie.operations.subscribe.payload.created]: { title: "movie2" },
+                        event: "CREATE",
+                        timestamp: expect.any(Number),
+                    },
+                },
+            ]);
+        });
+
+        async function createMovie(title: string): Promise<Response> {
+            const result = await supertest(server.path)
+                .post("")
+                .send({
+                    query: `
+                    mutation {
+                        ${typeMovie.operations.create}(input: [{ title: "${title}" }]) {
+                            ${typeMovie.plural} {
+                                title
+                            }
+                        }
+                    }
+                `,
+                })
+                .expect(200);
+            return result;
+        }
+
+        async function createMovieWithCypher(title: string): Promise<void> {
+            await testHelper.executeCypher(`CREATE(:${typeMovie} {title: "${title}"})`);
+        }
+    });
+});

--- a/packages/graphql/tests/e2e/subscriptions/issues/5787.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/issues/5787.e2e.test.ts
@@ -26,8 +26,8 @@ import { ApolloTestServer } from "../../setup/apollo-server";
 import { WebSocketTestClient } from "../../setup/ws-client";
 
 describe("https://github.com/neo4j/graphql/issues/5787", () => {
-    describe("With filterGraphQLEvents", () => {
-        const testHelper = new TestHelper({ cdc: true, filterGraphQLEvents: true });
+    describe("With onlyGraphQLEvents", () => {
+        const testHelper = new TestHelper({ cdc: true, onlyGraphQLEvents: true });
         let server: TestGraphQLServer;
         let wsClient: WebSocketTestClient;
         let typeMovie: UniqueType;
@@ -123,8 +123,8 @@ describe("https://github.com/neo4j/graphql/issues/5787", () => {
         }
     });
 
-    describe("Without filterGraphQLEvents", () => {
-        const testHelper = new TestHelper({ cdc: true, filterTxMeta: false });
+    describe("Without onlyGraphQLEvents", () => {
+        const testHelper = new TestHelper({ cdc: true, onlyGraphQLEvents: false });
         let server: TestGraphQLServer;
         let wsClient: WebSocketTestClient;
         let typeMovie: UniqueType;

--- a/packages/graphql/tests/utils/tests-helper.ts
+++ b/packages/graphql/tests/utils/tests-helper.ts
@@ -44,16 +44,16 @@ export class TestHelper {
     private subscriptionEngine?: Neo4jGraphQLSubscriptionsCDCEngine;
 
     private cdc: boolean;
-    private filterGraphQLEvents: boolean;
+    private onlyGraphQLEvents: boolean;
 
     constructor(
-        { cdc = false, filterGraphQLEvents = false }: { cdc: boolean; filterGraphQLEvents?: boolean } = {
+        { cdc = false, onlyGraphQLEvents = false }: { cdc: boolean; onlyGraphQLEvents?: boolean } = {
             cdc: false,
-            filterGraphQLEvents: false,
+            onlyGraphQLEvents: false,
         }
     ) {
         this.cdc = cdc;
-        this.filterGraphQLEvents = filterGraphQLEvents;
+        this.onlyGraphQLEvents = onlyGraphQLEvents;
     }
 
     public get database(): string {
@@ -80,7 +80,7 @@ export class TestHelper {
             queryConfig: {
                 database: this.database,
             },
-            filterGraphQLEvents: this.filterGraphQLEvents,
+            onlyGraphQLEvents: this.onlyGraphQLEvents,
         });
 
         return this.subscriptionEngine;

--- a/packages/graphql/tests/utils/tests-helper.ts
+++ b/packages/graphql/tests/utils/tests-helper.ts
@@ -44,8 +44,16 @@ export class TestHelper {
     private subscriptionEngine?: Neo4jGraphQLSubscriptionsCDCEngine;
 
     private cdc: boolean;
-    constructor({ cdc = false }: { cdc: boolean } = { cdc: false }) {
+    private filterGraphQLEvents: boolean;
+
+    constructor(
+        { cdc = false, filterGraphQLEvents = false }: { cdc: boolean; filterGraphQLEvents?: boolean } = {
+            cdc: false,
+            filterGraphQLEvents: false,
+        }
+    ) {
         this.cdc = cdc;
+        this.filterGraphQLEvents = filterGraphQLEvents;
     }
 
     public get database(): string {
@@ -72,6 +80,7 @@ export class TestHelper {
             queryConfig: {
                 database: this.database,
             },
+            filterGraphQLEvents: this.filterGraphQLEvents,
         });
 
         return this.subscriptionEngine;


### PR DESCRIPTION
# Description

Adds the option `filterGraphQLEvents` to only trigger CDC on GraphQL events