### PR TITLE
backport typename filter in v6

### DIFF
--- a/.changeset/fluffy-schools-promise.md
+++ b/.changeset/fluffy-schools-promise.md
@@ -1,0 +1,13 @@
+---
+"@neo4j/graphql": minor
+---
+
+Introduced the `typename` filter that superseded the `typename_IN` filter. 
+As part of the change, the flag `typename_IN` has been added to the `excludeDeprecatedFields` setting.
+
+```js
+const neoSchema = new Neo4jGraphQL({
+    typeDefs,
+    features: { excludeDeprecatedFields: { typename_IN: true } },
+});
+```

--- a/packages/graphql/src/schema/constants.ts
+++ b/packages/graphql/src/schema/constants.ts
@@ -64,6 +64,6 @@ export const DEPRECATE_OVERWRITE = {
 export const DEPRECATE_TYPENAME_IN = {
     name: DEPRECATED,
     args: {
-        reason: "The typename_IN filter is deprecated, please use the typename filters instead",
+        reason: "The typename_IN filter is deprecated, please use the typename filter instead",
     },
 };

--- a/packages/graphql/src/schema/constants.ts
+++ b/packages/graphql/src/schema/constants.ts
@@ -60,3 +60,10 @@ export const DEPRECATE_OVERWRITE = {
         reason: "The overwrite argument is deprecated and will be removed",
     },
 };
+
+export const DEPRECATE_TYPENAME_IN = {
+    name: DEPRECATED,
+    args: {
+        reason: "The typename_IN filter is deprecated, please use the typename filters instead",
+    },
+};

--- a/packages/graphql/src/schema/generation/where-input.ts
+++ b/packages/graphql/src/schema/generation/where-input.ts
@@ -32,7 +32,7 @@ import { UnionEntityAdapter } from "../../schema-model/entity/model-adapters/Uni
 import { RelationshipAdapter } from "../../schema-model/relationship/model-adapters/RelationshipAdapter";
 import type { RelationshipDeclarationAdapter } from "../../schema-model/relationship/model-adapters/RelationshipDeclarationAdapter";
 import type { Neo4jFeaturesSettings } from "../../types";
-import { DEPRECATE_IMPLICIT_EQUAL_FILTERS } from "../constants";
+import { DEPRECATE_IMPLICIT_EQUAL_FILTERS, DEPRECATE_TYPENAME_IN } from "../constants";
 import { getWhereFieldsForAttributes } from "../get-where-fields";
 import { withAggregateInputType } from "./aggregate-types";
 import {
@@ -143,7 +143,13 @@ export function withWhereInputType({
                 name: entityAdapter.operations.implementationEnumTypename,
                 values: enumValues,
             });
-            whereInputType.addFields({ typename_IN: { type: interfaceImplementation.NonNull.List } });
+            if (shouldAddDeprecatedFields(features, "typename_IN")) {
+                whereInputType.addFields({
+                    typename_IN: { type: interfaceImplementation.NonNull.List, directives: [DEPRECATE_TYPENAME_IN] },
+                });
+            }
+
+            whereInputType.addFields({ typename: { type: interfaceImplementation.NonNull.List } });
         }
     }
     return whereInputType;

--- a/packages/graphql/src/translate/queryAST/factory/FilterFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/FilterFactory.ts
@@ -430,7 +430,7 @@ export class FilterFactory {
                         filters: nestedFilters,
                     });
                 }
