### PR TITLE
Fix auth directives error mapping regex

### DIFF
--- a/.changeset/many-jars-swim.md
+++ b/.changeset/many-jars-swim.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+Fix error message for wrong `requireAuthentication` argument on `@authorization` directive

--- a/packages/graphql/src/schema/validation/utils/map-error.test.ts
+++ b/packages/graphql/src/schema/validation/utils/map-error.test.ts
@@ -510,6 +510,31 @@ describe("mapError", () => {
                 'Unknown argument "wrongFilter" on directive "@authorization". Did you mean "filter"?'
             );
         });
+
+        test("unknown argument requireAuthentication on directive", () => {
+            const errorOpts = {
+                nodes: [argumentNode],
+                extensions: undefined,
+                path: undefined,
+                source: undefined,
+                positions: undefined,
+                originalError: undefined,
+            };
+
+            // TODO: replace constructor to use errorOpts when dropping support for GraphQL15
+            const error = new GraphQLError(
+                'Unknown argument "requireAuthentication" on directive "@UserAuthorization".',
+                errorOpts.nodes,
+                errorOpts.source,
+                errorOpts.positions,
+                errorOpts.path,
+                errorOpts.originalError,
+                errorOpts.extensions
+            );
+            const mappedError = mapError(error);
+            expect(mappedError).toHaveProperty("message");
+            expect(mappedError.message).toBe('Unknown argument "requireAuthentication" on directive "@authorization".');
+        });
     });
 
     describe("UniqueDirectivesPerLocationRule", () => {

--- a/packages/graphql/src/schema/validation/utils/map-error.ts
+++ b/packages/graphql/src/schema/validation/utils/map-error.ts
@@ -74,7 +74,8 @@ function mapCustomRuleError(error: GraphQLError): GraphQLError {
     return error;
 }
 
-const RENAMED_DIRECTIVE_OR_TYPE = /(\s?"([^\s]*?([sS]ubscriptionsAuthorization|Authorization|Authentication)[^\s]*?)")/;
+const RENAMED_DIRECTIVE_OR_TYPE =
+    /(\s?"((?!requireAuthentication)[^\s]*?([sS]ubscriptionsAuthorization|Authorization|Authentication)[^\s]*?)")/;
 const WHERE_TYPE = /type(\s\\?".+?\\?")/; // <typename>Where / JwtPayloadWhere
 const JWT_PAYLOAD_DUMMY_VALUE_ERROR =
     /(?:(?:String)|(?:Int)|(?:Float)|(?:Boolean))(?: cannot represent a?\s?)(?:(?:non string)|(?:non-integer)|(?:non numeric)|(?:non boolean))(?: value)(:.+)/;


### PR DESCRIPTION
# Description

The error mapper logic uses a regex to find any dynamic directives (eg @UserAuthorization) and renames them to the corresponding user-facing directive (@authorization).
This PR fixes the regex to not match the requiredAuthentication argument.

## Complexity

Complexity: Low

# Issue

> **Note**
>
>  Please link to the GitHub issue(s) in which the proposal for this work was discussed
>  
>  To link to multiple issues, use full syntax for each, for example `Closes #1, closes #2, closes #3`

Closes 

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
