### PR TITLE
Node validation

### DIFF
--- a/packages/graphql/src/schema/validation/custom-rules/valid-types/node-missing-validation.test.ts
+++ b/packages/graphql/src/schema/validation/custom-rules/valid-types/node-missing-validation.test.ts
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { GraphQLSchema } from "graphql";
+import { gql } from "graphql-tag";
+import {
+    cypherDirective,
+    filterableDirective,
+    fulltextDirective,
+    idDirective,
+    mutationDirective,
+    populatedByDirective,
+    queryDirective,
+    relationshipDirective,
+    relayIdDirective,
+    selectableDirective,
+    settableDirective,
+    subscriptionDirective,
+    timestampDirective,
+    vectorDirective,
+} from "../../../../graphql/directives";
+import { authenticationDirectiveScaffold } from "../../../../graphql/directives/type-dependant-directives/authentication";
+import { authorizationDirectiveScaffold } from "../../../../graphql/directives/type-dependant-directives/authorization";
+import { subscriptionsAuthorizationDirectiveScaffold } from "../../../../graphql/directives/type-dependant-directives/subscriptions-authorization";
+import { validateSDL } from "../../validate-sdl";
+import { nodeMissingValidation } from "./node-missing-validation";
+
+describe("node missing validation", () => {
+    test.each([
+        authorizationDirectiveScaffold.name,
+        authenticationDirectiveScaffold.name,
+        subscriptionsAuthorizationDirectiveScaffold.name,
+        queryDirective.name,
+        mutationDirective.name,
+        subscriptionDirective.name,
+        fulltextDirective.name,
+        vectorDirective.name,
+    ])("when the %s directive is used on a type annotated with @node no error should be raised", (name) => {
+        const userDocument = gql`
+            type User @${name} @node {
+                id: ID!
+                name: String!
+            }
+        `;
+        const errors = validateSDL(userDocument, [nodeMissingValidation], new GraphQLSchema({}));
+        expect(errors).toBeInstanceOf(Array);
+        expect(errors).toHaveLength(0);
+    });
+
+    test.each([
+        authorizationDirectiveScaffold.name,
+        authenticationDirectiveScaffold.name,
+        subscriptionsAuthorizationDirectiveScaffold.name,
+        queryDirective.name,
+        mutationDirective.name,
+        subscriptionDirective.name,
+        fulltextDirective.name,
+        vectorDirective.name,
+    ])("when the %s directive is used on a type non annotated with @node an error should be raised", (name) => {
+        const userDocument = gql`
+            type User @${name} {
+                id: ID!
+                name: String!
+            }
+        `;
+        const errors = validateSDL(userDocument, [nodeMissingValidation], new GraphQLSchema({}));
+        expect(errors).toBeInstanceOf(Array);
+        expect(errors).toHaveLength(1);
+        expect(errors).toEqual([
+            expect.objectContaining({
+                message: expect.stringContaining(`requires to be used within the "@node" directive`),
+            }),
+        ]);
+    });
+
+    test("when a node-related directive is used on a extension type should raise an error when @node is not found", () => {
+        const userDocument = gql`
+            type User {
+                id: ID!
+                name: String!
+            }
+            extend type User @query(read: true) {
+                extra: String
+            }
+        `;
+        const errors = validateSDL(userDocument, [nodeMissingValidation], new GraphQLSchema({}));
+        expect(errors).toBeInstanceOf(Array);
+        expect(errors).toHaveLength(1);
+        expect(errors).toEqual([
+            expect.objectContaining({
+                message: expect.stringContaining(`requires to be used within the "@node" directive`),
+            }),
+        ]);
+    });
+
+    test("when a node-related directive is used on a extension type should not raise an error when @node is found", () => {
+        const userDocument = gql`
+            type User {
+                id: ID!
+                name: String!
+            }
+            extend type User @query(read: true) {
+                extra: String
+            }
+            extend type User @node {
+                extra2: String
+            }
+        `;
+        const errors = validateSDL(userDocument, [nodeMissingValidation], new GraphQLSchema({}));
+        expect(errors).toBeInstanceOf(Array);
+        expect(errors).toHaveLength(0);
+    });
+
+    test.each([
+        authorizationDirectiveScaffold.name,
+        authenticationDirectiveScaffold.name,
+        subscriptionsAuthorizationDirectiveScaffold.name,
+        relationshipDirective.name,
+        cypherDirective.name,
+        idDirective.name,
+        relayIdDirective.name,
+        timestampDirective.name,
+        populatedByDirective.name,
+        selectableDirective.name,
+        settableDirective.name,
+        filterableDirective.name,
+    ])(
+        "when the %s directive is used on a field on a type non annotated with @node an error should be raised",
+        (name) => {
+            const userDocument = gql`
+            type User @node {
+                id: ID!
+                name: String! @${name}
+            }
+        `;
+            const errors = validateSDL(userDocument, [nodeMissingValidation], new GraphQLSchema({}));
+            expect(errors).toBeInstanceOf(Array);
+            expect(errors).toHaveLength(0);
+        }
+    );
+
+    test.each([
+        authorizationDirectiveScaffold.name,
+        authenticationDirectiveScaffold.name,
+        subscriptionsAuthorizationDirectiveScaffold.name,
+        relationshipDirective.name,
+        cypherDirective.name,
+        idDirective.name,
+        relayIdDirective.name,
+        timestampDirective.name,
+        populatedByDirective.name,
+        selectableDirective.name,
+        settableDirective.name,
+        filterableDirective.name,
+    ])(
+        "when the %s directive is used on a field on a type non annotated with @node an error should be raised",
+        (name) => {
+            const userDocument = gql`
+            type User {
+                id: ID!
+                name: String! @${name}
+            }
+        `;
+            const errors = validateSDL(userDocument, [nodeMissingValidation], new GraphQLSchema({}));
+            expect(errors).toBeInstanceOf(Array);
+            expect(errors).toHaveLength(1);
+            expect(errors).toEqual([
+                expect.objectContaining({
+                    message: expect.stringContaining(`requires to be used within the "@node" directive`),
+                }),
+            ]);
+        }
+    );
+
+    test("node-related directives can be used within @node types, with @node defined in type extension", () => {
+        const userDocument = gql`
+            type User {
+                id: ID!
+                name: String!
+                posts: [Post!]! @relationship(type: "HAS_POST", direction: OUT)
+            }
+
+            extend type User @node
+
+            type Post @node {
+                id: ID!
+                title: String!
+            }
+        `;
+        const errors = validateSDL(userDocument, [nodeMissingValidation], new GraphQLSchema({}));
+        expect(errors).toBeInstanceOf(Array);
+        expect(errors).toHaveLength(0);
+    });
+
+    test("node-related directives can be used within @node types, with directive defined in type extension", () => {
+        const userDocument = gql`
+            type User @node {
+                id: ID!
+                name: String!
+            }
+
+            extend type User @node {
+                posts: [Post!]! @relationship(type: "HAS_POST", direction: OUT)
+            }
+
+            type Post @node {
+                id: ID!
+                title: String!
+            }
+        `;
+        const errors = validateSDL(userDocument, [nodeMissingValidation], new GraphQLSchema({}));
+        expect(errors).toBeInstanceOf(Array);
+        expect(errors).toHaveLength(0);
+    });
+});

