### PR TITLE
Remove limit on relationship introspection #5884

### DIFF
--- a/.changeset/afraid-spoons-give.md
+++ b/.changeset/afraid-spoons-give.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/introspector": patch
+---
+
+Remove limit on relationships introspection

--- a/packages/introspector/src/to-internal-struct.ts
+++ b/packages/introspector/src/to-internal-struct.ts
@@ -117,7 +117,6 @@ async function introspectRelationships(sessionFactory: () => Session): Promise<R
             const relationshipsRes = await conSession.readTransaction((tx) =>
                 tx.run(`
             MATCH (n)-[r:${escapedType}]->(m)
-            WITH n, r, m LIMIT 100
             WITH DISTINCT labels(n) AS from, labels(m) AS to
             WITH from, to WHERE SIZE(from) > 0 AND SIZE(to) > 0
             RETURN from, to, "${relType.replace(/"/g, '\\"')}" AS relType`)


### PR DESCRIPTION
# Description
Remove limit on relationships introspection

NOTE: this may have a detrimental effect on introspection performance on big databases. An alternative solution would be to have this limit defined as an optional parameter of the introspection