### PR TITLE
Implement query complexity estimation

### DIFF
--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -85,6 +85,7 @@
         "dot-prop": "^6.0.1",
         "graphql-compose": "^9.0.8",
         "graphql-parse-resolve-info": "^4.12.3",
+        "graphql-query-complexity": "^1.0.0",
         "graphql-relay": "^0.10.0",
         "jose": "^5.0.0",
         "pluralize": "^8.0.0",

--- a/packages/graphql/src/classes/ComplexityEstimatorHelper.ts
+++ b/packages/graphql/src/classes/ComplexityEstimatorHelper.ts
@@ -60,8 +60,8 @@ export class ComplexityEstimatorHelper {
                     complexity: ({childComplexity, args}) => {
                         const fieldDefaultComplexity = 1
                         const defaultLimitIfNotProvided = 1
-                        if(args.limit || args.first) {
-                            return childComplexity + (args.limit || args.first) * fieldDefaultComplexity
+                        if(args.limit ?? args.first) {
+                            return childComplexity + (args.limit ?? args.first) * fieldDefaultComplexity
                         }
                         return childComplexity + defaultLimitIfNotProvided
                         

--- a/packages/graphql/src/classes/ComplexityEstimatorHelper.ts
+++ b/packages/graphql/src/classes/ComplexityEstimatorHelper.ts
@@ -31,10 +31,8 @@ export class ComplexityEstimatorHelper {
 
     public registerField(parentObjectTypeNameOrInterfaceTypeName: string, fieldName: string): void {
         if(this.useComplexityEstimators) {
-            const existingFieldsForTypeName = this.objectTypeNameToFieldNamesMapForComplexityExtensions.get(parentObjectTypeNameOrInterfaceTypeName) || []
+            const existingFieldsForTypeName = this.objectTypeNameToFieldNamesMapForComplexityExtensions.get(parentObjectTypeNameOrInterfaceTypeName) ?? []
             this.objectTypeNameToFieldNamesMapForComplexityExtensions.set(parentObjectTypeNameOrInterfaceTypeName, existingFieldsForTypeName.concat(fieldName))
-
-            console.log(this.objectTypeNameToFieldNamesMapForComplexityExtensions)
         }
     }
 
@@ -94,7 +92,7 @@ export class ComplexityEstimatorHelper {
 
     public getComplexityEstimators(): ComplexityEstimator[] {
         if (!this.useComplexityEstimators) {
-            return [simpleEstimator({ defaultComplexity: 1 })]
+            return []
         }
         return [
             fieldExtensionsEstimator(),

--- a/packages/graphql/src/classes/ComplexityEstimatorHelper.ts
+++ b/packages/graphql/src/classes/ComplexityEstimatorHelper.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { type DefinitionNode,type GraphQLFieldExtensions, type GraphQLSchema, GraphQLInterfaceType, GraphQLObjectType, Kind } from "graphql";
+import type { ComplexityEstimator} from "graphql-query-complexity";
+import { fieldExtensionsEstimator, simpleEstimator } from "graphql-query-complexity";
+
+export class ComplexityEstimatorHelper {
+    private objectTypeNameToFieldNamesMapForComplexityExtensions: Map<string, string[]>;
+    private useComplexityEstimators: boolean;
+
+    constructor(useComplexityEstimators: boolean) {
+        this.useComplexityEstimators = useComplexityEstimators
+        this.objectTypeNameToFieldNamesMapForComplexityExtensions = new Map<string, string[]>();
+    }
+
+    public registerField(parentObjectTypeNameOrInterfaceTypeName: string, fieldName: string): void {
+        if(this.useComplexityEstimators) {
+            const existingFieldsForTypeName = this.objectTypeNameToFieldNamesMapForComplexityExtensions.get(parentObjectTypeNameOrInterfaceTypeName) || []
+            this.objectTypeNameToFieldNamesMapForComplexityExtensions.set(parentObjectTypeNameOrInterfaceTypeName, existingFieldsForTypeName.concat(fieldName))
+
+            console.log(this.objectTypeNameToFieldNamesMapForComplexityExtensions)
+        }
+    }
+
+    public hydrateDefinitionNodeWithComplexityExtensions(definition: DefinitionNode): DefinitionNode {
+        if(definition.kind !== Kind.OBJECT_TYPE_DEFINITION && definition.kind !== Kind.INTERFACE_TYPE_DEFINITION) {
+            return definition;
+        }
+        if(!this.objectTypeNameToFieldNamesMapForComplexityExtensions.has(definition.name.value)) {
+            return definition
+        }
+        
+        const fieldsWithComplexity = definition.fields?.map(f => {
+            const hasFieldComplexityEstimator = this.getFieldsForParentTypeName(definition.name.value).find(fieldName => fieldName === f.name.value)
+            if (!hasFieldComplexityEstimator) {
+                return f
+            }
+            return {
+                ...f,
+                extensions: {
+                    // COMPLEXITY FORMULA
+                    // c = c_child + lvl_limit * c_field, where
+                    // c_field = 1
+                    // lvl_limit defaults to 1
+                    // c_child comes from simpleEstimator 
+                    complexity: ({childComplexity, args}) => {
+                        const fieldDefaultComplexity = 1
+                        const defaultLimitIfNotProvided = 1
+                        if(args.limit || args.first) {
+                            return childComplexity + (args.limit || args.first) * fieldDefaultComplexity
+                        }
+                        return childComplexity + defaultLimitIfNotProvided
+                        
+                    },
+                },
+            }
+        })
+        return {
+            ...definition,
+            fields: fieldsWithComplexity,
+        }
+    }
+
+
+    public hydrateSchemaFromSDLWithASTNodeExtensions(schema: GraphQLSchema): void {
+        const types = schema.getTypeMap();
+        Object.values(types).forEach((type) => {
+            if (type instanceof GraphQLObjectType || type instanceof GraphQLInterfaceType) {
+                const fields = type.getFields();
+                Object.values(fields).forEach((field) => {
+                    if (field.astNode && 'extensions' in field.astNode) {
+                        field.extensions = field.astNode.extensions as GraphQLFieldExtensions<any, any, any>;
+                    }
+                });
+            }
+        });
+    }
+
+    public getComplexityEstimators(): ComplexityEstimator[] {
+        if (!this.useComplexityEstimators) {
+            return [simpleEstimator({ defaultComplexity: 1 })]
+        }
+        return [
+            fieldExtensionsEstimator(),
+            simpleEstimator({ defaultComplexity: 1 }),
+        ];
+    }
+
+    private getFieldsForParentTypeName(parentObjectTypeNameOrInterfaceTypeName: string): string[] {
+        return this.objectTypeNameToFieldNamesMapForComplexityExtensions.get(parentObjectTypeNameOrInterfaceTypeName) || []
+    }
+}

--- a/packages/graphql/src/classes/Neo4jGraphQL.ts
+++ b/packages/graphql/src/classes/Neo4jGraphQL.ts
@@ -23,7 +23,7 @@ import type { IExecutableSchemaDefinition } from "@graphql-tools/schema";
 import { addResolversToSchema, makeExecutableSchema } from "@graphql-tools/schema";
 import { forEachField, getResolversFromSchema } from "@graphql-tools/utils";
 import Debug from "debug";
-import {  type DocumentNode, type GraphQLSchema } from "graphql";
+import { type DocumentNode, type GraphQLSchema } from "graphql";
 import type { Driver, SessionConfig } from "neo4j-driver";
 import { DEBUG_ALL } from "../constants";
 import { makeAugmentedSchema } from "../schema";
@@ -50,7 +50,6 @@ import { Neo4jGraphQLSubscriptionsCDCEngine } from "./subscription/Neo4jGraphQLS
 import { assertIndexesAndConstraints } from "./utils/asserts-indexes-and-constraints";
 import { generateResolverComposition } from "./utils/generate-resolvers-composition";
 import checkNeo4jCompat from "./utils/verify-database";
-import type { ComplexityEstimator} from "graphql-query-complexity";
 import { ComplexityEstimatorHelper } from "./ComplexityEstimatorHelper";
 
 type TypeDefinitions = string | DocumentNode | TypeDefinitions[] | (() => TypeDefinitions);
@@ -195,10 +194,6 @@ class Neo4jGraphQL {
             sessionConfig,
             schemaModel: this.schemaModel,
         });
-    }
-
-    public getComplexityEstimators(): ComplexityEstimator[] {
-        return this.complexityEstimatorHelper.getComplexityEstimators();
     }
 
     private get nodes(): Node[] {

--- a/packages/graphql/src/classes/index.ts
+++ b/packages/graphql/src/classes/index.ts
@@ -17,9 +17,12 @@
  * limitations under the License.
  */
 
+import { fieldExtensionsEstimator, simpleEstimator } from "graphql-query-complexity";
+
 export * from "./Error";
 export { GraphElement } from "./GraphElement";
 export { Neo4jDatabaseInfo } from "./Neo4jDatabaseInfo";
 export { default as Neo4jGraphQL, Neo4jGraphQLConstructor } from "./Neo4jGraphQL";
 export { default as Node, NodeConstructor } from "./Node";
 export { default as Relationship } from "./Relationship";
+export const DefaultComplexityEstimators = [fieldExtensionsEstimator(), simpleEstimator({ defaultComplexity: 1 })];

--- a/packages/graphql/src/schema/augment/fulltext.ts
+++ b/packages/graphql/src/schema/augment/fulltext.ts
@@ -29,14 +29,17 @@ import {
     withFulltextWhereInputType,
 } from "../generation/fulltext-input";
 import { fulltextResolver } from "../resolvers/query/fulltext";
+import { type ComplexityEstimatorHelper } from "../../classes/ComplexityEstimatorHelper";
 
 export function augmentFulltextSchema({
     composer,
     concreteEntityAdapter,
+    complexityEstimatorHelper,
     features,
 }: {
     composer: SchemaComposer;
     concreteEntityAdapter: ConcreteEntityAdapter;
+    complexityEstimatorHelper: ComplexityEstimatorHelper
     features?: Neo4jFeaturesSettings;
 }) {
     if (!concreteEntityAdapter.annotations.fulltext) {
@@ -61,6 +64,7 @@ export function augmentFulltextSchema({
             after: GraphQLString,
         };
 
+        complexityEstimatorHelper.registerField("Query", index.queryName);
         composer.Query.addFields({
             [index.queryName]: {
                 type: withFulltextResultTypeConnection({ composer, concreteEntityAdapter }).NonNull,

--- a/packages/graphql/src/schema/augment/vector.ts
+++ b/packages/graphql/src/schema/augment/vector.ts
@@ -29,14 +29,17 @@ import {
     withVectorWhereInputType,
 } from "../generation/vector-input";
 import { vectorResolver } from "../resolvers/query/vector";
+import { type ComplexityEstimatorHelper } from "../../classes/ComplexityEstimatorHelper";
 
 export function augmentVectorSchema({
     composer,
     concreteEntityAdapter,
+    complexityEstimatorHelper,
     features,
 }: {
     composer: SchemaComposer;
     concreteEntityAdapter: ConcreteEntityAdapter;
+    complexityEstimatorHelper: ComplexityEstimatorHelper
     features?: Neo4jFeaturesSettings;
 }) {
     if (!concreteEntityAdapter.annotations.vector) {
@@ -67,6 +70,7 @@ export function augmentVectorSchema({
             vectorArgs["vector"] = new GraphQLList(new GraphQLNonNull(GraphQLFloat));
         }
 
+        complexityEstimatorHelper.registerField("Query", index.queryName);
         composer.Query.addFields({
             [index.queryName]: {
                 type: withVectorResultTypeConnection({ composer, concreteEntityAdapter }).NonNull,

--- a/packages/graphql/src/schema/make-augmented-schema.test.ts
+++ b/packages/graphql/src/schema/make-augmented-schema.test.ts
@@ -32,6 +32,7 @@ import { gql } from "graphql-tag";
 import { Node } from "../classes";
 import { generateModel } from "../schema-model/generate-model";
 import makeAugmentedSchema from "./make-augmented-schema";
+import { ComplexityEstimatorHelper } from "../classes/ComplexityEstimatorHelper";
 
 describe("makeAugmentedSchema", () => {
     test("should be a function", () => {
@@ -52,7 +53,7 @@ describe("makeAugmentedSchema", () => {
         `;
 
         const schemaModel = generateModel(mergeTypeDefs(typeDefs));
-        const neoSchema = makeAugmentedSchema({ document: typeDefs, schemaModel });
+        const neoSchema = makeAugmentedSchema({ document: typeDefs, schemaModel, complexityEstimatorHelper: new ComplexityEstimatorHelper(false) });
         const document = neoSchema.typeDefs;
         const queryObject = document.definitions.find(
             (x) => x.kind === Kind.OBJECT_TYPE_DEFINITION && x.name.value === "Query"
@@ -96,7 +97,7 @@ describe("makeAugmentedSchema", () => {
             `;
 
             const schemaModel = generateModel(mergeTypeDefs(typeDefs));
-            const neoSchema = makeAugmentedSchema({ document: typeDefs, schemaModel });
+            const neoSchema = makeAugmentedSchema({ document: typeDefs, schemaModel, complexityEstimatorHelper: new ComplexityEstimatorHelper(false) });
 
             const document = neoSchema.typeDefs;
 
@@ -127,6 +128,7 @@ describe("makeAugmentedSchema", () => {
                     },
                 },
                 schemaModel,
+                complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
             });
 
             const document = neoSchema.typeDefs;
@@ -159,6 +161,7 @@ describe("makeAugmentedSchema", () => {
                     },
                 },
                 schemaModel,
+                complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
             });
 
             const document = neoSchema.typeDefs;
@@ -194,6 +197,7 @@ describe("makeAugmentedSchema", () => {
                     },
                 },
                 schemaModel,
+                complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
             });
 
             const document = neoSchema.typeDefs;
@@ -233,6 +237,7 @@ describe("makeAugmentedSchema", () => {
                     },
                 },
                 schemaModel,
+                complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
             });
 
             const document = neoSchema.typeDefs;
@@ -266,7 +271,7 @@ describe("makeAugmentedSchema", () => {
             `;
 
             const schemaModel = generateModel(mergeTypeDefs(typeDefs));
-            const neoSchema = makeAugmentedSchema({ document: typeDefs, schemaModel });
+            const neoSchema = makeAugmentedSchema({ document: typeDefs, schemaModel, complexityEstimatorHelper: new ComplexityEstimatorHelper(false) });
 
             const document = neoSchema.typeDefs;
 
@@ -286,7 +291,7 @@ describe("makeAugmentedSchema", () => {
             `;
 
             const schemaModel = generateModel(mergeTypeDefs(typeDefs));
-            expect(() => makeAugmentedSchema({ document: typeDefs, schemaModel })).not.toThrow(
+            expect(() => makeAugmentedSchema({ document: typeDefs, schemaModel, complexityEstimatorHelper: new ComplexityEstimatorHelper(false) })).not.toThrow(
                 'Error: Type with name "ActionMapping" does not exists'
             );
         });

--- a/packages/graphql/src/schema/make-augmented-schema.ts
+++ b/packages/graphql/src/schema/make-augmented-schema.ts
@@ -88,6 +88,7 @@ import { getResolveAndSubscriptionMethods } from "./get-resolve-and-subscription
 import { filterInterfaceTypes } from "./make-augmented-schema/filter-interface-types";
 import { getUserDefinedDirectives } from "./make-augmented-schema/user-defined-directives";
 import { generateSubscriptionTypes } from "./subscriptions/generate-subscription-types";
+import { type ComplexityEstimatorHelper } from "../classes/ComplexityEstimatorHelper";
 
 function definitionNodeHasName(x: DefinitionNode): x is DefinitionNode & { name: NameNode } {
     return "name" in x;
@@ -99,12 +100,14 @@ function makeAugmentedSchema({
     userCustomResolvers,
     subgraph,
     schemaModel,
+    complexityEstimatorHelper,
 }: {
     document: DocumentNode;
     features?: Neo4jFeaturesSettings;
     userCustomResolvers?: IResolvers | Array<IResolvers>;
     subgraph?: Subgraph;
     schemaModel: Neo4jGraphQLSchemaModel;
+    complexityEstimatorHelper: ComplexityEstimatorHelper;
 }): {
     nodes: Node[];
     relationships: Relationship[];
@@ -223,11 +226,12 @@ function makeAugmentedSchema({
                 graphqlDirectivesToCompose(userDefinedDirectivesForUnion.get(unionEntityAdapter.name) || [])
             );
             if (unionEntityAdapter.isReadable) {
+                complexityEstimatorHelper.registerField("Query", unionEntityAdapter.operations.rootTypeFieldNames.read)
                 composer.Query.addFields({
                     [unionEntityAdapter.operations.rootTypeFieldNames.read]: findResolver({
                         entityAdapter: unionEntityAdapter,
                         composer,
-                        isLimitRequired: features?.limitRequired,
+                        isLimitRequired: features?.limitRequired,                     
                     }),
                 });
             }
@@ -246,6 +250,7 @@ function makeAugmentedSchema({
                 aggregationTypesMapper,
                 seenRelationshipPropertiesTypes,
                 features,
+                complexityEstimatorHelper,
             });
             const connectionFields = createConnectionFields({
                 entityAdapter: interfaceEntityAdapter,
@@ -287,6 +292,7 @@ function makeAugmentedSchema({
                 seenRelationshipPropertiesTypes,
                 userDefinedDirectivesForNode,
                 userDefinedFieldDirectivesForNode,
+                complexityEstimatorHelper,
             });
 
             const connectionFields = createConnectionFields({
@@ -359,10 +365,11 @@ function makeAugmentedSchema({
     if (!Object.values(composer.Subscription.getFields()).length) {
         composer.delete("Subscription");
     }
+
     const generatedTypeDefs = composer.toSDL();
-
+    
     let parsedDoc = parse(generatedTypeDefs);
-
+    
     const documentNames = new Set(parsedDoc.definitions.filter(definitionNodeHasName).map((x) => x.name.value));
     const resolveMethods = getResolveAndSubscriptionMethods(composer);
 
@@ -422,57 +429,10 @@ function makeAugmentedSchema({
         }
     });
 
-    // do not propagate Neo4jGraphQL directives on schema extensions
-    const schemaExtensionsWithoutNeo4jDirectives = asArray(schemaExtensions).map(
-        (schemaExtension): SchemaExtensionNode => {
-            return {
-                kind: schemaExtension.kind,
-                loc: schemaExtension.loc,
-                operationTypes: schemaExtension.operationTypes,
-                directives: schemaExtension.directives?.filter(
-                    (schemaDirective) =>
-                        !["query", "mutation", "subscription", "authentication"].includes(schemaDirective.name.value)
-                ),
-            };
-        }
-    );
-    const seen = {};
     parsedDoc = {
         ...parsedDoc,
-        definitions: [
-            ...parsedDoc.definitions.filter((definition) => {
-                // Filter out default scalars, they are not needed and can cause issues
-                if (definition.kind === Kind.SCALAR_TYPE_DEFINITION) {
-                    if (
-                        [
-                            GraphQLBoolean.name,
-                            GraphQLFloat.name,
-                            GraphQLID.name,
-                            GraphQLInt.name,
-                            GraphQLString.name,
-                        ].includes(definition.name.value)
-                    ) {
-                        return false;
-                    }
-                }
-
-                if (!("name" in definition)) {
-                    return true;
-                }
-
-                const n = definition.name?.value as string;
-
-                if (seen[n]) {
-                    return false;
-                }
-
-                seen[n] = n;
-
-                return true;
-            }),
-            ...schemaExtensionsWithoutNeo4jDirectives,
-        ],
-    };
+        definitions: getFinalDefinitionNodes(schemaExtensions, parsedDoc.definitions, complexityEstimatorHelper),
+    }
 
     return {
         nodes,
@@ -480,6 +440,60 @@ function makeAugmentedSchema({
         typeDefs: parsedDoc,
         resolvers: generatedResolvers,
     };
+}
+
+function getFinalDefinitionNodes(schemaExtensions: SchemaExtensionNode | undefined, definitions: readonly DefinitionNode[], complexityEstimatorHelper: ComplexityEstimatorHelper): DefinitionNode[] {
+    const definitionNodes: DefinitionNode[] = []
+    // do not propagate Neo4jGraphQL directives on schema extensions
+    asArray(schemaExtensions).reduce(
+      (acc, schemaExtension: SchemaExtensionNode) => {
+           acc.push({
+              kind: schemaExtension.kind,
+              loc: schemaExtension.loc,
+              operationTypes: schemaExtension.operationTypes,
+              directives: schemaExtension.directives?.filter(
+                  (schemaDirective) =>
+                      !["query", "mutation", "subscription", "authentication"].includes(schemaDirective.name.value)
+              ),
+          })
+          return acc;
+      }, definitionNodes)
+    // filter out some definition nodes
+    // add FieldEstimator extensions for complexity calculation
+    const seen = {}
+    definitions.reduce<DefinitionNode[]>((acc, definition) => {
+        if (shouldKeepDefinitionNode(definition, seen)) {
+            acc.push(complexityEstimatorHelper.hydrateDefinitionNodeWithComplexityExtensions(definition))
+        }
+        return acc;
+    }, definitionNodes)
+    return definitionNodes;
+}
+
+function shouldKeepDefinitionNode(definition: DefinitionNode, seen: Record<string, any>) {
+      // Filter out default scalars, they are not needed and can cause issues
+      if (definition.kind === Kind.SCALAR_TYPE_DEFINITION) {
+          if (
+              [
+                  GraphQLBoolean.name,
+                  GraphQLFloat.name,
+                  GraphQLID.name,
+                  GraphQLInt.name,
+                  GraphQLString.name,
+              ].includes(definition.name.value)
+          ) {
+              return false;
+          }
+      }
+      if (!("name" in definition)) {
+          return true;
+      }
+      const n = definition.name?.value as string;
+      if (seen[n]) {
+          return false;
+      }
+      seen[n] = n;
+      return true;
 }
 
 export default makeAugmentedSchema;
@@ -499,6 +513,7 @@ function generateObjectType({
     seenRelationshipPropertiesTypes,
     userDefinedDirectivesForNode,
     userDefinedFieldDirectivesForNode,
+    complexityEstimatorHelper,
 }: {
     composer: SchemaComposer;
     concreteEntityAdapter: ConcreteEntityAdapter;
@@ -512,6 +527,7 @@ function generateObjectType({
     seenRelationshipPropertiesTypes: Set<string>;
     userDefinedDirectivesForNode: Map<string, DirectiveNode[]>;
     userDefinedFieldDirectivesForNode: Map<string, Map<string, DirectiveNode[]>>;
+    complexityEstimatorHelper: ComplexityEstimatorHelper;
 }) {
     withWhereInputType({
         entityAdapter: concreteEntityAdapter,
@@ -519,8 +535,8 @@ function generateObjectType({
         features,
         composer,
     });
-    augmentFulltextSchema({ composer, concreteEntityAdapter, features });
-    augmentVectorSchema({ composer, concreteEntityAdapter, features });
+    augmentFulltextSchema({ composer, concreteEntityAdapter, features, complexityEstimatorHelper });
+    augmentVectorSchema({ composer, concreteEntityAdapter, features, complexityEstimatorHelper });
     withUniqueWhereInputType({ concreteEntityAdapter, composer });
     withCreateInputType({ entityAdapter: concreteEntityAdapter, userDefinedFieldDirectives, composer });
     withUpdateInputType({ entityAdapter: concreteEntityAdapter, userDefinedFieldDirectives, composer });
@@ -541,12 +557,14 @@ function generateObjectType({
         userDefinedFieldDirectivesForNode,
         features,
         seenRelationshipPropertiesTypes,
+        complexityEstimatorHelper,
     });
 
     ensureNonEmptyInput(composer, concreteEntityAdapter.operations.updateInputTypeName);
     ensureNonEmptyInput(composer, concreteEntityAdapter.operations.createInputTypeName);
 
     if (concreteEntityAdapter.isReadable) {
+        complexityEstimatorHelper.registerField("Query", concreteEntityAdapter.operations.rootTypeFieldNames.read)
         composer.Query.addFields({
             [concreteEntityAdapter.operations.rootTypeFieldNames.read]: findResolver({
                 entityAdapter: concreteEntityAdapter,
@@ -559,6 +577,8 @@ function generateObjectType({
             graphqlDirectivesToCompose(propagatedDirectives)
         );
 
+
+        complexityEstimatorHelper.registerField("Query", concreteEntityAdapter.operations.rootTypeFieldNames.connection)
         composer.Query.addFields({
             [concreteEntityAdapter.operations.rootTypeFieldNames.connection]: rootConnectionResolver({
                 composer,
@@ -641,6 +661,7 @@ function generateInterfaceObjectType({
     propagatedDirectivesForNode,
     aggregationTypesMapper,
     seenRelationshipPropertiesTypes,
+    complexityEstimatorHelper,
 }: {
     composer: SchemaComposer;
     interfaceEntityAdapter: InterfaceEntityAdapter;
@@ -651,6 +672,7 @@ function generateInterfaceObjectType({
     propagatedDirectivesForNode: Map<string, DirectiveNode[]>;
     aggregationTypesMapper: AggregationTypesMapper;
     seenRelationshipPropertiesTypes: Set<string>;
+    complexityEstimatorHelper: ComplexityEstimatorHelper;
 }) {
     const userDefinedFieldDirectives = userDefinedFieldDirectivesForNode.get(interfaceEntityAdapter.name) as Map<
         string,
@@ -681,10 +703,12 @@ function generateInterfaceObjectType({
         userDefinedFieldDirectivesForNode,
         features,
         seenRelationshipPropertiesTypes,
+        complexityEstimatorHelper,
     });
 
     const propagatedDirectives = propagatedDirectivesForNode.get(interfaceEntityAdapter.name) || [];
     if (interfaceEntityAdapter.isReadable) {
+        complexityEstimatorHelper.registerField("Query", interfaceEntityAdapter.operations.rootTypeFieldNames.read)
         composer.Query.addFields({
             [interfaceEntityAdapter.operations.rootTypeFieldNames.read]: findResolver({
                 entityAdapter: interfaceEntityAdapter,
@@ -698,6 +722,7 @@ function generateInterfaceObjectType({
             graphqlDirectivesToCompose(propagatedDirectives)
         );
 
+        complexityEstimatorHelper.registerField("Query", interfaceEntityAdapter.operations.rootTypeFieldNames.connection)
         composer.Query.addFields({
             [interfaceEntityAdapter.operations.rootTypeFieldNames.connection]: rootConnectionResolver({
                 composer,

--- a/packages/graphql/src/schema/make-augmented-schema.ts
+++ b/packages/graphql/src/schema/make-augmented-schema.ts
@@ -431,7 +431,7 @@ function makeAugmentedSchema({
 
     parsedDoc = {
         ...parsedDoc,
-        definitions: getFinalDefinitionNodes(schemaExtensions, parsedDoc.definitions, complexityEstimatorHelper),
+        definitions: getTransformedDefinitionNodesForAugmentedSchema({schemaExtensions, definitions: parsedDoc.definitions, complexityEstimatorHelper}),
     }
 
     return {
@@ -442,7 +442,15 @@ function makeAugmentedSchema({
     };
 }
 
-function getFinalDefinitionNodes(schemaExtensions: SchemaExtensionNode | undefined, definitions: readonly DefinitionNode[], complexityEstimatorHelper: ComplexityEstimatorHelper): DefinitionNode[] {
+function getTransformedDefinitionNodesForAugmentedSchema({ 
+  schemaExtensions, 
+  definitions,
+  complexityEstimatorHelper,
+}: {
+  schemaExtensions: SchemaExtensionNode | undefined; 
+  definitions: readonly DefinitionNode[]; 
+  complexityEstimatorHelper: ComplexityEstimatorHelper
+}): DefinitionNode[] {
     const definitionNodes: DefinitionNode[] = []
     // do not propagate Neo4jGraphQL directives on schema extensions
     asArray(schemaExtensions).reduce(

--- a/packages/graphql/src/schema/resolvers/query/read.test.ts
+++ b/packages/graphql/src/schema/resolvers/query/read.test.ts
@@ -35,7 +35,7 @@ describe("Read resolver", () => {
         });
         const concreteEntityAdapter = new ConcreteEntityAdapter(concreteEntity);
 
-        const result = findResolver({ entityAdapter: concreteEntityAdapter, composer: new SchemaComposer(),   isLimitRequired: undefined });
+        const result = findResolver({ entityAdapter: concreteEntityAdapter, composer: new SchemaComposer(), isLimitRequired: undefined });
         expect(result.type).toBe(`[Movie!]!`);
         expect(result.resolve).toBeInstanceOf(Function);
         expect(result.args).toMatchObject({

--- a/packages/graphql/src/schema/validation/schema-validation.test.ts
+++ b/packages/graphql/src/schema/validation/schema-validation.test.ts
@@ -26,6 +26,7 @@ import { Subgraph } from "../../classes/Subgraph";
 import { generateModel } from "../../schema-model/generate-model";
 import makeAugmentedSchema from "../make-augmented-schema";
 import { validateUserDefinition } from "./schema-validation";
+import { ComplexityEstimatorHelper } from "../../classes/ComplexityEstimatorHelper";
 
 describe("schema validation", () => {
     describe("JWT", () => {
@@ -50,6 +51,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument, jwt });
                 expect(executeValidate).not.toThrow();
@@ -78,6 +80,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument, jwt });
                 expect(executeValidate).not.toThrow();
@@ -104,6 +107,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument, jwt });
 
@@ -129,6 +133,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
                 expect(executeValidate).not.toThrow();
@@ -153,6 +158,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument, jwt });
                 expect(executeValidate).not.toThrow();
@@ -177,6 +183,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument, jwt });
 
@@ -211,6 +218,7 @@ describe("schema validation", () => {
             const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                 document: userDocument,
                 schemaModel,
+                complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
             });
             const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument, jwt });
             expect(executeValidate).not.toThrow();
@@ -236,6 +244,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument, jwt });
                 expect(executeValidate).not.toThrow();
@@ -254,6 +263,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
                 expect(executeValidate).not.toThrow();
@@ -278,6 +288,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument, jwt });
                 expect(executeValidate).not.toThrow();
@@ -302,6 +313,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument, jwt });
                 expect(executeValidate).not.toThrow();
@@ -320,6 +332,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
                 const errors = getError(executeValidate);
@@ -359,6 +372,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument, jwt });
                 const errors = getError(executeValidate);
@@ -398,6 +412,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument, jwt });
                 const errors = getError(executeValidate);
@@ -437,6 +452,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
 
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument, jwt });
@@ -479,6 +495,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
 
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument, jwt });
@@ -521,6 +538,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
 
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument, jwt });
@@ -563,6 +581,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
 
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument, jwt });
@@ -605,6 +624,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument, jwt });
 
@@ -645,6 +665,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument, jwt });
 
@@ -683,6 +704,7 @@ describe("schema validation", () => {
                     document: userDocument,
                     features: { subscriptions: true },
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
                 expect(executeValidate).not.toThrow();
@@ -701,6 +723,7 @@ describe("schema validation", () => {
                     document: userDocument,
                     features: { subscriptions: true },
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
                 expect(executeValidate).not.toThrow();
@@ -724,6 +747,7 @@ describe("schema validation", () => {
                     document: userDocument,
                     features: { subscriptions: true },
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
                 expect(executeValidate).not.toThrow();
@@ -744,6 +768,7 @@ describe("schema validation", () => {
                     document: userDocument,
                     features: { subscriptions: true },
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument }); //
 
@@ -777,6 +802,7 @@ describe("schema validation", () => {
                     document: userDocument,
                     features: { subscriptions: true },
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
 
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
@@ -799,6 +825,7 @@ describe("schema validation", () => {
                     document: userDocument,
                     features: { subscriptions: true },
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
 
@@ -831,6 +858,7 @@ describe("schema validation", () => {
                     document: userDocument,
                     features: { subscriptions: true },
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
 
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
@@ -850,6 +878,7 @@ describe("schema validation", () => {
                     document: userDocument,
                     features: { subscriptions: true },
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
 
@@ -887,6 +916,7 @@ describe("schema validation", () => {
                     document: userDocument,
                     features: { subscriptions: true },
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
                 expect(executeValidate).not.toThrow();
@@ -912,6 +942,7 @@ describe("schema validation", () => {
                     document: userDocument,
                     features: { subscriptions: true },
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
 
@@ -952,6 +983,7 @@ describe("schema validation", () => {
                     document: userDocument,
                     features: { subscriptions: true },
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
                 expect(executeValidate).toThrow(
@@ -975,6 +1007,7 @@ describe("schema validation", () => {
                     document: userDocument,
                     features: { subscriptions: true },
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
                 expect(executeValidate).not.toThrow();
@@ -999,6 +1032,7 @@ describe("schema validation", () => {
                     document: userDocument,
                     features: { subscriptions: true },
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
 
@@ -1032,6 +1066,7 @@ describe("schema validation", () => {
                     document: userDocument,
                     features: { subscriptions: true },
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
 
@@ -1065,6 +1100,7 @@ describe("schema validation", () => {
                     document: userDocument,
                     features: { subscriptions: true },
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
                 expect(executeValidate).not.toThrow();
@@ -1092,6 +1128,7 @@ describe("schema validation", () => {
                     document: userDocument,
                     features: { subscriptions: true },
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
                 expect(executeValidate).not.toThrow();
@@ -1123,6 +1160,7 @@ describe("schema validation", () => {
                     document: userDocument,
                     features: { subscriptions: true },
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
                 expect(executeValidate).not.toThrow();
@@ -1149,6 +1187,7 @@ describe("schema validation", () => {
                     document: userDocument,
                     features: { subscriptions: true },
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
 
@@ -1176,6 +1215,7 @@ describe("schema validation", () => {
                     document: userDocument,
                     features: { subscriptions: true },
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
 
@@ -1209,6 +1249,7 @@ describe("schema validation", () => {
                     document: userDocument,
                     features: { subscriptions: true },
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
                 expect(executeValidate).not.toThrow();
@@ -1230,6 +1271,7 @@ describe("schema validation", () => {
                     document: userDocument,
                     features: { subscriptions: true },
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
 
@@ -1272,6 +1314,7 @@ describe("schema validation", () => {
                     document: userDocument,
                     features: { subscriptions: true },
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
                 expect(executeValidate).toThrow(
@@ -1314,6 +1357,7 @@ describe("schema validation", () => {
                     document: userDocument,
                     features: { subscriptions: true },
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
                 expect(executeValidate).not.toThrow();
@@ -1352,6 +1396,7 @@ describe("schema validation", () => {
                     document: userDocument,
                     features: { subscriptions: true },
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
 
@@ -1395,6 +1440,7 @@ describe("schema validation", () => {
                     document: userDocument,
                     features: { subscriptions: true },
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () =>
                     validateUserDefinition({
@@ -1430,6 +1476,7 @@ describe("schema validation", () => {
                     document: userDocument,
                     features: { subscriptions: true },
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () =>
                     validateUserDefinition({
@@ -1467,6 +1514,7 @@ describe("schema validation", () => {
                     document: userDocument,
                     features: { subscriptions: true },
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () =>
                     validateUserDefinition({
@@ -1502,6 +1550,7 @@ describe("schema validation", () => {
                     document: userDocument,
                     features: { subscriptions: true },
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () =>
                     validateUserDefinition({
@@ -1550,6 +1599,7 @@ describe("schema validation", () => {
                     document: userDocument,
                     features: { subscriptions: true },
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () =>
                     validateUserDefinition({
@@ -1586,6 +1636,7 @@ describe("schema validation", () => {
                     document: userDocument,
                     features: { subscriptions: true },
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () =>
                     validateUserDefinition({
@@ -1625,6 +1676,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
                 expect(executeValidate).not.toThrow();
@@ -1642,6 +1694,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
                 expect(executeValidate).not.toThrow();
@@ -1664,6 +1717,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
                 expect(executeValidate).not.toThrow();
@@ -1681,6 +1735,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
 
@@ -1707,6 +1762,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
 
@@ -1735,6 +1791,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
 
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
@@ -1756,6 +1813,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
 
@@ -1782,6 +1840,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
 
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
@@ -1800,6 +1859,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
 
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
@@ -1825,6 +1885,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
 
@@ -1857,6 +1918,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
 
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
@@ -1882,6 +1944,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
 
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
@@ -1917,6 +1980,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
 
@@ -1941,6 +2005,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
                 expect(executeValidate).not.toThrow();
@@ -1964,6 +2029,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
 
@@ -1996,6 +2062,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
 
@@ -2028,6 +2095,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
                 expect(executeValidate).not.toThrow();
@@ -2054,6 +2122,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
                 expect(executeValidate).not.toThrow();
@@ -2084,6 +2153,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
                 expect(executeValidate).not.toThrow();
@@ -2109,6 +2179,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
 
@@ -2134,6 +2205,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
 
@@ -2161,6 +2233,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
 
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
@@ -2182,6 +2255,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
                 const errors = getError(executeValidate);
@@ -2216,6 +2290,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
 
@@ -2256,6 +2331,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
                 expect(executeValidate).not.toThrow();
@@ -2289,6 +2365,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
                 const errors = getError(executeValidate);
@@ -2322,6 +2399,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
 
                 const executeValidate = () =>
@@ -2354,6 +2432,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
 
                 const executeValidate = () =>
@@ -2386,6 +2465,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
 
                 const executeValidate = () =>
@@ -2422,6 +2502,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
 
                 const executeValidate = () =>
@@ -2465,6 +2546,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
 
                 const executeValidate = () =>
@@ -2501,6 +2583,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
 
                 const executeValidate = () =>
@@ -2536,6 +2619,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
                 expect(executeValidate).not.toThrow();
@@ -2559,6 +2643,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument, jwt });
                 expect(executeValidate).not.toThrow();
@@ -2587,6 +2672,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument, jwt });
                 expect(executeValidate).not.toThrow();
@@ -2604,6 +2690,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
 
@@ -2625,6 +2712,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
 
@@ -2659,6 +2747,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
 
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument, jwt });
@@ -2683,6 +2772,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument, jwt });
 
@@ -2709,6 +2799,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
 
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
@@ -2727,6 +2818,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
 
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
@@ -2749,6 +2841,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
 
@@ -2781,6 +2874,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
 
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
@@ -2824,6 +2918,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument, jwt });
 
@@ -2859,6 +2954,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument, jwt });
                 expect(executeValidate).not.toThrow();
@@ -2891,6 +2987,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument, jwt });
 
@@ -2930,6 +3027,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument, jwt });
 
@@ -2969,6 +3067,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument, jwt });
                 expect(executeValidate).not.toThrow();
@@ -3002,6 +3101,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument, jwt });
                 expect(executeValidate).not.toThrow();
@@ -3039,6 +3139,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument, jwt });
                 expect(executeValidate).not.toThrow();
@@ -3064,6 +3165,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
 
@@ -3089,6 +3191,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
 
@@ -3119,6 +3222,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
 
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument, jwt });
@@ -3138,6 +3242,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
                 const errors = getError(executeValidate);
@@ -3179,6 +3284,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument, jwt });
 
@@ -3229,6 +3335,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument, jwt });
                 expect(executeValidate).not.toThrow();
@@ -3269,6 +3376,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
                 const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument, jwt });
                 const errors = getError(executeValidate);
@@ -3306,6 +3414,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
 
                 const executeValidate = () =>
@@ -3346,6 +3455,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
 
                 const executeValidate = () =>
@@ -3386,6 +3496,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
 
                 const executeValidate = () =>
@@ -3419,6 +3530,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
 
                 const executeValidate = () =>
@@ -3469,6 +3581,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
 
                 const executeValidate = () =>
@@ -3513,6 +3626,7 @@ describe("schema validation", () => {
                 const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                     document: userDocument,
                     schemaModel,
+                    complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                 });
 
                 const executeValidate = () =>
@@ -3545,6 +3659,7 @@ describe("schema validation", () => {
             const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                 document: userDocument,
                 schemaModel,
+                complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
             });
 
             const executeValidate = () =>
@@ -3569,6 +3684,7 @@ describe("schema validation", () => {
             const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                 document: userDocument,
                 schemaModel,
+                complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
             });
 
             const executeValidate = () =>
@@ -3604,6 +3720,7 @@ describe("schema validation", () => {
                     const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                         document: userDocument,
                         schemaModel,
+                        complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                     });
                     const executeValidate = () =>
                         validateUserDefinition({
@@ -3627,6 +3744,7 @@ describe("schema validation", () => {
                     const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                         document: userDocument,
                         schemaModel,
+                        complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                     });
                     const executeValidate = () =>
                         validateUserDefinition({
@@ -3654,6 +3772,7 @@ describe("schema validation", () => {
                     const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                         document: userDocument,
                         schemaModel,
+                        complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                     });
                     const executeValidate = () =>
                         validateUserDefinition({
@@ -3687,6 +3806,7 @@ describe("schema validation", () => {
                         document: userDocument,
                         features: { subscriptions: true },
                         schemaModel,
+                        complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                     });
 
                     const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
@@ -3712,6 +3832,7 @@ describe("schema validation", () => {
                     const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                         document: userDocument,
                         schemaModel,
+                        complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                     });
                     const executeValidate = () =>
                         validateUserDefinition({
@@ -3742,6 +3863,7 @@ describe("schema validation", () => {
                     const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                         document: userDocument,
                         schemaModel,
+                        complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                     });
                     const executeValidate = () =>
                         validateUserDefinition({
@@ -3776,6 +3898,7 @@ describe("schema validation", () => {
                     const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                         document: userDocument,
                         schemaModel,
+                        complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                     });
                     const executeValidate = () =>
                         validateUserDefinition({
@@ -3799,6 +3922,7 @@ describe("schema validation", () => {
                     const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                         document: userDocument,
                         schemaModel,
+                        complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                     });
                     const executeValidate = () =>
                         validateUserDefinition({
@@ -3824,6 +3948,7 @@ describe("schema validation", () => {
                     const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                         document: userDocument,
                         schemaModel,
+                        complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                     });
                     const executeValidate = () =>
                         validateUserDefinition({
@@ -3854,6 +3979,7 @@ describe("schema validation", () => {
                     const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                         document: userDocument,
                         schemaModel,
+                        complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                     });
                     const executeValidate = () =>
                         validateUserDefinition({
@@ -3884,6 +4010,7 @@ describe("schema validation", () => {
                     const { typeDefs: augmentedDocument } = makeAugmentedSchema({
                         document: userDocument,
                         schemaModel,
+                        complexityEstimatorHelper: new ComplexityEstimatorHelper(false),
                     });
                     const executeValidate = () =>
                         validateUserDefinition({

--- a/packages/graphql/src/types/index.ts
+++ b/packages/graphql/src/types/index.ts
@@ -449,6 +449,7 @@ export type Neo4jFeaturesSettings = {
     excludeDeprecatedFields?: Record<string, never>;
     vector?: Neo4jVectorSettings;
     limitRequired?: boolean;
+    complexityEstimators?: boolean;
 };
 
 /** Parsed features used in context */

--- a/packages/graphql/tests/e2e/complexity-estimators.e2e.test.ts
+++ b/packages/graphql/tests/e2e/complexity-estimators.e2e.test.ts
@@ -43,15 +43,22 @@ describe("limitRequired enabled", () => {
                 }
          `;
 
-        const neoSchema = await testHelper.initNeo4jGraphQL({ typeDefs, features: {limitRequired: true, complexityEstimators: true} });
+        const neoSchema = await testHelper.initNeo4jGraphQL({
+            typeDefs,
+            features: { limitRequired: true, complexityEstimators: true },
+        });
 
-        // eslint-disable-next-line @typescript-eslint/require-await
-        server = new ApolloTestServer(neoSchema, async ({ req }) => ({
-            sessionConfig: {
-                database: testHelper.database,
-            },
-            token: req.headers.authorization,
-        }));
+        server = new ApolloTestServer(
+            neoSchema,
+            // eslint-disable-next-line @typescript-eslint/require-await
+            async ({ req }) => ({
+                sessionConfig: {
+                    database: testHelper.database,
+                },
+                token: req.headers.authorization,
+            }),
+            true
+        );
         await server.start();
     });
 
@@ -61,18 +68,21 @@ describe("limitRequired enabled", () => {
     });
 
     test("movies  result", async () => {
-      const complexity = await server.computeQueryComplexity(parse(`
+        const complexity = await server.computeQueryComplexity(
+            parse(`
           query {
             movies(limit: 9) {
               title
             }
           }
-      `))
-      expect(complexity).toBe(10)
-  });
+      `)
+        );
+        expect(complexity).toBe(10);
+    });
 
     test("movies with actors result", async () => {
-        const complexity = await server.computeQueryComplexity(parse(`
+        const complexity = await server.computeQueryComplexity(
+            parse(`
             query {
               movies(limit: 5) {
                 title
@@ -81,12 +91,14 @@ describe("limitRequired enabled", () => {
                 }
               }
             }
-        `))
-        expect(complexity).toBe(13)
+        `)
+        );
+        expect(complexity).toBe(13);
     });
 
     test("movies with actors and directors result", async () => {
-        const complexity = await server.computeQueryComplexity(parse(`
+        const complexity = await server.computeQueryComplexity(
+            parse(`
             query {
               movies(limit: 5) {
                 title
@@ -98,12 +110,14 @@ describe("limitRequired enabled", () => {
                 }
               }
             }
-      `))
-        expect(complexity).toBe(22)
+      `)
+        );
+        expect(complexity).toBe(22);
     });
 
     test("productions with actors and directors result", async () => {
-        const complexity = await server.computeQueryComplexity(parse(`
+        const complexity = await server.computeQueryComplexity(
+            parse(`
             query {
               productions(limit: 5) {
                 title
@@ -112,18 +126,19 @@ describe("limitRequired enabled", () => {
                 }
               }
             }
-        `))
-        expect(complexity).toBe(17)
+        `)
+        );
+        expect(complexity).toBe(17);
     });
 });
 
 describe("limitRequired not enabled", () => {
-  const testHelper = new TestHelper();
+    const testHelper = new TestHelper();
 
-  let server: TestGraphQLServer;
+    let server: TestGraphQLServer;
 
-  beforeAll(async () => {
-      const typeDefs = `
+    beforeAll(async () => {
+        const typeDefs = `
               interface Production {
                   title: String
                   actors: [Actor!]! @declareRelationship
@@ -138,25 +153,30 @@ describe("limitRequired not enabled", () => {
               }
        `;
 
-      const neoSchema = await testHelper.initNeo4jGraphQL({ typeDefs, features: {complexityEstimators: true} });
+        const neoSchema = await testHelper.initNeo4jGraphQL({ typeDefs, features: { complexityEstimators: true } });
 
-      // eslint-disable-next-line @typescript-eslint/require-await
-      server = new ApolloTestServer(neoSchema, async ({ req }) => ({
-          sessionConfig: {
-              database: testHelper.database,
-          },
-          token: req.headers.authorization,
-      }));
-      await server.start();
-  });
+        server = new ApolloTestServer(
+            neoSchema,
+            // eslint-disable-next-line @typescript-eslint/require-await
+            async ({ req }) => ({
+                sessionConfig: {
+                    database: testHelper.database,
+                },
+                token: req.headers.authorization,
+            }),
+            true
+        );
+        await server.start();
+    });
 
-  afterAll(async () => {
-      await testHelper.close();
-      await server.close();
-  });
+    afterAll(async () => {
+        await testHelper.close();
+        await server.close();
+    });
 
-  test("movies with actors and directors result - no limit args", async () => {
-    const complexity = await server.computeQueryComplexity(parse(`
+    test("movies with actors and directors result - no limit args", async () => {
+        const complexity = await server.computeQueryComplexity(
+            parse(`
         query {
           movies {
             title
@@ -168,12 +188,14 @@ describe("limitRequired not enabled", () => {
             }
           }
         }
-  `))
-    expect(complexity).toBe(6)
-});
+  `)
+        );
+        expect(complexity).toBe(6);
+    });
 
-  test("productions with actors and directors result - no limit args", async () => {
-    const complexity = await server.computeQueryComplexity(parse(`
+    test("productions with actors and directors result - no limit args", async () => {
+        const complexity = await server.computeQueryComplexity(
+            parse(`
         query {
           productions {
             title
@@ -182,7 +204,8 @@ describe("limitRequired not enabled", () => {
             }
           }
         }
-    `))
-    expect(complexity).toBe(4)
-});
+    `)
+        );
+        expect(complexity).toBe(4);
+    });
 });

--- a/packages/graphql/tests/e2e/complexity-estimators.e2e.test.ts
+++ b/packages/graphql/tests/e2e/complexity-estimators.e2e.test.ts
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TestHelper } from "../utils/tests-helper";
+import type { TestGraphQLServer } from "./setup/apollo-server";
+import { ApolloTestServer } from "./setup/apollo-server";
+import { parse } from "graphql";
+
+describe("limitRequired enabled", () => {
+    const testHelper = new TestHelper();
+
+    let server: TestGraphQLServer;
+
+    beforeAll(async () => {
+        const typeDefs = `
+                interface Production {
+                    title: String
+                    actors: [Actor!]! @declareRelationship
+                }
+                type Movie implements Production @node {
+                    title: String
+                    actors: [Actor!]! @relationship(type: "ACTED_IN", direction: IN)
+                    directors: [Actor!]! @relationship(type: "DIRECTED", direction: IN)
+                }
+                type Actor @node {
+                    name: String
+                }
+         `;
+
+        const neoSchema = await testHelper.initNeo4jGraphQL({ typeDefs, features: {limitRequired: true, complexityEstimators: true} });
+
+        // eslint-disable-next-line @typescript-eslint/require-await
+        server = new ApolloTestServer(neoSchema, async ({ req }) => ({
+            sessionConfig: {
+                database: testHelper.database,
+            },
+            token: req.headers.authorization,
+        }));
+        await server.start();
+    });
+
+    afterAll(async () => {
+        await testHelper.close();
+        await server.close();
+    });
+
+    test("movies  result", async () => {
+      const complexity = await server.computeQueryComplexity(parse(`
+          query {
+            movies(limit: 9) {
+              title
+            }
+          }
+      `))
+      expect(complexity).toBe(10)
+  });
+
+    test("movies with actors result", async () => {
+        const complexity = await server.computeQueryComplexity(parse(`
+            query {
+              movies(limit: 5) {
+                title
+                actors(limit: 6) {
+                  name
+                }
+              }
+            }
+        `))
+        expect(complexity).toBe(13)
+    });
+
+    test("movies with actors and directors result", async () => {
+        const complexity = await server.computeQueryComplexity(parse(`
+            query {
+              movies(limit: 5) {
+                title
+                actors(limit: 10) {
+                  name
+                }
+                directors(limit: 4) {
+                  name
+                }
+              }
+            }
+      `))
+        expect(complexity).toBe(22)
+    });
+
+    test("productions with actors and directors result", async () => {
+        const complexity = await server.computeQueryComplexity(parse(`
+            query {
+              productions(limit: 5) {
+                title
+                actors(limit: 10) {
+                  name
+                }
+              }
+            }
+        `))
+        expect(complexity).toBe(17)
+    });
+});
+
+describe("limitRequired not enabled", () => {
+  const testHelper = new TestHelper();
+
+  let server: TestGraphQLServer;
+
+  beforeAll(async () => {
+      const typeDefs = `
+              interface Production {
+                  title: String
+                  actors: [Actor!]! @declareRelationship
+              }
+              type Movie implements Production @node {
+                  title: String
+                  actors: [Actor!]! @relationship(type: "ACTED_IN", direction: IN)
+                  directors: [Actor!]! @relationship(type: "DIRECTED", direction: IN)
+              }
+              type Actor @node {
+                  name: String
+              }
+       `;
+
+      const neoSchema = await testHelper.initNeo4jGraphQL({ typeDefs, features: {complexityEstimators: true} });
+
+      // eslint-disable-next-line @typescript-eslint/require-await
+      server = new ApolloTestServer(neoSchema, async ({ req }) => ({
+          sessionConfig: {
+              database: testHelper.database,
+          },
+          token: req.headers.authorization,
+      }));
+      await server.start();
+  });
+
+  afterAll(async () => {
+      await testHelper.close();
+      await server.close();
+  });
+
+  test("movies with actors and directors result - no limit args", async () => {
+    const complexity = await server.computeQueryComplexity(parse(`
+        query {
+          movies {
+            title
+            actors {
+              name
+            }
+            directors {
+              name
+            }
+          }
+        }
+  `))
+    expect(complexity).toBe(6)
+});
+
+  test("productions with actors and directors result - no limit args", async () => {
+    const complexity = await server.computeQueryComplexity(parse(`
+        query {
+          productions {
+            title
+            actors {
+              name
+            }
+          }
+        }
+    `))
+    expect(complexity).toBe(4)
+});
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2100,6 +2100,7 @@ __metadata:
     graphql-compose: "npm:^9.0.8"
     graphql-middleware: "npm:6.1.35"
     graphql-parse-resolve-info: "npm:^4.12.3"
+    graphql-query-complexity: "npm:^1.0.0"
     graphql-relay: "npm:^0.10.0"
     graphql-tag: "npm:2.12.6"
     graphql-ws: "npm:5.16.0"
@@ -8637,6 +8638,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"graphql-query-complexity@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "graphql-query-complexity@npm:1.0.0"
+  dependencies:
+    lodash.get: "npm:^4.4.2"
+  peerDependencies:
+    graphql: ^14.6.0 || ^15.0.0 || ^16.0.0
+  checksum: 10c0/94b9e35eb6d504464cac25a077dc403b3c94666874748451b9175027e790216d8b52765f1d7b6a73bef80d8e0ba3a7fad52bf281080bf12be976f7edf1a3e5da
+  languageName: node
+  linkType: hard
+
 "graphql-relay@npm:^0.10.0":
   version: 0.10.2
   resolution: "graphql-relay@npm:0.10.2"
@@ -11204,6 +11216,13 @@ __metadata:
   version: 4.4.0
   resolution: "lodash.flatten@npm:4.4.0"
   checksum: 10c0/97e8f0d6b61fe4723c02ad0c6e67e51784c4a2c48f56ef283483e556ad01594cf9cec9c773e177bbbdbdb5d19e99b09d2487cb6b6e5dc405c2693e93b125bd3a
+  languageName: node
+  linkType: hard
+
+"lodash.get@npm:^4.4.2":
+  version: 4.4.2
+  resolution: "lodash.get@npm:4.4.2"
+  checksum: 10c0/48f40d471a1654397ed41685495acb31498d5ed696185ac8973daef424a749ca0c7871bf7b665d5c14f5cc479394479e0307e781f61d5573831769593411be6e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

Adds query complexity estimation using a dedicated lib by implementing a FieldExtensionsEstimator for relationship fields, all other fields have a default value of 1 by employing the SimpleEstimator with a defaultValue of 1 (this value is not configurable at this point in time).
A method is exposed to retrieve the list of estimators, which can then be extended if the client wishes to do so.

## Complexity

Complexity: Medium

# Issue

> **Note**
>
>  Please link to the GitHub issue(s) in which the proposal for this work was discussed
>  
>  To link to multiple issues, use full syntax for each, for example `Closes #1, closes #2, closes #3`

Closes 

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
