### PR TITLE
(6.x) Cypher filtering many to many relationships

### DIFF
--- a/.changeset/red-hairs-decide.md
+++ b/.changeset/red-hairs-decide.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": minor
+---
+
+Add filtering on many to many relationship custom cypher fields

--- a/packages/graphql/src/schema-model/generate-model.ts
+++ b/packages/graphql/src/schema-model/generate-model.ts
@@ -39,7 +39,8 @@ import type { Operations } from "./Neo4jGraphQLSchemaModel";
 import { Neo4jGraphQLSchemaModel } from "./Neo4jGraphQLSchemaModel";
 import { Operation } from "./Operation";
 import type { Attribute } from "./attribute/Attribute";
-import { ObjectType } from "./attribute/AttributeType";
+import type { AttributeType } from "./attribute/AttributeType";
+import { ListType, ObjectType } from "./attribute/AttributeType";
 import type { CompositeEntity } from "./entity/CompositeEntity";
 import { ConcreteEntity } from "./entity/ConcreteEntity";
 import type { Entity } from "./entity/Entity";
@@ -131,20 +132,31 @@ function addCompositeEntitiesToConcreteEntity(compositeEntities: CompositeEntity
     });
 }
 
+function getCypherTarget(schema: Neo4jGraphQLSchemaModel, attributeType: AttributeType): ConcreteEntity | undefined {
+    if (attributeType instanceof ListType) {
+        return getCypherTarget(schema, attributeType.ofType);
+    }
+    if (attributeType instanceof ObjectType) {
+        const foundConcreteEntity = schema.getConcreteEntity(attributeType.name);
+        if (!foundConcreteEntity) {
+            throw new Neo4jGraphQLSchemaValidationError(
+                `@cypher field must target type annotated with the @node directive${attributeType.name}, `
+            );
+        }
+        return schema.getConcreteEntity(attributeType.name);
+    }
+    if (attributeType instanceof InterfaceEntity || attributeType instanceof UnionEntity) {
+        throw new Error("@cypher field target cannot be an interface or an union");
+    }
+}
+
+// TODO: currently the below is used only for Filtering purposes, and therefore the target is set only for ObjectTypes but in the future we might want to use it for other types as well
 function hydrateCypherAnnotations(schema: Neo4jGraphQLSchemaModel, concreteEntities: ConcreteEntity[]) {
     for (const concreteEntity of concreteEntities) {
         for (const attributeField of concreteEntity.attributes.values()) {
             if (attributeField.annotations.cypher) {
-                if (attributeField.type instanceof ObjectType) {
-                    const foundConcreteEntity = schema.getConcreteEntity(attributeField.type.name);
-                    if (!foundConcreteEntity) {
-                        throw new Neo4jGraphQLSchemaValidationError(
-                            `Could not find concrete entity with name ${attributeField.type.name}`
-                        );
-                    }
-
-                    attributeField.annotations.cypher.targetEntity = foundConcreteEntity;
-                }
+                const target = getCypherTarget(schema, attributeField.type);
+                attributeField.annotations.cypher.targetEntity = target;
             }
         }
     }

--- a/packages/graphql/src/translate/queryAST/ast/filters/CypherRelationshipFilter.ts
+++ b/packages/graphql/src/translate/queryAST/ast/filters/CypherRelationshipFilter.ts
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Cypher from "@neo4j/cypher-builder";
+import type { AttributeAdapter } from "../../../../schema-model/attribute/model-adapters/AttributeAdapter";
+import type { QueryASTContext } from "../QueryASTContext";
+import type { QueryASTNode } from "../QueryASTNode";
+import type { CustomCypherSelection } from "../selection/CustomCypherSelection";
+import type { FilterOperator, RelationshipWhereOperator } from "./Filter";
+import { Filter } from "./Filter";
+
+export class CypherRelationshipFilter extends Filter {
+    private returnVariable: Cypher.Node;
+    private attribute: AttributeAdapter;
+    private selection: CustomCypherSelection;
+    private operator: FilterOperator;
+    private targetNodeFilters: Filter[] = [];
+    private isNot: boolean;
+
+    constructor({
+        selection,
+        attribute,
+        operator,
+        isNot,
+        returnVariable,
+    }: {
+        selection: CustomCypherSelection;
+        attribute: AttributeAdapter;
+        operator: RelationshipWhereOperator;
+        isNot: boolean;
+        returnVariable: Cypher.Node;
+    }) {
+        super();
+        this.selection = selection;
+        this.attribute = attribute;
+        this.isNot = isNot;
+        this.operator = operator;
+        this.returnVariable = returnVariable;
+    }
+
+    public getChildren(): QueryASTNode[] {
+        return [...this.targetNodeFilters, this.selection];
+    }
+
+    public addTargetNodeFilter(...filter: Filter[]): void {
+        this.targetNodeFilters.push(...filter);
+    }
+
+    public print(): string {
+        return `${super.print()} [${this.attribute.name}] <${this.isNot ? "NOT " : ""}${this.operator}>`;
+    }
+
+    public getSubqueries(context: QueryASTContext): Cypher.Clause[] {
+        const { selection, nestedContext } = this.selection.apply(context);
+
+        const cypherSubquery = selection.return([Cypher.collect(nestedContext.returnVariable), this.returnVariable]);
+
+        return [cypherSubquery];
+    }
+
+    public getPredicate(queryASTContext: QueryASTContext): Cypher.Predicate | undefined {
+        const context = queryASTContext.setTarget(this.returnVariable);
+
+        const predicate = this.createRelationshipOperation(context);
+        if (predicate) {
+            return this.wrapInNotIfNeeded(predicate);
+        }
+    }
+
+    private createRelationshipOperation(queryASTContext: QueryASTContext): Cypher.Predicate | undefined {
+        const x = new Cypher.Node();
+        const context = queryASTContext.setTarget(x);
+        const targetNodePredicates = this.targetNodeFilters.map((c) => c.getPredicate(context));
+        const innerPredicate = Cypher.and(...targetNodePredicates);
+
+        if (!innerPredicate) {
+            return;
+        }
+
+        switch (this.operator) {
+            case "ALL": {
+                return Cypher.all(x, this.returnVariable, innerPredicate);
+            }
+            case "SINGLE": {
+                return Cypher.single(x, this.returnVariable, innerPredicate);
+            }
+            case "NONE": {
+                return Cypher.none(x, this.returnVariable, innerPredicate);
+            }
+            case "SOME": {
+                return Cypher.any(x, this.returnVariable, innerPredicate);
+            }
+        }
+    }
+
+    private wrapInNotIfNeeded(predicate: Cypher.Predicate): Cypher.Predicate {
+        // TODO: Remove check for NONE when isNot is removed
+        if (this.isNot && this.operator !== "NONE") {
+            return Cypher.not(predicate);
+        }
+
+        return predicate;
+    }
+}

--- a/packages/graphql/tests/integration/directives/cypher/filtering/relationships/cypher-filtering-relationship-auth.int.test.ts
+++ b/packages/graphql/tests/integration/directives/cypher/filtering/relationships/cypher-filtering-relationship-auth.int.test.ts
@@ -31,7 +31,7 @@ describe("cypher directive filtering - relationship auth filter", () => {
         const Actor = testHelper.createUniqueType("Actor");
 
         const typeDefs = /* GraphQL */ `
-            type ${Movie} @node @authorization(filter: [{ where: { node: { actors_SOME: { name: "$jwt.custom_value" } } } }]) {
+            type ${Movie} @node @authorization(filter: [{ where: { node: { actors_SOME: { name_EQ: "$jwt.custom_value" } } } }]) {
                 title: String
                 rating: Float
                 actors: [${Actor}!]!
@@ -124,7 +124,7 @@ describe("cypher directive filtering - relationship auth filter", () => {
         const Actor = testHelper.createUniqueType("Actor");
 
         const typeDefs = /* GraphQL */ `
-            type ${Movie} @node @authorization(filter: [{ where: { node: { actors_SOME: { name: "$jwt.custom_value" } } } }]) {
+            type ${Movie} @node @authorization(filter: [{ where: { node: { actors_SOME: { name_EQ: "$jwt.custom_value" } } } }]) {
                 title: String
                 rating: Float
                 actors: [${Actor}!]!
@@ -211,7 +211,7 @@ describe("cypher directive filtering - relationship auth filter", () => {
         const Actor = testHelper.createUniqueType("Actor");
 
         const typeDefs = /* GraphQL */ `
-            type ${Movie} @node @authorization(validate: [{ where: { node: { actors_SOME: { name: "$jwt.custom_value" } } } }]) {
+            type ${Movie} @node @authorization(validate: [{ where: { node: { actors_SOME: { name_EQ: "$jwt.custom_value" } } } }]) {
                 title: String
                 rating: Float
                 actors: [${Actor}!]!
@@ -304,7 +304,7 @@ describe("cypher directive filtering - relationship auth filter", () => {
         const Actor = testHelper.createUniqueType("Actor");
 
         const typeDefs = /* GraphQL */ `
-            type ${Movie} @node @authorization(validate: [{ where: { node: { actors_SOME: { name: "$jwt.custom_value" } } } }]) {
+            type ${Movie} @node @authorization(validate: [{ where: { node: { actors_SOME: { name_EQ: "$jwt.custom_value" } } } }]) {
                 title: String
                 rating: Float
                 actors: [${Actor}!]!

--- a/packages/graphql/tests/integration/directives/cypher/filtering/relationships/cypher-filtering-relationship-auth.int.test.ts
+++ b/packages/graphql/tests/integration/directives/cypher/filtering/relationships/cypher-filtering-relationship-auth.int.test.ts
@@ -1,0 +1,384 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TestHelper } from "../../../../../utils/tests-helper";
+
+describe("cypher directive filtering - relationship auth filter", () => {
+    const testHelper = new TestHelper();
+
+    afterEach(async () => {
+        await testHelper.close();
+    });
+
+    test("relationship with auth filter on type PASS", async () => {
+        const Movie = testHelper.createUniqueType("Movie");
+        const Actor = testHelper.createUniqueType("Actor");
+
+        const typeDefs = /* GraphQL */ `
+            type ${Movie} @node @authorization(filter: [{ where: { node: { actors_SOME: { name: "$jwt.custom_value" } } } }]) {
+                title: String
+                rating: Float
+                actors: [${Actor}!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:ACTED_IN]-(actor:${Actor})
+                        RETURN actor
+                        """
+                        columnName: "actor"
+                    )
+            }
+
+            type ${Actor} @node {
+                name: String
+                movies: [${Movie}!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(movie:${Movie})
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        const token = testHelper.createBearerToken("secret", { custom_value: "Jada Pinkett Smith" });
+
+        await testHelper.initNeo4jGraphQL({
+            typeDefs,
+            features: {
+                authorization: {
+                    key: "secret",
+                },
+            },
+        });
+        await testHelper.executeCypher(
+            `
+            CREATE (m:${Movie} { title: "The Matrix", rating: 10.0 })
+            CREATE (m2:${Movie} { title: "The Matrix Reloaded", rating: 8.0 })
+            CREATE (m3:${Movie} { title: "The Matrix Revolutions", rating: 6.0 })
+            CREATE (a:${Actor} { name: "Keanu Reeves" })
+            CREATE (a)-[:ACTED_IN]->(m)
+            CREATE (a)-[:ACTED_IN]->(m2)
+            CREATE (a)-[:ACTED_IN]->(m3)
+            CREATE (a2:${Actor} { name: "Carrie-Anne Moss" })
+            CREATE (a2)-[:ACTED_IN]->(m)
+            CREATE (a2)-[:ACTED_IN]->(m2)
+            CREATE (a2)-[:ACTED_IN]->(m3)
+            CREATE (a3:${Actor} { name: "Jada Pinkett Smith" })
+            CREATE (a3)-[:ACTED_IN]->(m2)
+            CREATE (a3)-[:ACTED_IN]->(m3)
+            `,
+            {}
+        );
+
+        const query = /* GraphQL */ `
+            query {
+                ${Movie.operations.connection}(
+                    where: {
+                        rating_GT: 7.0
+                    }
+                ) {
+                    edges {
+                        node {
+                            title
+                        }
+                    }
+                }
+            }
+        `;
+
+        const gqlResult = await testHelper.executeGraphQLWithToken(query, token);
+
+        expect(gqlResult.errors).toBeFalsy();
+        expect(gqlResult?.data).toEqual({
+            [Movie.operations.connection]: {
+                edges: expect.toIncludeSameMembers([
+                    {
+                        node: {
+                            title: "The Matrix Reloaded",
+                        },
+                    },
+                ]),
+            },
+        });
+    });
+
+    test("relationship with auth filter on type FAIL", async () => {
+        const Movie = testHelper.createUniqueType("Movie");
+        const Actor = testHelper.createUniqueType("Actor");
+
+        const typeDefs = /* GraphQL */ `
+            type ${Movie} @node @authorization(filter: [{ where: { node: { actors_SOME: { name: "$jwt.custom_value" } } } }]) {
+                title: String
+                rating: Float
+                actors: [${Actor}!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:ACTED_IN]-(actor:${Actor})
+                        RETURN actor
+                        """
+                        columnName: "actor"
+                    )
+            }
+
+            type ${Actor} @node {
+                name: String
+                movies: [${Movie}!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(movie:${Movie})
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        const token = testHelper.createBearerToken("secret", { custom_value: "Something Incorrect" });
+
+        await testHelper.initNeo4jGraphQL({
+            typeDefs,
+            features: {
+                authorization: {
+                    key: "secret",
+                },
+            },
+        });
+        await testHelper.executeCypher(
+            `
+            CREATE (m:${Movie} { title: "The Matrix", rating: 10.0 })
+            CREATE (m2:${Movie} { title: "The Matrix Reloaded", rating: 8.0 })
+            CREATE (m3:${Movie} { title: "The Matrix Revolutions", rating: 6.0 })
+            CREATE (a:${Actor} { name: "Keanu Reeves" })
+            CREATE (a)-[:ACTED_IN]->(m)
+            CREATE (a)-[:ACTED_IN]->(m2)
+            CREATE (a)-[:ACTED_IN]->(m3)
+            CREATE (a2:${Actor} { name: "Carrie-Anne Moss" })
+            CREATE (a2)-[:ACTED_IN]->(m)
+            CREATE (a2)-[:ACTED_IN]->(m2)
+            CREATE (a2)-[:ACTED_IN]->(m3)
+            CREATE (a3:${Actor} { name: "Jada Pinkett Smith" })
+            CREATE (a3)-[:ACTED_IN]->(m2)
+            CREATE (a3)-[:ACTED_IN]->(m3)
+            `,
+            {}
+        );
+
+        const query = /* GraphQL */ `
+            query {
+                ${Movie.operations.connection}(
+                    where: {
+                        rating_GT: 7.0
+                    }
+                ) {
+                    edges {
+                        node {
+                            title
+                        }
+                    }
+                }
+            }
+        `;
+
+        const gqlResult = await testHelper.executeGraphQLWithToken(query, token);
+
+        expect(gqlResult.errors).toBeFalsy();
+        expect(gqlResult?.data).toEqual({
+            [Movie.operations.connection]: {
+                edges: [],
+            },
+        });
+    });
+
+    test("relationship with auth validate on type PASS", async () => {
+        const Movie = testHelper.createUniqueType("Movie");
+        const Actor = testHelper.createUniqueType("Actor");
+
+        const typeDefs = /* GraphQL */ `
+            type ${Movie} @node @authorization(validate: [{ where: { node: { actors_SOME: { name: "$jwt.custom_value" } } } }]) {
+                title: String
+                rating: Float
+                actors: [${Actor}!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:ACTED_IN]-(actor:${Actor})
+                        RETURN actor
+                        """
+                        columnName: "actor"
+                    )
+            }
+
+            type ${Actor} @node {
+                name: String
+                movies: [${Movie}!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(movie:${Movie})
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        const token = testHelper.createBearerToken("secret", { custom_value: "Jada Pinkett Smith" });
+
+        await testHelper.initNeo4jGraphQL({
+            typeDefs,
+            features: {
+                authorization: {
+                    key: "secret",
+                },
+            },
+        });
+        await testHelper.executeCypher(
+            `
+            CREATE (m:${Movie} { title: "The Matrix", rating: 10.0 })
+            CREATE (m2:${Movie} { title: "The Matrix Reloaded", rating: 8.0 })
+            CREATE (m3:${Movie} { title: "The Matrix Revolutions", rating: 6.0 })
+            CREATE (a:${Actor} { name: "Keanu Reeves" })
+            CREATE (a)-[:ACTED_IN]->(m)
+            CREATE (a)-[:ACTED_IN]->(m2)
+            CREATE (a)-[:ACTED_IN]->(m3)
+            CREATE (a2:${Actor} { name: "Carrie-Anne Moss" })
+            CREATE (a2)-[:ACTED_IN]->(m)
+            CREATE (a2)-[:ACTED_IN]->(m2)
+            CREATE (a2)-[:ACTED_IN]->(m3)
+            CREATE (a3:${Actor} { name: "Jada Pinkett Smith" })
+            CREATE (a3)-[:ACTED_IN]->(m2)
+            CREATE (a3)-[:ACTED_IN]->(m3)
+            `,
+            {}
+        );
+
+        const query = /* GraphQL */ `
+            query {
+                ${Movie.operations.connection}(
+                    where: {
+                        rating_LT: 7.0
+                    }
+                ) {
+                    edges {
+                        node {
+                            title
+                        }
+                    }
+                }
+            }
+        `;
+
+        const gqlResult = await testHelper.executeGraphQLWithToken(query, token);
+
+        expect(gqlResult.errors).toBeFalsy();
+        expect(gqlResult?.data).toEqual({
+            [Movie.operations.connection]: {
+                edges: expect.toIncludeSameMembers([
+                    {
+                        node: {
+                            title: "The Matrix Revolutions",
+                        },
+                    },
+                ]),
+            },
+        });
+    });
+
+    test("relationship with auth validate on type FAIL", async () => {
+        const Movie = testHelper.createUniqueType("Movie");
+        const Actor = testHelper.createUniqueType("Actor");
+
+        const typeDefs = /* GraphQL */ `
+            type ${Movie} @node @authorization(validate: [{ where: { node: { actors_SOME: { name: "$jwt.custom_value" } } } }]) {
+                title: String
+                rating: Float
+                actors: [${Actor}!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:ACTED_IN]-(actor:${Actor})
+                        RETURN actor
+                        """
+                        columnName: "actor"
+                    )
+            }
+
+            type ${Actor} @node {
+                name: String
+                movies: [${Movie}!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(movie:${Movie})
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        const token = testHelper.createBearerToken("secret", { custom_value: "Jada Pinkett Smith" });
+
+        await testHelper.initNeo4jGraphQL({
+            typeDefs,
+            features: {
+                authorization: {
+                    key: "secret",
+                },
+            },
+        });
+        await testHelper.executeCypher(
+            `
+            CREATE (m:${Movie} { title: "The Matrix", rating: 10.0 })
+            CREATE (m2:${Movie} { title: "The Matrix Reloaded", rating: 8.0 })
+            CREATE (m3:${Movie} { title: "The Matrix Revolutions", rating: 6.0 })
+            CREATE (a:${Actor} { name: "Keanu Reeves" })
+            CREATE (a)-[:ACTED_IN]->(m)
+            CREATE (a)-[:ACTED_IN]->(m2)
+            CREATE (a)-[:ACTED_IN]->(m3)
+            CREATE (a2:${Actor} { name: "Carrie-Anne Moss" })
+            CREATE (a2)-[:ACTED_IN]->(m)
+            CREATE (a2)-[:ACTED_IN]->(m2)
+            CREATE (a2)-[:ACTED_IN]->(m3)
+            CREATE (a3:${Actor} { name: "Jada Pinkett Smith" })
+            CREATE (a3)-[:ACTED_IN]->(m2)
+            CREATE (a3)-[:ACTED_IN]->(m3)
+            `,
+            {}
+        );
+
+        const query = /* GraphQL */ `
+            query {
+                ${Movie.operations.connection}(
+                    where: {
+                        rating_GT: 7.0
+                    }
+                ) {
+                    edges {
+                        node {
+                            title
+                        }
+                    }
+                }
+            }
+        `;
+
+        const gqlResult = await testHelper.executeGraphQLWithToken(query, token);
+
+        expect(gqlResult.errors).toHaveLength(1);
+        expect(gqlResult.errors?.[0]?.message).toBe("Forbidden");
+    });
+});

--- a/packages/graphql/tests/integration/directives/cypher/filtering/relationships/cypher-filtering-relationship-connection.int.test.ts
+++ b/packages/graphql/tests/integration/directives/cypher/filtering/relationships/cypher-filtering-relationship-connection.int.test.ts
@@ -1,0 +1,720 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TestHelper } from "../../../../../utils/tests-helper";
+
+describe("Connection API - cypher directive filtering - Relationship", () => {
+    const testHelper = new TestHelper();
+
+    afterEach(async () => {
+        await testHelper.close();
+    });
+
+    test("Connection API - relationship with single property filter", async () => {
+        const Movie = testHelper.createUniqueType("Movie");
+        const Actor = testHelper.createUniqueType("Actor");
+
+        const typeDefs = /* GraphQL */ `
+            type ${Movie} @node {
+                title: String
+                actors: [${Actor}!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:ACTED_IN]-(actor:${Actor})
+                        RETURN actor
+                        """
+                        columnName: "actor"
+                    )
+            }
+
+            type ${Actor} @node {
+                name: String
+                movies: [${Movie}!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(movie:${Movie})
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        await testHelper.initNeo4jGraphQL({ typeDefs });
+        await testHelper.executeCypher(
+            `
+            CREATE (m:${Movie} { title: "The Matrix" })
+            CREATE (m2:${Movie} { title: "The Matrix Reloaded" })
+            CREATE (m3:${Movie} { title: "The Matrix Revolutions" })
+            CREATE (a:${Actor} { name: "Keanu Reeves" })
+            CREATE (a)-[:ACTED_IN]->(m)
+            CREATE (a)-[:ACTED_IN]->(m2)
+            CREATE (a)-[:ACTED_IN]->(m3)
+            CREATE (a2:${Actor} { name: "Carrie-Anne Moss" })
+            CREATE (a2)-[:ACTED_IN]->(m)
+            CREATE (a2)-[:ACTED_IN]->(m2)
+            CREATE (a2)-[:ACTED_IN]->(m3)
+            CREATE (a3:${Actor} { name: "Jada Pinkett Smith" })
+            CREATE (a3)-[:ACTED_IN]->(m2)
+            CREATE (a3)-[:ACTED_IN]->(m3)
+            `,
+            {}
+        );
+
+        const query = /* GraphQL */ `
+            query {
+                ${Movie.operations.connection}(
+                    where: {
+                        actors: {
+                            name: "Jada Pinkett Smith"
+                        } 
+                    }
+                ) {
+                    edges {
+                        node {
+                            title
+                        }
+                    }
+                }
+            }
+        `;
+
+        const gqlResult = await testHelper.executeGraphQL(query);
+
+        expect(gqlResult.errors).toBeFalsy();
+        expect(gqlResult?.data).toEqual({
+            [Movie.operations.connection]: {
+                edges: expect.toIncludeSameMembers([
+                    {
+                        node: {
+                            title: "The Matrix Reloaded",
+                        },
+                    },
+                    {
+                        node: {
+                            title: "The Matrix Revolutions",
+                        },
+                    },
+                ]),
+            },
+        });
+    });
+
+    test("Connection API - relationship with single property filter NOT", async () => {
+        const Movie = testHelper.createUniqueType("Movie");
+        const Actor = testHelper.createUniqueType("Actor");
+
+        const typeDefs = /* GraphQL */ `
+            type ${Movie} @node {
+                title: String
+                actors: [${Actor}!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:ACTED_IN]-(actor:${Actor})
+                        RETURN actor
+                        """
+                        columnName: "actor"
+                    )
+            }
+
+            type ${Actor} @node {
+                name: String
+                movies: [${Movie}!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(movie:${Movie})
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        await testHelper.initNeo4jGraphQL({ typeDefs });
+        await testHelper.executeCypher(
+            `
+            CREATE (m:${Movie} { title: "The Matrix" })
+            CREATE (m2:${Movie} { title: "The Matrix Reloaded" })
+            CREATE (m3:${Movie} { title: "The Matrix Revolutions" })
+            CREATE (a:${Actor} { name: "Keanu Reeves" })
+            CREATE (a)-[:ACTED_IN]->(m)
+            CREATE (a)-[:ACTED_IN]->(m2)
+            CREATE (a)-[:ACTED_IN]->(m3)
+            CREATE (a2:${Actor} { name: "Carrie-Anne Moss" })
+            CREATE (a2)-[:ACTED_IN]->(m)
+            CREATE (a2)-[:ACTED_IN]->(m2)
+            CREATE (a2)-[:ACTED_IN]->(m3)
+            CREATE (a3:${Actor} { name: "Jada Pinkett Smith" })
+            CREATE (a3)-[:ACTED_IN]->(m2)
+            CREATE (a3)-[:ACTED_IN]->(m3)
+            `,
+            {}
+        );
+
+        const query = /* GraphQL */ `
+            query {
+                ${Movie.operations.connection}(
+                    where: {
+                        NOT: {
+                            actors: {
+                                name: "Jada Pinkett Smith"
+                            }
+                        }
+                    }
+                ) {
+                    edges {
+                        node {
+                            title
+                        }
+                    }
+                }
+            }
+        `;
+
+        const gqlResult = await testHelper.executeGraphQL(query);
+
+        expect(gqlResult.errors).toBeFalsy();
+        expect(gqlResult?.data).toEqual({
+            [Movie.operations.connection]: {
+                edges: expect.toIncludeSameMembers([
+                    {
+                        node: { title: "The Matrix" },
+                    },
+                ]),
+            },
+        });
+    });
+
+    test("Connection API - relationship with single property filter ALL", async () => {
+        const Movie = testHelper.createUniqueType("Movie");
+        const Actor = testHelper.createUniqueType("Actor");
+
+        const typeDefs = /* GraphQL */ `
+            type ${Movie} @node {
+                title: String
+                actors: [${Actor}!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:ACTED_IN]-(actor:${Actor})
+                        RETURN actor
+                        """
+                        columnName: "actor"
+                    )
+            }
+
+            type ${Actor} @node {
+                name: String
+                movies: [${Movie}!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(movie:${Movie})
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        await testHelper.initNeo4jGraphQL({ typeDefs });
+        await testHelper.executeCypher(
+            `
+            CREATE (m:${Movie} { title: "The Matrix" })
+            CREATE (m2:${Movie} { title: "The Matrix Reloaded" })
+            CREATE (a:${Actor} { name: "Keanu Reeves" })
+            CREATE (a)-[:ACTED_IN]->(m)
+            CREATE (a)-[:ACTED_IN]->(m2)
+            CREATE (a2:${Actor} { name: "Carrie-Anne Moss" })
+            CREATE (a2)-[:ACTED_IN]->(m)
+            `,
+            {}
+        );
+
+        const query = /* GraphQL */ `
+            query {
+                ${Movie.operations.connection}(
+                    where: {
+                        actors_ALL: {
+                            name: "Keanu Reeves"
+                        } 
+                    }
+                ) {
+                    edges {
+                        node {
+                            title
+                        }
+                    }
+                }
+            }
+        `;
+
+        const gqlResult = await testHelper.executeGraphQL(query);
+
+        expect(gqlResult.errors).toBeFalsy();
+        expect(gqlResult?.data).toEqual({
+            [Movie.operations.connection]: {
+                edges: expect.toIncludeSameMembers([
+                    {
+                        node: {
+                            title: "The Matrix Reloaded",
+                        },
+                    },
+                ]),
+            },
+        });
+    });
+
+    test("Connection API - relationship with single property filter SINGLE", async () => {
+        const Movie = testHelper.createUniqueType("Movie");
+        const Actor = testHelper.createUniqueType("Actor");
+
+        const typeDefs = /* GraphQL */ `
+            type ${Movie} @node {
+                title: String
+                actors: [${Actor}!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:ACTED_IN]-(actor:${Actor})
+                        RETURN actor
+                        """
+                        columnName: "actor"
+                    )
+            }
+
+            type ${Actor} @node {
+                name: String
+                movies: [${Movie}!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(movie:${Movie})
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        await testHelper.initNeo4jGraphQL({ typeDefs });
+        await testHelper.executeCypher(
+            `
+            CREATE (m:${Movie} { title: "The Matrix" })
+            CREATE (m2:${Movie} { title: "The Matrix Reloaded" })
+            CREATE (a:${Actor} { name: "Keanu Reeves" })
+            CREATE (a)-[:ACTED_IN]->(m)
+            CREATE (a2:${Actor} { name: "Carrie-Anne Moss" })
+            CREATE (a2)-[:ACTED_IN]->(m)
+            CREATE (a2)-[:ACTED_IN]->(m2)
+            CREATE (a3:${Actor} { name: "Carrie-Anne Moss" })
+            CREATE (a3)-[:ACTED_IN]->(m)
+            `,
+            {}
+        );
+
+        const query = /* GraphQL */ `
+            query {
+                ${Movie.operations.connection}(
+                    where: {
+                        actors_SINGLE: {
+                            name: "Carrie-Anne Moss"
+                        } 
+                    }
+                ) {
+                    edges {
+                        node {
+                            title
+                        }
+                    }
+                }
+            }
+        `;
+
+        const gqlResult = await testHelper.executeGraphQL(query);
+
+        expect(gqlResult.errors).toBeFalsy();
+        expect(gqlResult?.data).toEqual({
+            [Movie.operations.connection]: {
+                edges: expect.toIncludeSameMembers([
+                    {
+                        node: {
+                            title: "The Matrix Reloaded",
+                        },
+                    },
+                ]),
+            },
+        });
+    });
+
+    test("Connection API - relationship with single property filter SOME", async () => {
+        const Movie = testHelper.createUniqueType("Movie");
+        const Actor = testHelper.createUniqueType("Actor");
+
+        const typeDefs = /* GraphQL */ `
+            type ${Movie} @node {
+                title: String
+                actors: [${Actor}!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:ACTED_IN]-(actor:${Actor})
+                        RETURN actor
+                        """
+                        columnName: "actor"
+                    )
+            }
+
+            type ${Actor} @node {
+                name: String
+                movies: [${Movie}!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(movie:${Movie})
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        await testHelper.initNeo4jGraphQL({ typeDefs });
+        await testHelper.executeCypher(
+            `
+            CREATE (m:${Movie} { title: "The Matrix" })
+            CREATE (m2:${Movie} { title: "The Matrix Reloaded" })
+            CREATE (a:${Actor} { name: "Keanu Reeves" })
+            CREATE (a)-[:ACTED_IN]->(m)
+            CREATE (a)-[:ACTED_IN]->(m2)
+            CREATE (a2:${Actor} { name: "Carrie-Anne Moss" })
+            CREATE (a2)-[:ACTED_IN]->(m)
+            `,
+            {}
+        );
+
+        const query = /* GraphQL */ `
+            query {
+                ${Movie.operations.connection}(
+                    where: {
+                        actors_SOME: {
+                            name: "Keanu Reeves"
+                        } 
+                    }
+                ) {
+                    edges {
+                        node {
+                            title
+                        }
+                    }
+                }
+            }
+        `;
+
+        const gqlResult = await testHelper.executeGraphQL(query);
+
+        expect(gqlResult.errors).toBeFalsy();
+        expect(gqlResult?.data).toEqual({
+            [Movie.operations.connection]: {
+                edges: expect.toIncludeSameMembers([
+                    {
+                        node: {
+                            title: "The Matrix",
+                        },
+                    },
+                    {
+                        node: {
+                            title: "The Matrix Reloaded",
+                        },
+                    },
+                ]),
+            },
+        });
+    });
+
+    test("Connection API - relationship with single property filter SOME with sort", async () => {
+        const Movie = testHelper.createUniqueType("Movie");
+        const Actor = testHelper.createUniqueType("Actor");
+
+        const typeDefs = /* GraphQL */ `
+            type ${Movie} @node {
+                title: String
+                actors: [${Actor}!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:ACTED_IN]-(actor:${Actor})
+                        RETURN actor
+                        """
+                        columnName: "actor"
+                    )
+            }
+
+            type ${Actor} @node {
+                name: String
+                movies: [${Movie}!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(movie:${Movie})
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        await testHelper.initNeo4jGraphQL({ typeDefs });
+        await testHelper.executeCypher(
+            `
+            CREATE (m:${Movie} { title: "The Matrix" })
+            CREATE (m2:${Movie} { title: "The Matrix Reloaded" })
+            CREATE (a:${Actor} { name: "Keanu Reeves" })
+            CREATE (a)-[:ACTED_IN]->(m)
+            CREATE (a)-[:ACTED_IN]->(m2)
+            CREATE (a2:${Actor} { name: "Carrie-Anne Moss" })
+            CREATE (a2)-[:ACTED_IN]->(m)
+            `,
+            {}
+        );
+
+        const query = /* GraphQL */ `
+            query {
+                ${Movie.operations.connection}(
+                    where: {
+                        actors_SOME: {
+                            name: "Keanu Reeves"
+                        } 
+                    }
+                    sort: {
+                        title: DESC
+                    }
+                ) {
+                    edges {
+                        node {
+                            title
+                        }
+                    }
+                }
+            }
+        `;
+
+        const gqlResult = await testHelper.executeGraphQL(query);
+
+        expect(gqlResult.errors).toBeFalsy();
+        expect(gqlResult?.data).toEqual({
+            [Movie.operations.connection]: {
+                edges: [
+                    {
+                        node: {
+                            title: "The Matrix Reloaded",
+                        },
+                    },
+                    {
+                        node: {
+                            title: "The Matrix",
+                        },
+                    },
+                ],
+            },
+        });
+    });
+
+    test("Connection API - relationship with single property filter NONE", async () => {
+        const Movie = testHelper.createUniqueType("Movie");
+        const Actor = testHelper.createUniqueType("Actor");
+
+        const typeDefs = /* GraphQL */ `
+            type ${Movie} @node {
+                title: String
+                actors: [${Actor}!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:ACTED_IN]-(actor:${Actor})
+                        RETURN actor
+                        """
+                        columnName: "actor"
+                    )
+            }
+
+            type ${Actor} @node {
+                name: String
+                movies: [${Movie}!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(movie:${Movie})
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        await testHelper.initNeo4jGraphQL({ typeDefs });
+        await testHelper.executeCypher(
+            `
+            CREATE (m:${Movie} { title: "The Matrix" })
+            CREATE (m2:${Movie} { title: "The Matrix Reloaded" })
+            CREATE (a:${Actor} { name: "Keanu Reeves" })
+            CREATE (a)-[:ACTED_IN]->(m)
+            CREATE (a2:${Actor} { name: "Carrie-Anne Moss" })
+            CREATE (a2)-[:ACTED_IN]->(m2)
+            `,
+            {}
+        );
+
+        const query = /* GraphQL */ `
+            query {
+                ${Movie.operations.connection}(
+                    where: {
+                        actors_NONE: {
+                            name: "Keanu Reeves"
+                        } 
+                    }
+                ) {
+                    edges {
+                        node {
+                            title
+                        }
+                    }
+                }
+            }
+        `;
+
+        const gqlResult = await testHelper.executeGraphQL(query);
+
+        expect(gqlResult.errors).toBeFalsy();
+        expect(gqlResult?.data).toEqual({
+            [Movie.operations.connection]: {
+                edges: expect.toIncludeSameMembers([
+                    {
+                        node: {
+                            title: "The Matrix Reloaded",
+                        },
+                    },
+                ]),
+            },
+        });
+    });
+
+    test("relationship with multiple property filters", async () => {
+        const Movie = testHelper.createUniqueType("Movie");
+        const Actor = testHelper.createUniqueType("Actor");
+        const Genre = testHelper.createUniqueType("Genre");
+
+        const typeDefs = /* GraphQL */ `
+            type ${Movie} @node {
+                title: String
+                genres: [${Genre}!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:IN_GENRE]->(g:${Genre})
+                        RETURN g
+                        """
+                        columnName: "g"
+                    )
+                actors: [${Actor}!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:ACTED_IN]-(actor:${Actor})
+                        RETURN actor
+                        """
+                        columnName: "actor"
+                    )
+            }
+
+            type ${Actor} @node {
+                name: String
+                movies: [${Movie}!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(movie:${Movie})
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+
+            type ${Genre} @node {
+                name: String
+                movies: [${Movie}!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:IN_GENRE]-(movie:${Movie})
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        await testHelper.initNeo4jGraphQL({ typeDefs });
+        await testHelper.executeCypher(
+            `
+            CREATE (g:${Genre} { name: "Action" })
+            CREATE (g2:${Genre} { name: "Romance" })
+            CREATE (m:${Movie} { title: "The Matrix" })
+            CREATE (m2:${Movie} { title: "The Matrix Reloaded" })
+            CREATE (m3:${Movie} { title: "The Matrix Revolutions" })
+            CREATE (m4:${Movie} { title: "A different movie" })
+            CREATE (m)-[:IN_GENRE]->(g)
+            CREATE (m2)-[:IN_GENRE]->(g)
+            CREATE (m3)-[:IN_GENRE]->(g)
+            CREATE (m4)-[:IN_GENRE]->(g2)
+            CREATE (a:${Actor} { name: "Keanu Reeves" })
+            CREATE (a)-[:ACTED_IN]->(m)
+            CREATE (a)-[:ACTED_IN]->(m2)
+            CREATE (a)-[:ACTED_IN]->(m3)
+            CREATE (a2:${Actor} { name: "Carrie-Anne Moss" })
+            CREATE (a2)-[:ACTED_IN]->(m)
+            CREATE (a2)-[:ACTED_IN]->(m2)
+            CREATE (a2)-[:ACTED_IN]->(m3)
+            CREATE (a3:${Actor} { name: "Jada Pinkett Smith" })
+            CREATE (a3)-[:ACTED_IN]->(m2)
+            CREATE (a3)-[:ACTED_IN]->(m3)
+            `,
+            {}
+        );
+
+        const query = /* GraphQL */ `
+            query {
+                ${Movie.operations.connection}(
+                    where: { 
+                        OR: [
+                            { actors: { name: "Jada Pinkett Smith" } },
+                            { genres: { name: "Romance" } }
+                        ]
+                    }
+                )
+                {
+                    edges {
+                        node {
+                            title
+                        }
+                    }
+                }
+            }
+        `;
+
+        const gqlResult = await testHelper.executeGraphQL(query);
+
+        expect(gqlResult.errors).toBeFalsy();
+        expect(gqlResult?.data).toEqual({
+            [Movie.operations.connection]: {
+                edges: expect.toIncludeSameMembers([
+                    { node: { title: "A different movie" } },
+                    { node: { title: "The Matrix Reloaded" } },
+                    { node: { title: "The Matrix Revolutions" } },
+                ]),
+            },
+        });
+    });
+});

--- a/packages/graphql/tests/integration/directives/cypher/filtering/relationships/cypher-filtering-relationship-connection.int.test.ts
+++ b/packages/graphql/tests/integration/directives/cypher/filtering/relationships/cypher-filtering-relationship-connection.int.test.ts
@@ -82,7 +82,7 @@ describe("Connection API - cypher directive filtering - Relationship", () => {
                 ${Movie.operations.connection}(
                     where: {
                         actors: {
-                            name: "Jada Pinkett Smith"
+                            name_EQ: "Jada Pinkett Smith"
                         } 
                     }
                 ) {
@@ -173,7 +173,7 @@ describe("Connection API - cypher directive filtering - Relationship", () => {
                     where: {
                         NOT: {
                             actors: {
-                                name: "Jada Pinkett Smith"
+                                name_EQ: "Jada Pinkett Smith"
                             }
                         }
                     }
@@ -250,7 +250,7 @@ describe("Connection API - cypher directive filtering - Relationship", () => {
                 ${Movie.operations.connection}(
                     where: {
                         actors_ALL: {
-                            name: "Keanu Reeves"
+                            name_EQ: "Keanu Reeves"
                         } 
                     }
                 ) {
@@ -330,7 +330,7 @@ describe("Connection API - cypher directive filtering - Relationship", () => {
                 ${Movie.operations.connection}(
                     where: {
                         actors_SINGLE: {
-                            name: "Carrie-Anne Moss"
+                            name_EQ: "Carrie-Anne Moss"
                         } 
                     }
                 ) {
@@ -408,7 +408,7 @@ describe("Connection API - cypher directive filtering - Relationship", () => {
                 ${Movie.operations.connection}(
                     where: {
                         actors_SOME: {
-                            name: "Keanu Reeves"
+                            name_EQ: "Keanu Reeves"
                         } 
                     }
                 ) {
@@ -491,7 +491,7 @@ describe("Connection API - cypher directive filtering - Relationship", () => {
                 ${Movie.operations.connection}(
                     where: {
                         actors_SOME: {
-                            name: "Keanu Reeves"
+                            name_EQ: "Keanu Reeves"
                         } 
                     }
                     sort: {
@@ -576,7 +576,7 @@ describe("Connection API - cypher directive filtering - Relationship", () => {
                 ${Movie.operations.connection}(
                     where: {
                         actors_NONE: {
-                            name: "Keanu Reeves"
+                            name_EQ: "Keanu Reeves"
                         } 
                     }
                 ) {
@@ -689,8 +689,8 @@ describe("Connection API - cypher directive filtering - Relationship", () => {
                 ${Movie.operations.connection}(
                     where: { 
                         OR: [
-                            { actors: { name: "Jada Pinkett Smith" } },
-                            { genres: { name: "Romance" } }
+                            { actors: { name_EQ: "Jada Pinkett Smith" } },
+                            { genres: { name_EQ: "Romance" } }
                         ]
                     }
                 )

--- a/packages/graphql/tests/integration/directives/cypher/filtering/relationships/cypher-filtering-relationship.int.test.ts
+++ b/packages/graphql/tests/integration/directives/cypher/filtering/relationships/cypher-filtering-relationship.int.test.ts
@@ -82,7 +82,7 @@ describe("cypher directive filtering - Relationship", () => {
                 ${Movie.plural}(
                     where: {
                         actors: {
-                            name: "Jada Pinkett Smith"
+                            name_EQ: "Jada Pinkett Smith"
                         } 
                     }
                 ) {
@@ -163,7 +163,7 @@ describe("cypher directive filtering - Relationship", () => {
                     where: {
                         NOT: {
                             actors: {
-                                name: "Jada Pinkett Smith"
+                                name_EQ: "Jada Pinkett Smith"
                             }   
                         }
                     }
@@ -234,7 +234,7 @@ describe("cypher directive filtering - Relationship", () => {
                 ${Movie.plural}(
                     where: {
                         actors_ALL: {
-                            name: "Keanu Reeves"
+                            name_EQ: "Keanu Reeves"
                         } 
                     }
                 ) {
@@ -306,7 +306,7 @@ describe("cypher directive filtering - Relationship", () => {
                 ${Movie.plural}(
                     where: {
                         actors_SINGLE: {
-                            name: "Carrie-Anne Moss"
+                            name_EQ: "Carrie-Anne Moss"
                         } 
                     }
                 ) {
@@ -376,7 +376,7 @@ describe("cypher directive filtering - Relationship", () => {
                 ${Movie.plural}(
                     where: {
                         actors_SOME: {
-                            name: "Keanu Reeves"
+                            name_EQ: "Keanu Reeves"
                         } 
                     }
                 ) {
@@ -448,7 +448,7 @@ describe("cypher directive filtering - Relationship", () => {
                 ${Movie.plural}(
                     where: {
                         actors_NONE: {
-                            name: "Keanu Reeves"
+                            name_EQ: "Keanu Reeves"
                         } 
                     }
                 ) {
@@ -553,8 +553,8 @@ describe("cypher directive filtering - Relationship", () => {
                 ${Movie.plural}(
                     where: { 
                         OR: [
-                            { actors: { name: "Jada Pinkett Smith" } },
-                            { genres: { name: "Romance" } }
+                            { actors: { name_EQ: "Jada Pinkett Smith" } },
+                            { genres: { name_EQ: "Romance" } }
                         ]
                     }
                 )

--- a/packages/graphql/tests/integration/directives/cypher/filtering/relationships/cypher-filtering-relationship.int.test.ts
+++ b/packages/graphql/tests/integration/directives/cypher/filtering/relationships/cypher-filtering-relationship.int.test.ts
@@ -1,0 +1,584 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TestHelper } from "../../../../../utils/tests-helper";
+
+describe("cypher directive filtering - Relationship", () => {
+    const testHelper = new TestHelper();
+
+    afterEach(async () => {
+        await testHelper.close();
+    });
+
+    test("relationship with single property filter", async () => {
+        const Movie = testHelper.createUniqueType("Movie");
+        const Actor = testHelper.createUniqueType("Actor");
+
+        const typeDefs = /* GraphQL */ `
+            type ${Movie} @node {
+                title: String
+                actors: [${Actor}!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:ACTED_IN]-(actor:${Actor})
+                        RETURN actor
+                        """
+                        columnName: "actor"
+                    )
+            }
+
+            type ${Actor} @node {
+                name: String
+                movies: [${Movie}!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(movie:${Movie})
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        await testHelper.initNeo4jGraphQL({ typeDefs });
+        await testHelper.executeCypher(
+            `
+            CREATE (m:${Movie} { title: "The Matrix" })
+            CREATE (m2:${Movie} { title: "The Matrix Reloaded" })
+            CREATE (m3:${Movie} { title: "The Matrix Revolutions" })
+            CREATE (a:${Actor} { name: "Keanu Reeves" })
+            CREATE (a)-[:ACTED_IN]->(m)
+            CREATE (a)-[:ACTED_IN]->(m2)
+            CREATE (a)-[:ACTED_IN]->(m3)
+            CREATE (a2:${Actor} { name: "Carrie-Anne Moss" })
+            CREATE (a2)-[:ACTED_IN]->(m)
+            CREATE (a2)-[:ACTED_IN]->(m2)
+            CREATE (a2)-[:ACTED_IN]->(m3)
+            CREATE (a3:${Actor} { name: "Jada Pinkett Smith" })
+            CREATE (a3)-[:ACTED_IN]->(m2)
+            CREATE (a3)-[:ACTED_IN]->(m3)
+            `,
+            {}
+        );
+
+        const query = /* GraphQL */ `
+            query {
+                ${Movie.plural}(
+                    where: {
+                        actors: {
+                            name: "Jada Pinkett Smith"
+                        } 
+                    }
+                ) {
+                    title
+                }
+            }
+        `;
+
+        const gqlResult = await testHelper.executeGraphQL(query);
+
+        expect(gqlResult.errors).toBeFalsy();
+        expect(gqlResult?.data).toEqual({
+            [Movie.plural]: expect.toIncludeSameMembers([
+                {
+                    title: "The Matrix Reloaded",
+                },
+                {
+                    title: "The Matrix Revolutions",
+                },
+            ]),
+        });
+    });
+
+    test("relationship with single property filter NOT", async () => {
+        const Movie = testHelper.createUniqueType("Movie");
+        const Actor = testHelper.createUniqueType("Actor");
+
+        const typeDefs = /* GraphQL */ `
+            type ${Movie} @node {
+                title: String
+                actors: [${Actor}!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:ACTED_IN]-(actor:${Actor})
+                        RETURN actor
+                        """
+                        columnName: "actor"
+                    )
+            }
+
+            type ${Actor} @node {
+                name: String
+                movies: [${Movie}!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(movie:${Movie})
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        await testHelper.initNeo4jGraphQL({ typeDefs });
+        await testHelper.executeCypher(
+            `
+            CREATE (m:${Movie} { title: "The Matrix" })
+            CREATE (m2:${Movie} { title: "The Matrix Reloaded" })
+            CREATE (m3:${Movie} { title: "The Matrix Revolutions" })
+            CREATE (a:${Actor} { name: "Keanu Reeves" })
+            CREATE (a)-[:ACTED_IN]->(m)
+            CREATE (a)-[:ACTED_IN]->(m2)
+            CREATE (a)-[:ACTED_IN]->(m3)
+            CREATE (a2:${Actor} { name: "Carrie-Anne Moss" })
+            CREATE (a2)-[:ACTED_IN]->(m)
+            CREATE (a2)-[:ACTED_IN]->(m2)
+            CREATE (a2)-[:ACTED_IN]->(m3)
+            CREATE (a3:${Actor} { name: "Jada Pinkett Smith" })
+            CREATE (a3)-[:ACTED_IN]->(m2)
+            CREATE (a3)-[:ACTED_IN]->(m3)
+            `,
+            {}
+        );
+
+        const query = /* GraphQL */ `
+            query {
+                ${Movie.plural}(
+                    where: {
+                        NOT: {
+                            actors: {
+                                name: "Jada Pinkett Smith"
+                            }   
+                        }
+                    }
+                ) {
+                    title
+                }
+            }
+        `;
+
+        const gqlResult = await testHelper.executeGraphQL(query);
+
+        expect(gqlResult.errors).toBeFalsy();
+        expect(gqlResult?.data).toEqual({
+            [Movie.plural]: expect.toIncludeSameMembers([
+                {
+                    title: "The Matrix",
+                },
+            ]),
+        });
+    });
+
+    test("relationship with single property filter ALL", async () => {
+        const Movie = testHelper.createUniqueType("Movie");
+        const Actor = testHelper.createUniqueType("Actor");
+
+        const typeDefs = /* GraphQL */ `
+            type ${Movie} @node {
+                title: String
+                actors: [${Actor}!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:ACTED_IN]-(actor:${Actor})
+                        RETURN actor
+                        """
+                        columnName: "actor"
+                    )
+            }
+
+            type ${Actor} @node {
+                name: String
+                movies: [${Movie}!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(movie:${Movie})
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        await testHelper.initNeo4jGraphQL({ typeDefs });
+        await testHelper.executeCypher(
+            `
+            CREATE (m:${Movie} { title: "The Matrix" })
+            CREATE (m2:${Movie} { title: "The Matrix Reloaded" })
+            CREATE (a:${Actor} { name: "Keanu Reeves" })
+            CREATE (a)-[:ACTED_IN]->(m)
+            CREATE (a)-[:ACTED_IN]->(m2)
+            CREATE (a2:${Actor} { name: "Carrie-Anne Moss" })
+            CREATE (a2)-[:ACTED_IN]->(m)
+            `,
+            {}
+        );
+
+        const query = /* GraphQL */ `
+            query {
+                ${Movie.plural}(
+                    where: {
+                        actors_ALL: {
+                            name: "Keanu Reeves"
+                        } 
+                    }
+                ) {
+                    title
+                }
+            }
+        `;
+
+        const gqlResult = await testHelper.executeGraphQL(query);
+
+        expect(gqlResult.errors).toBeFalsy();
+        expect(gqlResult?.data).toEqual({
+            [Movie.plural]: expect.toIncludeSameMembers([
+                {
+                    title: "The Matrix Reloaded",
+                },
+            ]),
+        });
+    });
+
+    test("relationship with single property filter SINGLE", async () => {
+        const Movie = testHelper.createUniqueType("Movie");
+        const Actor = testHelper.createUniqueType("Actor");
+
+        const typeDefs = /* GraphQL */ `
+            type ${Movie} @node {
+                title: String
+                actors: [${Actor}!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:ACTED_IN]-(actor:${Actor})
+                        RETURN actor
+                        """
+                        columnName: "actor"
+                    )
+            }
+
+            type ${Actor} @node {
+                name: String
+                movies: [${Movie}!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(movie:${Movie})
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        await testHelper.initNeo4jGraphQL({ typeDefs });
+        await testHelper.executeCypher(
+            `
+            CREATE (m:${Movie} { title: "The Matrix" })
+            CREATE (m2:${Movie} { title: "The Matrix Reloaded" })
+            CREATE (a:${Actor} { name: "Keanu Reeves" })
+            CREATE (a)-[:ACTED_IN]->(m)
+            CREATE (a2:${Actor} { name: "Carrie-Anne Moss" })
+            CREATE (a2)-[:ACTED_IN]->(m)
+            CREATE (a2)-[:ACTED_IN]->(m2)
+            CREATE (a3:${Actor} { name: "Carrie-Anne Moss" })
+            CREATE (a3)-[:ACTED_IN]->(m)
+            `,
+            {}
+        );
+
+        const query = /* GraphQL */ `
+            query {
+                ${Movie.plural}(
+                    where: {
+                        actors_SINGLE: {
+                            name: "Carrie-Anne Moss"
+                        } 
+                    }
+                ) {
+                    title
+                }
+            }
+        `;
+
+        const gqlResult = await testHelper.executeGraphQL(query);
+
+        expect(gqlResult.errors).toBeFalsy();
+        expect(gqlResult?.data).toEqual({
+            [Movie.plural]: expect.toIncludeSameMembers([
+                {
+                    title: "The Matrix Reloaded",
+                },
+            ]),
+        });
+    });
+
+    test("relationship with single property filter SOME", async () => {
+        const Movie = testHelper.createUniqueType("Movie");
+        const Actor = testHelper.createUniqueType("Actor");
+
+        const typeDefs = /* GraphQL */ `
+            type ${Movie} @node {
+                title: String
+                actors: [${Actor}!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:ACTED_IN]-(actor:${Actor})
+                        RETURN actor
+                        """
+                        columnName: "actor"
+                    )
+            }
+
+            type ${Actor} @node {
+                name: String
+                movies: [${Movie}!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(movie:${Movie})
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        await testHelper.initNeo4jGraphQL({ typeDefs });
+        await testHelper.executeCypher(
+            `
+            CREATE (m:${Movie} { title: "The Matrix" })
+            CREATE (m2:${Movie} { title: "The Matrix Reloaded" })
+            CREATE (a:${Actor} { name: "Keanu Reeves" })
+            CREATE (a)-[:ACTED_IN]->(m)
+            CREATE (a)-[:ACTED_IN]->(m2)
+            CREATE (a2:${Actor} { name: "Carrie-Anne Moss" })
+            CREATE (a2)-[:ACTED_IN]->(m)
+            `,
+            {}
+        );
+
+        const query = /* GraphQL */ `
+            query {
+                ${Movie.plural}(
+                    where: {
+                        actors_SOME: {
+                            name: "Keanu Reeves"
+                        } 
+                    }
+                ) {
+                    title
+                }
+            }
+        `;
+
+        const gqlResult = await testHelper.executeGraphQL(query);
+
+        expect(gqlResult.errors).toBeFalsy();
+        expect(gqlResult?.data).toEqual({
+            [Movie.plural]: expect.toIncludeSameMembers([
+                {
+                    title: "The Matrix",
+                },
+                {
+                    title: "The Matrix Reloaded",
+                },
+            ]),
+        });
+    });
+
+    test("relationship with single property filter NONE", async () => {
+        const Movie = testHelper.createUniqueType("Movie");
+        const Actor = testHelper.createUniqueType("Actor");
+
+        const typeDefs = /* GraphQL */ `
+            type ${Movie} @node {
+                title: String
+                actors: [${Actor}!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:ACTED_IN]-(actor:${Actor})
+                        RETURN actor
+                        """
+                        columnName: "actor"
+                    )
+            }
+
+            type ${Actor} @node {
+                name: String
+                movies: [${Movie}!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(movie:${Movie})
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        await testHelper.initNeo4jGraphQL({ typeDefs });
+        await testHelper.executeCypher(
+            `
+            CREATE (m:${Movie} { title: "The Matrix" })
+            CREATE (m2:${Movie} { title: "The Matrix Reloaded" })
+            CREATE (a:${Actor} { name: "Keanu Reeves" })
+            CREATE (a)-[:ACTED_IN]->(m)
+            CREATE (a2:${Actor} { name: "Carrie-Anne Moss" })
+            CREATE (a2)-[:ACTED_IN]->(m2)
+            `,
+            {}
+        );
+
+        const query = /* GraphQL */ `
+            query {
+                ${Movie.plural}(
+                    where: {
+                        actors_NONE: {
+                            name: "Keanu Reeves"
+                        } 
+                    }
+                ) {
+                    title
+                }
+            }
+        `;
+
+        const gqlResult = await testHelper.executeGraphQL(query);
+
+        expect(gqlResult.errors).toBeFalsy();
+        expect(gqlResult?.data).toEqual({
+            [Movie.plural]: expect.toIncludeSameMembers([
+                {
+                    title: "The Matrix Reloaded",
+                },
+            ]),
+        });
+    });
+
+    test("relationship with multiple property filters", async () => {
+        const Movie = testHelper.createUniqueType("Movie");
+        const Actor = testHelper.createUniqueType("Actor");
+        const Genre = testHelper.createUniqueType("Genre");
+
+        const typeDefs = /* GraphQL */ `
+            type ${Movie} @node {
+                title: String
+                genres: [${Genre}!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:IN_GENRE]->(g:${Genre})
+                        RETURN g
+                        """
+                        columnName: "g"
+                    )
+                actors: [${Actor}!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:ACTED_IN]-(actor:${Actor})
+                        RETURN actor
+                        """
+                        columnName: "actor"
+                    )
+            }
+
+            type ${Actor} @node {
+                name: String
+                movies: [${Movie}!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(movie:${Movie})
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+
+            type ${Genre} @node {
+                name: String
+                movies: [${Movie}!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:IN_GENRE]-(movie:${Movie})
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        await testHelper.initNeo4jGraphQL({ typeDefs });
+        await testHelper.executeCypher(
+            `
+            CREATE (g:${Genre} { name: "Action" })
+            CREATE (g2:${Genre} { name: "Romance" })
+            CREATE (m:${Movie} { title: "The Matrix" })
+            CREATE (m2:${Movie} { title: "The Matrix Reloaded" })
+            CREATE (m3:${Movie} { title: "The Matrix Revolutions" })
+            CREATE (m4:${Movie} { title: "A different movie" })
+            CREATE (m)-[:IN_GENRE]->(g)
+            CREATE (m2)-[:IN_GENRE]->(g)
+            CREATE (m3)-[:IN_GENRE]->(g)
+            CREATE (m4)-[:IN_GENRE]->(g2)
+            CREATE (a:${Actor} { name: "Keanu Reeves" })
+            CREATE (a)-[:ACTED_IN]->(m)
+            CREATE (a)-[:ACTED_IN]->(m2)
+            CREATE (a)-[:ACTED_IN]->(m3)
+            CREATE (a2:${Actor} { name: "Carrie-Anne Moss" })
+            CREATE (a2)-[:ACTED_IN]->(m)
+            CREATE (a2)-[:ACTED_IN]->(m2)
+            CREATE (a2)-[:ACTED_IN]->(m3)
+            CREATE (a3:${Actor} { name: "Jada Pinkett Smith" })
+            CREATE (a3)-[:ACTED_IN]->(m2)
+            CREATE (a3)-[:ACTED_IN]->(m3)
+            `,
+            {}
+        );
+
+        const query = /* GraphQL */ `
+            query {
+                ${Movie.plural}(
+                    where: { 
+                        OR: [
+                            { actors: { name: "Jada Pinkett Smith" } },
+                            { genres: { name: "Romance" } }
+                        ]
+                    }
+                )
+                {
+                    title
+                }
+            }
+        `;
+
+        const gqlResult = await testHelper.executeGraphQL(query);
+
+        expect(gqlResult.errors).toBeFalsy();
+        expect(gqlResult?.data).toEqual({
+            [Movie.plural]: expect.toIncludeSameMembers([
+                {
+                    title: "A different movie",
+                },
+                {
+                    title: "The Matrix Reloaded",
+                },
+                {
+                    title: "The Matrix Revolutions",
+                },
+            ]),
+        });
+    });
+});

--- a/packages/graphql/tests/schema/directives/cypher.test.ts
+++ b/packages/graphql/tests/schema/directives/cypher.test.ts
@@ -934,6 +934,11 @@ describe("Cypher", () => {
               NOT: BlogWhere
               OR: [BlogWhere!]
               post: PostWhere
+              posts: PostWhere
+              posts_ALL: PostWhere
+              posts_NONE: PostWhere
+              posts_SINGLE: PostWhere
+              posts_SOME: PostWhere
               title: String @deprecated(reason: \\"Please use the explicit _EQ version\\")
               title_CONTAINS: String
               title_ENDS_WITH: String
@@ -1209,6 +1214,11 @@ describe("Cypher", () => {
               NOT: ActorWhere
               OR: [ActorWhere!]
               movie: MovieWhere
+              movies: MovieWhere
+              movies_ALL: MovieWhere
+              movies_NONE: MovieWhere
+              movies_SINGLE: MovieWhere
+              movies_SOME: MovieWhere
               name: String @deprecated(reason: \\"Please use the explicit _EQ version\\")
               name_CONTAINS: String
               name_ENDS_WITH: String
@@ -1287,6 +1297,11 @@ describe("Cypher", () => {
               NOT: MovieWhere
               OR: [MovieWhere!]
               actor: ActorWhere
+              actors: ActorWhere
+              actors_ALL: ActorWhere
+              actors_NONE: ActorWhere
+              actors_SINGLE: ActorWhere
+              actors_SOME: ActorWhere
             }
 
             type MoviesConnection {
@@ -1395,7 +1410,7 @@ describe("Cypher", () => {
         `);
     });
 
-    test("Filters should be generated only on 1:1 Relationship/Object custom cypher fields", async () => {
+    test("Filters should be generated on 1:1 and *:* Relationship/Object custom cypher fields", async () => {
         const typeDefs = /* GraphQL */ `
             type Movie @node {
                 actors: [Actor]
@@ -1493,6 +1508,11 @@ describe("Cypher", () => {
               NOT: ActorWhere
               OR: [ActorWhere!]
               movie: MovieWhere
+              movies: MovieWhere
+              movies_ALL: MovieWhere
+              movies_NONE: MovieWhere
+              movies_SINGLE: MovieWhere
+              movies_SOME: MovieWhere
               name: String @deprecated(reason: \\"Please use the explicit _EQ version\\")
               name_CONTAINS: String
               name_ENDS_WITH: String
@@ -1571,6 +1591,11 @@ describe("Cypher", () => {
               NOT: MovieWhere
               OR: [MovieWhere!]
               actor: ActorWhere
+              actors: ActorWhere
+              actors_ALL: ActorWhere
+              actors_NONE: ActorWhere
+              actors_SINGLE: ActorWhere
+              actors_SOME: ActorWhere
             }
 
             type MoviesConnection {

--- a/packages/graphql/tests/schema/interfaces.test.ts
+++ b/packages/graphql/tests/schema/interfaces.test.ts
@@ -357,6 +357,11 @@ describe("Interfaces", () => {
               AND: [MovieWhere!]
               NOT: MovieWhere
               OR: [MovieWhere!]
+              customQuery: MovieWhere
+              customQuery_ALL: MovieWhere
+              customQuery_NONE: MovieWhere
+              customQuery_SINGLE: MovieWhere
+              customQuery_SOME: MovieWhere
               id: ID @deprecated(reason: \\"Please use the explicit _EQ version\\")
               id_CONTAINS: ID
               id_ENDS_WITH: ID
@@ -781,6 +786,11 @@ describe("Interfaces", () => {
               AND: [MovieWhere!]
               NOT: MovieWhere
               OR: [MovieWhere!]
+              customQuery: MovieWhere
+              customQuery_ALL: MovieWhere
+              customQuery_NONE: MovieWhere
+              customQuery_SINGLE: MovieWhere
+              customQuery_SOME: MovieWhere
               id: ID @deprecated(reason: \\"Please use the explicit _EQ version\\")
               id_CONTAINS: ID
               id_ENDS_WITH: ID

--- a/packages/graphql/tests/tck/directives/cypher/filtering/relationships/cypher-filtering-relationship-auth.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher/filtering/relationships/cypher-filtering-relationship-auth.test.ts
@@ -1,0 +1,388 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Neo4jGraphQL } from "../../../../../../src";
+import { createBearerToken } from "../../../../../utils/create-bearer-token";
+import { formatCypher, formatParams, translateQuery } from "../../../../utils/tck-test-utils";
+
+describe("cypher directive filtering - relationship auth filter", () => {
+    test("relationship with auth filter on type PASS", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Movie @node @authorization(filter: [{ where: { node: { actors: { name: "$jwt.custom_value" } } } }]) {
+                title: String
+                rating: Float
+                actors: [Actor!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                        RETURN actor
+                        """
+                        columnName: "actor"
+                    )
+            }
+
+            type Actor @node {
+                name: String
+                movies: [Movie!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(movie:Movie)
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        const token = createBearerToken("secret", { custom_value: "Keanu Reeves" });
+
+        const neoSchema: Neo4jGraphQL = new Neo4jGraphQL({
+            typeDefs,
+            features: {
+                authorization: {
+                    key: "secret",
+                },
+            },
+        });
+
+        const query = /* GraphQL */ `
+            query {
+                moviesConnection(where: { rating_LT: 7.0 }) {
+                    edges {
+                        node {
+                            title
+                        }
+                    }
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query, { token });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this0:Movie)
+            CALL {
+                WITH this0
+                CALL {
+                    WITH this0
+                    WITH this0 AS this
+                    MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                    RETURN actor
+                }
+                WITH actor AS this1
+                RETURN collect(this1) AS this2
+            }
+            WITH *
+            WHERE (this0.rating < $param0 AND ($isAuthenticated = true AND any(this3 IN this2 WHERE ($jwt.custom_value IS NOT NULL AND this3.name = $jwt.custom_value))))
+            WITH collect({ node: this0 }) AS edges
+            WITH edges, size(edges) AS totalCount
+            CALL {
+                WITH edges
+                UNWIND edges AS edge
+                WITH edge.node AS this0
+                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var4
+            }
+            RETURN { edges: var4, totalCount: totalCount } AS this"
+        `);
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": 7,
+                \\"isAuthenticated\\": true,
+                \\"jwt\\": {
+                    \\"roles\\": [],
+                    \\"custom_value\\": \\"Keanu Reeves\\"
+                }
+            }"
+        `);
+    });
+
+    test("relationship with auth filter on type FAIL", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Movie @node @authorization(filter: [{ where: { node: { actors: { name: "$jwt.custom_value" } } } }]) {
+                title: String
+                rating: Float
+                actors: [Actor!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                        RETURN actor
+                        """
+                        columnName: "actor"
+                    )
+            }
+
+            type Actor @node {
+                name: String
+                movies: [Movie!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(movie:Movie)
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        const token = createBearerToken("secret", { custom_value: "Something Incorrect" });
+
+        const neoSchema: Neo4jGraphQL = new Neo4jGraphQL({
+            typeDefs,
+            features: {
+                authorization: {
+                    key: "secret",
+                },
+            },
+        });
+
+        const query = /* GraphQL */ `
+            query {
+                moviesConnection(where: { rating_LT: 7.0 }) {
+                    edges {
+                        node {
+                            title
+                        }
+                    }
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query, { token });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this0:Movie)
+            CALL {
+                WITH this0
+                CALL {
+                    WITH this0
+                    WITH this0 AS this
+                    MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                    RETURN actor
+                }
+                WITH actor AS this1
+                RETURN collect(this1) AS this2
+            }
+            WITH *
+            WHERE (this0.rating < $param0 AND ($isAuthenticated = true AND any(this3 IN this2 WHERE ($jwt.custom_value IS NOT NULL AND this3.name = $jwt.custom_value))))
+            WITH collect({ node: this0 }) AS edges
+            WITH edges, size(edges) AS totalCount
+            CALL {
+                WITH edges
+                UNWIND edges AS edge
+                WITH edge.node AS this0
+                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var4
+            }
+            RETURN { edges: var4, totalCount: totalCount } AS this"
+        `);
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": 7,
+                \\"isAuthenticated\\": true,
+                \\"jwt\\": {
+                    \\"roles\\": [],
+                    \\"custom_value\\": \\"Something Incorrect\\"
+                }
+            }"
+        `);
+    });
+
+    test("relationship with auth validate on type PASS", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Movie
+                @node
+                @authorization(validate: [{ where: { node: { actors: { name: "$jwt.custom_value" } } } }]) {
+                title: String
+                rating: Float
+                actors: [Actor!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                        RETURN actor
+                        """
+                        columnName: "actor"
+                    )
+            }
+
+            type Actor @node {
+                name: String
+                movies: [Movie!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(movie:Movie)
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        const token = createBearerToken("secret", { custom_value: "Keanu Reeves" });
+
+        const neoSchema: Neo4jGraphQL = new Neo4jGraphQL({
+            typeDefs,
+            features: {
+                authorization: {
+                    key: "secret",
+                },
+            },
+        });
+
+        const query = /* GraphQL */ `
+            query {
+                moviesConnection(where: { rating_LT: 7.0 }) {
+                    edges {
+                        node {
+                            title
+                        }
+                    }
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query, { token });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this0:Movie)
+            CALL {
+                WITH this0
+                CALL {
+                    WITH this0
+                    WITH this0 AS this
+                    MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                    RETURN actor
+                }
+                WITH actor AS this1
+                RETURN collect(this1) AS this2
+            }
+            WITH *
+            WHERE (this0.rating < $param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND any(this3 IN this2 WHERE ($jwt.custom_value IS NOT NULL AND this3.name = $jwt.custom_value))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WITH collect({ node: this0 }) AS edges
+            WITH edges, size(edges) AS totalCount
+            CALL {
+                WITH edges
+                UNWIND edges AS edge
+                WITH edge.node AS this0
+                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var4
+            }
+            RETURN { edges: var4, totalCount: totalCount } AS this"
+        `);
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": 7,
+                \\"isAuthenticated\\": true,
+                \\"jwt\\": {
+                    \\"roles\\": [],
+                    \\"custom_value\\": \\"Keanu Reeves\\"
+                }
+            }"
+        `);
+    });
+
+    test("relationship with auth validate on type FAIL", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Movie
+                @node
+                @authorization(validate: [{ where: { node: { actors: { name: "$jwt.custom_value" } } } }]) {
+                title: String
+                rating: Float
+                actors: [Actor!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                        RETURN actor
+                        """
+                        columnName: "actor"
+                    )
+            }
+
+            type Actor @node {
+                name: String
+                movies: [Movie!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(movie:Movie)
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        const token = createBearerToken("secret", { custom_value: "Something Incorrect" });
+
+        const neoSchema: Neo4jGraphQL = new Neo4jGraphQL({
+            typeDefs,
+            features: {
+                authorization: {
+                    key: "secret",
+                },
+            },
+        });
+
+        const query = /* GraphQL */ `
+            query {
+                moviesConnection(where: { rating_GT: 7.0 }) {
+                    edges {
+                        node {
+                            title
+                        }
+                    }
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query, { token });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this0:Movie)
+            CALL {
+                WITH this0
+                CALL {
+                    WITH this0
+                    WITH this0 AS this
+                    MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                    RETURN actor
+                }
+                WITH actor AS this1
+                RETURN collect(this1) AS this2
+            }
+            WITH *
+            WHERE (this0.rating > $param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND any(this3 IN this2 WHERE ($jwt.custom_value IS NOT NULL AND this3.name = $jwt.custom_value))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WITH collect({ node: this0 }) AS edges
+            WITH edges, size(edges) AS totalCount
+            CALL {
+                WITH edges
+                UNWIND edges AS edge
+                WITH edge.node AS this0
+                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var4
+            }
+            RETURN { edges: var4, totalCount: totalCount } AS this"
+        `);
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": 7,
+                \\"isAuthenticated\\": true,
+                \\"jwt\\": {
+                    \\"roles\\": [],
+                    \\"custom_value\\": \\"Something Incorrect\\"
+                }
+            }"
+        `);
+    });
+});

--- a/packages/graphql/tests/tck/directives/cypher/filtering/relationships/cypher-filtering-relationship-auth.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher/filtering/relationships/cypher-filtering-relationship-auth.test.ts
@@ -24,7 +24,9 @@ import { formatCypher, formatParams, translateQuery } from "../../../../utils/tc
 describe("cypher directive filtering - relationship auth filter", () => {
     test("relationship with auth filter on type PASS", async () => {
         const typeDefs = /* GraphQL */ `
-            type Movie @node @authorization(filter: [{ where: { node: { actors: { name: "$jwt.custom_value" } } } }]) {
+            type Movie
+                @node
+                @authorization(filter: [{ where: { node: { actors: { name_EQ: "$jwt.custom_value" } } } }]) {
                 title: String
                 rating: Float
                 actors: [Actor!]!
@@ -114,7 +116,9 @@ describe("cypher directive filtering - relationship auth filter", () => {
 
     test("relationship with auth filter on type FAIL", async () => {
         const typeDefs = /* GraphQL */ `
-            type Movie @node @authorization(filter: [{ where: { node: { actors: { name: "$jwt.custom_value" } } } }]) {
+            type Movie
+                @node
+                @authorization(filter: [{ where: { node: { actors: { name_EQ: "$jwt.custom_value" } } } }]) {
                 title: String
                 rating: Float
                 actors: [Actor!]!
@@ -206,7 +210,7 @@ describe("cypher directive filtering - relationship auth filter", () => {
         const typeDefs = /* GraphQL */ `
             type Movie
                 @node
-                @authorization(validate: [{ where: { node: { actors: { name: "$jwt.custom_value" } } } }]) {
+                @authorization(validate: [{ where: { node: { actors: { name_EQ: "$jwt.custom_value" } } } }]) {
                 title: String
                 rating: Float
                 actors: [Actor!]!
@@ -298,7 +302,7 @@ describe("cypher directive filtering - relationship auth filter", () => {
         const typeDefs = /* GraphQL */ `
             type Movie
                 @node
-                @authorization(validate: [{ where: { node: { actors: { name: "$jwt.custom_value" } } } }]) {
+                @authorization(validate: [{ where: { node: { actors: { name_EQ: "$jwt.custom_value" } } } }]) {
                 title: String
                 rating: Float
                 actors: [Actor!]!

--- a/packages/graphql/tests/tck/directives/cypher/filtering/relationships/cypher-filtering-relationship-connection.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher/filtering/relationships/cypher-filtering-relationship-connection.test.ts
@@ -1,0 +1,675 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Neo4jGraphQL } from "../../../../../../src";
+import { formatCypher, formatParams, translateQuery } from "../../../../utils/tck-test-utils";
+
+describe("Connection API - cypher directive filtering - Relationship", () => {
+    test("Connection API - relationship with single property filter", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Movie @node {
+                title: String
+                actors: [Actor!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                        RETURN actor
+                        """
+                        columnName: "actor"
+                    )
+            }
+
+            type Actor @node {
+                name: String
+                movies: [Movie!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(movie:Movie)
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        const neoSchema: Neo4jGraphQL = new Neo4jGraphQL({
+            typeDefs,
+        });
+
+        const query = /* GraphQL */ `
+            query {
+                moviesConnection(where: { actors: { name: "Jada Pinkett Smith" } }) {
+                    edges {
+                        node {
+                            title
+                        }
+                    }
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this0:Movie)
+            CALL {
+                WITH this0
+                CALL {
+                    WITH this0
+                    WITH this0 AS this
+                    MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                    RETURN actor
+                }
+                WITH actor AS this1
+                RETURN collect(this1) AS this2
+            }
+            WITH *
+            WHERE any(this3 IN this2 WHERE this3.name = $param0)
+            WITH collect({ node: this0 }) AS edges
+            WITH edges, size(edges) AS totalCount
+            CALL {
+                WITH edges
+                UNWIND edges AS edge
+                WITH edge.node AS this0
+                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var4
+            }
+            RETURN { edges: var4, totalCount: totalCount } AS this"
+        `);
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"Jada Pinkett Smith\\"
+            }"
+        `);
+    });
+
+    test("Connection API - relationship with single property filter NOT", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Movie @node {
+                title: String
+                actors: [Actor!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                        RETURN actor
+                        """
+                        columnName: "actor"
+                    )
+            }
+
+            type Actor @node {
+                name: String
+                movies: [Movie!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(movie:Movie)
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        const neoSchema: Neo4jGraphQL = new Neo4jGraphQL({
+            typeDefs,
+        });
+
+        const query = /* GraphQL */ `
+            query {
+                moviesConnection(where: { NOT: { actors: { name: "Jada Pinkett Smith" } } }) {
+                    edges {
+                        node {
+                            title
+                        }
+                    }
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this0:Movie)
+            CALL {
+                WITH this0
+                CALL {
+                    WITH this0
+                    WITH this0 AS this
+                    MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                    RETURN actor
+                }
+                WITH actor AS this1
+                RETURN collect(this1) AS this2
+            }
+            WITH *
+            WHERE NOT (any(this3 IN this2 WHERE this3.name = $param0))
+            WITH collect({ node: this0 }) AS edges
+            WITH edges, size(edges) AS totalCount
+            CALL {
+                WITH edges
+                UNWIND edges AS edge
+                WITH edge.node AS this0
+                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var4
+            }
+            RETURN { edges: var4, totalCount: totalCount } AS this"
+        `);
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"Jada Pinkett Smith\\"
+            }"
+        `);
+    });
+
+    test("Connection API - relationship with single property filter ALL", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Movie @node {
+                title: String
+                actors: [Actor!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                        RETURN actor
+                        """
+                        columnName: "actor"
+                    )
+            }
+
+            type Actor @node {
+                name: String
+                movies: [Movie!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(movie:Movie)
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        const neoSchema: Neo4jGraphQL = new Neo4jGraphQL({
+            typeDefs,
+        });
+
+        const query = /* GraphQL */ `
+            query {
+                moviesConnection(where: { actors_ALL: { name: "Keanu Reeves" } }) {
+                    edges {
+                        node {
+                            title
+                        }
+                    }
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this0:Movie)
+            CALL {
+                WITH this0
+                CALL {
+                    WITH this0
+                    WITH this0 AS this
+                    MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                    RETURN actor
+                }
+                WITH actor AS this1
+                RETURN collect(this1) AS this2
+            }
+            WITH *
+            WHERE all(this3 IN this2 WHERE this3.name = $param0)
+            WITH collect({ node: this0 }) AS edges
+            WITH edges, size(edges) AS totalCount
+            CALL {
+                WITH edges
+                UNWIND edges AS edge
+                WITH edge.node AS this0
+                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var4
+            }
+            RETURN { edges: var4, totalCount: totalCount } AS this"
+        `);
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"Keanu Reeves\\"
+            }"
+        `);
+    });
+
+    test("Connection API - relationship with single property filter SINGLE", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Movie @node {
+                title: String
+                actors: [Actor!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                        RETURN actor
+                        """
+                        columnName: "actor"
+                    )
+            }
+
+            type Actor @node {
+                name: String
+                movies: [Movie!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(movie:Movie)
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        const neoSchema: Neo4jGraphQL = new Neo4jGraphQL({
+            typeDefs,
+        });
+
+        const query = /* GraphQL */ `
+            query {
+                moviesConnection(where: { actors_SINGLE: { name: "Carrie-Anne Moss" } }) {
+                    edges {
+                        node {
+                            title
+                        }
+                    }
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this0:Movie)
+            CALL {
+                WITH this0
+                CALL {
+                    WITH this0
+                    WITH this0 AS this
+                    MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                    RETURN actor
+                }
+                WITH actor AS this1
+                RETURN collect(this1) AS this2
+            }
+            WITH *
+            WHERE single(this3 IN this2 WHERE this3.name = $param0)
+            WITH collect({ node: this0 }) AS edges
+            WITH edges, size(edges) AS totalCount
+            CALL {
+                WITH edges
+                UNWIND edges AS edge
+                WITH edge.node AS this0
+                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var4
+            }
+            RETURN { edges: var4, totalCount: totalCount } AS this"
+        `);
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"Carrie-Anne Moss\\"
+            }"
+        `);
+    });
+
+    test("Connection API - relationship with single property filter SOME", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Movie @node {
+                title: String
+                actors: [Actor!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                        RETURN actor
+                        """
+                        columnName: "actor"
+                    )
+            }
+
+            type Actor @node {
+                name: String
+                movies: [Movie!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(movie:Movie)
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        const neoSchema: Neo4jGraphQL = new Neo4jGraphQL({
+            typeDefs,
+        });
+
+        const query = /* GraphQL */ `
+            query {
+                moviesConnection(where: { actors_SOME: { name: "Keanu Reeves" } }) {
+                    edges {
+                        node {
+                            title
+                        }
+                    }
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this0:Movie)
+            CALL {
+                WITH this0
+                CALL {
+                    WITH this0
+                    WITH this0 AS this
+                    MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                    RETURN actor
+                }
+                WITH actor AS this1
+                RETURN collect(this1) AS this2
+            }
+            WITH *
+            WHERE any(this3 IN this2 WHERE this3.name = $param0)
+            WITH collect({ node: this0 }) AS edges
+            WITH edges, size(edges) AS totalCount
+            CALL {
+                WITH edges
+                UNWIND edges AS edge
+                WITH edge.node AS this0
+                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var4
+            }
+            RETURN { edges: var4, totalCount: totalCount } AS this"
+        `);
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"Keanu Reeves\\"
+            }"
+        `);
+    });
+
+    test("Connection API - relationship with single property filter SOME with sort", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Movie @node {
+                title: String
+                actors: [Actor!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                        RETURN actor
+                        """
+                        columnName: "actor"
+                    )
+            }
+
+            type Actor @node {
+                name: String
+                movies: [Movie!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(movie:Movie)
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        const neoSchema: Neo4jGraphQL = new Neo4jGraphQL({
+            typeDefs,
+        });
+
+        const query = /* GraphQL */ `
+            query {
+                moviesConnection(where: { actors_SOME: { name: "Keanu Reeves" } }, sort: { title: DESC }) {
+                    edges {
+                        node {
+                            title
+                        }
+                    }
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this0:Movie)
+            CALL {
+                WITH this0
+                CALL {
+                    WITH this0
+                    WITH this0 AS this
+                    MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                    RETURN actor
+                }
+                WITH actor AS this1
+                RETURN collect(this1) AS this2
+            }
+            WITH *
+            WHERE any(this3 IN this2 WHERE this3.name = $param0)
+            WITH collect({ node: this0 }) AS edges
+            WITH edges, size(edges) AS totalCount
+            CALL {
+                WITH edges
+                UNWIND edges AS edge
+                WITH edge.node AS this0
+                WITH *
+                ORDER BY this0.title DESC
+                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var4
+            }
+            RETURN { edges: var4, totalCount: totalCount } AS this"
+        `);
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"Keanu Reeves\\"
+            }"
+        `);
+    });
+
+    test("Connection API - relationship with single property filter NONE", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Movie @node {
+                title: String
+                actors: [Actor!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                        RETURN actor
+                        """
+                        columnName: "actor"
+                    )
+            }
+
+            type Actor @node {
+                name: String
+                movies: [Movie!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(movie:Movie)
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        const neoSchema: Neo4jGraphQL = new Neo4jGraphQL({
+            typeDefs,
+        });
+
+        const query = /* GraphQL */ `
+            query {
+                moviesConnection(where: { actors_NONE: { name: "Keanu Reeves" } }) {
+                    edges {
+                        node {
+                            title
+                        }
+                    }
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this0:Movie)
+            CALL {
+                WITH this0
+                CALL {
+                    WITH this0
+                    WITH this0 AS this
+                    MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                    RETURN actor
+                }
+                WITH actor AS this1
+                RETURN collect(this1) AS this2
+            }
+            WITH *
+            WHERE none(this3 IN this2 WHERE this3.name = $param0)
+            WITH collect({ node: this0 }) AS edges
+            WITH edges, size(edges) AS totalCount
+            CALL {
+                WITH edges
+                UNWIND edges AS edge
+                WITH edge.node AS this0
+                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var4
+            }
+            RETURN { edges: var4, totalCount: totalCount } AS this"
+        `);
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"Keanu Reeves\\"
+            }"
+        `);
+    });
+
+    test("relationship with multiple property filters", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Movie @node {
+                title: String
+                genres: [Genre!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:IN_GENRE]->(g:Genre)
+                        RETURN g
+                        """
+                        columnName: "g"
+                    )
+                actors: [Actor!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                        RETURN actor
+                        """
+                        columnName: "actor"
+                    )
+            }
+
+            type Actor @node {
+                name: String
+                movies: [Movie!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(movie:Movie)
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+
+            type Genre @node {
+                name: String
+                movies: [Movie!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:IN_GENRE]-(movie:Movie)
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        const neoSchema: Neo4jGraphQL = new Neo4jGraphQL({
+            typeDefs,
+        });
+
+        const query = /* GraphQL */ `
+            query {
+                moviesConnection(
+                    where: { OR: [{ actors: { name: "Jada Pinkett Smith" } }, { genres: { name: "Romance" } }] }
+                ) {
+                    edges {
+                        node {
+                            title
+                        }
+                    }
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this0:Movie)
+            CALL {
+                WITH this0
+                CALL {
+                    WITH this0
+                    WITH this0 AS this
+                    MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                    RETURN actor
+                }
+                WITH actor AS this1
+                RETURN collect(this1) AS this2
+            }
+            CALL {
+                WITH this0
+                CALL {
+                    WITH this0
+                    WITH this0 AS this
+                    MATCH (this)-[:IN_GENRE]->(g:Genre)
+                    RETURN g
+                }
+                WITH g AS this3
+                RETURN collect(this3) AS this4
+            }
+            WITH *
+            WHERE (any(this5 IN this2 WHERE this5.name = $param0) OR any(this6 IN this4 WHERE this6.name = $param1))
+            WITH collect({ node: this0 }) AS edges
+            WITH edges, size(edges) AS totalCount
+            CALL {
+                WITH edges
+                UNWIND edges AS edge
+                WITH edge.node AS this0
+                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var7
+            }
+            RETURN { edges: var7, totalCount: totalCount } AS this"
+        `);
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"Jada Pinkett Smith\\",
+                \\"param1\\": \\"Romance\\"
+            }"
+        `);
+    });
+});

--- a/packages/graphql/tests/tck/directives/cypher/filtering/relationships/cypher-filtering-relationship-connection.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher/filtering/relationships/cypher-filtering-relationship-connection.test.ts
@@ -54,7 +54,7 @@ describe("Connection API - cypher directive filtering - Relationship", () => {
 
         const query = /* GraphQL */ `
             query {
-                moviesConnection(where: { actors: { name: "Jada Pinkett Smith" } }) {
+                moviesConnection(where: { actors: { name_EQ: "Jada Pinkett Smith" } }) {
                     edges {
                         node {
                             title
@@ -131,7 +131,7 @@ describe("Connection API - cypher directive filtering - Relationship", () => {
 
         const query = /* GraphQL */ `
             query {
-                moviesConnection(where: { NOT: { actors: { name: "Jada Pinkett Smith" } } }) {
+                moviesConnection(where: { NOT: { actors: { name_EQ: "Jada Pinkett Smith" } } }) {
                     edges {
                         node {
                             title
@@ -208,7 +208,7 @@ describe("Connection API - cypher directive filtering - Relationship", () => {
 
         const query = /* GraphQL */ `
             query {
-                moviesConnection(where: { actors_ALL: { name: "Keanu Reeves" } }) {
+                moviesConnection(where: { actors_ALL: { name_EQ: "Keanu Reeves" } }) {
                     edges {
                         node {
                             title
@@ -285,7 +285,7 @@ describe("Connection API - cypher directive filtering - Relationship", () => {
 
         const query = /* GraphQL */ `
             query {
-                moviesConnection(where: { actors_SINGLE: { name: "Carrie-Anne Moss" } }) {
+                moviesConnection(where: { actors_SINGLE: { name_EQ: "Carrie-Anne Moss" } }) {
                     edges {
                         node {
                             title
@@ -362,7 +362,7 @@ describe("Connection API - cypher directive filtering - Relationship", () => {
 
         const query = /* GraphQL */ `
             query {
-                moviesConnection(where: { actors_SOME: { name: "Keanu Reeves" } }) {
+                moviesConnection(where: { actors_SOME: { name_EQ: "Keanu Reeves" } }) {
                     edges {
                         node {
                             title
@@ -439,7 +439,7 @@ describe("Connection API - cypher directive filtering - Relationship", () => {
 
         const query = /* GraphQL */ `
             query {
-                moviesConnection(where: { actors_SOME: { name: "Keanu Reeves" } }, sort: { title: DESC }) {
+                moviesConnection(where: { actors_SOME: { name_EQ: "Keanu Reeves" } }, sort: { title: DESC }) {
                     edges {
                         node {
                             title
@@ -518,7 +518,7 @@ describe("Connection API - cypher directive filtering - Relationship", () => {
 
         const query = /* GraphQL */ `
             query {
-                moviesConnection(where: { actors_NONE: { name: "Keanu Reeves" } }) {
+                moviesConnection(where: { actors_NONE: { name_EQ: "Keanu Reeves" } }) {
                     edges {
                         node {
                             title
@@ -616,7 +616,7 @@ describe("Connection API - cypher directive filtering - Relationship", () => {
         const query = /* GraphQL */ `
             query {
                 moviesConnection(
-                    where: { OR: [{ actors: { name: "Jada Pinkett Smith" } }, { genres: { name: "Romance" } }] }
+                    where: { OR: [{ actors: { name_EQ: "Jada Pinkett Smith" } }, { genres: { name_EQ: "Romance" } }] }
                 ) {
                     edges {
                         node {

--- a/packages/graphql/tests/tck/directives/cypher/filtering/relationships/cypher-filtering-relationship.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher/filtering/relationships/cypher-filtering-relationship.test.ts
@@ -54,7 +54,7 @@ describe("cypher directive filtering - Relationship", () => {
 
         const query = /* GraphQL */ `
             query {
-                movies(where: { actors: { name: "Jada Pinkett Smith" } }) {
+                movies(where: { actors: { name_EQ: "Jada Pinkett Smith" } }) {
                     title
                 }
             }
@@ -119,7 +119,7 @@ describe("cypher directive filtering - Relationship", () => {
 
         const query = /* GraphQL */ `
             query {
-                movies(where: { NOT: { actors: { name: "Jada Pinkett Smith" } } }) {
+                movies(where: { NOT: { actors: { name_EQ: "Jada Pinkett Smith" } } }) {
                     title
                 }
             }
@@ -184,7 +184,7 @@ describe("cypher directive filtering - Relationship", () => {
 
         const query = /* GraphQL */ `
             query {
-                movies(where: { actors_ALL: { name: "Keanu Reeves" } }) {
+                movies(where: { actors_ALL: { name_EQ: "Keanu Reeves" } }) {
                     title
                 }
             }
@@ -249,7 +249,7 @@ describe("cypher directive filtering - Relationship", () => {
 
         const query = /* GraphQL */ `
             query {
-                movies(where: { actors_SINGLE: { name: "Carrie-Anne Moss" } }) {
+                movies(where: { actors_SINGLE: { name_EQ: "Carrie-Anne Moss" } }) {
                     title
                 }
             }
@@ -314,7 +314,7 @@ describe("cypher directive filtering - Relationship", () => {
 
         const query = /* GraphQL */ `
             query {
-                movies(where: { actors_SOME: { name: "Keanu Reeves" } }) {
+                movies(where: { actors_SOME: { name_EQ: "Keanu Reeves" } }) {
                     title
                 }
             }
@@ -378,7 +378,7 @@ describe("cypher directive filtering - Relationship", () => {
         });
         const query = /* GraphQL */ `
             query {
-                movies(where: { actors_NONE: { name: "Keanu Reeves" } }) {
+                movies(where: { actors_NONE: { name_EQ: "Keanu Reeves" } }) {
                     title
                 }
             }
@@ -463,7 +463,9 @@ describe("cypher directive filtering - Relationship", () => {
 
         const query = /* GraphQL */ `
             query {
-                movies(where: { OR: [{ actors: { name: "Jada Pinkett Smith" } }, { genres: { name: "Romance" } }] }) {
+                movies(
+                    where: { OR: [{ actors: { name_EQ: "Jada Pinkett Smith" } }, { genres: { name_EQ: "Romance" } }] }
+                ) {
                     title
                 }
             }

--- a/packages/graphql/tests/tck/directives/cypher/filtering/relationships/cypher-filtering-relationship.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher/filtering/relationships/cypher-filtering-relationship.test.ts
@@ -1,0 +1,509 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Neo4jGraphQL } from "../../../../../../src";
+import { formatCypher, formatParams, translateQuery } from "../../../../utils/tck-test-utils";
+
+describe("cypher directive filtering - Relationship", () => {
+    test("relationship with single property filter", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Movie @node {
+                title: String
+                actors: [Actor!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                        RETURN actor
+                        """
+                        columnName: "actor"
+                    )
+            }
+
+            type Actor @node {
+                name: String
+                movies: [Movie!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(movie:Movie)
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        const neoSchema: Neo4jGraphQL = new Neo4jGraphQL({
+            typeDefs,
+        });
+
+        const query = /* GraphQL */ `
+            query {
+                movies(where: { actors: { name: "Jada Pinkett Smith" } }) {
+                    title
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:Movie)
+            CALL {
+                WITH this
+                CALL {
+                    WITH this
+                    WITH this AS this
+                    MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                    RETURN actor
+                }
+                WITH actor AS this0
+                RETURN collect(this0) AS this1
+            }
+            WITH *
+            WHERE any(this2 IN this1 WHERE this2.name = $param0)
+            RETURN this { .title } AS this"
+        `);
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"Jada Pinkett Smith\\"
+            }"
+        `);
+    });
+
+    test("relationship with single property filter NOT", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Movie @node {
+                title: String
+                actors: [Actor!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                        RETURN actor
+                        """
+                        columnName: "actor"
+                    )
+            }
+
+            type Actor @node {
+                name: String
+                movies: [Movie!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(movie:Movie)
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        const neoSchema: Neo4jGraphQL = new Neo4jGraphQL({
+            typeDefs,
+        });
+
+        const query = /* GraphQL */ `
+            query {
+                movies(where: { NOT: { actors: { name: "Jada Pinkett Smith" } } }) {
+                    title
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:Movie)
+            CALL {
+                WITH this
+                CALL {
+                    WITH this
+                    WITH this AS this
+                    MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                    RETURN actor
+                }
+                WITH actor AS this0
+                RETURN collect(this0) AS this1
+            }
+            WITH *
+            WHERE NOT (any(this2 IN this1 WHERE this2.name = $param0))
+            RETURN this { .title } AS this"
+        `);
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"Jada Pinkett Smith\\"
+            }"
+        `);
+    });
+
+    test("relationship with single property filter ALL", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Movie @node {
+                title: String
+                actors: [Actor!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                        RETURN actor
+                        """
+                        columnName: "actor"
+                    )
+            }
+
+            type Actor @node {
+                name: String
+                movies: [Movie!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(movie:Movie)
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        const neoSchema: Neo4jGraphQL = new Neo4jGraphQL({
+            typeDefs,
+        });
+
+        const query = /* GraphQL */ `
+            query {
+                movies(where: { actors_ALL: { name: "Keanu Reeves" } }) {
+                    title
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:Movie)
+            CALL {
+                WITH this
+                CALL {
+                    WITH this
+                    WITH this AS this
+                    MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                    RETURN actor
+                }
+                WITH actor AS this0
+                RETURN collect(this0) AS this1
+            }
+            WITH *
+            WHERE all(this2 IN this1 WHERE this2.name = $param0)
+            RETURN this { .title } AS this"
+        `);
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"Keanu Reeves\\"
+            }"
+        `);
+    });
+
+    test("relationship with single property filter SINGLE", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Movie @node {
+                title: String
+                actors: [Actor!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                        RETURN actor
+                        """
+                        columnName: "actor"
+                    )
+            }
+
+            type Actor @node {
+                name: String
+                movies: [Movie!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(movie:Movie)
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        const neoSchema: Neo4jGraphQL = new Neo4jGraphQL({
+            typeDefs,
+        });
+
+        const query = /* GraphQL */ `
+            query {
+                movies(where: { actors_SINGLE: { name: "Carrie-Anne Moss" } }) {
+                    title
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:Movie)
+            CALL {
+                WITH this
+                CALL {
+                    WITH this
+                    WITH this AS this
+                    MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                    RETURN actor
+                }
+                WITH actor AS this0
+                RETURN collect(this0) AS this1
+            }
+            WITH *
+            WHERE single(this2 IN this1 WHERE this2.name = $param0)
+            RETURN this { .title } AS this"
+        `);
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"Carrie-Anne Moss\\"
+            }"
+        `);
+    });
+
+    test("relationship with single property filter SOME", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Movie @node {
+                title: String
+                actors: [Actor!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                        RETURN actor
+                        """
+                        columnName: "actor"
+                    )
+            }
+
+            type Actor @node {
+                name: String
+                movies: [Movie!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(movie:Movie)
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        const neoSchema: Neo4jGraphQL = new Neo4jGraphQL({
+            typeDefs,
+        });
+
+        const query = /* GraphQL */ `
+            query {
+                movies(where: { actors_SOME: { name: "Keanu Reeves" } }) {
+                    title
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:Movie)
+            CALL {
+                WITH this
+                CALL {
+                    WITH this
+                    WITH this AS this
+                    MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                    RETURN actor
+                }
+                WITH actor AS this0
+                RETURN collect(this0) AS this1
+            }
+            WITH *
+            WHERE any(this2 IN this1 WHERE this2.name = $param0)
+            RETURN this { .title } AS this"
+        `);
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"Keanu Reeves\\"
+            }"
+        `);
+    });
+
+    test("relationship with single property filter NONE", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Movie @node {
+                title: String
+                actors: [Actor!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                        RETURN actor
+                        """
+                        columnName: "actor"
+                    )
+            }
+
+            type Actor @node {
+                name: String
+                movies: [Movie!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(movie:Movie)
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        const neoSchema: Neo4jGraphQL = new Neo4jGraphQL({
+            typeDefs,
+        });
+        const query = /* GraphQL */ `
+            query {
+                movies(where: { actors_NONE: { name: "Keanu Reeves" } }) {
+                    title
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:Movie)
+            CALL {
+                WITH this
+                CALL {
+                    WITH this
+                    WITH this AS this
+                    MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                    RETURN actor
+                }
+                WITH actor AS this0
+                RETURN collect(this0) AS this1
+            }
+            WITH *
+            WHERE none(this2 IN this1 WHERE this2.name = $param0)
+            RETURN this { .title } AS this"
+        `);
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"Keanu Reeves\\"
+            }"
+        `);
+    });
+
+    test("relationship with multiple property filters", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Movie @node {
+                title: String
+                genres: [Genre!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:IN_GENRE]->(g:Genre)
+                        RETURN g
+                        """
+                        columnName: "g"
+                    )
+                actors: [Actor!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                        RETURN actor
+                        """
+                        columnName: "actor"
+                    )
+            }
+
+            type Actor @node {
+                name: String
+                movies: [Movie!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[:ACTED_IN]->(movie:Movie)
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+
+            type Genre @node {
+                name: String
+                movies: [Movie!]!
+                    @cypher(
+                        statement: """
+                        MATCH (this)<-[:IN_GENRE]-(movie:Movie)
+                        RETURN movie
+                        """
+                        columnName: "movie"
+                    )
+            }
+        `;
+
+        const neoSchema: Neo4jGraphQL = new Neo4jGraphQL({
+            typeDefs,
+        });
+
+        const query = /* GraphQL */ `
+            query {
+                movies(where: { OR: [{ actors: { name: "Jada Pinkett Smith" } }, { genres: { name: "Romance" } }] }) {
+                    title
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:Movie)
+            CALL {
+                WITH this
+                CALL {
+                    WITH this
+                    WITH this AS this
+                    MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                    RETURN actor
+                }
+                WITH actor AS this0
+                RETURN collect(this0) AS this1
+            }
+            CALL {
+                WITH this
+                CALL {
+                    WITH this
+                    WITH this AS this
+                    MATCH (this)-[:IN_GENRE]->(g:Genre)
+                    RETURN g
+                }
+                WITH g AS this2
+                RETURN collect(this2) AS this3
+            }
+            WITH *
+            WHERE (any(this4 IN this1 WHERE this4.name = $param0) OR any(this5 IN this3 WHERE this5.name = $param1))
+            RETURN this { .title } AS this"
+        `);
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"Jada Pinkett Smith\\",
+                \\"param1\\": \\"Romance\\"
+            }"
+        `);
+    });
+});


### PR DESCRIPTION
# Description

This PR adds the ability to filter on many to many (m:m) relationship cypher fields. An example:

Type definitions:
```gql
type Movie @node {
    title: String
    actors: [Actor!]!
        @cypher(
            statement: """
            MATCH (this)<-[:ACTED_IN]-(actor:Actor)
            RETURN actor
            """
            columnName: "actor"
        )
}

type Actor @node {
    name: String
    movies: [Movie!]!
        @cypher(
            statement: """
            MATCH (this)-[:ACTED_IN]->(movie:Movie)
            RETURN movie
            """
            columnName: "movie"
        )
}
```

You can now query with a filter based on the `actors` field:
```gql
query {
  movies(where: { actors: { name: "Jada Pinkett Smith" } }) {
      title
  }
}
```

## Complexity

Medium

# Issue

Closes #554.

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [x] TCK tests have been updated
- [x] Integration tests have been updated
- [ ] Example applications have been updated
- [x] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