-                if (key === "typename_IN") {
+                if (key === "typename_IN" || key === "typename") {
                     const acceptedEntities = entity.concreteEntities.filter((concreteEntity) => {
                         return valueAsArray.some((typenameFilterValue) => typenameFilterValue === concreteEntity.name);
                     });

--- a/packages/graphql/src/types/index.ts
+++ b/packages/graphql/src/types/index.ts
@@ -453,6 +453,7 @@ export type Neo4jFeaturesSettings = {
         deprecatedOptionsArgument?: boolean;
         directedArgument?: boolean;
         connectOrCreate?: boolean;
+        typename_IN?: boolean;
     };
     vector?: Neo4jVectorSettings;
 };

--- a/packages/graphql/tests/integration/filtering/typename-in.int.test.ts
+++ b/packages/graphql/tests/integration/filtering/typename-in.int.test.ts
@@ -88,7 +88,7 @@ describe("typename_IN", () => {
     test("top-level", async () => {
         const query = `
         {
-            productions(where: { OR: [{ AND: [{ title_EQ: "The Matrix" }, { typename_IN: [${Movie.name}] }] }, { typename_IN: [${Series.name}] }]}) {
+            productions(where: { OR: [{ AND: [{ title_EQ: "The Matrix" }, { typename: [${Movie.name}] }] }, { typename: [${Series.name}] }]}) {
                 __typename
                 title
             }
@@ -116,8 +116,8 @@ describe("typename_IN", () => {
         {
             ${Actor.plural} {
                 actedIn(where: { OR: [
-                    { AND: [{ title_EQ: "The Matrix" }, { typename_IN: [${Movie.name}] }] }
-                    { typename_IN: [${Series.name}] }
+                    { AND: [{ title_EQ: "The Matrix" }, { typename: [${Movie.name}] }] }
+                    { typename: [${Series.name}] }
                 ] }) {
                     __typename
                     title
@@ -149,7 +149,7 @@ describe("typename_IN", () => {
     test("aggregation", async () => {
         const query = `
         {
-            productionsAggregate(where: { OR: [ { typename_IN: [${Movie.name}, ${Series.name}] } { typename_IN: [${Cartoon.name}] } ] }) {
+            productionsAggregate(where: { OR: [ { typename: [${Movie.name}, ${Series.name}] } { typename: [${Cartoon.name}] } ] }) {
                 count
             }
         }  
@@ -168,7 +168,7 @@ describe("typename_IN", () => {
         const query = `
         {
             ${Actor.plural} {
-                actedInAggregate(where: { NOT:  { typename_IN: [${Movie.name}, ${Series.name}] } }) {
+                actedInAggregate(where: { NOT:  { typename: [${Movie.name}, ${Series.name}] } }) {
                     count
                 }
             }

--- a/packages/graphql/tests/schema/comments.test.ts
+++ b/packages/graphql/tests/schema/comments.test.ts
@@ -1139,7 +1139,8 @@ describe("Comments", () => {
                   title_EQ: String
                   title_IN: [String!]
                   title_STARTS_WITH: String
-                  typename_IN: [ProductionImplementation!]
+                  typename: [ProductionImplementation!]
+                  typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
                 }
 
                 type ProductionsConnection {

--- a/packages/graphql/tests/schema/comments.test.ts
+++ b/packages/graphql/tests/schema/comments.test.ts
@@ -1140,7 +1140,7 @@ describe("Comments", () => {
                   title_IN: [String!]
                   title_STARTS_WITH: String
                   typename: [ProductionImplementation!]
-                  typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+                  typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
                 }
 
                 type ProductionsConnection {

--- a/packages/graphql/tests/schema/connections/interfaces.test.ts
+++ b/packages/graphql/tests/schema/connections/interfaces.test.ts
@@ -243,7 +243,8 @@ describe("Connection with interfaces", () => {
               movies: ProductionWhere
               moviesAggregate: CreatureMoviesAggregateInput
               moviesConnection: CreatureMoviesConnectionWhere
-              typename_IN: [CreatureImplementation!]
+              typename: [CreatureImplementation!]
+              typename_IN: [CreatureImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
             }
 
             type CreaturesConnection {
@@ -804,7 +805,8 @@ describe("Connection with interfaces", () => {
               id_EQ: ID
               id_IN: [ID]
               id_STARTS_WITH: ID
-              typename_IN: [ProductionImplementation!]
+              typename: [ProductionImplementation!]
+              typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
             }
 
             type ProductionsConnection {

--- a/packages/graphql/tests/schema/connections/interfaces.test.ts
+++ b/packages/graphql/tests/schema/connections/interfaces.test.ts
@@ -244,7 +244,7 @@ describe("Connection with interfaces", () => {
               moviesAggregate: CreatureMoviesAggregateInput
               moviesConnection: CreatureMoviesConnectionWhere
               typename: [CreatureImplementation!]
-              typename_IN: [CreatureImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+              typename_IN: [CreatureImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
             }
 
             type CreaturesConnection {
@@ -806,7 +806,7 @@ describe("Connection with interfaces", () => {
               id_IN: [ID]
               id_STARTS_WITH: ID
               typename: [ProductionImplementation!]
-              typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+              typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
             }
 
             type ProductionsConnection {

--- a/packages/graphql/tests/schema/directive-preserve.test.ts
+++ b/packages/graphql/tests/schema/directive-preserve.test.ts
@@ -1603,7 +1603,8 @@ describe("Directive-preserve", () => {
               title_EQ: String
               title_IN: [String!]
               title_STARTS_WITH: String
-              typename_IN: [ProductionImplementation!]
+              typename: [ProductionImplementation!]
+              typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
             }
 
             type ProductionsConnection {
@@ -2517,7 +2518,8 @@ describe("Directive-preserve", () => {
               title_EQ: String
               title_IN: [String!]
               title_STARTS_WITH: String
-              typename_IN: [ProductionImplementation!]
+              typename: [ProductionImplementation!]
+              typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
             }
 
             type ProductionsConnection {
@@ -3454,7 +3456,8 @@ describe("Directive-preserve", () => {
               title_EQ: String
               title_IN: [String!]
               title_STARTS_WITH: String
-              typename_IN: [ProductionImplementation!]
+              typename: [ProductionImplementation!]
+              typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
             }
 
             type ProductionsConnection {

--- a/packages/graphql/tests/schema/directive-preserve.test.ts
+++ b/packages/graphql/tests/schema/directive-preserve.test.ts
@@ -1604,7 +1604,7 @@ describe("Directive-preserve", () => {
               title_IN: [String!]
               title_STARTS_WITH: String
               typename: [ProductionImplementation!]
-              typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+              typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
             }
 
             type ProductionsConnection {
@@ -2519,7 +2519,7 @@ describe("Directive-preserve", () => {
               title_IN: [String!]
               title_STARTS_WITH: String
               typename: [ProductionImplementation!]
-              typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+              typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
             }
 
             type ProductionsConnection {
@@ -3457,7 +3457,7 @@ describe("Directive-preserve", () => {
               title_IN: [String!]
               title_STARTS_WITH: String
               typename: [ProductionImplementation!]
-              typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+              typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
             }
 
             type ProductionsConnection {

--- a/packages/graphql/tests/schema/directives/customResolver.test.ts
+++ b/packages/graphql/tests/schema/directives/customResolver.test.ts
@@ -201,7 +201,8 @@ describe("@customResolver directive", () => {
               customResolver_EQ: String
               customResolver_IN: [String]
               customResolver_STARTS_WITH: String
-              typename_IN: [UserInterfaceImplementation!]
+              typename: [UserInterfaceImplementation!]
+              typename_IN: [UserInterfaceImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
             }
 
             type UserInterfacesConnection {

--- a/packages/graphql/tests/schema/directives/customResolver.test.ts
+++ b/packages/graphql/tests/schema/directives/customResolver.test.ts
@@ -202,7 +202,7 @@ describe("@customResolver directive", () => {
               customResolver_IN: [String]
               customResolver_STARTS_WITH: String
               typename: [UserInterfaceImplementation!]
-              typename_IN: [UserInterfaceImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+              typename_IN: [UserInterfaceImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
             }
 
             type UserInterfacesConnection {

--- a/packages/graphql/tests/schema/directives/cypher.test.ts
+++ b/packages/graphql/tests/schema/directives/cypher.test.ts
@@ -1355,7 +1355,7 @@ describe("Cypher", () => {
               NOT: ProductionWhere
               OR: [ProductionWhere!]
               typename: [ProductionImplementation!]
-              typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+              typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
             }
 
             type ProductionsConnection {

--- a/packages/graphql/tests/schema/directives/cypher.test.ts
+++ b/packages/graphql/tests/schema/directives/cypher.test.ts
@@ -1354,7 +1354,8 @@ describe("Cypher", () => {
               AND: [ProductionWhere!]
               NOT: ProductionWhere
               OR: [ProductionWhere!]
-              typename_IN: [ProductionImplementation!]
+              typename: [ProductionImplementation!]
+              typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
             }
 
             type ProductionsConnection {

--- a/packages/graphql/tests/schema/directives/default.test.ts
+++ b/packages/graphql/tests/schema/directives/default.test.ts
@@ -255,7 +255,8 @@ describe("@default directive", () => {
               toBeOverridden_EQ: String
               toBeOverridden_IN: [String!]
               toBeOverridden_STARTS_WITH: String
-              typename_IN: [UserInterfaceImplementation!]
+              typename: [UserInterfaceImplementation!]
+              typename_IN: [UserInterfaceImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
             }
 
             type UserInterfacesConnection {

--- a/packages/graphql/tests/schema/directives/default.test.ts
+++ b/packages/graphql/tests/schema/directives/default.test.ts
@@ -256,7 +256,7 @@ describe("@default directive", () => {
               toBeOverridden_IN: [String!]
               toBeOverridden_STARTS_WITH: String
               typename: [UserInterfaceImplementation!]
-              typename_IN: [UserInterfaceImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+              typename_IN: [UserInterfaceImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
             }
 
             type UserInterfacesConnection {

--- a/packages/graphql/tests/schema/directives/filterable.test.ts
+++ b/packages/graphql/tests/schema/directives/filterable.test.ts
@@ -5891,7 +5891,8 @@ describe("@filterable directive", () => {
                       AND: [PersonWhere!]
                       NOT: PersonWhere
                       OR: [PersonWhere!]
-                      typename_IN: [PersonImplementation!]
+                      typename: [PersonImplementation!]
+                      typename_IN: [PersonImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
                       username: String @deprecated(reason: \\"Please use the explicit _EQ version\\")
                       username_CONTAINS: String
                       username_ENDS_WITH: String
@@ -6587,7 +6588,8 @@ describe("@filterable directive", () => {
                       AND: [PersonWhere!]
                       NOT: PersonWhere
                       OR: [PersonWhere!]
-                      typename_IN: [PersonImplementation!]
+                      typename: [PersonImplementation!]
+                      typename_IN: [PersonImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
                       username: String @deprecated(reason: \\"Please use the explicit _EQ version\\")
                       username_CONTAINS: String
                       username_ENDS_WITH: String
@@ -7248,7 +7250,8 @@ describe("@filterable directive", () => {
                       AND: [PersonWhere!]
                       NOT: PersonWhere
                       OR: [PersonWhere!]
-                      typename_IN: [PersonImplementation!]
+                      typename: [PersonImplementation!]
+                      typename_IN: [PersonImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
                       username: String @deprecated(reason: \\"Please use the explicit _EQ version\\")
                       username_CONTAINS: String
                       username_ENDS_WITH: String

--- a/packages/graphql/tests/schema/directives/filterable.test.ts
+++ b/packages/graphql/tests/schema/directives/filterable.test.ts
@@ -5892,7 +5892,7 @@ describe("@filterable directive", () => {
                       NOT: PersonWhere
                       OR: [PersonWhere!]
                       typename: [PersonImplementation!]
-                      typename_IN: [PersonImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+                      typename_IN: [PersonImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
                       username: String @deprecated(reason: \\"Please use the explicit _EQ version\\")
                       username_CONTAINS: String
                       username_ENDS_WITH: String
@@ -6589,7 +6589,7 @@ describe("@filterable directive", () => {
                       NOT: PersonWhere
                       OR: [PersonWhere!]
                       typename: [PersonImplementation!]
-                      typename_IN: [PersonImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+                      typename_IN: [PersonImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
                       username: String @deprecated(reason: \\"Please use the explicit _EQ version\\")
                       username_CONTAINS: String
                       username_ENDS_WITH: String
@@ -7251,7 +7251,7 @@ describe("@filterable directive", () => {
                       NOT: PersonWhere
                       OR: [PersonWhere!]
                       typename: [PersonImplementation!]
-                      typename_IN: [PersonImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+                      typename_IN: [PersonImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
                       username: String @deprecated(reason: \\"Please use the explicit _EQ version\\")
                       username_CONTAINS: String
                       username_ENDS_WITH: String

--- a/packages/graphql/tests/schema/directives/private.test.ts
+++ b/packages/graphql/tests/schema/directives/private.test.ts
@@ -180,7 +180,7 @@ describe("@private directive", () => {
               id_IN: [ID]
               id_STARTS_WITH: ID
               typename: [UserInterfaceImplementation!]
-              typename_IN: [UserInterfaceImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+              typename_IN: [UserInterfaceImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
             }
 
             type UserInterfacesConnection {
@@ -395,7 +395,7 @@ describe("@private directive", () => {
               id_IN: [ID]
               id_STARTS_WITH: ID
               typename: [UserInterfaceImplementation!]
-              typename_IN: [UserInterfaceImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+              typename_IN: [UserInterfaceImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
             }
 
             type UserInterfacesConnection {

--- a/packages/graphql/tests/schema/directives/private.test.ts
+++ b/packages/graphql/tests/schema/directives/private.test.ts
@@ -179,7 +179,8 @@ describe("@private directive", () => {
               id_EQ: ID
               id_IN: [ID]
               id_STARTS_WITH: ID
-              typename_IN: [UserInterfaceImplementation!]
+              typename: [UserInterfaceImplementation!]
+              typename_IN: [UserInterfaceImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
             }
 
             type UserInterfacesConnection {
@@ -393,7 +394,8 @@ describe("@private directive", () => {
               id_EQ: ID
               id_IN: [ID]
               id_STARTS_WITH: ID
-              typename_IN: [UserInterfaceImplementation!]
+              typename: [UserInterfaceImplementation!]
+              typename_IN: [UserInterfaceImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
             }
 
             type UserInterfacesConnection {

--- a/packages/graphql/tests/schema/directives/relationship-aggregate.test.ts
+++ b/packages/graphql/tests/schema/directives/relationship-aggregate.test.ts
@@ -1381,7 +1381,8 @@ describe("@relationship directive, aggregate argument", () => {
                       password_EQ: String
                       password_IN: [String!]
                       password_STARTS_WITH: String
-                      typename_IN: [PersonImplementation!]
+                      typename: [PersonImplementation!]
+                      typename_IN: [PersonImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
                       username: String @deprecated(reason: \\"Please use the explicit _EQ version\\")
                       username_CONTAINS: String
                       username_ENDS_WITH: String
@@ -1849,7 +1850,8 @@ describe("@relationship directive, aggregate argument", () => {
                       password_EQ: String
                       password_IN: [String!]
                       password_STARTS_WITH: String
-                      typename_IN: [PersonImplementation!]
+                      typename: [PersonImplementation!]
+                      typename_IN: [PersonImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
                       username: String @deprecated(reason: \\"Please use the explicit _EQ version\\")
                       username_CONTAINS: String
                       username_ENDS_WITH: String

--- a/packages/graphql/tests/schema/directives/relationship-aggregate.test.ts
+++ b/packages/graphql/tests/schema/directives/relationship-aggregate.test.ts
@@ -1382,7 +1382,7 @@ describe("@relationship directive, aggregate argument", () => {
                       password_IN: [String!]
                       password_STARTS_WITH: String
                       typename: [PersonImplementation!]
-                      typename_IN: [PersonImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+                      typename_IN: [PersonImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
                       username: String @deprecated(reason: \\"Please use the explicit _EQ version\\")
                       username_CONTAINS: String
                       username_ENDS_WITH: String
@@ -1851,7 +1851,7 @@ describe("@relationship directive, aggregate argument", () => {
                       password_IN: [String!]
                       password_STARTS_WITH: String
                       typename: [PersonImplementation!]
-                      typename_IN: [PersonImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+                      typename_IN: [PersonImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
                       username: String @deprecated(reason: \\"Please use the explicit _EQ version\\")
                       username_CONTAINS: String
                       username_ENDS_WITH: String

--- a/packages/graphql/tests/schema/directives/relationship-nested-operations.test.ts
+++ b/packages/graphql/tests/schema/directives/relationship-nested-operations.test.ts
@@ -8350,7 +8350,8 @@ describe("Relationship nested operations", () => {
                   name_EQ: String
                   name_IN: [String]
                   name_STARTS_WITH: String
-                  typename_IN: [PersonImplementation!]
+                  typename: [PersonImplementation!]
+                  typename_IN: [PersonImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
                 }
 
                 type Query {
@@ -8837,7 +8838,8 @@ describe("Relationship nested operations", () => {
                   name_EQ: String
                   name_IN: [String]
                   name_STARTS_WITH: String
-                  typename_IN: [PersonImplementation!]
+                  typename: [PersonImplementation!]
+                  typename_IN: [PersonImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
                 }
 
                 type Query {
@@ -9323,7 +9325,8 @@ describe("Relationship nested operations", () => {
                   name_EQ: String
                   name_IN: [String]
                   name_STARTS_WITH: String
-                  typename_IN: [PersonImplementation!]
+                  typename: [PersonImplementation!]
+                  typename_IN: [PersonImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
                 }
 
                 type Query {
@@ -9805,7 +9808,8 @@ describe("Relationship nested operations", () => {
                   name_EQ: String
                   name_IN: [String]
                   name_STARTS_WITH: String
-                  typename_IN: [PersonImplementation!]
+                  typename: [PersonImplementation!]
+                  typename_IN: [PersonImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
                 }
 
                 type Query {
@@ -10286,7 +10290,8 @@ describe("Relationship nested operations", () => {
                   name_EQ: String
                   name_IN: [String]
                   name_STARTS_WITH: String
-                  typename_IN: [PersonImplementation!]
+                  typename: [PersonImplementation!]
+                  typename_IN: [PersonImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
                 }
 
                 type Query {
@@ -10763,7 +10768,8 @@ describe("Relationship nested operations", () => {
                   name_EQ: String
                   name_IN: [String]
                   name_STARTS_WITH: String
-                  typename_IN: [PersonImplementation!]
+                  typename: [PersonImplementation!]
+                  typename_IN: [PersonImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
                 }
 
                 type Query {
@@ -11388,7 +11394,8 @@ describe("Relationship nested operations", () => {
                   name_EQ: String
                   name_IN: [String]
                   name_STARTS_WITH: String
-                  typename_IN: [PersonImplementation!]
+                  typename: [PersonImplementation!]
+                  typename_IN: [PersonImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
                 }
 
                 type Query {
@@ -11989,7 +11996,8 @@ describe("Relationship nested operations", () => {
                   name_EQ: String
                   name_IN: [String]
                   name_STARTS_WITH: String
-                  typename_IN: [PersonImplementation!]
+                  typename: [PersonImplementation!]
+                  typename_IN: [PersonImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
                 }
 
                 type Query {

--- a/packages/graphql/tests/schema/directives/relationship-nested-operations.test.ts
+++ b/packages/graphql/tests/schema/directives/relationship-nested-operations.test.ts
@@ -8351,7 +8351,7 @@ describe("Relationship nested operations", () => {
                   name_IN: [String]
                   name_STARTS_WITH: String
                   typename: [PersonImplementation!]
-                  typename_IN: [PersonImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+                  typename_IN: [PersonImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
                 }
 
                 type Query {
@@ -8839,7 +8839,7 @@ describe("Relationship nested operations", () => {
                   name_IN: [String]
                   name_STARTS_WITH: String
                   typename: [PersonImplementation!]
-                  typename_IN: [PersonImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+                  typename_IN: [PersonImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
                 }
 
                 type Query {
@@ -9326,7 +9326,7 @@ describe("Relationship nested operations", () => {
                   name_IN: [String]
                   name_STARTS_WITH: String
                   typename: [PersonImplementation!]
-                  typename_IN: [PersonImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+                  typename_IN: [PersonImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
                 }
 
                 type Query {
@@ -9809,7 +9809,7 @@ describe("Relationship nested operations", () => {
                   name_IN: [String]
                   name_STARTS_WITH: String
                   typename: [PersonImplementation!]
-                  typename_IN: [PersonImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+                  typename_IN: [PersonImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
                 }
 
                 type Query {
@@ -10291,7 +10291,7 @@ describe("Relationship nested operations", () => {
                   name_IN: [String]
                   name_STARTS_WITH: String
                   typename: [PersonImplementation!]
-                  typename_IN: [PersonImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+                  typename_IN: [PersonImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
                 }
 
                 type Query {
@@ -10769,7 +10769,7 @@ describe("Relationship nested operations", () => {
                   name_IN: [String]
                   name_STARTS_WITH: String
                   typename: [PersonImplementation!]
-                  typename_IN: [PersonImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+                  typename_IN: [PersonImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
                 }
 
                 type Query {
@@ -11395,7 +11395,7 @@ describe("Relationship nested operations", () => {
                   name_IN: [String]
                   name_STARTS_WITH: String
                   typename: [PersonImplementation!]
-                  typename_IN: [PersonImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+                  typename_IN: [PersonImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
                 }
 
                 type Query {
@@ -11997,7 +11997,7 @@ describe("Relationship nested operations", () => {
                   name_IN: [String]
                   name_STARTS_WITH: String
                   typename: [PersonImplementation!]
-                  typename_IN: [PersonImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+                  typename_IN: [PersonImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
                 }
 
                 type Query {

--- a/packages/graphql/tests/schema/directives/selectable.test.ts
+++ b/packages/graphql/tests/schema/directives/selectable.test.ts
@@ -2852,7 +2852,7 @@ describe("@selectable", () => {
                   title_IN: [String!]
                   title_STARTS_WITH: String
                   typename: [ProductionImplementation!]
-                  typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+                  typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
                 }
 
                 type ProductionsConnection {
@@ -3413,7 +3413,7 @@ describe("@selectable", () => {
                   title_IN: [String!]
                   title_STARTS_WITH: String
                   typename: [ProductionImplementation!]
-                  typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+                  typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
                 }
 
                 type ProductionsConnection {

--- a/packages/graphql/tests/schema/directives/selectable.test.ts
+++ b/packages/graphql/tests/schema/directives/selectable.test.ts
@@ -2851,7 +2851,8 @@ describe("@selectable", () => {
                   title_EQ: String
                   title_IN: [String!]
                   title_STARTS_WITH: String
-                  typename_IN: [ProductionImplementation!]
+                  typename: [ProductionImplementation!]
+                  typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
                 }
 
                 type ProductionsConnection {
@@ -3411,7 +3412,8 @@ describe("@selectable", () => {
                   title_EQ: String
                   title_IN: [String!]
                   title_STARTS_WITH: String
-                  typename_IN: [ProductionImplementation!]
+                  typename: [ProductionImplementation!]
+                  typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
                 }
 
                 type ProductionsConnection {

--- a/packages/graphql/tests/schema/directives/settable.test.ts
+++ b/packages/graphql/tests/schema/directives/settable.test.ts
@@ -5030,7 +5030,8 @@ describe("@settable", () => {
                   title_EQ: String
                   title_IN: [String!]
                   title_STARTS_WITH: String
-                  typename_IN: [ProductionImplementation!]
+                  typename: [ProductionImplementation!]
+                  typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
                 }
 
                 type ProductionsConnection {
@@ -5566,7 +5567,8 @@ describe("@settable", () => {
                   title_EQ: String
                   title_IN: [String!]
                   title_STARTS_WITH: String
-                  typename_IN: [ProductionImplementation!]
+                  typename: [ProductionImplementation!]
+                  typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
                 }
 
                 type ProductionsConnection {
@@ -6344,7 +6346,8 @@ describe("@settable", () => {
                   title_EQ: String
                   title_IN: [String!]
                   title_STARTS_WITH: String
-                  typename_IN: [ProductionImplementation!]
+                  typename: [ProductionImplementation!]
+                  typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
                 }
 
                 type ProductionsConnection {
@@ -7263,7 +7266,8 @@ describe("@settable", () => {
                   title_EQ: String
                   title_IN: [String!]
                   title_STARTS_WITH: String
-                  typename_IN: [ProductionImplementation!]
+                  typename: [ProductionImplementation!]
+                  typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
                 }
 
                 type ProductionsConnection {

--- a/packages/graphql/tests/schema/directives/settable.test.ts
+++ b/packages/graphql/tests/schema/directives/settable.test.ts
@@ -5031,7 +5031,7 @@ describe("@settable", () => {
                   title_IN: [String!]
                   title_STARTS_WITH: String
                   typename: [ProductionImplementation!]
-                  typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+                  typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
                 }
 
                 type ProductionsConnection {
@@ -5568,7 +5568,7 @@ describe("@settable", () => {
                   title_IN: [String!]
                   title_STARTS_WITH: String
                   typename: [ProductionImplementation!]
-                  typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+                  typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
                 }
 
                 type ProductionsConnection {
@@ -6347,7 +6347,7 @@ describe("@settable", () => {
                   title_IN: [String!]
                   title_STARTS_WITH: String
                   typename: [ProductionImplementation!]
-                  typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+                  typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
                 }
 
                 type ProductionsConnection {
@@ -7267,7 +7267,7 @@ describe("@settable", () => {
                   title_IN: [String!]
                   title_STARTS_WITH: String
                   typename: [ProductionImplementation!]
-                  typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+                  typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
                 }
 
                 type ProductionsConnection {

--- a/packages/graphql/tests/schema/inheritance.test.ts
+++ b/packages/graphql/tests/schema/inheritance.test.ts
@@ -583,7 +583,7 @@ describe("inheritance", () => {
               name_IN: [String]
               name_STARTS_WITH: String
               typename: [PersonImplementation!]
-              typename_IN: [PersonImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+              typename_IN: [PersonImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
             }
 
             type Query {

--- a/packages/graphql/tests/schema/inheritance.test.ts
+++ b/packages/graphql/tests/schema/inheritance.test.ts
@@ -582,7 +582,8 @@ describe("inheritance", () => {
               name_EQ: String
               name_IN: [String]
               name_STARTS_WITH: String
-              typename_IN: [PersonImplementation!]
+              typename: [PersonImplementation!]
+              typename_IN: [PersonImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
             }
 
             type Query {

--- a/packages/graphql/tests/schema/interface-relationships.test.ts
+++ b/packages/graphql/tests/schema/interface-relationships.test.ts
@@ -510,7 +510,8 @@ describe("Interface Relationships", () => {
               title_EQ: String
               title_IN: [String!]
               title_STARTS_WITH: String
-              typename_IN: [ProductionImplementation!]
+              typename: [ProductionImplementation!]
+              typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
             }
 
             type ProductionsConnection {
@@ -1681,7 +1682,8 @@ describe("Interface Relationships", () => {
               title_EQ: String
               title_IN: [String!]
               title_STARTS_WITH: String
-              typename_IN: [ProductionImplementation!]
+              typename: [ProductionImplementation!]
+              typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
             }
 
             type ProductionsConnection {
@@ -3156,7 +3158,8 @@ describe("Interface Relationships", () => {
               title_EQ: String
               title_IN: [String!]
               title_STARTS_WITH: String
-              typename_IN: [ProductionImplementation!]
+              typename: [ProductionImplementation!]
+              typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
             }
 
             type ProductionsConnection {
@@ -3912,7 +3915,8 @@ describe("Interface Relationships", () => {
               Return Interface1s where some of the related Interface2s match this filter
               \\"\\"\\"
               interface2_SOME: Interface2Where
-              typename_IN: [Interface1Implementation!]
+              typename: [Interface1Implementation!]
+              typename_IN: [Interface1Implementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
             }
 
             type Interface1sConnection {
@@ -3980,7 +3984,8 @@ describe("Interface Relationships", () => {
               field2_EQ: String
               field2_IN: [String]
               field2_STARTS_WITH: String
-              typename_IN: [Interface2Implementation!]
+              typename: [Interface2Implementation!]
+              typename_IN: [Interface2Implementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
             }
 
             type Interface2sConnection {
@@ -5095,7 +5100,8 @@ describe("Interface Relationships", () => {
               Return Interface1s where some of the related Interface2s match this filter
               \\"\\"\\"
               interface2_SOME: Interface2Where
-              typename_IN: [Interface1Implementation!]
+              typename: [Interface1Implementation!]
+              typename_IN: [Interface1Implementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
             }
 
             type Interface1sConnection {
@@ -5163,7 +5169,8 @@ describe("Interface Relationships", () => {
               field2_EQ: String
               field2_IN: [String]
               field2_STARTS_WITH: String
-              typename_IN: [Interface2Implementation!]
+              typename: [Interface2Implementation!]
+              typename_IN: [Interface2Implementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
             }
 
             type Interface2sConnection {
@@ -6385,7 +6392,8 @@ describe("Interface Relationships", () => {
               Return Interface1s where some of the related Interface2s match this filter
               \\"\\"\\"
               interface2_SOME: Interface2Where
-              typename_IN: [Interface1Implementation!]
+              typename: [Interface1Implementation!]
+              typename_IN: [Interface1Implementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
             }
 
             type Interface1sConnection {
@@ -6453,7 +6461,8 @@ describe("Interface Relationships", () => {
               field2_EQ: String
               field2_IN: [String]
               field2_STARTS_WITH: String
-              typename_IN: [Interface2Implementation!]
+              typename: [Interface2Implementation!]
+              typename_IN: [Interface2Implementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
             }
 
             type Interface2sConnection {
@@ -7902,7 +7911,8 @@ describe("Interface Relationships", () => {
               id_EQ: ID
               id_IN: [ID]
               id_STARTS_WITH: ID
-              typename_IN: [ContentImplementation!]
+              typename: [ContentImplementation!]
+              typename_IN: [ContentImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
             }
 
             type ContentsConnection {
@@ -9198,7 +9208,8 @@ describe("Interface Relationships", () => {
               title_EQ: String
               title_IN: [String!]
               title_STARTS_WITH: String
-              typename_IN: [ProductionImplementation!]
+              typename: [ProductionImplementation!]
+              typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
             }
 
             type ProductionsConnection {
@@ -9679,7 +9690,8 @@ describe("Interface Relationships", () => {
               title_EQ: String
               title_IN: [String!]
               title_STARTS_WITH: String
-              typename_IN: [ShowImplementation!]
+              typename: [ShowImplementation!]
+              typename_IN: [ShowImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
             }
 
             type ShowsConnection {

--- a/packages/graphql/tests/schema/interface-relationships.test.ts
+++ b/packages/graphql/tests/schema/interface-relationships.test.ts
@@ -511,7 +511,7 @@ describe("Interface Relationships", () => {
               title_IN: [String!]
               title_STARTS_WITH: String
               typename: [ProductionImplementation!]
-              typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+              typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
             }
 
             type ProductionsConnection {
@@ -1683,7 +1683,7 @@ describe("Interface Relationships", () => {
               title_IN: [String!]
               title_STARTS_WITH: String
               typename: [ProductionImplementation!]
-              typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+              typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
             }
 
             type ProductionsConnection {
@@ -3159,7 +3159,7 @@ describe("Interface Relationships", () => {
               title_IN: [String!]
               title_STARTS_WITH: String
               typename: [ProductionImplementation!]
-              typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+              typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
             }
 
             type ProductionsConnection {
@@ -3916,7 +3916,7 @@ describe("Interface Relationships", () => {
               \\"\\"\\"
               interface2_SOME: Interface2Where
               typename: [Interface1Implementation!]
-              typename_IN: [Interface1Implementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+              typename_IN: [Interface1Implementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
             }
 
             type Interface1sConnection {
@@ -3985,7 +3985,7 @@ describe("Interface Relationships", () => {
               field2_IN: [String]
               field2_STARTS_WITH: String
               typename: [Interface2Implementation!]
-              typename_IN: [Interface2Implementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+              typename_IN: [Interface2Implementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
             }
 
             type Interface2sConnection {
@@ -5101,7 +5101,7 @@ describe("Interface Relationships", () => {
               \\"\\"\\"
               interface2_SOME: Interface2Where
               typename: [Interface1Implementation!]
-              typename_IN: [Interface1Implementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+              typename_IN: [Interface1Implementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
             }
 
             type Interface1sConnection {
@@ -5170,7 +5170,7 @@ describe("Interface Relationships", () => {
               field2_IN: [String]
               field2_STARTS_WITH: String
               typename: [Interface2Implementation!]
-              typename_IN: [Interface2Implementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+              typename_IN: [Interface2Implementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
             }
 
             type Interface2sConnection {
@@ -6393,7 +6393,7 @@ describe("Interface Relationships", () => {
               \\"\\"\\"
               interface2_SOME: Interface2Where
               typename: [Interface1Implementation!]
-              typename_IN: [Interface1Implementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+              typename_IN: [Interface1Implementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
             }
 
             type Interface1sConnection {
@@ -6462,7 +6462,7 @@ describe("Interface Relationships", () => {
               field2_IN: [String]
               field2_STARTS_WITH: String
               typename: [Interface2Implementation!]
-              typename_IN: [Interface2Implementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+              typename_IN: [Interface2Implementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
             }
 
             type Interface2sConnection {
@@ -7912,7 +7912,7 @@ describe("Interface Relationships", () => {
               id_IN: [ID]
               id_STARTS_WITH: ID
               typename: [ContentImplementation!]
-              typename_IN: [ContentImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+              typename_IN: [ContentImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
             }
 
             type ContentsConnection {
@@ -9209,7 +9209,7 @@ describe("Interface Relationships", () => {
               title_IN: [String!]
               title_STARTS_WITH: String
               typename: [ProductionImplementation!]
-              typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+              typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
             }
 
             type ProductionsConnection {
@@ -9691,7 +9691,7 @@ describe("Interface Relationships", () => {
               title_IN: [String!]
               title_STARTS_WITH: String
               typename: [ShowImplementation!]
-              typename_IN: [ShowImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+              typename_IN: [ShowImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
             }
 
             type ShowsConnection {

--- a/packages/graphql/tests/schema/interfaces.test.ts
+++ b/packages/graphql/tests/schema/interfaces.test.ts
@@ -322,7 +322,8 @@ describe("Interfaces", () => {
               movies_SINGLE: MovieWhere
               \\"\\"\\"Return MovieNodes where some of the related Movies match this filter\\"\\"\\"
               movies_SOME: MovieWhere
-              typename_IN: [MovieNodeImplementation!]
+              typename: [MovieNodeImplementation!]
+              typename_IN: [MovieNodeImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
             }
 
             type MovieNodesConnection {
@@ -751,7 +752,8 @@ describe("Interfaces", () => {
               movies_SINGLE: MovieWhere
               \\"\\"\\"Return MovieNodes where some of the related Movies match this filter\\"\\"\\"
               movies_SOME: MovieWhere
-              typename_IN: [MovieNodeImplementation!]
+              typename: [MovieNodeImplementation!]
+              typename_IN: [MovieNodeImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
             }
 
             type MovieNodesConnection {

--- a/packages/graphql/tests/schema/interfaces.test.ts
+++ b/packages/graphql/tests/schema/interfaces.test.ts
@@ -323,7 +323,7 @@ describe("Interfaces", () => {
               \\"\\"\\"Return MovieNodes where some of the related Movies match this filter\\"\\"\\"
               movies_SOME: MovieWhere
               typename: [MovieNodeImplementation!]
-              typename_IN: [MovieNodeImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+              typename_IN: [MovieNodeImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
             }
 
             type MovieNodesConnection {
@@ -753,7 +753,7 @@ describe("Interfaces", () => {
               \\"\\"\\"Return MovieNodes where some of the related Movies match this filter\\"\\"\\"
               movies_SOME: MovieWhere
               typename: [MovieNodeImplementation!]
-              typename_IN: [MovieNodeImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+              typename_IN: [MovieNodeImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
             }
 
             type MovieNodesConnection {

--- a/packages/graphql/tests/schema/issues/2377.test.ts
+++ b/packages/graphql/tests/schema/issues/2377.test.ts
@@ -422,7 +422,7 @@ describe("https://github.com/neo4j/graphql/issues/2377", () => {
               type_EQ: ResourceType
               type_IN: [ResourceType!]
               typename: [ResourceEntityImplementation!]
-              typename_IN: [ResourceEntityImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+              typename_IN: [ResourceEntityImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
             }
 
             input ResourceOnCreateInput {

--- a/packages/graphql/tests/schema/issues/2377.test.ts
+++ b/packages/graphql/tests/schema/issues/2377.test.ts
@@ -421,7 +421,8 @@ describe("https://github.com/neo4j/graphql/issues/2377", () => {
               type: ResourceType @deprecated(reason: \\"Please use the explicit _EQ version\\")
               type_EQ: ResourceType
               type_IN: [ResourceType!]
-              typename_IN: [ResourceEntityImplementation!]
+              typename: [ResourceEntityImplementation!]
+              typename_IN: [ResourceEntityImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
             }
 
             input ResourceOnCreateInput {

--- a/packages/graphql/tests/schema/issues/2993.test.ts
+++ b/packages/graphql/tests/schema/issues/2993.test.ts
@@ -207,7 +207,7 @@ describe("https://github.com/neo4j/graphql/issues/2993", () => {
               id_IN: [ID!]
               id_STARTS_WITH: ID
               typename: [ProfileImplementation!]
-              typename_IN: [ProfileImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+              typename_IN: [ProfileImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
               userName: String @deprecated(reason: \\"Please use the explicit _EQ version\\")
               userName_CONTAINS: String
               userName_ENDS_WITH: String

--- a/packages/graphql/tests/schema/issues/2993.test.ts
+++ b/packages/graphql/tests/schema/issues/2993.test.ts
@@ -206,7 +206,8 @@ describe("https://github.com/neo4j/graphql/issues/2993", () => {
               id_EQ: ID
               id_IN: [ID!]
               id_STARTS_WITH: ID
-              typename_IN: [ProfileImplementation!]
+              typename: [ProfileImplementation!]
+              typename_IN: [ProfileImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
               userName: String @deprecated(reason: \\"Please use the explicit _EQ version\\")
               userName_CONTAINS: String
               userName_ENDS_WITH: String

--- a/packages/graphql/tests/schema/issues/3439.test.ts
+++ b/packages/graphql/tests/schema/issues/3439.test.ts
@@ -423,7 +423,8 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               id_EQ: String
               id_IN: [String!]
               id_STARTS_WITH: String
-              typename_IN: [INodeImplementation!]
+              typename: [INodeImplementation!]
+              typename_IN: [INodeImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
             }
 
             type INodesConnection {
@@ -503,7 +504,8 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               name_EQ: String
               name_IN: [String!]
               name_STARTS_WITH: String
-              typename_IN: [IProductImplementation!]
+              typename: [IProductImplementation!]
+              typename_IN: [IProductImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
             }
 
             type IProductsConnection {
@@ -1502,7 +1504,8 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               name_EQ: String
               name_IN: [String!]
               name_STARTS_WITH: String
-              typename_IN: [IProductImplementation!]
+              typename: [IProductImplementation!]
+              typename_IN: [IProductImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
             }
 
             type IProductsConnection {
@@ -2703,7 +2706,8 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               name_EQ: String
               name_IN: [String!]
               name_STARTS_WITH: String
-              typename_IN: [IProductImplementation!]
+              typename: [IProductImplementation!]
+              typename_IN: [IProductImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
             }
 
             type IProductsConnection {
@@ -4028,7 +4032,8 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               name_EQ: String
               name_IN: [String!]
               name_STARTS_WITH: String
-              typename_IN: [IProductImplementation!]
+              typename: [IProductImplementation!]
+              typename_IN: [IProductImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
             }
 
             type IProductsConnection {

--- a/packages/graphql/tests/schema/issues/3439.test.ts
+++ b/packages/graphql/tests/schema/issues/3439.test.ts
@@ -424,7 +424,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               id_IN: [String!]
               id_STARTS_WITH: String
               typename: [INodeImplementation!]
-              typename_IN: [INodeImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+              typename_IN: [INodeImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
             }
 
             type INodesConnection {
@@ -505,7 +505,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               name_IN: [String!]
               name_STARTS_WITH: String
               typename: [IProductImplementation!]
-              typename_IN: [IProductImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+              typename_IN: [IProductImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
             }
 
             type IProductsConnection {
@@ -1505,7 +1505,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               name_IN: [String!]
               name_STARTS_WITH: String
               typename: [IProductImplementation!]
-              typename_IN: [IProductImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+              typename_IN: [IProductImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
             }
 
             type IProductsConnection {
@@ -2707,7 +2707,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               name_IN: [String!]
               name_STARTS_WITH: String
               typename: [IProductImplementation!]
-              typename_IN: [IProductImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+              typename_IN: [IProductImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
             }
 
             type IProductsConnection {
@@ -4033,7 +4033,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               name_IN: [String!]
               name_STARTS_WITH: String
               typename: [IProductImplementation!]
-              typename_IN: [IProductImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+              typename_IN: [IProductImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
             }
 
             type IProductsConnection {

--- a/packages/graphql/tests/schema/issues/3698.test.ts
+++ b/packages/graphql/tests/schema/issues/3698.test.ts
@@ -468,7 +468,7 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
               name_IN: [String!]
               name_STARTS_WITH: String
               typename: [IProductImplementation!]
-              typename_IN: [IProductImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+              typename_IN: [IProductImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
             }
 
             type IProductsConnection {
@@ -1356,7 +1356,7 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
               name_IN: [String!]
               name_STARTS_WITH: String
               typename: [IProductImplementation!]
-              typename_IN: [IProductImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+              typename_IN: [IProductImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
             }
 
             type IProductsConnection {
@@ -2227,7 +2227,7 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
               name_IN: [String!]
               name_STARTS_WITH: String
               typename: [IProductImplementation!]
-              typename_IN: [IProductImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+              typename_IN: [IProductImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
             }
 
             type IProductsConnection {

--- a/packages/graphql/tests/schema/issues/3698.test.ts
+++ b/packages/graphql/tests/schema/issues/3698.test.ts
@@ -467,7 +467,8 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
               name_EQ: String
               name_IN: [String!]
               name_STARTS_WITH: String
-              typename_IN: [IProductImplementation!]
+              typename: [IProductImplementation!]
+              typename_IN: [IProductImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
             }
 
             type IProductsConnection {
@@ -1354,7 +1355,8 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
               name_EQ: String
               name_IN: [String!]
               name_STARTS_WITH: String
-              typename_IN: [IProductImplementation!]
+              typename: [IProductImplementation!]
+              typename_IN: [IProductImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
             }
 
             type IProductsConnection {
@@ -2224,7 +2226,8 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
               name_EQ: String
               name_IN: [String!]
               name_STARTS_WITH: String
-              typename_IN: [IProductImplementation!]
+              typename: [IProductImplementation!]
+              typename_IN: [IProductImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
             }
 
             type IProductsConnection {

--- a/packages/graphql/tests/schema/issues/4511.test.ts
+++ b/packages/graphql/tests/schema/issues/4511.test.ts
@@ -224,7 +224,8 @@ describe("https://github.com/neo4j/graphql/issues/4511", () => {
               movies: ProductionWhere
               moviesAggregate: CreatureMoviesAggregateInput
               moviesConnection: CreatureMoviesConnectionWhere
-              typename_IN: [CreatureImplementation!]
+              typename: [CreatureImplementation!]
+              typename_IN: [CreatureImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
             }
 
             type CreaturesConnection {
@@ -691,7 +692,8 @@ describe("https://github.com/neo4j/graphql/issues/4511", () => {
               id_EQ: ID
               id_IN: [ID]
               id_STARTS_WITH: ID
-              typename_IN: [ProductionImplementation!]
+              typename: [ProductionImplementation!]
+              typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
             }
 
             type ProductionsConnection {

--- a/packages/graphql/tests/schema/issues/4511.test.ts
+++ b/packages/graphql/tests/schema/issues/4511.test.ts
@@ -225,7 +225,7 @@ describe("https://github.com/neo4j/graphql/issues/4511", () => {
               moviesAggregate: CreatureMoviesAggregateInput
               moviesConnection: CreatureMoviesConnectionWhere
               typename: [CreatureImplementation!]
-              typename_IN: [CreatureImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+              typename_IN: [CreatureImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
             }
 
             type CreaturesConnection {
@@ -693,7 +693,7 @@ describe("https://github.com/neo4j/graphql/issues/4511", () => {
               id_IN: [ID]
               id_STARTS_WITH: ID
               typename: [ProductionImplementation!]
-              typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+              typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
             }
 
             type ProductionsConnection {

--- a/packages/graphql/tests/schema/issues/4615.test.ts
+++ b/packages/graphql/tests/schema/issues/4615.test.ts
@@ -1061,7 +1061,8 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
               title_EQ: String
               title_IN: [String!]
               title_STARTS_WITH: String
-              typename_IN: [ShowImplementation!]
+              typename: [ShowImplementation!]
+              typename_IN: [ShowImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
             }
 
             type ShowsConnection {

--- a/packages/graphql/tests/schema/issues/4615.test.ts
+++ b/packages/graphql/tests/schema/issues/4615.test.ts
@@ -1062,7 +1062,7 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
               title_IN: [String!]
               title_STARTS_WITH: String
               typename: [ShowImplementation!]
-              typename_IN: [ShowImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+              typename_IN: [ShowImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
             }
 
             type ShowsConnection {

--- a/packages/graphql/tests/schema/math.test.ts
+++ b/packages/graphql/tests/schema/math.test.ts
@@ -1626,7 +1626,7 @@ describe("Algebraic", () => {
               NOT: ProductionWhere
               OR: [ProductionWhere!]
               typename: [ProductionImplementation!]
-              typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+              typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
               viewers: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
               viewers_EQ: Int
               viewers_GT: Int

--- a/packages/graphql/tests/schema/math.test.ts
+++ b/packages/graphql/tests/schema/math.test.ts
@@ -1625,7 +1625,8 @@ describe("Algebraic", () => {
               AND: [ProductionWhere!]
               NOT: ProductionWhere
               OR: [ProductionWhere!]
-              typename_IN: [ProductionImplementation!]
+              typename: [ProductionImplementation!]
+              typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
               viewers: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
               viewers_EQ: Int
               viewers_GT: Int

--- a/packages/graphql/tests/schema/remove-deprecated/comments.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/comments.test.ts
@@ -1145,7 +1145,8 @@ describe("Comments", () => {
                   title_EQ: String
                   title_IN: [String!]
                   title_STARTS_WITH: String
-                  typename_IN: [ProductionImplementation!]
+                  typename: [ProductionImplementation!]
+                  typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
                 }
 
                 type ProductionsConnection {

--- a/packages/graphql/tests/schema/remove-deprecated/comments.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/comments.test.ts
@@ -1146,7 +1146,7 @@ describe("Comments", () => {
                   title_IN: [String!]
                   title_STARTS_WITH: String
                   typename: [ProductionImplementation!]
-                  typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+                  typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
                 }
 
                 type ProductionsConnection {

--- a/packages/graphql/tests/schema/remove-deprecated/directed-argument.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/directed-argument.test.ts
@@ -770,7 +770,7 @@ describe("Deprecated directed argument", () => {
               title_IN: [String!]
               title_STARTS_WITH: String
               typename: [ProductionImplementation!]
-              typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+              typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
             }
 
             type ProductionsConnection {

--- a/packages/graphql/tests/schema/remove-deprecated/directed-argument.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/directed-argument.test.ts
@@ -769,7 +769,8 @@ describe("Deprecated directed argument", () => {
               title_EQ: String
               title_IN: [String!]
               title_STARTS_WITH: String
-              typename_IN: [ProductionImplementation!]
+              typename: [ProductionImplementation!]
+              typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
             }
 
             type ProductionsConnection {

--- a/packages/graphql/tests/schema/remove-deprecated/options-argument.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/options-argument.test.ts
@@ -722,7 +722,7 @@ describe("Deprecated options argument", () => {
               title_IN: [String!]
               title_STARTS_WITH: String
               typename: [ProductionImplementation!]
-              typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+              typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
             }
 
             type ProductionsConnection {

--- a/packages/graphql/tests/schema/remove-deprecated/options-argument.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/options-argument.test.ts
@@ -721,7 +721,8 @@ describe("Deprecated options argument", () => {
               title_EQ: String
               title_IN: [String!]
               title_STARTS_WITH: String
-              typename_IN: [ProductionImplementation!]
+              typename: [ProductionImplementation!]
+              typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
             }
 
             type ProductionsConnection {

--- a/packages/graphql/tests/schema/remove-deprecated/typename_IN.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/typename_IN.test.ts
@@ -1,0 +1,377 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { printSchemaWithDirectives } from "@graphql-tools/utils";
+import { lexicographicSortSchema } from "graphql/utilities";
+import { Neo4jGraphQL } from "../../../src";
+
+describe("typename_IN", () => {
+    test("should remove typename_IN", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Series implements Production @node {
+                id: ID!
+                title: String!
+                numberOfEpisodes: Int!
+            }
+
+            type Movie implements Production @node {
+                id: ID!
+                title: String!
+            }
+
+            interface Production {
+                id: ID!
+                title: String!
+            }
+        `;
+        const neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            features: {
+                excludeDeprecatedFields: {
+                    typename_IN: true,
+                },
+            },
+        });
+
+        const printedSchema = printSchemaWithDirectives(lexicographicSortSchema(await neoSchema.getSchema()));
+
+        expect(printedSchema).toMatchInlineSnapshot(`
+            "schema {
+              query: Query
+              mutation: Mutation
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships created during a create mutation
+            \\"\\"\\"
+            type CreateInfo {
+              nodesCreated: Int!
+              relationshipsCreated: Int!
+            }
+
+            type CreateMoviesMutationResponse {
+              info: CreateInfo!
+              movies: [Movie!]!
+            }
+
+            type CreateSeriesMutationResponse {
+              info: CreateInfo!
+              series: [Series!]!
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships deleted during a delete mutation
+            \\"\\"\\"
+            type DeleteInfo {
+              nodesDeleted: Int!
+              relationshipsDeleted: Int!
+            }
+
+            type IDAggregateSelection {
+              longest: ID
+              shortest: ID
+            }
+
+            type IntAggregateSelection {
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
+            }
+
+            type Movie implements Production {
+              id: ID!
+              title: String!
+            }
+
+            type MovieAggregateSelection {
+              count: Int!
+              id: IDAggregateSelection!
+              title: StringAggregateSelection!
+            }
+
+            input MovieCreateInput {
+              id: ID!
+              title: String!
+            }
+
+            type MovieEdge {
+              cursor: String!
+              node: Movie!
+            }
+
+            input MovieOptions {
+              limit: Int
+              offset: Int
+              \\"\\"\\"
+              Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array.
+              \\"\\"\\"
+              sort: [MovieSort!]
+            }
+
+            \\"\\"\\"
+            Fields to sort Movies by. The order in which sorts are applied is not guaranteed when specifying many fields in one MovieSort object.
+            \\"\\"\\"
+            input MovieSort {
+              id: SortDirection
+              title: SortDirection
+            }
+
+            input MovieUpdateInput {
+              id: ID @deprecated(reason: \\"Please use the explicit _SET field\\")
+              id_SET: ID
+              title: String @deprecated(reason: \\"Please use the explicit _SET field\\")
+              title_SET: String
+            }
+
+            input MovieWhere {
+              AND: [MovieWhere!]
+              NOT: MovieWhere
+              OR: [MovieWhere!]
+              id: ID @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              id_CONTAINS: ID
+              id_ENDS_WITH: ID
+              id_EQ: ID
+              id_IN: [ID!]
+              id_STARTS_WITH: ID
+              title: String @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              title_CONTAINS: String
+              title_ENDS_WITH: String
+              title_EQ: String
+              title_IN: [String!]
+              title_STARTS_WITH: String
+            }
+
+            type MoviesConnection {
+              edges: [MovieEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type Mutation {
+              createMovies(input: [MovieCreateInput!]!): CreateMoviesMutationResponse!
+              createSeries(input: [SeriesCreateInput!]!): CreateSeriesMutationResponse!
+              deleteMovies(where: MovieWhere): DeleteInfo!
+              deleteSeries(where: SeriesWhere): DeleteInfo!
+              updateMovies(update: MovieUpdateInput, where: MovieWhere): UpdateMoviesMutationResponse!
+              updateSeries(update: SeriesUpdateInput, where: SeriesWhere): UpdateSeriesMutationResponse!
+            }
+
+            \\"\\"\\"Pagination information (Relay)\\"\\"\\"
+            type PageInfo {
+              endCursor: String
+              hasNextPage: Boolean!
+              hasPreviousPage: Boolean!
+              startCursor: String
+            }
+
+            interface Production {
+              id: ID!
+              title: String!
+            }
+
+            type ProductionAggregateSelection {
+              count: Int!
+              id: IDAggregateSelection!
+              title: StringAggregateSelection!
+            }
+
+            type ProductionEdge {
+              cursor: String!
+              node: Production!
+            }
+
+            enum ProductionImplementation {
+              Movie
+              Series
+            }
+
+            input ProductionOptions {
+              limit: Int
+              offset: Int
+              \\"\\"\\"
+              Specify one or more ProductionSort objects to sort Productions by. The sorts will be applied in the order in which they are arranged in the array.
+              \\"\\"\\"
+              sort: [ProductionSort!]
+            }
+
+            \\"\\"\\"
+            Fields to sort Productions by. The order in which sorts are applied is not guaranteed when specifying many fields in one ProductionSort object.
+            \\"\\"\\"
+            input ProductionSort {
+              id: SortDirection
+              title: SortDirection
+            }
+
+            input ProductionWhere {
+              AND: [ProductionWhere!]
+              NOT: ProductionWhere
+              OR: [ProductionWhere!]
+              id: ID @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              id_CONTAINS: ID
+              id_ENDS_WITH: ID
+              id_EQ: ID
+              id_IN: [ID!]
+              id_STARTS_WITH: ID
+              title: String @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              title_CONTAINS: String
+              title_ENDS_WITH: String
+              title_EQ: String
+              title_IN: [String!]
+              title_STARTS_WITH: String
+              typename: [ProductionImplementation!]
+            }
+
+            type ProductionsConnection {
+              edges: [ProductionEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type Query {
+              movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
+              productions(limit: Int, offset: Int, options: ProductionOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ProductionSort!], where: ProductionWhere): [Production!]!
+              productionsAggregate(where: ProductionWhere): ProductionAggregateSelection!
+              productionsConnection(after: String, first: Int, sort: [ProductionSort!], where: ProductionWhere): ProductionsConnection!
+              series(limit: Int, offset: Int, options: SeriesOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [SeriesSort!], where: SeriesWhere): [Series!]!
+              seriesAggregate(where: SeriesWhere): SeriesAggregateSelection!
+              seriesConnection(after: String, first: Int, sort: [SeriesSort!], where: SeriesWhere): SeriesConnection!
+            }
+
+            type Series implements Production {
+              id: ID!
+              numberOfEpisodes: Int!
+              title: String!
+            }
+
+            type SeriesAggregateSelection {
+              count: Int!
+              id: IDAggregateSelection!
+              numberOfEpisodes: IntAggregateSelection!
+              title: StringAggregateSelection!
+            }
+
+            type SeriesConnection {
+              edges: [SeriesEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            input SeriesCreateInput {
+              id: ID!
+              numberOfEpisodes: Int!
+              title: String!
+            }
+
+            type SeriesEdge {
+              cursor: String!
+              node: Series!
+            }
+
+            input SeriesOptions {
+              limit: Int
+              offset: Int
+              \\"\\"\\"
+              Specify one or more SeriesSort objects to sort Series by. The sorts will be applied in the order in which they are arranged in the array.
+              \\"\\"\\"
+              sort: [SeriesSort!]
+            }
+
+            \\"\\"\\"
+            Fields to sort Series by. The order in which sorts are applied is not guaranteed when specifying many fields in one SeriesSort object.
+            \\"\\"\\"
+            input SeriesSort {
+              id: SortDirection
+              numberOfEpisodes: SortDirection
+              title: SortDirection
+            }
+
+            input SeriesUpdateInput {
+              id: ID @deprecated(reason: \\"Please use the explicit _SET field\\")
+              id_SET: ID
+              numberOfEpisodes: Int @deprecated(reason: \\"Please use the explicit _SET field\\")
+              numberOfEpisodes_DECREMENT: Int
+              numberOfEpisodes_INCREMENT: Int
+              numberOfEpisodes_SET: Int
+              title: String @deprecated(reason: \\"Please use the explicit _SET field\\")
+              title_SET: String
+            }
+
+            input SeriesWhere {
+              AND: [SeriesWhere!]
+              NOT: SeriesWhere
+              OR: [SeriesWhere!]
+              id: ID @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              id_CONTAINS: ID
+              id_ENDS_WITH: ID
+              id_EQ: ID
+              id_IN: [ID!]
+              id_STARTS_WITH: ID
+              numberOfEpisodes: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              numberOfEpisodes_EQ: Int
+              numberOfEpisodes_GT: Int
+              numberOfEpisodes_GTE: Int
+              numberOfEpisodes_IN: [Int!]
+              numberOfEpisodes_LT: Int
+              numberOfEpisodes_LTE: Int
+              title: String @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              title_CONTAINS: String
+              title_ENDS_WITH: String
+              title_EQ: String
+              title_IN: [String!]
+              title_STARTS_WITH: String
+            }
+
+            \\"\\"\\"An enum for sorting in either ascending or descending order.\\"\\"\\"
+            enum SortDirection {
+              \\"\\"\\"Sort by field values in ascending order.\\"\\"\\"
+              ASC
+              \\"\\"\\"Sort by field values in descending order.\\"\\"\\"
+              DESC
+            }
+
+            type StringAggregateSelection {
+              longest: String
+              shortest: String
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships created and deleted during an update mutation
+            \\"\\"\\"
+            type UpdateInfo {
+              nodesCreated: Int!
+              nodesDeleted: Int!
+              relationshipsCreated: Int!
+              relationshipsDeleted: Int!
+            }
+
+            type UpdateMoviesMutationResponse {
+              info: UpdateInfo!
+              movies: [Movie!]!
+            }
+
+            type UpdateSeriesMutationResponse {
+              info: UpdateInfo!
+              series: [Series!]!
+            }"
+        `);
+    });
+});

--- a/packages/graphql/tests/schema/subscriptions.test.ts
+++ b/packages/graphql/tests/schema/subscriptions.test.ts
@@ -5041,7 +5041,7 @@ describe("Subscriptions", () => {
               moviesAggregate: CreatureMoviesAggregateInput
               moviesConnection: CreatureMoviesConnectionWhere
               typename: [CreatureImplementation!]
-              typename_IN: [CreatureImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+              typename_IN: [CreatureImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
             }
 
             type CreaturesConnection {
@@ -5509,7 +5509,7 @@ describe("Subscriptions", () => {
               id_IN: [ID]
               id_STARTS_WITH: ID
               typename: [ProductionImplementation!]
-              typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+              typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
             }
 
             type ProductionsConnection {

--- a/packages/graphql/tests/schema/subscriptions.test.ts
+++ b/packages/graphql/tests/schema/subscriptions.test.ts
@@ -5040,7 +5040,8 @@ describe("Subscriptions", () => {
               movies: ProductionWhere
               moviesAggregate: CreatureMoviesAggregateInput
               moviesConnection: CreatureMoviesConnectionWhere
-              typename_IN: [CreatureImplementation!]
+              typename: [CreatureImplementation!]
+              typename_IN: [CreatureImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
             }
 
             type CreaturesConnection {
@@ -5507,7 +5508,8 @@ describe("Subscriptions", () => {
               id_EQ: ID
               id_IN: [ID]
               id_STARTS_WITH: ID
-              typename_IN: [ProductionImplementation!]
+              typename: [ProductionImplementation!]
+              typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
             }
 
             type ProductionsConnection {

--- a/packages/graphql/tests/schema/union-interface-relationship.test.ts
+++ b/packages/graphql/tests/schema/union-interface-relationship.test.ts
@@ -1754,7 +1754,7 @@ describe("Union Interface Relationships", () => {
               reviewerId_LT: Int
               reviewerId_LTE: Int
               typename: [ReviewerImplementation!]
-              typename_IN: [ReviewerImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
+              typename_IN: [ReviewerImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
             }
 
             type ReviewersConnection {

--- a/packages/graphql/tests/schema/union-interface-relationship.test.ts
+++ b/packages/graphql/tests/schema/union-interface-relationship.test.ts
@@ -1753,7 +1753,8 @@ describe("Union Interface Relationships", () => {
               reviewerId_IN: [Int]
               reviewerId_LT: Int
               reviewerId_LTE: Int
-              typename_IN: [ReviewerImplementation!]
+              typename: [ReviewerImplementation!]
+              typename_IN: [ReviewerImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filters instead\\")
             }
 
             type ReviewersConnection {


### PR DESCRIPTION
# Description

As the title, this PR backports the typename filter in favor of typename_IN in version 6 of the library.

The flag `typename_IN` is been added to the `excludeDeprecatedFields` config.

