### PR TITLE
Deprecates the private directive

### DIFF
--- a/.changeset/stale-knives-shake.md
+++ b/.changeset/stale-knives-shake.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+Deprecates `@private` directive. The private directive was aimed to be used in conjunction with the OGM, which is no longer supported.

--- a/packages/graphql/src/schema/validation/custom-rules/warnings/deprecated-private.ts
+++ b/packages/graphql/src/schema/validation/custom-rules/warnings/deprecated-private.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ASTVisitor, ObjectTypeDefinitionNode } from "graphql";
+import { privateDirective } from "../../../../graphql/directives";
+
+export function WarnPrivateDeprecation() {
+    return function (): ASTVisitor {
+        let warningAlreadyIssued = false;
+
+        return {
+            ObjectTypeDefinition(objectTypeDefinition: ObjectTypeDefinitionNode) {
+                if (["Query", "Mutation", "Subscription"].includes(objectTypeDefinition.name.value)) {
+                    return;
+                }
+                if (warningAlreadyIssued) {
+                    return;
+                }
+                let hasPrivateDirective = false;
+                for (const field of objectTypeDefinition.fields || []) {
+                    for (const directive of field.directives ?? []) {
+                        if (directive.name.value === privateDirective.name) {
+                            hasPrivateDirective = true;
+                        }
+                    }
+                }
+
+                if (hasPrivateDirective) {
+                    console.warn(`Future library versions will not support @private directive.`);
+                    warningAlreadyIssued = true;
+                }
+            },
+        };
+    };
+}

--- a/packages/graphql/src/schema/validation/validate-document.ts
+++ b/packages/graphql/src/schema/validation/validate-document.ts
@@ -62,6 +62,7 @@ import {
 import { ValidFieldTypes } from "./custom-rules/valid-types/valid-field-types";
 import { ValidObjectType } from "./custom-rules/valid-types/valid-object-type";
 import { WarnIfAuthorizationFeatureDisabled } from "./custom-rules/warnings/authorization-feature-disabled";
+import { WarnPrivateDeprecation } from "./custom-rules/warnings/deprecated-private";
 import { WarnUniqueDeprecation } from "./custom-rules/warnings/deprecated-unique";
 import { WarnIfAMaxLimitCanBeBypassedThroughInterface } from "./custom-rules/warnings/limit-max-can-be-bypassed";
 import { WarnIfListOfListsFieldDefinition } from "./custom-rules/warnings/list-of-lists";
@@ -237,6 +238,7 @@ function runValidationRulesOnFilteredDocument({
             WarnIfTypeIsNotMarkedAsNode(),
             WarnIfQueryDirectionIsUsedWithDeprecatedValues,
             WarnUniqueDeprecation(),
+            WarnPrivateDeprecation(),
         ],
         schema
     );

--- a/packages/graphql/tests/integration/migration-warnings/private-directive.test.ts
+++ b/packages/graphql/tests/integration/migration-warnings/private-directive.test.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Neo4jGraphQL } from "../../../src/classes";
+
+describe("deprecated @unique warnings", () => {
+    let warn: jest.SpyInstance;
+
+    beforeEach(() => {
+        warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        warn.mockReset();
+    });
+
+    test("warning on unique usage", async () => {
+        const typeDefs = /* GraphQL */ `
+            type User @node {
+                id: ID! @private
+                firstName: String!
+            }
+
+            type Movie @node {
+                id: ID! @private
+                title: String!
+            }
+        `;
+
+        const neoSchema = new Neo4jGraphQL({
+            typeDefs: typeDefs,
+            validate: true,
+        });
+        await neoSchema.getSchema();
+        expect(warn).toHaveBeenCalledWith("Future library versions will not support @private directive.");
+    });
+});


### PR DESCRIPTION
# Description

Deprecates `@private` directive. The private directive was aimed to be used in conjunction with the OGM, which is no longer supported.