--- a/packages/graphql/src/schema/validation/custom-rules/valid-types/node-missing-validation.test.ts
+++ b/packages/graphql/src/schema/validation/custom-rules/valid-types/node-missing-validation.test.ts
@@ -20,22 +20,14 @@
 import { GraphQLSchema } from "graphql";
 import { gql } from "graphql-tag";
 import {
-    cypherDirective,
-    filterableDirective,
     fulltextDirective,
-    idDirective,
     mutationDirective,
-    populatedByDirective,
     queryDirective,
     relationshipDirective,
     relayIdDirective,
-    selectableDirective,
-    settableDirective,
     subscriptionDirective,
-    timestampDirective,
     vectorDirective,
 } from "../../../../graphql/directives";
-import { authenticationDirectiveScaffold } from "../../../../graphql/directives/type-dependant-directives/authentication";
 import { authorizationDirectiveScaffold } from "../../../../graphql/directives/type-dependant-directives/authorization";
 import { subscriptionsAuthorizationDirectiveScaffold } from "../../../../graphql/directives/type-dependant-directives/subscriptions-authorization";
 import { validateSDL } from "../../validate-sdl";
@@ -44,7 +36,6 @@ import { nodeMissingValidation } from "./node-missing-validation";
 describe("node missing validation", () => {
     test.each([
         authorizationDirectiveScaffold.name,
-        authenticationDirectiveScaffold.name,
         subscriptionsAuthorizationDirectiveScaffold.name,
         queryDirective.name,
         mutationDirective.name,
@@ -65,7 +56,6 @@ describe("node missing validation", () => {
 
     test.each([
         authorizationDirectiveScaffold.name,
-        authenticationDirectiveScaffold.name,
         subscriptionsAuthorizationDirectiveScaffold.name,
         queryDirective.name,
         mutationDirective.name,
@@ -129,17 +119,9 @@ describe("node missing validation", () => {
 
     test.each([
         authorizationDirectiveScaffold.name,
-        authenticationDirectiveScaffold.name,
         subscriptionsAuthorizationDirectiveScaffold.name,
         relationshipDirective.name,
-        cypherDirective.name,
-        idDirective.name,
         relayIdDirective.name,
-        timestampDirective.name,
-        populatedByDirective.name,
-        selectableDirective.name,
-        settableDirective.name,
-        filterableDirective.name,
     ])(
         "when the %s directive is used on a field on a type non annotated with @node an error should be raised",
         (name) => {
@@ -157,17 +139,9 @@ describe("node missing validation", () => {
 
     test.each([
         authorizationDirectiveScaffold.name,
-        authenticationDirectiveScaffold.name,
         subscriptionsAuthorizationDirectiveScaffold.name,
         relationshipDirective.name,
-        cypherDirective.name,
-        idDirective.name,
         relayIdDirective.name,
-        timestampDirective.name,
-        populatedByDirective.name,
-        selectableDirective.name,
-        settableDirective.name,
-        filterableDirective.name,
     ])(
         "when the %s directive is used on a field on a type non annotated with @node an error should be raised",
         (name) => {

--- a/packages/graphql/src/schema/validation/custom-rules/valid-types/node-missing-validation.ts
+++ b/packages/graphql/src/schema/validation/custom-rules/valid-types/node-missing-validation.ts
@@ -1,0 +1,175 @@
+// /*
+//  * Copyright (c) "Neo4j"
+//  * Neo4j Sweden AB [http://neo4j.com]
+//  *
+//  * This file is part of Neo4j.
+//  *
+//  * Licensed under the Apache License, Version 2.0 (the "License");
+//  * you may not use this file except in compliance with the License.
+//  * You may obtain a copy of the License at
+//  *
+//  *     http://www.apache.org/licenses/LICENSE-2.0
+//  *
+//  * Unless required by applicable law or agreed to in writing, software
+//  * distributed under the License is distributed on an "AS IS" BASIS,
+//  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  * See the License for the specific language governing permissions and
+//  * limitations under the License.
+//  */
+
+import type { ASTVisitor, FieldDefinitionNode, ObjectTypeDefinitionNode, ObjectTypeExtensionNode } from "graphql";
+import { Kind } from "graphql";
+import type { SDLValidationContext } from "graphql/validation/ValidationContext";
+import {
+    cypherDirective,
+    filterableDirective,
+    fulltextDirective,
+    idDirective,
+    mutationDirective,
+    nodeDirective,
+    populatedByDirective,
+    queryDirective,
+    relationshipDirective,
+    relayIdDirective,
+    selectableDirective,
+    settableDirective,
+    subscriptionDirective,
+    timestampDirective,
+    vectorDirective,
+} from "../../../../graphql/directives";
+import { authenticationDirectiveScaffold } from "../../../../graphql/directives/type-dependant-directives/authentication";
+import { authorizationDirectiveScaffold } from "../../../../graphql/directives/type-dependant-directives/authorization";
+import { subscriptionsAuthorizationDirectiveScaffold } from "../../../../graphql/directives/type-dependant-directives/subscriptions-authorization";
+import { asArray } from "../../../../utils/utils";
+import { assertValid, createGraphQLError, DocumentValidationError } from "../utils/document-validation-error";
+import { getPathToNode } from "../utils/path-parser";
+
+type ObjectExtensionsTypeMap = {
+    extensions: ObjectTypeExtensionNode[];
+    definition: ObjectTypeDefinitionNode;
+};
+export function nodeMissingValidation(context: SDLValidationContext): ASTVisitor {
+    const extensionsTypeMap: Record<string, ObjectExtensionsTypeMap> = context
+        .getDocument()
+        .definitions.reduce((acc, def): Record<string, ObjectExtensionsTypeMap> => {
+            if (def.kind === Kind.OBJECT_TYPE_EXTENSION || def.kind === Kind.OBJECT_TYPE_DEFINITION) {
+                const typeName = def.name.value;
+                if (!acc[typeName]) {
+                    acc[typeName] = { extensions: [], definition: undefined };
+                }
+                if (def.kind === Kind.OBJECT_TYPE_EXTENSION) {
+                    if (acc[typeName].extensions) {
+                        acc[typeName].extensions.push(def);
+                    } else {
+                        acc[typeName].extensions = [def];
+                    }
+                } else {
+                    acc[typeName].definition = def;
+                }
+            }
+            return acc;
+        }, {});
+    return {
+        FieldDefinition(fieldDefinitionNode: FieldDefinitionNode, _key, _parent, path, ancestors) {
+            const [_pathToNode, _traversedDef, parentOfTraversedDef] = getPathToNode(path, ancestors);
+            if (!parentOfTraversedDef) {
+                return;
+            }
+            const parentTypeAndExtensions = extensionsTypeMap[parentOfTraversedDef.name.value];
+            if (!parentTypeAndExtensions) {
+                return;
+            }
+            const allDirectives = [
+                ...(parentTypeAndExtensions.definition.directives ?? []),
+                ...parentTypeAndExtensions.extensions.flatMap((ext) => ext.directives ?? []),
+            ];
+            const nodeUsage = allDirectives?.find((directive) => directive.name.value === nodeDirective.name);
+            if (nodeUsage) {
+                return;
+            }
+            // if `@node` is not found then check that check that no directives that requires `@node` are present
+            const { isValid, errorMsg } = assertValid(() => {
+                const nodeRelatedDirectives = [
+                    authorizationDirectiveScaffold.name,
+                    authenticationDirectiveScaffold.name,
+                    subscriptionsAuthorizationDirectiveScaffold.name,
+                    relationshipDirective.name,
+                    cypherDirective.name,
+                    idDirective.name,
+                    relayIdDirective.name,
+                    timestampDirective.name,
+                    populatedByDirective.name,
+                    selectableDirective.name,
+                    settableDirective.name,
+                    filterableDirective.name,
+                ];
+
+                for (const directive of fieldDefinitionNode.directives ?? []) {
+                    if (nodeRelatedDirectives.includes(directive.name.value)) {
+                        throw new DocumentValidationError(
+                            `Directive "${directive.name.value}" requires to be used within the "@node" directive`,
+                            []
+                        );
+                    }
+                }
+            });
+
+            if (!isValid) {
+                context.reportError(
+                    createGraphQLError({
+                        nodes: [fieldDefinitionNode],
+                        path,
+                        errorMsg,
+                    })
+                );
+            }
+
+            return;
+        },
+        ObjectTypeDefinition(objectTypeDefinitionNode: ObjectTypeDefinitionNode) {
+            const { directives } = objectTypeDefinitionNode;
+            const objectTypeExtensionNodes = extensionsTypeMap[objectTypeDefinitionNode.name.value]?.extensions;
+
+            const extensionsDirectives = asArray(objectTypeExtensionNodes).flatMap((extensionNode) => {
+                return extensionNode.directives ?? [];
+            });
+            const allDirectives = [...(directives ?? []), ...extensionsDirectives];
+            const nodeUsage = allDirectives?.find((directive) => directive.name.value === nodeDirective.name);
+            if (nodeUsage) {
+                return;
+            }
+            // if `@node` is not found then check that check that no directives that requires `@node` are present
+            const nodeRelatedDirectives = [
+                authorizationDirectiveScaffold.name,
+                authenticationDirectiveScaffold.name,
+                subscriptionsAuthorizationDirectiveScaffold.name,
+                queryDirective.name,
+                mutationDirective.name,
+                subscriptionDirective.name,
+                fulltextDirective.name,
+                vectorDirective.name,
+            ];
+
+            const { isValid, errorMsg } = assertValid(() => {
+                for (const directive of allDirectives ?? []) {
+                    if (nodeRelatedDirectives.includes(directive.name.value)) {
+                        throw new DocumentValidationError(
+                            `Directive "${directive.name.value}" requires to be used within the "@node" directive`,
+                            []
+                        );
+                    }
+                }
+            });
+
+            if (!isValid) {
+                context.reportError(
+                    createGraphQLError({
+                        nodes: [objectTypeDefinitionNode],
+                        path: [objectTypeDefinitionNode.name.value],
+                        errorMsg,
+                    })
+                );
+            }
+        },
+    };
+}

--- a/packages/graphql/src/schema/validation/custom-rules/valid-types/node-missing-validation.ts
+++ b/packages/graphql/src/schema/validation/custom-rules/valid-types/node-missing-validation.ts
@@ -21,23 +21,15 @@ import type { ASTVisitor, FieldDefinitionNode, ObjectTypeDefinitionNode, ObjectT
 import { Kind } from "graphql";
 import type { SDLValidationContext } from "graphql/validation/ValidationContext";
 import {
-    cypherDirective,
-    filterableDirective,
     fulltextDirective,
-    idDirective,
     mutationDirective,
     nodeDirective,
-    populatedByDirective,
     queryDirective,
     relationshipDirective,
     relayIdDirective,
-    selectableDirective,
-    settableDirective,
     subscriptionDirective,
-    timestampDirective,
     vectorDirective,
 } from "../../../../graphql/directives";
-import { authenticationDirectiveScaffold } from "../../../../graphql/directives/type-dependant-directives/authentication";
 import { authorizationDirectiveScaffold } from "../../../../graphql/directives/type-dependant-directives/authorization";
 import { subscriptionsAuthorizationDirectiveScaffold } from "../../../../graphql/directives/type-dependant-directives/subscriptions-authorization";
 import { asArray } from "../../../../utils/utils";
@@ -48,6 +40,25 @@ type ObjectExtensionsTypeMap = {
     extensions: ObjectTypeExtensionNode[];
     definition: ObjectTypeDefinitionNode;
 };
+/**
+ *  The below validation is here to help users to catch common issues
+ *  when using directives that are supposed to be used within the `@node` directive
+ *  but the `@node` directive is missing.
+ *  The below will raise an error if any of these cases are found:
+ *  if any of the following directive are found in a type that is not annotated with `@node`:
+ *  - authorization
+ *  - subscriptionAuthorization
+ *  - query
+ *  - mutation
+ *  - subscription
+ *  - fulltext
+ *  - vector
+ *  if any of the following directive are found in a field that is not annotated with `@node`:
+ *  - authorization
+ *  - subscriptionAuthorization
+ *  - relationship
+ *  - relayId
+ **/
 export function nodeMissingValidation(context: SDLValidationContext): ASTVisitor {
     const extensionsTypeMap: Record<string, ObjectExtensionsTypeMap> = context
         .getDocument()
@@ -71,6 +82,9 @@ export function nodeMissingValidation(context: SDLValidationContext): ASTVisitor
         }, {});
     return {
         FieldDefinition(fieldDefinitionNode: FieldDefinitionNode, _key, _parent, path, ancestors) {
+            if (!fieldDefinitionNode.directives?.length) {
+                return;
+            }
             const [_pathToNode, _traversedDef, parentOfTraversedDef] = getPathToNode(path, ancestors);
             if (!parentOfTraversedDef) {
                 return;
@@ -91,17 +105,9 @@ export function nodeMissingValidation(context: SDLValidationContext): ASTVisitor
             const { isValid, errorMsg } = assertValid(() => {
                 const nodeRelatedDirectives = [
                     authorizationDirectiveScaffold.name,
-                    authenticationDirectiveScaffold.name,
                     subscriptionsAuthorizationDirectiveScaffold.name,
                     relationshipDirective.name,
-                    cypherDirective.name,
-                    idDirective.name,
                     relayIdDirective.name,
-                    timestampDirective.name,
-                    populatedByDirective.name,
-                    selectableDirective.name,
-                    settableDirective.name,
-                    filterableDirective.name,
                 ];
 
                 for (const directive of fieldDefinitionNode.directives ?? []) {
@@ -141,7 +147,6 @@ export function nodeMissingValidation(context: SDLValidationContext): ASTVisitor
             // if `@node` is not found then check that check that no directives that requires `@node` are present
             const nodeRelatedDirectives = [
                 authorizationDirectiveScaffold.name,
-                authenticationDirectiveScaffold.name,
                 subscriptionsAuthorizationDirectiveScaffold.name,
                 queryDirective.name,
                 mutationDirective.name,

--- a/packages/graphql/src/schema/validation/validate-document.ts
+++ b/packages/graphql/src/schema/validation/validate-document.ts
@@ -69,6 +69,7 @@ import { WarnObjectFieldsWithoutResolver } from "./custom-rules/warnings/object-
 import { WarnIfSubscriptionsAuthorizationMissing } from "./custom-rules/warnings/subscriptions-authorization-missing";
 import { validateSchemaCustomizations } from "./validate-schema-customizations";
 import { validateSDL } from "./validate-sdl";
+import { nodeMissingValidation } from "./custom-rules/valid-types/node-missing-validation";
 
 function filterDocument(document: DocumentNode, filterDirectives: boolean = false): DocumentNode {
     const nodeNames = document.definitions
@@ -231,6 +232,7 @@ function runValidationRulesOnFilteredDocument({
             }),
             ValidListInNodeType,
             WarnIfSubscriptionsAuthorizationMissing(Boolean(features?.subscriptions)),
+            nodeMissingValidation,
         ],
         schema
     );


### PR DESCRIPTION
This PR adds validation errors to help identify common mistakes when a directive is expected to be used in the context of a `@node` type but the `@node` type is missing.

A follow-up PR will be open to cover cases when a field references a type expected to be `@node` but is not marked as a `@node`, for instance a`@relationship` field that targets an object type without the `@node` directive. 

## Complexity

Complexity: Low

