### PR TITLE
fix authentication tests

### DIFF
--- a/packages/graphql/src/schema/resolvers/subscriptions/where/utils/get-filtering-fn.ts
+++ b/packages/graphql/src/schema/resolvers/subscriptions/where/utils/get-filtering-fn.ts
@@ -78,9 +78,9 @@ export function getFilteringFn<T>(
 
     const operators = { ...operatorCheckMap, ...overrides };
 
-    const op = operators[operator];
-    if (!op) {
+    const comparatorFunction = operators[operator];
+    if (!comparatorFunction) {
         throw new Error(`Operator ${operator} not supported`);
     }
-    return op;
+    return comparatorFunction;
 }

--- a/packages/graphql/src/schema/resolvers/subscriptions/where/utils/get-filtering-fn.ts
+++ b/packages/graphql/src/schema/resolvers/subscriptions/where/utils/get-filtering-fn.ts
@@ -62,6 +62,10 @@ const operatorCheckMap = {
     gt: legacyOperatorCheckMap.GT,
     gte: legacyOperatorCheckMap.GTE,
     in: legacyOperatorCheckMap.IN,
+    startsWith: legacyOperatorCheckMap.STARTS_WITH,
+    endsWith: legacyOperatorCheckMap.ENDS_WITH,
+    contains: legacyOperatorCheckMap.CONTAINS,
+    includes: legacyOperatorCheckMap.INCLUDES,
 };
 
 export function getFilteringFn<T>(
@@ -74,5 +78,9 @@ export function getFilteringFn<T>(
 
     const operators = { ...operatorCheckMap, ...overrides };
 
-    return operators[operator];
+    const op = operators[operator];
+    if (!op) {
+        throw new Error(`Operator ${operator} not supported`);
+    }
+    return op;
 }

--- a/packages/graphql/tests/integration/directives/authorization/is-authenticated.int.test.ts
+++ b/packages/graphql/tests/integration/directives/authorization/is-authenticated.int.test.ts
@@ -188,7 +188,7 @@ describe("auth/is-authenticated", () => {
             const typeDefs = /* GraphQL */ `
                 type ${User} @node {
                     id: ID
-                    password: String  @authentication(operations: [READ]) 
+                    password: String @authentication(operations: [READ]) 
                 }
             `;
 


### PR DESCRIPTION
Fix the authentication tests, during a merge resolution I removed the alias for `includes` , `startsWith` ,`endsWith`.
