### PR TITLE
Filter fields with @customResolver from projection (LTS)

### DIFF
--- a/.changeset/breezy-jars-design.md
+++ b/.changeset/breezy-jars-design.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+Fixed bug where fields decorated with `@customResolver` were included in the projection of the generated Cypher query

--- a/packages/graphql/src/translate/queryAST/factory/FieldFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/FieldFactory.ts
@@ -77,6 +77,16 @@ export class FieldFactory {
                     context,
                     field: field.name,
                 });
+
+                const attribute = entity.findAttribute(fieldName);
+                if (attribute) {
+                    const customResolver = attribute.annotations.customResolver;
+                    if (customResolver) {
+                        // We don't want to project the custom resolver field itself
+                        return;
+                    }
+                }
+
                 const relationship = entity.findRelationship(fieldName);
                 if (relationship) {
                     if (isConnection) {

--- a/packages/graphql/tests/tck/directives/customResolver.test.ts
+++ b/packages/graphql/tests/tck/directives/customResolver.test.ts
@@ -80,7 +80,7 @@ describe("@customResolver directive", () => {
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
                 "MATCH (this:User)
-                RETURN this { .firstName, .lastName, .fullName } AS this"
+                RETURN this { .firstName, .lastName } AS this"
             `);
 
             expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -100,7 +100,7 @@ describe("@customResolver directive", () => {
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
                 "MATCH (this:User)
-                RETURN this { .firstName, .fullName, .lastName } AS this"
+                RETURN this { .firstName, .lastName } AS this"
             `);
 
             expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -119,7 +119,7 @@ describe("@customResolver directive", () => {
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
                 "MATCH (this:User)
-                RETURN this { .fullName, .firstName, .lastName } AS this"
+                RETURN this { .firstName, .lastName } AS this"
             `);
 
             expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -162,7 +162,7 @@ describe("@customResolver directive", () => {
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
                 "MATCH (this:User)
-                RETURN this { .firstName, .fullName } AS this"
+                RETURN this { .firstName } AS this"
             `);
 
             expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -181,7 +181,7 @@ describe("@customResolver directive", () => {
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
                 "MATCH (this:User)
-                RETURN this { .fullName } AS this"
+                RETURN this {  } AS this"
             `);
 
             expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -256,7 +256,7 @@ describe("@customResolver directive", () => {
                     WITH this1 { city: var4 } AS this1
                     RETURN head(collect(this1)) AS var5
                 }
-                RETURN this { .firstName, .lastName, .fullName, address: var5 } AS this"
+                RETURN this { .firstName, .lastName, address: var5 } AS this"
             `);
 
             expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -312,7 +312,7 @@ describe("@customResolver directive", () => {
                     WITH this1 { city: var4 } AS this1
                     RETURN head(collect(this1)) AS var5
                 }
-                RETURN this { .lastName, .fullName, .firstName, address: var5 } AS this"
+                RETURN this { .lastName, .firstName, address: var5 } AS this"
             `);
 
             expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -343,7 +343,7 @@ describe("@customResolver directive", () => {
                     WITH this1 { city: var4 } AS this1
                     RETURN head(collect(this1)) AS var5
                 }
-                RETURN this { .fullName, .firstName, .lastName, address: var5 } AS this"
+                RETURN this { .firstName, .lastName, address: var5 } AS this"
             `);
 
             expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -425,7 +425,7 @@ describe("@customResolver directive", () => {
                     WITH var2
                     RETURN collect(var2) AS var2
                 }
-                RETURN this { .name, .publicationsWithAuthor, publications: var2 } AS this"
+                RETURN this { .name, publications: var2 } AS this"
             `);
 
             expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -484,7 +484,7 @@ describe("@customResolver directive", () => {
                     WITH var2
                     RETURN collect(var2) AS var2
                 }
-                RETURN this { .publicationsWithAuthor, .name, publications: var2 } AS this"
+                RETURN this { .name, publications: var2 } AS this"
             `);
 
             expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -519,7 +519,7 @@ describe("@customResolver directive", () => {
                     WITH var2
                     RETURN collect(var2) AS var2
                 }
-                RETURN this { .publicationsWithAuthor, .name, publications: var2 } AS this"
+                RETURN this { .name, publications: var2 } AS this"
             `);
 
             expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -606,7 +606,7 @@ describe("@customResolver directive", () => {
                     WITH var2
                     RETURN collect(var2) AS var2
                 }
-                RETURN this { .name, .publicationsWithAuthor, publications: var2 } AS this"
+                RETURN this { .name, publications: var2 } AS this"
             `);
 
             expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -665,7 +665,7 @@ describe("@customResolver directive", () => {
                     WITH var2
                     RETURN collect(var2) AS var2
                 }
-                RETURN this { .publicationsWithAuthor, .name, publications: var2 } AS this"
+                RETURN this { .name, publications: var2 } AS this"
             `);
 
             expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -700,7 +700,7 @@ describe("@customResolver directive", () => {
                     WITH var2
                     RETURN collect(var2) AS var2
                 }
-                RETURN this { .publicationsWithAuthor, .name, publications: var2 } AS this"
+                RETURN this { .name, publications: var2 } AS this"
             `);
 
             expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);


### PR DESCRIPTION
# Description

Fields decorated with `@customResolver` were being included in the Cypher projection, and this fix addresses that.

## Complexity

Complexity: Low

# Issue

Closes #5595 
