### PR TITLE
Top Level aggregations in connections

### DIFF
--- a/.changeset/hot-windows-whisper.md
+++ b/.changeset/hot-windows-whisper.md
@@ -1,0 +1,20 @@
+---
+"@neo4j/graphql": minor
+---
+
+Add aggregate fieldd in connection:
+
+```graphql
+query {
+    moviesConnection {
+        aggregate {
+            node {
+                count
+                int {
+                    longest
+                }
+            }
+        }
+    }
+}
+```

--- a/.changeset/thin-goats-begin.md
+++ b/.changeset/thin-goats-begin.md
@@ -1,0 +1,25 @@
+---
+"@neo4j/graphql": patch
+---
+
+Deprecated old aggregate operations:
+
+```graphql
+query {
+    moviesAggregate {
+        count
+        rating {
+            min
+        }
+    }
+}
+```
+
+These fields can be completely removed from the schema with the new flag `deprecatedAggregateOperations`:
+
+```js
+const neoSchema = new Neo4jGraphQL({
+    typeDefs,
+    features: { excludeDeprecatedFields: { deprecatedAggregateOperations: true } },
+});
+```

--- a/packages/graphql/src/schema-model/entity/model-adapters/ImplementingEntityOperations.ts
+++ b/packages/graphql/src/schema-model/entity/model-adapters/ImplementingEntityOperations.ts
@@ -33,6 +33,8 @@ export type RootTypeFieldNames = {
 type AggregateTypeNames = {
     selection: string;
     input: string;
+    connection: string;
+    node: string;
 };
 
 type MutationResponseTypeNames = {
@@ -161,6 +163,8 @@ export class ImplementingEntityOperations<T extends InterfaceEntityAdapter | Con
         return {
             selection: `${this.entityAdapter.name}AggregateSelection`,
             input: `${this.entityAdapter.name}AggregateSelectionInput`,
+            connection: `${this.entityAdapter.name}Aggregate`,
+            node: `${this.entityAdapter.name}AggregateNode`,
         };
     }
 

--- a/packages/graphql/src/schema/constants.ts
+++ b/packages/graphql/src/schema/constants.ts
@@ -18,6 +18,8 @@
  */
 
 import { DEPRECATED } from "../constants";
+import type { ConcreteEntityAdapter } from "../schema-model/entity/model-adapters/ConcreteEntityAdapter";
+import type { InterfaceEntityAdapter } from "../schema-model/entity/model-adapters/InterfaceEntityAdapter";
 
 export const DEPRECATE_IMPLICIT_EQUAL_FILTERS = {
     name: DEPRECATED,
@@ -61,7 +63,6 @@ export const DEPRECATE_OVERWRITE = {
     },
 };
 
-
 export const DEPRECATE_ID_AGGREGATION = {
     name: DEPRECATED,
     args: {
@@ -75,3 +76,12 @@ export const DEPRECATE_TYPENAME_IN = {
         reason: "The typename_IN filter is deprecated, please use the typename filter instead",
     },
 };
+
+export function DEPRECATE_AGGREGATION(entity: ConcreteEntityAdapter | InterfaceEntityAdapter) {
+    return {
+        name: DEPRECATED,
+        args: {
+            reason: `Please use the explicit the field "aggregate" inside "${entity.operations.rootTypeFieldNames.connection}"`,
+        },
+    };
+}

--- a/packages/graphql/src/schema/generation/aggregate-types.ts
+++ b/packages/graphql/src/schema/generation/aggregate-types.ts
@@ -63,7 +63,51 @@ export function withAggregateSelectionType({
         directives: graphqlDirectivesToCompose(propagatedDirectives),
     });
     aggregateSelection.addFields(makeAggregableFields({ entityAdapter, aggregationTypesMapper, features }));
+
+    createConnectionAggregate({
+        entityAdapter,
+        aggregationTypesMapper,
+        propagatedDirectives,
+        composer,
+        features,
+    });
     return aggregateSelection;
+}
+
+/** Create aggregate field inside connections */
+function createConnectionAggregate({
+    entityAdapter,
+    aggregationTypesMapper,
+    propagatedDirectives,
+    composer,
+    features,
+}: {
+    entityAdapter: ConcreteEntityAdapter | InterfaceEntityAdapter;
+    aggregationTypesMapper: AggregationTypesMapper;
+    propagatedDirectives: DirectiveNode[];
+    composer: SchemaComposer;
+    features: Neo4jFeaturesSettings | undefined;
+}): ObjectTypeComposer {
+    const aggregateNode = composer.createObjectTC({
+        name: entityAdapter.operations.aggregateTypeNames.node,
+        fields: {
+            count: {
+                type: new GraphQLNonNull(GraphQLInt),
+                resolve: numericalResolver,
+                args: {},
+            },
+        },
+        directives: graphqlDirectivesToCompose(propagatedDirectives),
+    });
+    aggregateNode.addFields(makeAggregableFields({ entityAdapter, aggregationTypesMapper, features }));
+
+    return composer.createObjectTC({
+        name: entityAdapter.operations.aggregateTypeNames.connection,
+        fields: {
+            node: aggregateNode.NonNull,
+        },
+        directives: graphqlDirectivesToCompose(propagatedDirectives),
+    });
 }
 
 function makeAggregableFields({

--- a/packages/graphql/src/schema/make-augmented-schema.ts
+++ b/packages/graphql/src/schema/make-augmented-schema.ts
@@ -72,6 +72,7 @@ import { RelationshipDeclarationAdapter } from "../schema-model/relationship/mod
 import type { CypherField, Neo4jFeaturesSettings } from "../types";
 import { filterTruthy } from "../utils/utils";
 import { augmentVectorSchema } from "./augment/vector";
+import { DEPRECATE_AGGREGATION } from "./constants";
 import { createConnectionFields } from "./create-connection-fields";
 import { addGlobalNodeFields } from "./create-global-nodes";
 import { createRelationshipFields } from "./create-relationship-fields/create-relationship-fields";
@@ -580,15 +581,16 @@ function generateObjectType({
             features,
         });
 
+        // TODO: remove with deprecated flag
         composer.Query.addFields({
             [concreteEntityAdapter.operations.rootTypeFieldNames.aggregate]: aggregateResolver({
                 entityAdapter: concreteEntityAdapter,
             }),
         });
-        composer.Query.setFieldDirectives(
-            concreteEntityAdapter.operations.rootTypeFieldNames.aggregate,
-            graphqlDirectivesToCompose(propagatedDirectives)
-        );
+        composer.Query.setFieldDirectives(concreteEntityAdapter.operations.rootTypeFieldNames.aggregate, [
+            ...graphqlDirectivesToCompose(propagatedDirectives),
+            DEPRECATE_AGGREGATION(concreteEntityAdapter),
+        ]);
     }
 
     if (concreteEntityAdapter.isCreatable) {
@@ -725,9 +727,9 @@ function generateInterfaceObjectType({
                 entityAdapter: interfaceEntityAdapter,
             }),
         });
-        composer.Query.setFieldDirectives(
-            interfaceEntityAdapter.operations.rootTypeFieldNames.aggregate,
-            graphqlDirectivesToCompose(propagatedDirectives)
-        );
+        composer.Query.setFieldDirectives(interfaceEntityAdapter.operations.rootTypeFieldNames.aggregate, [
+            ...graphqlDirectivesToCompose(propagatedDirectives),
+            DEPRECATE_AGGREGATION(interfaceEntityAdapter),
+        ]);
     }
 }

--- a/packages/graphql/src/schema/make-augmented-schema.ts
+++ b/packages/graphql/src/schema/make-augmented-schema.ts
@@ -84,6 +84,7 @@ import { withObjectType } from "./generation/object-type";
 import { withMutationResponseTypes } from "./generation/response-types";
 import { withOptionsInputType } from "./generation/sort-and-options-input";
 import { withUpdateInputType } from "./generation/update-input";
+import { shouldAddDeprecatedFields } from "./generation/utils";
 import { withUniqueWhereInputType, withWhereInputType } from "./generation/where-input";
 import getNodes from "./get-nodes";
 import { getResolveAndSubscriptionMethods } from "./get-resolve-and-subscription-methods";
@@ -581,16 +582,17 @@ function generateObjectType({
             features,
         });
 
-        // TODO: remove with deprecated flag
-        composer.Query.addFields({
-            [concreteEntityAdapter.operations.rootTypeFieldNames.aggregate]: aggregateResolver({
-                entityAdapter: concreteEntityAdapter,
-            }),
-        });
-        composer.Query.setFieldDirectives(concreteEntityAdapter.operations.rootTypeFieldNames.aggregate, [
-            ...graphqlDirectivesToCompose(propagatedDirectives),
-            DEPRECATE_AGGREGATION(concreteEntityAdapter),
-        ]);
+        if (shouldAddDeprecatedFields(features, "deprecatedAggregateOperations")) {
+            composer.Query.addFields({
+                [concreteEntityAdapter.operations.rootTypeFieldNames.aggregate]: aggregateResolver({
+                    entityAdapter: concreteEntityAdapter,
+                }),
+            });
+            composer.Query.setFieldDirectives(concreteEntityAdapter.operations.rootTypeFieldNames.aggregate, [
+                ...graphqlDirectivesToCompose(propagatedDirectives),
+                DEPRECATE_AGGREGATION(concreteEntityAdapter),
+            ]);
+        }
     }
 
     if (concreteEntityAdapter.isCreatable) {
@@ -722,14 +724,17 @@ function generateInterfaceObjectType({
             features,
         });
 
-        composer.Query.addFields({
-            [interfaceEntityAdapter.operations.rootTypeFieldNames.aggregate]: aggregateResolver({
-                entityAdapter: interfaceEntityAdapter,
-            }),
-        });
-        composer.Query.setFieldDirectives(interfaceEntityAdapter.operations.rootTypeFieldNames.aggregate, [
-            ...graphqlDirectivesToCompose(propagatedDirectives),
-            DEPRECATE_AGGREGATION(interfaceEntityAdapter),
-        ]);
+        if (shouldAddDeprecatedFields(features, "deprecatedAggregateOperations")) {
+            composer.Query.addFields({
+                [interfaceEntityAdapter.operations.rootTypeFieldNames.aggregate]: aggregateResolver({
+                    entityAdapter: interfaceEntityAdapter,
+                }),
+            });
+
+            composer.Query.setFieldDirectives(interfaceEntityAdapter.operations.rootTypeFieldNames.aggregate, [
+                ...graphqlDirectivesToCompose(propagatedDirectives),
+                DEPRECATE_AGGREGATION(interfaceEntityAdapter),
+            ]);
+        }
     }
 }

--- a/packages/graphql/src/schema/pagination.test.ts
+++ b/packages/graphql/src/schema/pagination.test.ts
@@ -47,6 +47,7 @@ describe("cursor-pagination", () => {
                 selectionSet: undefined,
             });
             expect(result).toStrictEqual({
+                aggregate: {},
                 edges: arraySlice.map((edge, index) => ({ ...edge, cursor: offsetToCursor(index) })),
                 pageInfo: {
                     hasNextPage: false,
@@ -68,6 +69,7 @@ describe("cursor-pagination", () => {
                 selectionSet: undefined,
             });
             expect(result).toStrictEqual({
+                aggregate: {},
                 edges: arraySlice.map((edge, index) => ({ ...edge, cursor: offsetToCursor(index) })),
                 pageInfo: {
                     hasNextPage: false,
@@ -88,6 +90,7 @@ describe("cursor-pagination", () => {
                 selectionSet: undefined,
             });
             expect(result).toStrictEqual({
+                aggregate: {},
                 edges: arraySlice.map((edge, index) => ({ ...edge, cursor: offsetToCursor(index + 11) })),
                 pageInfo: {
                     hasNextPage: false,

--- a/packages/graphql/src/schema/pagination.ts
+++ b/packages/graphql/src/schema/pagination.ts
@@ -92,6 +92,7 @@ export function createConnectionWithEdgeProperties({
     const sliceStart = lastEdgeCursor + 1;
 
     const edges: any[] = source?.edges || [];
+    const aggregate: any = source?.aggregate || {};
 
     const selections = selectionSet?.selections || [];
 
@@ -114,6 +115,7 @@ export function createConnectionWithEdgeProperties({
 
     const pageInfoKey = getAliasKey({ selectionSet, key: "pageInfo" });
     const edgesKey = getAliasKey({ selectionSet, key: "edges" });
+    const aggregateKey = getAliasKey({ selectionSet, key: "aggregate" });
     const pageInfoField = selections.find((x): x is FieldNode => x.kind === Kind.FIELD && x.name.value === "pageInfo");
     const pageInfoSelectionSet = pageInfoField?.selectionSet;
     const startCursorKey = getAliasKey({ selectionSet: pageInfoSelectionSet, key: "startCursor" });
@@ -123,6 +125,7 @@ export function createConnectionWithEdgeProperties({
 
     return {
         [edgesKey]: mappedEdges,
+        [aggregateKey]: aggregate,
         [pageInfoKey]: {
             [startCursorKey]: startCursor,
             [endCursorKey]: endCursor,

--- a/packages/graphql/src/schema/resolvers/query/aggregate.ts
+++ b/packages/graphql/src/schema/resolvers/query/aggregate.ts
@@ -21,11 +21,11 @@ import type { GraphQLResolveInfo } from "graphql";
 import type { ConcreteEntityAdapter } from "../../../schema-model/entity/model-adapters/ConcreteEntityAdapter";
 import type { InterfaceEntityAdapter } from "../../../schema-model/entity/model-adapters/InterfaceEntityAdapter";
 import { translateAggregate } from "../../../translate";
+import { isConcreteEntity } from "../../../translate/queryAST/utils/is-concrete-entity";
 import type { Neo4jGraphQLTranslationContext } from "../../../types/neo4j-graphql-translation-context";
 import { execute } from "../../../utils";
 import getNeo4jResolveTree from "../../../utils/get-neo4j-resolve-tree";
 import type { Neo4jGraphQLComposedContext } from "../composition/wrap-query-and-mutation";
-import { isConcreteEntity } from "../../../translate/queryAST/utils/is-concrete-entity";
 
 export function aggregateResolver({
     entityAdapter,

--- a/packages/graphql/src/schema/resolvers/query/root-connection.ts
+++ b/packages/graphql/src/schema/resolvers/query/root-connection.ts
@@ -25,7 +25,7 @@ import {
     type GraphQLResolveInfo,
     type SelectionSetNode,
 } from "graphql";
-import type { InputTypeComposer, SchemaComposer } from "graphql-compose";
+import type { InputTypeComposer, ObjectTypeComposerFieldConfigMapDefinition, SchemaComposer } from "graphql-compose";
 import { PageInfo } from "../../../graphql/objects/PageInfo";
 import type { ConcreteEntityAdapter } from "../../../schema-model/entity/model-adapters/ConcreteEntityAdapter";
 import type { InterfaceEntityAdapter } from "../../../schema-model/entity/model-adapters/InterfaceEntityAdapter";
@@ -72,7 +72,7 @@ export function rootConnectionResolver({
 
         const connection = createConnectionWithEdgeProperties({
             selectionSet: resolveTree as unknown as SelectionSetNode,
-            source: { edges: record.edges },
+            source: { edges: record.edges, aggregate: record.aggregate },
             args: { first: args.first, after: args.after },
             totalCount,
         });
@@ -81,6 +81,7 @@ export function rootConnectionResolver({
             totalCount,
             edges: connection.edges,
             pageInfo: connection.pageInfo,
+            aggregate: connection.aggregate,
         };
     }
 
@@ -93,13 +94,19 @@ export function rootConnectionResolver({
         directives: graphqlDirectivesToCompose(propagatedDirectives),
     });
 
+    const rootFields: ObjectTypeComposerFieldConfigMapDefinition<any, any> = {
+        totalCount: new GraphQLNonNull(GraphQLInt),
+        pageInfo: new GraphQLNonNull(PageInfo),
+        edges: rootEdge.NonNull.List.NonNull,
+    };
+
+    if (entityAdapter.isAggregable) {
+        rootFields["aggregate"] = `${entityAdapter.operations.aggregateTypeNames.connection}!`;
+    }
+
     const rootConnection = composer.createObjectTC({
         name: `${entityAdapter.upperFirstPlural}Connection`,
-        fields: {
-            totalCount: new GraphQLNonNull(GraphQLInt),
-            pageInfo: new GraphQLNonNull(PageInfo),
-            edges: rootEdge.NonNull.List.NonNull,
-        },
+        fields: rootFields,
         directives: graphqlDirectivesToCompose(propagatedDirectives),
     });
 

--- a/packages/graphql/src/schema/validation/schema-validation.test.ts
+++ b/packages/graphql/src/schema/validation/schema-validation.test.ts
@@ -89,7 +89,9 @@ describe("schema validation", () => {
                 `;
                 const userDocument = gql`
                     ${jwtType}
-                    type User @node @authorization(filter: [{ where: { jwt: { thisClaimDoesNotExist: "something" } } }]) {
+                    type User
+                        @node
+                        @authorization(filter: [{ where: { jwt: { thisClaimDoesNotExist: "something" } } }]) {
                         id: ID!
                         name: String!
                     }
@@ -727,7 +729,9 @@ describe("schema validation", () => {
 
             test("should validate directive argument name", () => {
                 const userDocument = gql`
-                    type User @node @subscriptionsAuthorization(wrongFilter: [{ where: { node: { id: "$jwt.sub" } } }]) {
+                    type User
+                        @node
+                        @subscriptionsAuthorization(wrongFilter: [{ where: { node: { id: "$jwt.sub" } } }]) {
                         id: ID!
                         name: String!
                     }
@@ -1446,7 +1450,9 @@ describe("schema validation", () => {
                         name: String!
                     }
 
-                    type Post @node @subscriptionsAuthorization(filter: [{ where: { node: { content: "$jwt.sub" } } }]) {
+                    type Post
+                        @node
+                        @subscriptionsAuthorization(filter: [{ where: { node: { content: "$jwt.sub" } } }]) {
                         content: String!
                         author: User! @relationship(type: "HAS_AUTHOR", direction: OUT)
                     }
@@ -2391,7 +2397,11 @@ describe("schema validation", () => {
                 const userDocument = gql`
                     extend schema @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@shareable"])
 
-                    type User @node @shareable @authorization(wrongFilter: [{ where: { node: { id: "$jwt.sub" } } }]) @node {
+                    type User
+                        @node
+                        @shareable
+                        @authorization(wrongFilter: [{ where: { node: { id: "$jwt.sub" } } }])
+                        @node {
                         id: ID!
                         name: String!
                     }
@@ -2631,7 +2641,10 @@ describe("schema validation", () => {
                 `;
                 const userDocument = gql`
                     ${jwtType}
-                    type User @node @plural(value: "Users") @authentication(operations: [CREATE], jwt: { sub: "test" }) {
+                    type User
+                        @node
+                        @plural(value: "Users")
+                        @authentication(operations: [CREATE], jwt: { sub: "test" }) {
                         id: ID!
                         name: String!
                     }
@@ -3495,7 +3508,11 @@ describe("schema validation", () => {
                     extend schema @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@shareable"])
 
                     ${jwtType}
-                    type User @node @plural(value: "Users") @shareable @authentication(ops: [CREATE], jwt: { sub: "test" }) {
+                    type User
+                        @node
+                        @plural(value: "Users")
+                        @shareable
+                        @authentication(ops: [CREATE], jwt: { sub: "test" }) {
                         id: ID!
                         name: String!
                     }
@@ -3580,11 +3597,13 @@ describe("schema validation", () => {
                 });
 
             const errors = getError(executeValidate);
-            expect(errors).toHaveLength(2);
+            expect(errors).toHaveLength(3);
             expect(errors[0]).not.toBeInstanceOf(NoErrorThrownError);
             expect(errors[0]).toHaveProperty("message", "Field cannot be named keanu");
             expect(errors[1]).not.toBeInstanceOf(NoErrorThrownError);
             expect(errors[1]).toHaveProperty("message", "Field cannot be named keanu");
+            expect(errors[2]).not.toBeInstanceOf(NoErrorThrownError);
+            expect(errors[2]).toHaveProperty("message", "Field cannot be named keanu");
         });
     });
 
@@ -3867,7 +3886,8 @@ describe("schema validation", () => {
                             name: String!
                         }
 
-                        type Post @node
+                        type Post
+                            @node
                             @authorization(
                                 filter: [{ where: { node: { author_NOT_A_QUANTIFIER: { name: "Simone" } } } }]
                             ) {

--- a/packages/graphql/src/translate/queryAST/ast/fields/ConnectionAggregationField.ts
+++ b/packages/graphql/src/translate/queryAST/ast/fields/ConnectionAggregationField.ts
@@ -21,16 +21,14 @@ import Cypher from "@neo4j/cypher-builder";
 import { QueryASTContext } from "../QueryASTContext";
 import type { QueryASTNode } from "../QueryASTNode";
 import type { AggregationOperation } from "../operations/AggregationOperation";
-import { CypherOperation } from "../operations/CypherOperation";
-import { CypherScalarOperation } from "../operations/CypherScalarOperation";
 import type { CompositeAggregationOperation } from "../operations/composite/CompositeAggregationOperation";
-import { CompositeCypherOperation } from "../operations/composite/CompositeCypherOperation";
 import { Field } from "./Field";
 
+/** An aggregate field inside connection */
 export class ConnectionAggregationField extends Field {
     public operation: AggregationOperation | CompositeAggregationOperation;
 
-    public nodeAlias: string;
+    private nodeAlias: string;
 
     private projectionExpr: Cypher.Expr | undefined;
 
@@ -64,15 +62,5 @@ export class ConnectionAggregationField extends Field {
         const result = this.operation.transpile(subqueryContext);
         this.projectionExpr = result.projectionExpr;
         return result.clauses;
-    }
-
-    public isCypherField(): this is this & {
-        operation: CypherOperation | CypherScalarOperation | CompositeCypherOperation;
-    } {
-        return (
-            this.operation instanceof CypherOperation ||
-            this.operation instanceof CypherScalarOperation ||
-            this.operation instanceof CompositeCypherOperation
-        );
     }
 }

--- a/packages/graphql/src/translate/queryAST/ast/fields/ConnectionAggregationField.ts
+++ b/packages/graphql/src/translate/queryAST/ast/fields/ConnectionAggregationField.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Cypher from "@neo4j/cypher-builder";
+import { QueryASTContext } from "../QueryASTContext";
+import type { QueryASTNode } from "../QueryASTNode";
+import type { AggregationOperation } from "../operations/AggregationOperation";
+import { CypherOperation } from "../operations/CypherOperation";
+import { CypherScalarOperation } from "../operations/CypherScalarOperation";
+import type { CompositeAggregationOperation } from "../operations/composite/CompositeAggregationOperation";
+import { CompositeCypherOperation } from "../operations/composite/CompositeCypherOperation";
+import { Field } from "./Field";
+
+export class ConnectionAggregationField extends Field {
+    public operation: AggregationOperation | CompositeAggregationOperation;
+
+    public nodeAlias: string;
+
+    private projectionExpr: Cypher.Expr | undefined;
+
+    constructor({
+        operation,
+        alias,
+        nodeAlias,
+    }: {
+        operation: AggregationOperation | CompositeAggregationOperation;
+        alias: string;
+        nodeAlias: string;
+    }) {
+        super(alias);
+        this.operation = operation;
+        this.nodeAlias = nodeAlias;
+    }
+
+    public getChildren(): QueryASTNode[] {
+        return [this.operation];
+    }
+
+    public getProjectionField(): Record<string, Cypher.Expr> {
+        if (!this.projectionExpr) {
+            throw new Error("Projection expression of operation not available (has transpile been called)?");
+        }
+        return { [this.alias]: new Cypher.Map({ [this.nodeAlias]: this.projectionExpr }) };
+    }
+
+    public getSubqueries(context: QueryASTContext): Cypher.Clause[] {
+        const subqueryContext = new QueryASTContext({ ...context, returnVariable: new Cypher.Variable() });
+        const result = this.operation.transpile(subqueryContext);
+        this.projectionExpr = result.projectionExpr;
+        return result.clauses;
+    }
+
+    public isCypherField(): this is this & {
+        operation: CypherOperation | CypherScalarOperation | CompositeCypherOperation;
+    } {
+        return (
+            this.operation instanceof CypherOperation ||
+            this.operation instanceof CypherScalarOperation ||
+            this.operation instanceof CompositeCypherOperation
+        );
+    }
+}

--- a/packages/graphql/src/translate/queryAST/ast/operations/ConnectionReadOperation.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/ConnectionReadOperation.ts
@@ -44,7 +44,7 @@ export class ConnectionReadOperation extends Operation {
     public nodeFields: Field[] = [];
     public edgeFields: Field[] = []; // TODO: merge with attachedTo?
 
-    public aggregationField: ConnectionAggregationField | undefined;
+    public aggregationField: ConnectionAggregationField | undefined; // TODO: multiple aggregations
 
     public filters: Filter[] = [];
     protected pagination: Pagination | undefined;
@@ -130,6 +130,33 @@ export class ConnectionReadOperation extends Operation {
         );
     }
 
+    protected transpileAggregation(context: QueryASTContext): {
+        subqueries: Cypher.Clause[];
+        fields: Array<[Cypher.Expr, Cypher.Variable]>;
+        returnMap: Record<string, Cypher.Variable>;
+    } {
+        const returnMap: Record<string, Cypher.Variable> = {};
+        let extraFieldsSubqueries: Cypher.Clause[] = [];
+        let extraFields: Array<[Cypher.Expr, Cypher.Variable]> = [];
+        if (this.aggregationField) {
+            extraFieldsSubqueries = this.aggregationField.getSubqueries(context);
+
+            const aggregationProjectionField = this.aggregationField.getProjectionField();
+
+            extraFields = Object.entries(aggregationProjectionField).map(([key, value]) => {
+                const variable = new Cypher.Variable();
+                returnMap[key] = variable;
+                return [value, variable];
+            });
+        }
+
+        return {
+            fields: extraFields,
+            subqueries: extraFieldsSubqueries,
+            returnMap,
+        };
+    }
+
     public transpile(context: QueryASTContext): OperationTranspileResult {
         if (!context.target) throw new Error();
 
@@ -155,20 +182,11 @@ export class ConnectionReadOperation extends Operation {
 
         const filtersSubqueries = [...authFilterSubqueries, ...normalFilterSubqueries];
 
-        const returnMap: Record<string, Cypher.Variable> = {};
-        let extraFieldsSubqueries: Cypher.Clause[] = [];
-        let extraFields: Array<[Cypher.Expr, Cypher.Variable]> = [];
-        if (this.aggregationField) {
-            extraFieldsSubqueries = this.aggregationField.getSubqueries(nestedContext);
-
-            const aggregationProjectionField = this.aggregationField.getProjectionField();
-
-            extraFields = Object.entries(aggregationProjectionField).map(([key, value]) => {
-                const variable = new Cypher.Variable();
-                returnMap[key] = variable;
-                return [value, variable];
-            });
-        }
+        const {
+            returnMap,
+            fields: extraFields,
+            subqueries: extraFieldsSubqueries,
+        } = this.transpileAggregation(nestedContext);
 
         const edgesVar = new Cypher.NamedVariable("edges");
         const totalCount = new Cypher.NamedVariable("totalCount");

--- a/packages/graphql/src/translate/queryAST/ast/operations/ConnectionReadOperation.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/ConnectionReadOperation.ts
@@ -24,6 +24,7 @@ import { filterTruthy } from "../../../../utils/utils";
 import { wrapSubqueriesInCypherCalls } from "../../utils/wrap-subquery-in-calls";
 import type { QueryASTContext } from "../QueryASTContext";
 import type { QueryASTNode } from "../QueryASTNode";
+import type { ConnectionAggregationField } from "../fields/ConnectionAggregationField";
 import type { Field } from "../fields/Field";
 import { OperationField } from "../fields/OperationField";
 import type { Filter } from "../filters/Filter";
@@ -42,7 +43,10 @@ export class ConnectionReadOperation extends Operation {
 
     public nodeFields: Field[] = [];
     public edgeFields: Field[] = []; // TODO: merge with attachedTo?
-    protected filters: Filter[] = [];
+
+    public aggregationField: ConnectionAggregationField | undefined;
+
+    public filters: Filter[] = [];
     protected pagination: Pagination | undefined;
     protected sortFields: Array<{ node: Sort[]; edge: Sort[] }> = [];
     protected authFilters: AuthorizationFilters[] = [];
@@ -97,6 +101,7 @@ export class ConnectionReadOperation extends Operation {
             this.selection,
             ...this.nodeFields,
             ...this.edgeFields,
+            this.aggregationField,
             ...this.filters,
             ...this.authFilters,
             this.pagination,
@@ -107,7 +112,8 @@ export class ConnectionReadOperation extends Operation {
     protected getWithCollectEdgesAndTotalCount(
         nestedContext: QueryASTContext<Cypher.Node>,
         edgesVar: Cypher.Variable,
-        totalCount: Cypher.Variable
+        totalCount: Cypher.Variable,
+        extraColumns?: Array<[Cypher.Expr, Cypher.Variable]>
     ): Cypher.With {
         const nodeAndRelationshipMap = new Cypher.Map({
             node: nestedContext.target,
@@ -117,10 +123,11 @@ export class ConnectionReadOperation extends Operation {
             nodeAndRelationshipMap.set("relationship", nestedContext.relationship);
         }
 
-        return new Cypher.With([Cypher.collect(nodeAndRelationshipMap), edgesVar]).with(edgesVar, [
-            Cypher.size(edgesVar),
-            totalCount,
-        ]);
+        return new Cypher.With([Cypher.collect(nodeAndRelationshipMap), edgesVar], ...(extraColumns ?? [])).with(
+            edgesVar,
+            [Cypher.size(edgesVar), totalCount],
+            ...(extraColumns ?? []).map((c) => c[1])
+        );
     }
 
     public transpile(context: QueryASTContext): OperationTranspileResult {
@@ -148,6 +155,21 @@ export class ConnectionReadOperation extends Operation {
 
         const filtersSubqueries = [...authFilterSubqueries, ...normalFilterSubqueries];
 
+        const returnMap: Record<string, Cypher.Variable> = {};
+        let extraFieldsSubqueries: Cypher.Clause[] = [];
+        let extraFields: Array<[Cypher.Expr, Cypher.Variable]> = [];
+        if (this.aggregationField) {
+            extraFieldsSubqueries = this.aggregationField.getSubqueries(nestedContext);
+
+            const aggregationProjectionField = this.aggregationField.getProjectionField();
+
+            extraFields = Object.entries(aggregationProjectionField).map(([key, value]) => {
+                const variable = new Cypher.Variable();
+                returnMap[key] = variable;
+                return [value, variable];
+            });
+        }
+
         const edgesVar = new Cypher.NamedVariable("edges");
         const totalCount = new Cypher.NamedVariable("totalCount");
         const edgesProjectionVar = new Cypher.Variable();
@@ -169,13 +191,15 @@ export class ConnectionReadOperation extends Operation {
         const withCollectEdgesAndTotalCount = this.getWithCollectEdgesAndTotalCount(
             nestedContext,
             edgesVar,
-            totalCount
+            totalCount,
+            extraFields
         );
 
         const returnClause = new Cypher.Return([
             new Cypher.Map({
                 edges: edgesProjectionVar,
                 totalCount: totalCount,
+                ...returnMap,
             }),
             context.returnVariable,
         ]);
@@ -187,6 +211,7 @@ export class ConnectionReadOperation extends Operation {
                     selectionClause,
                     ...filtersSubqueries,
                     withWhere,
+                    ...extraFieldsSubqueries,
                     withCollectEdgesAndTotalCount,
                     unwindAndProjectionSubquery,
                     returnClause

--- a/packages/graphql/src/translate/queryAST/ast/operations/ConnectionReadOperation.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/ConnectionReadOperation.ts
@@ -44,7 +44,7 @@ export class ConnectionReadOperation extends Operation {
     public nodeFields: Field[] = [];
     public edgeFields: Field[] = []; // TODO: merge with attachedTo?
 
-    private aggregationField: ConnectionAggregationField | undefined; // TODO: multiple aggregations
+    private aggregationField: ConnectionAggregationField | undefined;
 
     public filters: Filter[] = [];
     protected pagination: Pagination | undefined;

--- a/packages/graphql/src/translate/queryAST/ast/operations/ConnectionReadOperation.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/ConnectionReadOperation.ts
@@ -44,7 +44,7 @@ export class ConnectionReadOperation extends Operation {
     public nodeFields: Field[] = [];
     public edgeFields: Field[] = []; // TODO: merge with attachedTo?
 
-    public aggregationField: ConnectionAggregationField | undefined; // TODO: multiple aggregations
+    private aggregationField: ConnectionAggregationField | undefined; // TODO: multiple aggregations
 
     public filters: Filter[] = [];
     protected pagination: Pagination | undefined;
@@ -92,6 +92,12 @@ export class ConnectionReadOperation extends Operation {
         this.pagination = pagination;
     }
 
+    /** Sets the aggregation field and adds the needed filters */
+    public setAggregationField(aggregationField: ConnectionAggregationField): void {
+        this.aggregationField = aggregationField;
+        this.aggregationField.operation.addFilters(...this.filters);
+    }
+
     public getChildren(): QueryASTNode[] {
         const sortFields = this.sortFields.flatMap((s) => {
             return [...s.edge, ...s.node];
@@ -113,7 +119,7 @@ export class ConnectionReadOperation extends Operation {
         nestedContext: QueryASTContext<Cypher.Node>,
         edgesVar: Cypher.Variable,
         totalCount: Cypher.Variable,
-        extraColumns?: Array<[Cypher.Expr, Cypher.Variable]>
+        extraColumns: Array<[Cypher.Expr, Cypher.Variable]> = []
     ): Cypher.With {
         const nodeAndRelationshipMap = new Cypher.Map({
             node: nestedContext.target,
@@ -123,38 +129,13 @@ export class ConnectionReadOperation extends Operation {
             nodeAndRelationshipMap.set("relationship", nestedContext.relationship);
         }
 
-        return new Cypher.With([Cypher.collect(nodeAndRelationshipMap), edgesVar], ...(extraColumns ?? [])).with(
+        const extraColumnsVariables = extraColumns.map((c) => c[1]);
+
+        return new Cypher.With([Cypher.collect(nodeAndRelationshipMap), edgesVar], ...extraColumns).with(
             edgesVar,
             [Cypher.size(edgesVar), totalCount],
-            ...(extraColumns ?? []).map((c) => c[1])
+            ...extraColumnsVariables
         );
-    }
-
-    protected transpileAggregation(context: QueryASTContext): {
-        subqueries: Cypher.Clause[];
-        fields: Array<[Cypher.Expr, Cypher.Variable]>;
-        returnMap: Record<string, Cypher.Variable>;
-    } {
-        const returnMap: Record<string, Cypher.Variable> = {};
-        let extraFieldsSubqueries: Cypher.Clause[] = [];
-        let extraFields: Array<[Cypher.Expr, Cypher.Variable]> = [];
-        if (this.aggregationField) {
-            extraFieldsSubqueries = this.aggregationField.getSubqueries(context);
-
-            const aggregationProjectionField = this.aggregationField.getProjectionField();
-
-            extraFields = Object.entries(aggregationProjectionField).map(([key, value]) => {
-                const variable = new Cypher.Variable();
-                returnMap[key] = variable;
-                return [value, variable];
-            });
-        }
-
-        return {
-            fields: extraFields,
-            subqueries: extraFieldsSubqueries,
-            returnMap,
-        };
     }
 
     public transpile(context: QueryASTContext): OperationTranspileResult {
@@ -183,9 +164,9 @@ export class ConnectionReadOperation extends Operation {
         const filtersSubqueries = [...authFilterSubqueries, ...normalFilterSubqueries];
 
         const {
-            returnMap,
-            fields: extraFields,
-            subqueries: extraFieldsSubqueries,
+            projectionMap: aggregationProjection,
+            fields: aggregationFields,
+            subqueries: aggregationSubqueries,
         } = this.transpileAggregation(nestedContext);
 
         const edgesVar = new Cypher.NamedVariable("edges");
@@ -210,14 +191,14 @@ export class ConnectionReadOperation extends Operation {
             nestedContext,
             edgesVar,
             totalCount,
-            extraFields
+            aggregationFields
         );
 
         const returnClause = new Cypher.Return([
             new Cypher.Map({
                 edges: edgesProjectionVar,
                 totalCount: totalCount,
-                ...returnMap,
+                ...aggregationProjection,
             }),
             context.returnVariable,
         ]);
@@ -229,7 +210,7 @@ export class ConnectionReadOperation extends Operation {
                     selectionClause,
                     ...filtersSubqueries,
                     withWhere,
-                    ...extraFieldsSubqueries,
+                    ...aggregationSubqueries,
                     withCollectEdgesAndTotalCount,
                     unwindAndProjectionSubquery,
                     returnClause
@@ -345,6 +326,39 @@ export class ConnectionReadOperation extends Operation {
             });
 
         return projectionMap;
+    }
+
+    private transpileAggregation(context: QueryASTContext): {
+        subqueries: Cypher.Clause[];
+        fields: Array<[Cypher.Expr, Cypher.Variable]>;
+        projectionMap: Record<string, Cypher.Variable>;
+    } {
+        if (!this.aggregationField) {
+            return {
+                fields: [],
+                subqueries: [],
+                projectionMap: {},
+            };
+        }
+        const projectionMap: Record<string, Cypher.Variable> = {};
+
+        const subqueries = this.aggregationField.getSubqueries(context);
+
+        const aggregationProjectionField = this.aggregationField.getProjectionField();
+
+        const fields: Array<[Cypher.Expr, Cypher.Variable]> = Object.entries(aggregationProjectionField).map(
+            ([key, value]) => {
+                const variable = new Cypher.Variable();
+                projectionMap[key] = variable;
+                return [value, variable];
+            }
+        );
+
+        return {
+            fields,
+            subqueries,
+            projectionMap,
+        };
     }
 
     private generateSortAndPaginationClause(context: QueryASTContext<Cypher.Node>): Cypher.With | undefined {

--- a/packages/graphql/src/translate/queryAST/ast/operations/composite/CompositeConnectionPartial.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/composite/CompositeConnectionPartial.ts
@@ -25,6 +25,11 @@ import { ConnectionReadOperation } from "../ConnectionReadOperation";
 import type { OperationTranspileResult } from "../operations";
 
 export class CompositeConnectionPartial extends ConnectionReadOperation {
+    /** Prints the name of the Node */
+    public print(): string {
+        return `${super.print()} <${this.target.name}>`;
+    }
+
     public transpile(context: QueryASTContext): OperationTranspileResult {
         // eslint-disable-next-line prefer-const
         let { selection: clause, nestedContext } = this.selection.apply(context);

--- a/packages/graphql/src/translate/queryAST/ast/operations/composite/CompositeConnectionReadOperation.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/composite/CompositeConnectionReadOperation.ts
@@ -35,7 +35,7 @@ export class CompositeConnectionReadOperation extends Operation {
     protected sortFields: Array<{ node: Sort[]; edge: Sort[] }> = [];
     private pagination: Pagination | undefined;
 
-    private aggregationField: ConnectionAggregationField | undefined; // TODO: multiple aggregations
+    private aggregationField: ConnectionAggregationField | undefined;
 
     constructor(children: CompositeConnectionPartial[]) {
         super();

--- a/packages/graphql/src/translate/queryAST/ast/operations/composite/CompositeConnectionReadOperation.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/composite/CompositeConnectionReadOperation.ts
@@ -25,6 +25,7 @@ import { filterTruthy } from "../../../../../utils/utils";
 import { hasTarget } from "../../../utils/context-has-target";
 import { QueryASTContext } from "../../QueryASTContext";
 import type { QueryASTNode } from "../../QueryASTNode";
+import type { ConnectionAggregationField } from "../../fields/ConnectionAggregationField";
 import type { Pagination } from "../../pagination/Pagination";
 import type { Sort, SortField } from "../../sort/Sort";
 import type { CompositeConnectionPartial } from "./CompositeConnectionPartial";
@@ -34,9 +35,39 @@ export class CompositeConnectionReadOperation extends Operation {
     protected sortFields: Array<{ node: Sort[]; edge: Sort[] }> = [];
     private pagination: Pagination | undefined;
 
+    public aggregationField: ConnectionAggregationField | undefined; // TODO: multiple aggregations
+
     constructor(children: CompositeConnectionPartial[]) {
         super();
         this.children = children;
+    }
+
+    // NOTE: duplicate from ConnectionReadOperation
+    protected transpileAggregation(context: QueryASTContext): {
+        subqueries: Cypher.Clause[];
+        fields: Array<[Cypher.Expr, Cypher.Variable]>;
+        returnMap: Record<string, Cypher.Variable>;
+    } {
+        const returnMap: Record<string, Cypher.Variable> = {};
+        let extraFieldsSubqueries: Cypher.Clause[] = [];
+        let extraFields: Array<[Cypher.Expr, Cypher.Variable]> = [];
+        if (this.aggregationField) {
+            extraFieldsSubqueries = this.aggregationField.getSubqueries(context);
+
+            const aggregationProjectionField = this.aggregationField.getProjectionField();
+
+            extraFields = Object.entries(aggregationProjectionField).map(([key, value]) => {
+                const variable = new Cypher.Variable();
+                returnMap[key] = variable;
+                return [value, variable];
+            });
+        }
+
+        return {
+            fields: extraFields,
+            subqueries: extraFieldsSubqueries,
+            returnMap,
+        };
     }
 
     public transpile(context: QueryASTContext): OperationTranspileResult {
@@ -94,18 +125,31 @@ export class CompositeConnectionReadOperation extends Operation {
             orderSubquery = new Cypher.Call(extraWithOrder).importWith(edgesVar);
         }
 
-        nestedSubquery.with([Cypher.collect(edgeVar), edgesVar]).with(edgesVar, [Cypher.size(edgesVar), totalCount]);
+        const {
+            fields: extraFields,
+            subqueries: aggregateSubqueries,
+            returnMap: aggregateReturnMap,
+        } = this.transpileAggregation(context);
+
+        const subqueryWith = new Cypher.With([Cypher.collect(edgeVar), edgesVar], ...extraFields).with(
+            edgesVar,
+            [Cypher.size(edgesVar), totalCount],
+            ...(extraFields ?? []).map((c) => c[1])
+        );
 
         const returnClause = new Cypher.Return([
             new Cypher.Map({
                 edges: returnEdgesVar,
                 totalCount: totalCount,
+                ...aggregateReturnMap,
             }),
             context.returnVariable,
         ]);
 
         return {
-            clauses: [Cypher.utils.concat(nestedSubquery, orderSubquery, returnClause)],
+            clauses: [
+                Cypher.utils.concat(nestedSubquery, ...aggregateSubqueries, subqueryWith, orderSubquery, returnClause),
+            ],
             projectionExpr: context.returnVariable,
         };
     }
@@ -123,7 +167,7 @@ export class CompositeConnectionReadOperation extends Operation {
             return [...s.edge, ...s.node];
         });
 
-        return filterTruthy([...this.children, ...sortFields, this.pagination]);
+        return filterTruthy([...this.children, this.aggregationField, ...sortFields, this.pagination]);
     }
 
     protected getSortFields(

--- a/packages/graphql/src/translate/queryAST/ast/operations/composite/CompositeConnectionReadOperation.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/composite/CompositeConnectionReadOperation.ts
@@ -35,39 +35,11 @@ export class CompositeConnectionReadOperation extends Operation {
     protected sortFields: Array<{ node: Sort[]; edge: Sort[] }> = [];
     private pagination: Pagination | undefined;
 
-    public aggregationField: ConnectionAggregationField | undefined; // TODO: multiple aggregations
+    private aggregationField: ConnectionAggregationField | undefined; // TODO: multiple aggregations
 
     constructor(children: CompositeConnectionPartial[]) {
         super();
         this.children = children;
-    }
-
-    // NOTE: duplicate from ConnectionReadOperation
-    protected transpileAggregation(context: QueryASTContext): {
-        subqueries: Cypher.Clause[];
-        fields: Array<[Cypher.Expr, Cypher.Variable]>;
-        returnMap: Record<string, Cypher.Variable>;
-    } {
-        const returnMap: Record<string, Cypher.Variable> = {};
-        let extraFieldsSubqueries: Cypher.Clause[] = [];
-        let extraFields: Array<[Cypher.Expr, Cypher.Variable]> = [];
-        if (this.aggregationField) {
-            extraFieldsSubqueries = this.aggregationField.getSubqueries(context);
-
-            const aggregationProjectionField = this.aggregationField.getProjectionField();
-
-            extraFields = Object.entries(aggregationProjectionField).map(([key, value]) => {
-                const variable = new Cypher.Variable();
-                returnMap[key] = variable;
-                return [value, variable];
-            });
-        }
-
-        return {
-            fields: extraFields,
-            subqueries: extraFieldsSubqueries,
-            returnMap,
-        };
     }
 
     public transpile(context: QueryASTContext): OperationTranspileResult {
@@ -126,15 +98,16 @@ export class CompositeConnectionReadOperation extends Operation {
         }
 
         const {
-            fields: extraFields,
+            fields: aggregateFields,
             subqueries: aggregateSubqueries,
-            returnMap: aggregateReturnMap,
+            projectionMap: aggregateReturnMap,
         } = this.transpileAggregation(context);
 
-        const subqueryWith = new Cypher.With([Cypher.collect(edgeVar), edgesVar], ...extraFields).with(
+        const aggregateVariables = aggregateFields.map((c) => c[1]);
+        const subqueryWith = new Cypher.With([Cypher.collect(edgeVar), edgesVar], ...aggregateFields).with(
             edgesVar,
             [Cypher.size(edgesVar), totalCount],
-            ...(extraFields ?? []).map((c) => c[1])
+            ...aggregateVariables
         );
 
         const returnClause = new Cypher.Return([
@@ -162,6 +135,10 @@ export class CompositeConnectionReadOperation extends Operation {
         this.pagination = pagination;
     }
 
+    public setAggregationField(aggregationField: ConnectionAggregationField): void {
+        this.aggregationField = aggregationField;
+    }
+
     public getChildren(): QueryASTNode[] {
         const sortFields = this.sortFields.flatMap((s) => {
             return [...s.edge, ...s.node];
@@ -181,5 +158,39 @@ export class CompositeConnectionReadOperation extends Operation {
 
             return [...nodeFields, ...edgeFields];
         });
+    }
+
+    // NOTE: duplicate from ConnectionReadOperation
+    private transpileAggregation(context: QueryASTContext): {
+        subqueries: Cypher.Clause[];
+        fields: Array<[Cypher.Expr, Cypher.Variable]>;
+        projectionMap: Record<string, Cypher.Variable>;
+    } {
+        if (!this.aggregationField) {
+            return {
+                fields: [],
+                subqueries: [],
+                projectionMap: {},
+            };
+        }
+        const projectionMap: Record<string, Cypher.Variable> = {};
+
+        const subqueries = this.aggregationField.getSubqueries(context);
+
+        const aggregationProjectionField = this.aggregationField.getProjectionField();
+
+        const fields: Array<[Cypher.Expr, Cypher.Variable]> = Object.entries(aggregationProjectionField).map(
+            ([key, value]) => {
+                const variable = new Cypher.Variable();
+                projectionMap[key] = variable;
+                return [value, variable];
+            }
+        );
+
+        return {
+            fields,
+            subqueries,
+            projectionMap,
+        };
     }
 }

--- a/packages/graphql/src/translate/queryAST/factory/OperationFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/OperationFactory.ts
@@ -170,7 +170,7 @@ export class OperationsFactory {
                 if (!entity || isUnionEntity(entity)) {
                     throw new Error("Aggregate operations are not supported for Union types");
                 }
-                return this.aggregateFactory.createAggregationOperation(entity, resolveTree, context);
+                return this.aggregateFactory.createAggregationOperation({ entityOrRel: entity, resolveTree, context });
             }
             case "CREATE": {
                 assertIsConcreteEntity(entity);
@@ -230,7 +230,7 @@ export class OperationsFactory {
         resolveTree: ResolveTree,
         context: Neo4jGraphQLTranslationContext
     ): AggregationOperation | CompositeAggregationOperation {
-        return this.aggregateFactory.createAggregationOperation(entityOrRel, resolveTree, context);
+        return this.aggregateFactory.createAggregationOperation({ entityOrRel, resolveTree, context });
     }
 
     public splitConnectionFields(rawFields: Record<string, ResolveTree>): {

--- a/packages/graphql/src/translate/queryAST/factory/Operations/AggregateFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/Operations/AggregateFactory.ts
@@ -310,7 +310,6 @@ export class AggregateFactory {
             operation.setNodeFields(nodeFields);
             operation.setEdgeFields(edgeFields);
         } else {
-            console.log("HERE");
             const rawProjectionFields = {
                 ...resolveTree.fieldsByTypeName[entity.operations.aggregateTypeNames.selection],
                 ...resolveTree.fieldsByTypeName[entity.operations.aggregateTypeNames.node], // Handles both, deprecated and new aggregation parsing

--- a/packages/graphql/src/translate/queryAST/factory/Operations/AggregateFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/Operations/AggregateFactory.ts
@@ -18,7 +18,7 @@
  */
 
 import type { ResolveTree } from "graphql-parse-resolve-info";
-import type { ConcreteEntityAdapter } from "../../../../schema-model/entity/model-adapters/ConcreteEntityAdapter";
+import { ConcreteEntityAdapter } from "../../../../schema-model/entity/model-adapters/ConcreteEntityAdapter";
 import type { InterfaceEntityAdapter } from "../../../../schema-model/entity/model-adapters/InterfaceEntityAdapter";
 import { RelationshipAdapter } from "../../../../schema-model/relationship/model-adapters/RelationshipAdapter";
 import type { Neo4jGraphQLTranslationContext } from "../../../../types/neo4j-graphql-translation-context";
@@ -138,6 +138,7 @@ export class AggregateFactory {
             }
         } else {
             if (isConcreteEntity(entity)) {
+                // HERE
                 let selection: EntitySelection;
                 // NOTE: If we introduce vector index aggregation, checking the phrase will cause a problem
                 if (context.resolveTree.args.fulltext || context.resolveTree.args.phrase) {
@@ -232,8 +233,16 @@ export class AggregateFactory {
         edge: ResolveTree | undefined;
         fields: Record<string, ResolveTree>;
     } {
+        // Handle new aggregation node inside connection
+        let nodeFields: Record<string, ResolveTree> = {};
+        if (adapter instanceof ConcreteEntityAdapter) {
+            nodeFields = resolveTree.fieldsByTypeName[adapter.operations.aggregateTypeNames.node] ?? {};
+        }
+
         const rawProjectionFields = {
+            // Handle deprecated aggregations
             ...resolveTree.fieldsByTypeName[adapter.operations.getAggregationFieldTypename()],
+            ...nodeFields,
         };
 
         return this.queryASTFactory.operationsFactory.splitConnectionFields(rawProjectionFields);
@@ -301,8 +310,10 @@ export class AggregateFactory {
             operation.setNodeFields(nodeFields);
             operation.setEdgeFields(edgeFields);
         } else {
+            console.log("HERE");
             const rawProjectionFields = {
                 ...resolveTree.fieldsByTypeName[entity.operations.aggregateTypeNames.selection],
+                ...resolveTree.fieldsByTypeName[entity.operations.aggregateTypeNames.node], // Handles both, deprecated and new aggregation parsing
             };
 
             const fields = this.queryASTFactory.fieldFactory.createAggregationFields(entity, rawProjectionFields);

--- a/packages/graphql/src/translate/queryAST/factory/Operations/AggregateFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/Operations/AggregateFactory.ts
@@ -138,7 +138,6 @@ export class AggregateFactory {
             }
         } else {
             if (isConcreteEntity(entity)) {
-                // HERE
                 let selection: EntitySelection;
                 // NOTE: If we introduce vector index aggregation, checking the phrase will cause a problem
                 if (context.resolveTree.args.fulltext || context.resolveTree.args.phrase) {
@@ -233,7 +232,6 @@ export class AggregateFactory {
         edge: ResolveTree | undefined;
         fields: Record<string, ResolveTree>;
     } {
-        // Handle new aggregation node inside connection
         let nodeFields: Record<string, ResolveTree> = {};
         if (adapter instanceof ConcreteEntityAdapter) {
             nodeFields = resolveTree.fieldsByTypeName[adapter.operations.aggregateTypeNames.node] ?? {};

--- a/packages/graphql/src/translate/queryAST/factory/Operations/AggregateFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/Operations/AggregateFactory.ts
@@ -42,11 +42,15 @@ export class AggregateFactory {
     }
 
     // TODO: dupe from read operation
-    public createAggregationOperation(
-        entityOrRel: ConcreteEntityAdapter | RelationshipAdapter | InterfaceEntityAdapter,
-        resolveTree: ResolveTree,
-        context: Neo4jGraphQLTranslationContext
-    ): AggregationOperation | CompositeAggregationOperation {
+    public createAggregationOperation({
+        entityOrRel,
+        resolveTree,
+        context,
+    }: {
+        entityOrRel: ConcreteEntityAdapter | RelationshipAdapter | InterfaceEntityAdapter;
+        resolveTree: ResolveTree;
+        context: Neo4jGraphQLTranslationContext;
+    }): AggregationOperation | CompositeAggregationOperation {
         let entity: ConcreteEntityAdapter | InterfaceEntityAdapter;
         if (entityOrRel instanceof RelationshipAdapter) {
             entity = entityOrRel.target as ConcreteEntityAdapter; // TODO: check this seems wrong but outside of the scope of this PR

--- a/packages/graphql/src/translate/queryAST/factory/Operations/ConnectionFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/Operations/ConnectionFactory.ts
@@ -31,6 +31,8 @@ import type { RelationshipAdapter } from "../../../../schema-model/relationship/
 import type { ConnectionQueryArgs } from "../../../../types";
 import type { Neo4jGraphQLTranslationContext } from "../../../../types/neo4j-graphql-translation-context";
 import { checkEntityAuthentication } from "../../../authorization/check-authentication";
+import { getResolveTreeByFieldName } from "../../../utils/resolveTree";
+import { ConnectionAggregationField } from "../../ast/fields/ConnectionAggregationField";
 import type { Field } from "../../ast/fields/Field";
 import { ConnectionReadOperation } from "../../ast/operations/ConnectionReadOperation";
 import { CompositeConnectionPartial } from "../../ast/operations/composite/CompositeConnectionPartial";
@@ -46,15 +48,18 @@ import { isUnionEntity } from "../../utils/is-union-entity";
 import type { QueryASTFactory } from "../QueryASTFactory";
 import { findFieldsByNameInFieldsByTypeNameField } from "../parsers/find-fields-by-name-in-fields-by-type-name-field";
 import { getFieldsByTypeName } from "../parsers/get-fields-by-type-name";
+import { AggregateFactory } from "./AggregateFactory";
 import { FulltextFactory } from "./FulltextFactory";
 
 export class ConnectionFactory {
     private queryASTFactory: QueryASTFactory;
     private fulltextFactory: FulltextFactory;
+    private aggregateFactory: AggregateFactory;
 
     constructor(queryASTFactory: QueryASTFactory) {
         this.queryASTFactory = queryASTFactory;
         this.fulltextFactory = new FulltextFactory(queryASTFactory);
+        this.aggregateFactory = new AggregateFactory(queryASTFactory);
     }
 
     public createCompositeConnectionOperationAST({
@@ -88,20 +93,22 @@ export class ConnectionFactory {
                     directed,
                     targetOverride: concreteEntity,
                 });
-                resolveTreeEdgeFields = this.parseConnectionFields({
+                const { edges } = this.parseConnectionFields({
                     entityOrRel: relationship,
                     target: concreteEntity,
                     resolveTree,
                 });
+                resolveTreeEdgeFields = edges;
             } else {
                 selection = new NodeSelection({
                     target: concreteEntity,
                 });
-                resolveTreeEdgeFields = this.parseConnectionFields({
+                const { edges } = this.parseConnectionFields({
                     entityOrRel: concreteEntity,
                     target: concreteEntity,
                     resolveTree,
                 });
+                resolveTreeEdgeFields = edges;
             }
 
             const connectionPartial = new CompositeConnectionPartial({
@@ -162,16 +169,19 @@ export class ConnectionFactory {
 
         let selection: EntitySelection;
         let resolveTreeEdgeFields: Record<string, ResolveTree>;
+        let resolveTreeAggregate: ResolveTree | undefined;
         if (relationship) {
             selection = new RelationshipSelection({
                 relationship,
                 directed: resolveTree.args.directed as boolean | undefined,
             });
-            resolveTreeEdgeFields = this.parseConnectionFields({
+            const { edges, aggregate } = this.parseConnectionFields({
                 entityOrRel: relationship,
                 target,
                 resolveTree,
             });
+            resolveTreeEdgeFields = edges;
+            resolveTreeAggregate = aggregate;
         } else {
             if (context.resolveTree.args.fulltext || context.resolveTree.args.phrase) {
                 selection = this.fulltextFactory.getFulltextSelection(target, context);
@@ -180,15 +190,38 @@ export class ConnectionFactory {
                     target,
                 });
             }
-            resolveTreeEdgeFields = this.parseConnectionFields({
+            const { edges, aggregate } = this.parseConnectionFields({
                 entityOrRel: target,
                 target,
                 resolveTree,
             });
+            resolveTreeEdgeFields = edges;
+            resolveTreeAggregate = aggregate;
         }
         const operation = new ConnectionReadOperation({ relationship, target, selection });
+        const resolveTreeAggregateFields =
+            resolveTreeAggregate?.fieldsByTypeName[target.operations.aggregateTypeNames.connection];
+        if (resolveTreeAggregate && resolveTreeAggregateFields) {
+            const nodeField = getResolveTreeByFieldName({ fieldName: "node", selection: resolveTreeAggregateFields });
+            if (nodeField) {
+                // Maybe this should be using operationFactory instead
+                const aggregationOperation = this.aggregateFactory.createAggregationOperation({
+                    entityOrRel: relationship ?? target,
+                    resolveTree: nodeField,
+                    context,
+                });
 
-        return this.hydrateConnectionOperationAST({
+                const aggregationField = new ConnectionAggregationField({
+                    alias: resolveTreeAggregate.name, // Alias is hanlded by graphql on top level
+                    nodeAlias: nodeField.alias,
+                    operation: aggregationOperation,
+                });
+
+                operation.aggregationField = aggregationField;
+            }
+        }
+
+        this.hydrateConnectionOperationAST({
             relationship,
             target: target,
             resolveTree,
@@ -197,11 +230,15 @@ export class ConnectionFactory {
             whereArgs: resolveTreeWhere,
             resolveTreeEdgeFields,
         });
+
+        if (operation.aggregationField) {
+            operation.aggregationField.operation.addFilters(...operation.filters);
+        }
+        return operation;
     }
 
-    // eslint-disable-next-line @typescript-eslint/comma-dangle
     private hydrateConnectionOperationsASTWithSort<
-        T extends ConnectionReadOperation | CompositeConnectionReadOperation
+        T extends ConnectionReadOperation | CompositeConnectionReadOperation,
     >({
         entityOrRel,
         resolveTree,
@@ -399,7 +436,7 @@ export class ConnectionFactory {
         entityOrRel: RelationshipAdapter | ConcreteEntityAdapter;
         target: ConcreteEntityAdapter;
         resolveTree: ResolveTree;
-    }): Record<string, ResolveTree> {
+    }): { edges: Record<string, ResolveTree>; aggregate: ResolveTree | undefined } {
         // Get interfaces of the entity
         const entityInterfaces = getEntityInterfaces(target);
 
@@ -420,13 +457,13 @@ export class ConnectionFactory {
         ]);
 
         const edgeFieldsRaw = findFieldsByNameInFieldsByTypeNameField(resolveTreeConnectionFields, "edges");
-
+        const aggregateFieldsRaw = findFieldsByNameInFieldsByTypeNameField(resolveTreeConnectionFields, "aggregate");
         const interfacesEdgeFields = entityInterfaces.map((interfaceAdapter) => {
             return getFieldsByTypeName(edgeFieldsRaw, `${interfaceAdapter.name}Edge`);
         });
 
         const concreteEdgeFields = getFieldsByTypeName(edgeFieldsRaw, entityOrRel.operations.relationshipFieldTypename);
 
-        return mergeDeep([...interfacesEdgeFields, concreteEdgeFields]);
+        return { edges: mergeDeep([...interfacesEdgeFields, concreteEdgeFields]), aggregate: aggregateFieldsRaw[0] };
     }
 }

--- a/packages/graphql/src/translate/queryAST/factory/Operations/ConnectionFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/Operations/ConnectionFactory.ts
@@ -227,7 +227,7 @@ export class ConnectionFactory {
         });
         this.hydrateConnectionOperationWithAggregation({
             target,
-            resolveTreeAggregate: resolveTreeAggregate[0], //TODO: suport for multiple aggregate fields
+            resolveTreeAggregate: resolveTreeAggregate[0],
             relationship,
             context,
             operation,

--- a/packages/graphql/src/translate/queryAST/factory/Operations/ConnectionFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/Operations/ConnectionFactory.ts
@@ -94,22 +94,20 @@ export class ConnectionFactory {
                     directed,
                     targetOverride: concreteEntity,
                 });
-                const { edges } = this.parseConnectionFields({
+                resolveTreeEdgeFields = this.parseConnectionFields({
                     entityOrRel: relationship,
                     target: concreteEntity,
                     resolveTree,
                 });
-                resolveTreeEdgeFields = edges;
             } else {
                 selection = new NodeSelection({
                     target: concreteEntity,
                 });
-                const { edges } = this.parseConnectionFields({
+                resolveTreeEdgeFields = this.parseConnectionFields({
                     entityOrRel: concreteEntity,
                     target: concreteEntity,
                     resolveTree,
                 });
-                resolveTreeEdgeFields = edges;
             }
 
             const connectionPartial = new CompositeConnectionPartial({
@@ -131,43 +129,6 @@ export class ConnectionFactory {
 
         const compositeConnectionOp = new CompositeConnectionReadOperation(concreteConnectionOperations);
 
-        if (isInterfaceEntity(target)) {
-            const fields = resolveTree.fieldsByTypeName[target.operations.connectionFieldTypename];
-            if (fields) {
-                const resolveTreeAggregate = findFieldsByNameInFieldsByTypeNameField(fields, "aggregate")[0];
-                if (resolveTreeAggregate) {
-                    const resolveTreeAggregateFields =
-                        resolveTreeAggregate.fieldsByTypeName[target.operations.aggregateTypeNames.connection];
-
-                    if (resolveTreeAggregateFields) {
-                        // Maybe this should be using operationFactory instead
-                        const nodeField = getResolveTreeByFieldName({
-                            fieldName: "node",
-                            selection: resolveTreeAggregateFields,
-                        });
-
-                        if (nodeField) {
-                            const typeNameNode = target.operations.aggregateTypeNames.node;
-                            // Sugar syntax for aggregations. This allows to use normal aggregations in each composite field, by renaming the type name
-                            nodeField.fieldsByTypeName[typeNameNode] =
-                                nodeField.fieldsByTypeName[target.operations.aggregateTypeNames.node] ?? {};
-                            const aggregationOperation = this.aggregateFactory.createAggregationOperation({
-                                entityOrRel: relationship ?? target,
-                                resolveTree: nodeField,
-                                context,
-                            });
-                            const aggregationField = new ConnectionAggregationField({
-                                alias: resolveTreeAggregate.name, // Alias is hanlded by graphql on top level
-                                nodeAlias: nodeField.alias,
-                                operation: aggregationOperation,
-                            });
-                            compositeConnectionOp.aggregationField = aggregationField;
-                        }
-                    }
-                }
-            }
-        }
-
         // These sort fields will be duplicated on nested "CompositeConnectionPartial"
 
         this.hydrateConnectionOperationsASTWithSort({
@@ -176,6 +137,22 @@ export class ConnectionFactory {
             operation: compositeConnectionOp,
             context,
         });
+
+        if (isInterfaceEntity(target)) {
+            const fields = resolveTree.fieldsByTypeName[target.operations.connectionFieldTypename];
+            if (fields) {
+                const resolveTreeAggregate = findFieldsByNameInFieldsByTypeNameField(fields, "aggregate")[0];
+
+                this.hydrateConnectionOperationWithAggregation({
+                    target,
+                    resolveTreeAggregate,
+                    relationship,
+                    context,
+                    operation: compositeConnectionOp,
+                });
+            }
+        }
+
         return compositeConnectionOp;
     }
 
@@ -207,19 +184,16 @@ export class ConnectionFactory {
 
         let selection: EntitySelection;
         let resolveTreeEdgeFields: Record<string, ResolveTree>;
-        let resolveTreeAggregate: ResolveTree | undefined;
         if (relationship) {
             selection = new RelationshipSelection({
                 relationship,
                 directed: resolveTree.args.directed as boolean | undefined,
             });
-            const { edges, aggregate } = this.parseConnectionFields({
+            resolveTreeEdgeFields = this.parseConnectionFields({
                 entityOrRel: relationship,
                 target,
                 resolveTree,
             });
-            resolveTreeEdgeFields = edges;
-            resolveTreeAggregate = aggregate;
         } else {
             if (context.resolveTree.args.fulltext || context.resolveTree.args.phrase) {
                 selection = this.fulltextFactory.getFulltextSelection(target, context);
@@ -228,36 +202,13 @@ export class ConnectionFactory {
                     target,
                 });
             }
-            const { edges, aggregate } = this.parseConnectionFields({
+            resolveTreeEdgeFields = this.parseConnectionFields({
                 entityOrRel: target,
                 target,
                 resolveTree,
             });
-            resolveTreeEdgeFields = edges;
-            resolveTreeAggregate = aggregate;
         }
         const operation = new ConnectionReadOperation({ relationship, target, selection });
-        const resolveTreeAggregateFields =
-            resolveTreeAggregate?.fieldsByTypeName[target.operations.aggregateTypeNames.connection];
-        if (resolveTreeAggregate && resolveTreeAggregateFields) {
-            const nodeField = getResolveTreeByFieldName({ fieldName: "node", selection: resolveTreeAggregateFields });
-            if (nodeField) {
-                // Maybe this should be using operationFactory instead
-                const aggregationOperation = this.aggregateFactory.createAggregationOperation({
-                    entityOrRel: relationship ?? target,
-                    resolveTree: nodeField,
-                    context,
-                });
-
-                const aggregationField = new ConnectionAggregationField({
-                    alias: resolveTreeAggregate.name, // Alias is hanlded by graphql on top level
-                    nodeAlias: nodeField.alias,
-                    operation: aggregationOperation,
-                });
-
-                operation.aggregationField = aggregationField;
-            }
-        }
 
         this.hydrateConnectionOperationAST({
             relationship,
@@ -269,10 +220,54 @@ export class ConnectionFactory {
             resolveTreeEdgeFields,
         });
 
-        if (operation.aggregationField) {
-            operation.aggregationField.operation.addFilters(...operation.filters);
-        }
+        const resolveTreeAggregate = this.parseAggregateFields({
+            entityOrRel: relationship ?? target,
+            target,
+            resolveTree,
+        });
+        this.hydrateConnectionOperationWithAggregation({
+            target,
+            resolveTreeAggregate: resolveTreeAggregate[0], //TODO: suport for multiple aggregate fields
+            relationship,
+            context,
+            operation,
+        });
+
         return operation;
+    }
+
+    private hydrateConnectionOperationWithAggregation({
+        target,
+        resolveTreeAggregate,
+        relationship,
+        context,
+        operation,
+    }: {
+        target: ConcreteEntityAdapter | InterfaceEntityAdapter;
+        resolveTreeAggregate: ResolveTree | undefined;
+        relationship: RelationshipAdapter | undefined;
+        context: Neo4jGraphQLTranslationContext;
+        operation: ConnectionReadOperation | CompositeConnectionReadOperation;
+    }) {
+        const resolveTreeAggregateFields =
+            resolveTreeAggregate?.fieldsByTypeName[target.operations.aggregateTypeNames.connection];
+        if (resolveTreeAggregate && resolveTreeAggregateFields) {
+            const nodeField = getResolveTreeByFieldName({ fieldName: "node", selection: resolveTreeAggregateFields });
+            if (nodeField) {
+                const aggregationOperation = this.aggregateFactory.createAggregationOperation({
+                    entityOrRel: relationship ?? target,
+                    resolveTree: nodeField,
+                    context,
+                });
+                const aggregationField = new ConnectionAggregationField({
+                    alias: resolveTreeAggregate.name, // Alias is hanlded by graphql on top level
+                    nodeAlias: nodeField.alias,
+                    operation: aggregationOperation,
+                });
+
+                operation.setAggregationField(aggregationField);
+            }
+        }
     }
 
     private hydrateConnectionOperationsASTWithSort<
@@ -466,6 +461,23 @@ export class ConnectionFactory {
         return operation;
     }
 
+    private parseAggregateFields({
+        target,
+        resolveTree,
+        entityOrRel,
+    }: {
+        entityOrRel: RelationshipAdapter | ConcreteEntityAdapter;
+        target: ConcreteEntityAdapter;
+        resolveTree: ResolveTree;
+    }): ResolveTree[] {
+        const resolveTreeConnectionFields = this.parseConnectionResolveTree({
+            entityOrRel,
+            target,
+            resolveTree,
+        });
+        return findFieldsByNameInFieldsByTypeNameField(resolveTreeConnectionFields, "aggregate");
+    }
+
     private parseConnectionFields({
         target,
         resolveTree,
@@ -474,7 +486,33 @@ export class ConnectionFactory {
         entityOrRel: RelationshipAdapter | ConcreteEntityAdapter;
         target: ConcreteEntityAdapter;
         resolveTree: ResolveTree;
-    }): { edges: Record<string, ResolveTree>; aggregate: ResolveTree | undefined } {
+    }): Record<string, ResolveTree> {
+        const resolveTreeConnectionFields = this.parseConnectionResolveTree({
+            entityOrRel,
+            target,
+            resolveTree,
+        });
+
+        const entityInterfaces = getEntityInterfaces(target);
+        const edgeFieldsRaw = findFieldsByNameInFieldsByTypeNameField(resolveTreeConnectionFields, "edges");
+        const interfacesEdgeFields = entityInterfaces.map((interfaceAdapter) => {
+            return getFieldsByTypeName(edgeFieldsRaw, `${interfaceAdapter.name}Edge`);
+        });
+
+        const concreteEdgeFields = getFieldsByTypeName(edgeFieldsRaw, entityOrRel.operations.relationshipFieldTypename);
+
+        return mergeDeep([...interfacesEdgeFields, concreteEdgeFields]);
+    }
+
+    private parseConnectionResolveTree({
+        target,
+        resolveTree,
+        entityOrRel,
+    }: {
+        entityOrRel: RelationshipAdapter | ConcreteEntityAdapter;
+        target: ConcreteEntityAdapter;
+        resolveTree: ResolveTree;
+    }): Record<string, ResolveTree> {
         // Get interfaces of the entity
         const entityInterfaces = getEntityInterfaces(target);
 
@@ -489,19 +527,6 @@ export class ConnectionFactory {
                 ]),
         };
 
-        const resolveTreeConnectionFields: Record<string, ResolveTree> = mergeDeep<Record<string, ResolveTree>[]>([
-            ...interfacesFields,
-            concreteProjectionFields,
-        ]);
-
-        const edgeFieldsRaw = findFieldsByNameInFieldsByTypeNameField(resolveTreeConnectionFields, "edges");
-        const aggregateFieldsRaw = findFieldsByNameInFieldsByTypeNameField(resolveTreeConnectionFields, "aggregate");
-        const interfacesEdgeFields = entityInterfaces.map((interfaceAdapter) => {
-            return getFieldsByTypeName(edgeFieldsRaw, `${interfaceAdapter.name}Edge`);
-        });
-
-        const concreteEdgeFields = getFieldsByTypeName(edgeFieldsRaw, entityOrRel.operations.relationshipFieldTypename);
-
-        return { edges: mergeDeep([...interfacesEdgeFields, concreteEdgeFields]), aggregate: aggregateFieldsRaw[0] };
+        return mergeDeep<Record<string, ResolveTree>[]>([...interfacesFields, concreteProjectionFields]);
     }
 }

--- a/packages/graphql/src/translate/queryAST/factory/Operations/ConnectionFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/Operations/ConnectionFactory.ts
@@ -87,6 +87,7 @@ export class ConnectionFactory {
         const concreteConnectionOperations = concreteEntities.map((concreteEntity: ConcreteEntityAdapter) => {
             let selection: EntitySelection;
             let resolveTreeEdgeFields: Record<string, ResolveTree>;
+
             if (relationship) {
                 selection = new RelationshipSelection({
                     relationship,
@@ -129,6 +130,43 @@ export class ConnectionFactory {
         });
 
         const compositeConnectionOp = new CompositeConnectionReadOperation(concreteConnectionOperations);
+
+        if (isInterfaceEntity(target)) {
+            const fields = resolveTree.fieldsByTypeName[target.operations.connectionFieldTypename];
+            if (fields) {
+                const resolveTreeAggregate = findFieldsByNameInFieldsByTypeNameField(fields, "aggregate")[0];
+                if (resolveTreeAggregate) {
+                    const resolveTreeAggregateFields =
+                        resolveTreeAggregate.fieldsByTypeName[target.operations.aggregateTypeNames.connection];
+
+                    if (resolveTreeAggregateFields) {
+                        // Maybe this should be using operationFactory instead
+                        const nodeField = getResolveTreeByFieldName({
+                            fieldName: "node",
+                            selection: resolveTreeAggregateFields,
+                        });
+
+                        if (nodeField) {
+                            const typeNameNode = target.operations.aggregateTypeNames.node;
+                            // Sugar syntax for aggregations. This allows to use normal aggregations in each composite field, by renaming the type name
+                            nodeField.fieldsByTypeName[typeNameNode] =
+                                nodeField.fieldsByTypeName[target.operations.aggregateTypeNames.node] ?? {};
+                            const aggregationOperation = this.aggregateFactory.createAggregationOperation({
+                                entityOrRel: relationship ?? target,
+                                resolveTree: nodeField,
+                                context,
+                            });
+                            const aggregationField = new ConnectionAggregationField({
+                                alias: resolveTreeAggregate.name, // Alias is hanlded by graphql on top level
+                                nodeAlias: nodeField.alias,
+                                operation: aggregationOperation,
+                            });
+                            compositeConnectionOp.aggregationField = aggregationField;
+                        }
+                    }
+                }
+            }
+        }
 
         // These sort fields will be duplicated on nested "CompositeConnectionPartial"
 

--- a/packages/graphql/src/types/index.ts
+++ b/packages/graphql/src/types/index.ts
@@ -455,6 +455,7 @@ export type Neo4jFeaturesSettings = {
         connectOrCreate?: boolean;
         idAggregations?: boolean;
         typename_IN?: boolean;
+        deprecatedAggregateOperations?: boolean;
     };
     vector?: Neo4jVectorSettings;
 };

--- a/packages/graphql/tests/integration/aggregations/top-level/alias.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/alias.int.test.ts
@@ -125,4 +125,95 @@ describe("aggregations-top_level-alias", () => {
             },
         });
     });
+
+    test("using multiple aliased aggregate projections", async () => {
+        const typeDefs = `
+            type ${typeMovie} @node {
+                testString: ID!
+                title: String!
+                imdbRating: Int!
+            }
+        `;
+
+        const testString = generate({
+            charset: "alphabetic",
+            readable: true,
+        });
+
+        const minDate = new Date();
+
+        const maxDate = new Date();
+        maxDate.setDate(maxDate.getDate() + 1);
+
+        await testHelper.initNeo4jGraphQL({ typeDefs });
+
+        await testHelper.executeCypher(
+            `
+                    CREATE (:${typeMovie} {testString: "${testString}", id: "1", title: "1", imdbRating: 1, createdAt: datetime("${minDate.toISOString()}")})
+                    CREATE (:${typeMovie} {testString: "${testString}", id: "22", title: "22", imdbRating: 2, createdAt: datetime()})
+                    CREATE (:${typeMovie} {testString: "${testString}", id: "333", title: "333", imdbRating: 3, createdAt: datetime()})
+                    CREATE (:${typeMovie} {testString: "${testString}", id: "4444", title: "4444", imdbRating: 4, createdAt: datetime("${maxDate.toISOString()}")})
+                `
+        );
+
+        const query = /* GraphQL */ `
+                {
+                    ${typeMovie.operations.connection}(where: { testString_EQ: "${testString}" }) {
+                        aggr1: aggregate {
+                            node {
+                                count
+                                title {
+                                    shortest: shortest
+                                    longest: longest
+                                }
+                                imdbRating: imdbRating {
+                                    min: min
+                                    max: max
+                                    average: average
+                                }        
+                            }
+                        }
+                        aggr2: aggregate {
+                            node {
+                                _title: title {
+                                    shortest: shortest
+                                    longest: longest
+                                }    
+                            }
+                        }
+                    }
+                }
+            `;
+
+        const gqlResult = await testHelper.executeGraphQL(query);
+
+        expect(gqlResult.errors).toBeUndefined();
+
+        expect(gqlResult.data).toEqual({
+            [typeMovie.operations.connection]: {
+                aggr1: {
+                    node: {
+                        count: 4,
+                        title: {
+                            shortest: "1",
+                            longest: "4444",
+                        },
+                        imdbRating: {
+                            min: 1,
+                            max: 4,
+                            average: 2.5,
+                        },
+                    },
+                },
+                aggr2: {
+                    node: {
+                        _title: {
+                            shortest: "1",
+                            longest: "4444",
+                        },
+                    },
+                },
+            },
+        });
+    });
 });

--- a/packages/graphql/tests/integration/deprecations/aggregations/top-level/alias.int.test.ts
+++ b/packages/graphql/tests/integration/deprecations/aggregations/top-level/alias.int.test.ts
@@ -18,8 +18,8 @@
  */
 
 import { generate } from "randomstring";
-import type { UniqueType } from "../../../utils/graphql-types";
-import { TestHelper } from "../../../utils/tests-helper";
+import type { UniqueType } from "../../../../utils/graphql-types";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("aggregations-top_level-alias", () => {
     const testHelper = new TestHelper();
@@ -67,28 +67,24 @@ describe("aggregations-top_level-alias", () => {
 
         const query = /* GraphQL */ `
                 {
-                    ${typeMovie.operations.connection}(where: { testString_EQ: "${testString}" }) {
-                        aggr: aggregate {
-                            n: node {
-                                _count: count
-                                _id: id {
-                                    _shortest: shortest
-                                    _longest: longest
-                                }
-                                _title: title {
-                                    _shortest: shortest
-                                    _longest: longest
-                                }
-                                _imdbRating: imdbRating {
-                                    _min: min
-                                    _max: max
-                                    _average: average
-                                }
-                                _createdAt: createdAt {
-                                    _min: min
-                                    _max: max
-                                }
-                            }
+                    ${typeMovie.operations.aggregate}(where: { testString_EQ: "${testString}" }) {
+                        _count: count
+                        _id: id {
+                            _shortest: shortest
+                            _longest: longest
+                        }
+                        _title: title {
+                            _shortest: shortest
+                            _longest: longest
+                        }
+                        _imdbRating: imdbRating {
+                            _min: min
+                            _max: max
+                            _average: average
+                        }
+                        _createdAt: createdAt {
+                            _min: min
+                            _max: max
                         }
                     }
                 }
@@ -98,30 +94,24 @@ describe("aggregations-top_level-alias", () => {
 
         expect(gqlResult.errors).toBeUndefined();
 
-        expect(gqlResult.data).toEqual({
-            [typeMovie.operations.connection]: {
-                aggr: {
-                    n: {
-                        _count: 4,
-                        _id: {
-                            _shortest: "1",
-                            _longest: "4444",
-                        },
-                        _title: {
-                            _shortest: "1",
-                            _longest: "4444",
-                        },
-                        _imdbRating: {
-                            _min: 1,
-                            _max: 4,
-                            _average: 2.5,
-                        },
-                        _createdAt: {
-                            _min: minDate.toISOString(),
-                            _max: maxDate.toISOString(),
-                        },
-                    },
-                },
+        expect((gqlResult.data as any)[typeMovie.operations.aggregate]).toEqual({
+            _count: 4,
+            _id: {
+                _shortest: "1",
+                _longest: "4444",
+            },
+            _title: {
+                _shortest: "1",
+                _longest: "4444",
+            },
+            _imdbRating: {
+                _min: 1,
+                _max: 4,
+                _average: 2.5,
+            },
+            _createdAt: {
+                _min: minDate.toISOString(),
+                _max: maxDate.toISOString(),
             },
         });
     });

--- a/packages/graphql/tests/integration/deprecations/aggregations/top-level/authorization.int.test.ts
+++ b/packages/graphql/tests/integration/deprecations/aggregations/top-level/authorization.int.test.ts
@@ -18,8 +18,8 @@
  */
 
 import { generate } from "randomstring";
-import { createBearerToken } from "../../../utils/create-bearer-token";
-import { TestHelper } from "../../../utils/tests-helper";
+import { createBearerToken } from "../../../../utils/create-bearer-token";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("aggregations-top_level authorization", () => {
     const testHelper = new TestHelper();
@@ -46,12 +46,8 @@ describe("aggregations-top_level authorization", () => {
 
         const query = `
             {
-                ${randomType.operations.connection} {
-                    aggregate {
-                        node {
-                            count
-                        }
-                    }
+                ${randomType.operations.aggregate} {
+                    count
                 }
             }
         `;
@@ -77,21 +73,18 @@ describe("aggregations-top_level authorization", () => {
     });
 
     test("should append auth where to predicate and return post count for this user", async () => {
-        const Post = testHelper.createUniqueType("Post");
-        const User = testHelper.createUniqueType("User");
-
         const typeDefs = /* GraphQL */ `
-            type ${User} @node {
+            type User @node {
                 id: ID
-                posts: [${Post}!]! @relationship(type: "POSTED", direction: OUT)
+                posts: [Post!]! @relationship(type: "POSTED", direction: OUT)
             }
 
-            type ${Post} @node {
+            type Post @node {
                 content: String
-                creator: ${User}! @relationship(type: "POSTED", direction: IN)
+                creator: User! @relationship(type: "POSTED", direction: IN)
             }
 
-            extend type ${Post}
+            extend type Post
                 @authorization(
                     filter: [{ operations: [AGGREGATE], where: { node: { creator: { id_EQ: "$jwt.sub" } } } }]
                 )
@@ -103,12 +96,8 @@ describe("aggregations-top_level authorization", () => {
 
         const query = `
             {
-                ${Post.operations.connection} {
-                    aggregate {
-                        node {
-                            count
-                        }
-                    }
+                postsAggregate {
+                    count
                 }
             }
         `;
@@ -123,7 +112,7 @@ describe("aggregations-top_level authorization", () => {
         });
 
         await testHelper.executeCypher(`
-                CREATE (:${User} {id: "${userId}"})-[:POSTED]->(:${Post} {content: randomUUID()})
+                CREATE (:User {id: "${userId}"})-[:POSTED]->(:Post {content: randomUUID()})
             `);
 
         const token = createBearerToken(secret, { sub: userId });
@@ -133,12 +122,8 @@ describe("aggregations-top_level authorization", () => {
         expect(gqlResult.errors).toBeUndefined();
 
         expect(gqlResult.data).toEqual({
-            [Post.operations.connection]: {
-                aggregate: {
-                    node: {
-                        count: 1,
-                    },
-                },
+            postsAggregate: {
+                count: 1,
             },
         });
     });
@@ -167,14 +152,10 @@ describe("aggregations-top_level authorization", () => {
 
         const query = `
             {
-                moviesConnection(where: {id_EQ: "${movieId}"}) {
-                    aggregate {
-                        node {
-                            imdbRatingInt {
-                                min
-                                max
-                            }
-                        }
+                moviesAggregate(where: {id_EQ: "${movieId}"}) {
+                    imdbRatingInt {
+                        min
+                        max
                     }
                 }
             }
@@ -224,14 +205,10 @@ describe("aggregations-top_level authorization", () => {
 
         const query = `
             {
-                moviesConnection(where: {id_EQ: "${movieId}"}) {
-                    aggregate {
-                        node {
-                            someId {
-                                shortest
-                                longest
-                            }
-                        }
+                moviesAggregate(where: {id_EQ: "${movieId}"}) {
+                    someId {
+                        shortest
+                        longest
                     }
                 }
             }
@@ -281,15 +258,11 @@ describe("aggregations-top_level authorization", () => {
 
         const query = `
             {
-                moviesConnection(where: {id_EQ: "${movieId}"}) {
-                    aggregate {
-                        node {
-                            someString {
-                                shortest
-                                longest
-                            }
-                        }
-                    }    
+                moviesAggregate(where: {id_EQ: "${movieId}"}) {
+                    someString {
+                        shortest
+                        longest
+                    }
                 }
             }
         `;
@@ -338,14 +311,10 @@ describe("aggregations-top_level authorization", () => {
 
         const query = `
             {
-                moviesConnection(where: {id_EQ: "${movieId}"}) {
-                    aggregate {
-                        node {
-                            imdbRatingFloat {
-                                min
-                                max
-                            }
-                        }
+                moviesAggregate(where: {id_EQ: "${movieId}"}) {
+                    imdbRatingFloat {
+                        min
+                        max
                     }
                 }
             }
@@ -395,14 +364,10 @@ describe("aggregations-top_level authorization", () => {
 
         const query = `
             {
-                moviesConnection(where: {id_EQ: "${movieId}"}) {
-                    aggregate {
-                        node {
-                            imdbRatingBigInt {
-                                min
-                                max
-                            }
-                        }
+                moviesAggregate(where: {id_EQ: "${movieId}"}) {
+                    imdbRatingBigInt {
+                        min
+                        max
                     }
                 }
             }
@@ -452,14 +417,10 @@ describe("aggregations-top_level authorization", () => {
 
         const query = `
             {
-                moviesConnection(where: {id_EQ: "${movieId}"}) {
-                    aggregate {
-                        node {
-                            createdAt {
-                                min
-                                max
-                            }
-                        }
+                moviesAggregate(where: {id_EQ: "${movieId}"}) {
+                    createdAt {
+                        min
+                        max
                     }
                 }
             }
@@ -509,14 +470,10 @@ describe("aggregations-top_level authorization", () => {
 
         const query = `
             {
-                moviesConnection(where: {id_EQ: "${movieId}"}) {
-                    aggregate {
-                        node {
-                            screenTime {
-                                min
-                                max
-                            }
-                        }
+                moviesAggregate(where: {id_EQ: "${movieId}"}) {
+                    screenTime {
+                        min
+                        max
                     }
                 }
             }

--- a/packages/graphql/tests/integration/deprecations/aggregations/top-level/basic.int.test.ts
+++ b/packages/graphql/tests/integration/deprecations/aggregations/top-level/basic.int.test.ts
@@ -40,21 +40,14 @@ describe("aggregations-top_level-basic", () => {
         await testHelper.initNeo4jGraphQL({ typeDefs });
 
         await testHelper.executeCypher(`
-            CREATE (:${randomType.name} {id: "asd"})
-            CREATE (:${randomType.name} {id: "asd3"})
+            CREATE (:${randomType.name} {id: randomUUID()})
+            CREATE (:${randomType.name} {id: randomUUID()})
         `);
 
         const query = `
                 {
-                    ${randomType.operations.connection} {
-                        aggregate {
-                            node {
-                                count
-                                id {
-                                    longest 
-                                }
-                            }
-                        }
+                    ${randomType.operations.aggregate} {
+                        count
                     }
                 }
             `;
@@ -63,17 +56,8 @@ describe("aggregations-top_level-basic", () => {
 
         expect(gqlResult.errors).toBeUndefined();
 
-        expect(gqlResult.data).toEqual({
-            [randomType.operations.connection]: {
-                aggregate: {
-                    node: {
-                        count: 2,
-                        id: {
-                            longest: "asd3",
-                        },
-                    },
-                },
-            },
+        expect((gqlResult.data as any)[randomType.operations.aggregate]).toEqual({
+            count: 2,
         });
     });
 });

--- a/packages/graphql/tests/integration/deprecations/aggregations/top-level/basic.int.test.ts
+++ b/packages/graphql/tests/integration/deprecations/aggregations/top-level/basic.int.test.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import { TestHelper } from "../../../utils/tests-helper";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("aggregations-top_level-basic", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/deprecations/aggregations/top-level/bigint.test.ts
+++ b/packages/graphql/tests/integration/deprecations/aggregations/top-level/bigint.test.ts
@@ -18,7 +18,7 @@
  */
 
 import { generate } from "randomstring";
-import { TestHelper } from "../../../utils/tests-helper";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("aggregations-top_level-bigint", () => {
     const testHelper = new TestHelper();
@@ -35,7 +35,7 @@ describe("aggregations-top_level-bigint", () => {
         const movieType = testHelper.createUniqueType("Movie");
 
         const typeDefs = `
-            type ${movieType} @node {
+            type ${movieType.name} @node {
                 testString: String
                 imdbRatingBigInt: BigInt
             }
@@ -50,10 +50,10 @@ describe("aggregations-top_level-bigint", () => {
 
         await testHelper.executeCypher(
             `
-                    CREATE (:${movieType} {testString: $testString, imdbRatingBigInt: ${bigInt}1})
-                    CREATE (:${movieType} {testString: $testString, imdbRatingBigInt: ${bigInt}2})
-                    CREATE (:${movieType} {testString: $testString, imdbRatingBigInt: ${bigInt}3})
-                    CREATE (:${movieType} {testString: $testString, imdbRatingBigInt: ${bigInt}4})
+                    CREATE (:${movieType.name} {testString: $testString, imdbRatingBigInt: ${bigInt}1})
+                    CREATE (:${movieType.name} {testString: $testString, imdbRatingBigInt: ${bigInt}2})
+                    CREATE (:${movieType.name} {testString: $testString, imdbRatingBigInt: ${bigInt}3})
+                    CREATE (:${movieType.name} {testString: $testString, imdbRatingBigInt: ${bigInt}4})
                 `,
             {
                 testString,
@@ -62,13 +62,9 @@ describe("aggregations-top_level-bigint", () => {
 
         const query = `
                 {
-                    ${movieType.operations.connection}(where: {testString_EQ: "${testString}"}) {
-                        aggregate {
-                            node {
-                                imdbRatingBigInt {
-                                    min
-                                }
-                            }
+                    ${movieType.operations.aggregate}(where: {testString_EQ: "${testString}"}) {
+                        imdbRatingBigInt {
+                            min
                         }
                     }
                 }
@@ -78,15 +74,9 @@ describe("aggregations-top_level-bigint", () => {
 
         expect(gqlResult.errors).toBeUndefined();
 
-        expect(gqlResult.data).toEqual({
-            [movieType.operations.connection]: {
-                aggregate: {
-                    node: {
-                        imdbRatingBigInt: {
-                            min: `${bigInt}1`,
-                        },
-                    },
-                },
+        expect((gqlResult.data as any)[movieType.operations.aggregate]).toEqual({
+            imdbRatingBigInt: {
+                min: `${bigInt}1`,
             },
         });
     });
@@ -122,14 +112,10 @@ describe("aggregations-top_level-bigint", () => {
 
         const query = `
                 {
-                    ${movieType.operations.connection}(where: {testString_EQ: "${testString}"}) {
-                    aggregate { 
-                        node {
-                            imdbRatingBigInt {
-                                max
-                                }
-                            }
-                        }    
+                    ${movieType.operations.aggregate}(where: {testString_EQ: "${testString}"}) {
+                        imdbRatingBigInt {
+                            max
+                        }
                     }
                 }
             `;
@@ -138,15 +124,9 @@ describe("aggregations-top_level-bigint", () => {
 
         expect(gqlResult.errors).toBeUndefined();
 
-        expect(gqlResult.data).toEqual({
-            [movieType.operations.connection]: {
-                aggregate: {
-                    node: {
-                        imdbRatingBigInt: {
-                            max: `${bigInt}4`,
-                        },
-                    },
-                },
+        expect((gqlResult.data as any)[movieType.operations.aggregate]).toEqual({
+            imdbRatingBigInt: {
+                max: `${bigInt}4`,
             },
         });
     });
@@ -182,15 +162,11 @@ describe("aggregations-top_level-bigint", () => {
 
         const query = `
                 {
-                    ${movieType.operations.connection}(where: {testString_EQ: "${testString}"}) {
-                    aggregate { 
-                        node {
-                            imdbRatingBigInt {
-                                average
-                                }
-                            }
+                    ${movieType.operations.aggregate}(where: {testString_EQ: "${testString}"}) {
+                        imdbRatingBigInt {
+                            average
                         }
-                    }    
+                    }
                 }
             `;
 
@@ -198,15 +174,9 @@ describe("aggregations-top_level-bigint", () => {
 
         expect(gqlResult.errors).toBeUndefined();
 
-        expect(gqlResult.data).toEqual({
-            [movieType.operations.connection]: {
-                aggregate: {
-                    node: {
-                        imdbRatingBigInt: {
-                            average: `${bigInt}2.5`,
-                        },
-                    },
-                },
+        expect((gqlResult.data as any)[movieType.operations.aggregate]).toEqual({
+            imdbRatingBigInt: {
+                average: `${bigInt}2.5`,
             },
         });
     });
@@ -242,14 +212,10 @@ describe("aggregations-top_level-bigint", () => {
 
         const query = `
                 {
-                    ${movieType.operations.connection}(where: {testString_EQ: "${testString}"}) {
-                        aggregate {
-                            node {
-                                imdbRatingBigInt {
-                                    sum
-                                }
-                            }
-                        }    
+                    ${movieType.operations.aggregate}(where: {testString_EQ: "${testString}"}) {
+                        imdbRatingBigInt {
+                            sum
+                        }
                     }
                 }
             `;
@@ -258,15 +224,9 @@ describe("aggregations-top_level-bigint", () => {
 
         expect(gqlResult.errors).toBeUndefined();
 
-        expect(gqlResult.data).toEqual({
-            [movieType.operations.connection]: {
-                aggregate: {
-                    node: {
-                        imdbRatingBigInt: {
-                            sum: "85899345890",
-                        },
-                    },
-                },
+        expect((gqlResult.data as any)[movieType.operations.aggregate]).toEqual({
+            imdbRatingBigInt: {
+                sum: "85899345890",
             },
         });
     });
@@ -302,17 +262,13 @@ describe("aggregations-top_level-bigint", () => {
 
         const query = `
                 {
-                    ${movieType.operations.connection}(where: {testString_EQ: "${testString}"}) {
-                        aggregate {
-                            node {
-                                imdbRatingBigInt {
-                                    min
-                                    max
-                                    average
-                                    sum
-                                }
-                            }
-                        }    
+                    ${movieType.operations.aggregate}(where: {testString_EQ: "${testString}"}) {
+                        imdbRatingBigInt {
+                            min
+                            max
+                            average
+                            sum
+                        }
                     }
                 }
             `;
@@ -321,18 +277,12 @@ describe("aggregations-top_level-bigint", () => {
 
         expect(gqlResult.errors).toBeUndefined();
 
-        expect(gqlResult.data).toEqual({
-            [movieType.operations.connection]: {
-                aggregate: {
-                    node: {
-                        imdbRatingBigInt: {
-                            min: `${bigInt}1`,
-                            max: `${bigInt}4`,
-                            average: `${bigInt}2.5`,
-                            sum: "85899345890",
-                        },
-                    },
-                },
+        expect((gqlResult.data as any)[movieType.operations.aggregate]).toEqual({
+            imdbRatingBigInt: {
+                min: `${bigInt}1`,
+                max: `${bigInt}4`,
+                average: `${bigInt}2.5`,
+                sum: "85899345890",
             },
         });
     });

--- a/packages/graphql/tests/integration/deprecations/aggregations/top-level/count.int.test.ts
+++ b/packages/graphql/tests/integration/deprecations/aggregations/top-level/count.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import { generate } from "randomstring";
-import { TestHelper } from "../../../utils/tests-helper";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("Aggregate -> count", () => {
     const testHelper = new TestHelper();
@@ -49,12 +49,8 @@ describe("Aggregate -> count", () => {
 
         const query = `
                 {
-                    ${randomType.operations.connection}{
-                        aggregate {
-                            node {
-                                count
-                            }
-                        }
+                    ${randomType.operations.aggregate}{
+                      count
                     }
                 }
             `;
@@ -62,15 +58,7 @@ describe("Aggregate -> count", () => {
         const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
-        expect(gqlResult.data).toEqual({
-            [randomType.operations.connection]: {
-                aggregate: {
-                    node: {
-                        count: 2,
-                    },
-                },
-            },
-        });
+        expect((gqlResult.data as any)[randomType.operations.aggregate].count).toBe(2);
     });
 
     test("should count nodes with where and or predicate", async () => {
@@ -92,27 +80,18 @@ describe("Aggregate -> count", () => {
             charset: "alphabetic",
         });
 
-        const id3 = generate({
-            charset: "alphabetic",
-        });
-
         await testHelper.executeCypher(
             `
                 CREATE (:${randomType.name} {id: $id1})
                 CREATE (:${randomType.name} {id: $id2})
-                CREATE (:${randomType.name} {id: $id3})
             `,
-            { id1, id2, id3 }
+            { id1, id2 }
         );
 
         const query = `
                 {
-                  ${randomType.operations.connection}(where: { OR: [{id_EQ: "${id1}"}, {id_EQ: "${id2}"}] }){
-                    aggregate {
-                        node {
-                            count
-                        }
-                    }
+                  ${randomType.operations.aggregate}(where: { OR: [{id_EQ: "${id1}"}, {id_EQ: "${id2}"}] }){
+                    count
                   }
                 }
             `;
@@ -121,14 +100,6 @@ describe("Aggregate -> count", () => {
 
         expect(gqlResult.errors).toBeUndefined();
 
-        expect(gqlResult.data).toEqual({
-            [randomType.operations.connection]: {
-                aggregate: {
-                    node: {
-                        count: 2,
-                    },
-                },
-            },
-        });
+        expect((gqlResult.data as any)[randomType.operations.aggregate].count).toBe(2);
     });
 });

--- a/packages/graphql/tests/integration/deprecations/aggregations/top-level/datetime.int.test.ts
+++ b/packages/graphql/tests/integration/deprecations/aggregations/top-level/datetime.int.test.ts
@@ -18,8 +18,8 @@
  */
 
 import { generate } from "randomstring";
-import type { UniqueType } from "../../../utils/graphql-types";
-import { TestHelper } from "../../../utils/tests-helper";
+import type { UniqueType } from "../../../../utils/graphql-types";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("aggregations-top_level-datetime", () => {
     const testHelper = new TestHelper();
@@ -64,13 +64,9 @@ describe("aggregations-top_level-datetime", () => {
 
         const query = `
                 {
-                    ${Movie.operations.connection}(where: {testString_EQ: "${testString}"}) {
-                        aggregate {
-                            node {
-                                createdAt {
-                                    min
-                                }
-                            }
+                    ${Movie.operations.aggregate}(where: {testString_EQ: "${testString}"}) {
+                        createdAt {
+                            min
                         }
                     }
                 }
@@ -80,15 +76,9 @@ describe("aggregations-top_level-datetime", () => {
 
         expect(gqlResult.errors).toBeUndefined();
 
-        expect(gqlResult.data).toEqual({
-            [Movie.operations.connection]: {
-                aggregate: {
-                    node: {
-                        createdAt: {
-                            min: minDate.toISOString(),
-                        },
-                    },
-                },
+        expect((gqlResult.data as any)[Movie.operations.aggregate]).toEqual({
+            createdAt: {
+                min: minDate.toISOString(),
             },
         });
     });
@@ -118,14 +108,10 @@ describe("aggregations-top_level-datetime", () => {
 
         const query = `
                 {
-                    ${Movie.operations.connection}(where: {testString_EQ: "${testString}"}) {
-                        aggregate {
-                            node {
-                                createdAt {
-                                    max
-                                }
-                            }
-                        }    
+                    ${Movie.operations.aggregate}(where: {testString_EQ: "${testString}"}) {
+                        createdAt {
+                            max
+                        }
                     }
                 }
             `;
@@ -134,15 +120,9 @@ describe("aggregations-top_level-datetime", () => {
 
         expect(gqlResult.errors).toBeUndefined();
 
-        expect(gqlResult.data).toEqual({
-            [Movie.operations.connection]: {
-                aggregate: {
-                    node: {
-                        createdAt: {
-                            max: maxDate.toISOString(),
-                        },
-                    },
-                },
+        expect((gqlResult.data as any)[Movie.operations.aggregate]).toEqual({
+            createdAt: {
+                max: maxDate.toISOString(),
             },
         });
     });
@@ -172,16 +152,12 @@ describe("aggregations-top_level-datetime", () => {
 
         const query = `
                 {
-                    ${Movie.operations.connection}(where: {testString_EQ: "${testString}"}) {
-                        aggregate {
-                            node {
-                                createdAt {
-                                    min
-                                    max
-                                }
-                            }
+                    ${Movie.operations.aggregate}(where: {testString_EQ: "${testString}"}) {
+                        createdAt {
+                            min
+                            max
                         }
-                    }    
+                    }
                 }
             `;
 
@@ -189,16 +165,10 @@ describe("aggregations-top_level-datetime", () => {
 
         expect(gqlResult.errors).toBeUndefined();
 
-        expect(gqlResult.data).toEqual({
-            [Movie.operations.connection]: {
-                aggregate: {
-                    node: {
-                        createdAt: {
-                            min: minDate.toISOString(),
-                            max: maxDate.toISOString(),
-                        },
-                    },
-                },
+        expect((gqlResult.data as any)[Movie.operations.aggregate]).toEqual({
+            createdAt: {
+                min: minDate.toISOString(),
+                max: maxDate.toISOString(),
             },
         });
     });

--- a/packages/graphql/tests/integration/deprecations/aggregations/top-level/duration.int.test.ts
+++ b/packages/graphql/tests/integration/deprecations/aggregations/top-level/duration.int.test.ts
@@ -19,8 +19,8 @@
 
 import neo4jDriver from "neo4j-driver";
 import { generate } from "randomstring";
-import type { UniqueType } from "../../../utils/graphql-types";
-import { TestHelper } from "../../../utils/tests-helper";
+import type { UniqueType } from "../../../../utils/graphql-types";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("aggregations-top_level-duration", () => {
     const testHelper = new TestHelper();
@@ -68,13 +68,9 @@ describe("aggregations-top_level-duration", () => {
 
         const query = `
                 {
-                    ${Movie.operations.connection}(where: {testString_EQ: "${testString}"}) {
-                        aggregate {
-                            node {
-                                runningTime {
-                                    min
-                                }
-                            }
+                    ${Movie.operations.aggregate}(where: {testString_EQ: "${testString}"}) {
+                        runningTime {
+                            min
                         }
                     }
                 }
@@ -84,15 +80,9 @@ describe("aggregations-top_level-duration", () => {
 
         expect(gqlResult.errors).toBeUndefined();
 
-        expect(gqlResult.data).toEqual({
-            [Movie.operations.connection]: {
-                aggregate: {
-                    node: {
-                        runningTime: {
-                            min: minDuration.toString(),
-                        },
-                    },
-                },
+        expect((gqlResult.data as any)[Movie.operations.aggregate]).toEqual({
+            runningTime: {
+                min: minDuration.toString(),
             },
         });
     });
@@ -122,13 +112,9 @@ describe("aggregations-top_level-duration", () => {
 
         const query = `
                 {
-                    ${Movie.operations.connection}(where: {testString_EQ: "${testString}"}) {
-                        aggregate {
-                            node {
-                                runningTime {
-                                    max
-                                }
-                            }
+                    ${Movie.operations.aggregate}(where: {testString_EQ: "${testString}"}) {
+                        runningTime {
+                            max
                         }
                     }
                 }
@@ -138,15 +124,9 @@ describe("aggregations-top_level-duration", () => {
 
         expect(gqlResult.errors).toBeUndefined();
 
-        expect(gqlResult.data).toEqual({
-            [Movie.operations.connection]: {
-                aggregate: {
-                    node: {
-                        runningTime: {
-                            max: maxDuration.toString(),
-                        },
-                    },
-                },
+        expect((gqlResult.data as any)[Movie.operations.aggregate]).toEqual({
+            runningTime: {
+                max: maxDuration.toString(),
             },
         });
     });
@@ -176,14 +156,10 @@ describe("aggregations-top_level-duration", () => {
 
         const query = `
                 {
-                    ${Movie.operations.connection}(where: {testString_EQ: "${testString}"}) {
-                        aggregate {
-                            node {
-                                runningTime {
-                                    min
-                                    max
-                                }
-                            }
+                    ${Movie.operations.aggregate}(where: {testString_EQ: "${testString}"}) {
+                        runningTime {
+                            min
+                            max
                         }
                     }
                 }
@@ -193,16 +169,10 @@ describe("aggregations-top_level-duration", () => {
 
         expect(gqlResult.errors).toBeUndefined();
 
-        expect(gqlResult.data).toEqual({
-            [Movie.operations.connection]: {
-                aggregate: {
-                    node: {
-                        runningTime: {
-                            min: minDuration.toString(),
-                            max: maxDuration.toString(),
-                        },
-                    },
-                },
+        expect((gqlResult.data as any)[Movie.operations.aggregate]).toEqual({
+            runningTime: {
+                min: minDuration.toString(),
+                max: maxDuration.toString(),
             },
         });
     });

--- a/packages/graphql/tests/integration/deprecations/aggregations/top-level/float.int.test.ts
+++ b/packages/graphql/tests/integration/deprecations/aggregations/top-level/float.int.test.ts
@@ -18,8 +18,8 @@
  */
 
 import { generate } from "randomstring";
-import type { UniqueType } from "../../../utils/graphql-types";
-import { TestHelper } from "../../../utils/tests-helper";
+import type { UniqueType } from "../../../../utils/graphql-types";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("aggregations-top_level-float", () => {
     const testHelper = new TestHelper();
@@ -60,13 +60,9 @@ describe("aggregations-top_level-float", () => {
 
         const query = `
                 {
-                    ${Movie.operations.connection}(where: {testString_EQ: "${testString}"}) {
-                        aggregate { 
-                            node{
-                                imdbRating {
-                                    min
-                                }
-                            }
+                    ${Movie.operations.aggregate}(where: {testString_EQ: "${testString}"}) {
+                        imdbRating {
+                            min
                         }
                     }
                 }
@@ -76,15 +72,9 @@ describe("aggregations-top_level-float", () => {
 
         expect(gqlResult.errors).toBeUndefined();
 
-        expect(gqlResult.data).toEqual({
-            [Movie.operations.connection]: {
-                aggregate: {
-                    node: {
-                        imdbRating: {
-                            min: expect.closeTo(1.1),
-                        },
-                    },
-                },
+        expect((gqlResult.data as any)[Movie.operations.aggregate]).toEqual({
+            imdbRating: {
+                min: expect.closeTo(1.1),
             },
         });
     });
@@ -109,13 +99,9 @@ describe("aggregations-top_level-float", () => {
 
         const query = `
                 {
-                    ${Movie.operations.connection}(where: {testString_EQ: "${testString}"}) {
-                        aggregate {
-                            node {
-                                imdbRating {
-                                    max
-                                }
-                            }
+                    ${Movie.operations.aggregate}(where: {testString_EQ: "${testString}"}) {
+                        imdbRating {
+                            max
                         }
                     }
                 }
@@ -129,15 +115,9 @@ describe("aggregations-top_level-float", () => {
 
         expect(gqlResult.errors).toBeUndefined();
 
-        expect(gqlResult.data).toEqual({
-            [Movie.operations.connection]: {
-                aggregate: {
-                    node: {
-                        imdbRating: {
-                            max: expect.closeTo(4.1),
-                        },
-                    },
-                },
+        expect((gqlResult.data as any)[Movie.operations.aggregate]).toEqual({
+            imdbRating: {
+                max: expect.closeTo(4.1),
             },
         });
     });
@@ -162,13 +142,9 @@ describe("aggregations-top_level-float", () => {
 
         const query = `
                 {
-                    ${Movie.operations.connection}(where: {testString_EQ: "${testString}"}) {
-                        aggregate {
-                            node {
-                                imdbRating {
-                                    average
-                                }
-                            }
+                    ${Movie.operations.aggregate}(where: {testString_EQ: "${testString}"}) {
+                        imdbRating {
+                            average
                         }
                     }
                 }
@@ -182,15 +158,9 @@ describe("aggregations-top_level-float", () => {
 
         expect(gqlResult.errors).toBeUndefined();
 
-        expect(gqlResult.data).toEqual({
-            [Movie.operations.connection]: {
-                aggregate: {
-                    node: {
-                        imdbRating: {
-                            average: expect.closeTo(2.6),
-                        },
-                    },
-                },
+        expect((gqlResult.data as any)[Movie.operations.aggregate]).toEqual({
+            imdbRating: {
+                average: expect.closeTo(2.6),
             },
         });
     });
@@ -215,15 +185,11 @@ describe("aggregations-top_level-float", () => {
 
         const query = `
                 {
-                ${Movie.operations.connection}(where: {testString_EQ: "${testString}"}) {
-                    aggregate {
-                        node {
-                            imdbRating {
-                                    sum
-                                }
-                            }
+                ${Movie.operations.aggregate}(where: {testString_EQ: "${testString}"}) {
+                        imdbRating {
+                            sum
                         }
-                    }    
+                    }
                 }
             `;
 
@@ -235,15 +201,9 @@ describe("aggregations-top_level-float", () => {
 
         expect(gqlResult.errors).toBeUndefined();
 
-        expect(gqlResult.data).toEqual({
-            [Movie.operations.connection]: {
-                aggregate: {
-                    node: {
-                        imdbRating: {
-                            sum: expect.closeTo(10.4),
-                        },
-                    },
-                },
+        expect((gqlResult.data as any)[Movie.operations.aggregate]).toEqual({
+            imdbRating: {
+                sum: expect.closeTo(10.4),
             },
         });
     });
@@ -268,16 +228,12 @@ describe("aggregations-top_level-float", () => {
 
         const query = `
                 {
-                    ${Movie.operations.connection}(where: {testString_EQ: "${testString}"}) {
-                        aggregate {
-                            node {
-                                imdbRating {
-                                    min
-                                    max
-                                    average
-                                    sum
-                                }
-                            }
+                    ${Movie.operations.aggregate}(where: {testString_EQ: "${testString}"}) {
+                        imdbRating {
+                            min
+                            max
+                            average
+                            sum
                         }
                     }
                 }
@@ -291,18 +247,12 @@ describe("aggregations-top_level-float", () => {
 
         expect(gqlResult.errors).toBeUndefined();
 
-        expect(gqlResult.data).toEqual({
-            [Movie.operations.connection]: {
-                aggregate: {
-                    node: {
-                        imdbRating: {
-                            min: expect.closeTo(1.1),
-                            max: expect.closeTo(4.1),
-                            average: expect.closeTo(2.6),
-                            sum: expect.closeTo(10.4),
-                        },
-                    },
-                },
+        expect((gqlResult.data as any)[Movie.operations.aggregate]).toEqual({
+            imdbRating: {
+                min: expect.closeTo(1.1),
+                max: expect.closeTo(4.1),
+                average: expect.closeTo(2.6),
+                sum: expect.closeTo(10.4),
             },
         });
     });

--- a/packages/graphql/tests/integration/deprecations/aggregations/top-level/id.int.test.ts
+++ b/packages/graphql/tests/integration/deprecations/aggregations/top-level/id.int.test.ts
@@ -18,8 +18,8 @@
  */
 
 import { generate } from "randomstring";
-import type { UniqueType } from "../../../utils/graphql-types";
-import { TestHelper } from "../../../utils/tests-helper";
+import type { UniqueType } from "../../../../utils/graphql-types";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("aggregations-top_level-id", () => {
     const testHelper = new TestHelper();
@@ -61,13 +61,9 @@ describe("aggregations-top_level-id", () => {
 
         const query = `
                 {
-                    ${Movie.operations.connection}(where: {testId_EQ: "${id}"}) {
-                        aggregate {
-                            node {
-                                id {
-                                    shortest
-                                }
-                            }
+                    ${Movie.operations.aggregate}(where: {testId_EQ: "${id}"}) {
+                        id {
+                            shortest
                         }
                     }
                 }
@@ -81,15 +77,9 @@ describe("aggregations-top_level-id", () => {
 
         expect(gqlResult.errors).toBeUndefined();
 
-        expect(gqlResult.data).toEqual({
-            [Movie.operations.connection]: {
-                aggregate: {
-                    node: {
-                        id: {
-                            shortest: "1",
-                        },
-                    },
-                },
+        expect((gqlResult.data as any)[Movie.operations.aggregate]).toEqual({
+            id: {
+                shortest: "1",
             },
         });
     });
@@ -114,14 +104,10 @@ describe("aggregations-top_level-id", () => {
 
         const query = `
                 {
-                    ${Movie.operations.connection}(where: {testId_EQ: "${id}"}) {
-                        aggregate {
-                        node {
-                            id {
-                                    longest
-                                }
-                            }
-                        }    
+                    ${Movie.operations.aggregate}(where: {testId_EQ: "${id}"}) {
+                        id {
+                            longest
+                        }
                     }
                 }
             `;
@@ -134,15 +120,9 @@ describe("aggregations-top_level-id", () => {
 
         expect(gqlResult.errors).toBeUndefined();
 
-        expect(gqlResult.data).toEqual({
-            [Movie.operations.connection]: {
-                aggregate: {
-                    node: {
-                        id: {
-                            longest: "4444",
-                        },
-                    },
-                },
+        expect((gqlResult.data as any)[Movie.operations.aggregate]).toEqual({
+            id: {
+                longest: "4444",
             },
         });
     });
@@ -167,14 +147,10 @@ describe("aggregations-top_level-id", () => {
 
         const query = `
                 {
-                    ${Movie.operations.connection}(where: {testId_EQ: "${id}"}) {
-                        aggregate {
-                            node {
-                                id {
-                                    shortest
-                                    longest
-                                }
-                            }
+                    ${Movie.operations.aggregate}(where: {testId_EQ: "${id}"}) {
+                        id {
+                            shortest
+                            longest
                         }
                     }
                 }
@@ -188,16 +164,10 @@ describe("aggregations-top_level-id", () => {
 
         expect(gqlResult.errors).toBeUndefined();
 
-        expect(gqlResult.data).toEqual({
-            [Movie.operations.connection]: {
-                aggregate: {
-                    node: {
-                        id: {
-                            shortest: "1",
-                            longest: "4444",
-                        },
-                    },
-                },
+        expect((gqlResult.data as any)[Movie.operations.aggregate]).toEqual({
+            id: {
+                shortest: "1",
+                longest: "4444",
             },
         });
     });

--- a/packages/graphql/tests/integration/deprecations/aggregations/top-level/int.int.test.ts
+++ b/packages/graphql/tests/integration/deprecations/aggregations/top-level/int.int.test.ts
@@ -18,8 +18,8 @@
  */
 
 import { generate } from "randomstring";
-import type { UniqueType } from "../../../utils/graphql-types";
-import { TestHelper } from "../../../utils/tests-helper";
+import type { UniqueType } from "../../../../utils/graphql-types";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("aggregations-top_level-int", () => {
     const testHelper = new TestHelper();
@@ -61,14 +61,10 @@ describe("aggregations-top_level-int", () => {
 
         const query = `
                 {
-                    ${Movie.operations.connection}(where: {testString_EQ: "${testString}"}) {
-                        aggregate {
-                            node {
-                                imdbRating {
-                                        min
-                                    }
-                            }
-                        }   
+                    ${Movie.operations.aggregate}(where: {testString_EQ: "${testString}"}) {
+                        imdbRating {
+                            min
+                        }
                     }
                 }
             `;
@@ -81,15 +77,9 @@ describe("aggregations-top_level-int", () => {
 
         expect(gqlResult.errors).toBeUndefined();
 
-        expect(gqlResult.data).toEqual({
-            [Movie.operations.connection]: {
-                aggregate: {
-                    node: {
-                        imdbRating: {
-                            min: 1,
-                        },
-                    },
-                },
+        expect((gqlResult.data as any)[Movie.operations.aggregate]).toEqual({
+            imdbRating: {
+                min: 1,
             },
         });
     });
@@ -114,14 +104,10 @@ describe("aggregations-top_level-int", () => {
 
         const query = `
                 {
-                    ${Movie.operations.connection}(where: {testString_EQ: "${testString}"}) {
-                        aggregate {
-                            node {
-                                imdbRating {
-                                        max
-                                    }
-                            }
-                        }   
+                    ${Movie.operations.aggregate}(where: {testString_EQ: "${testString}"}) {
+                        imdbRating {
+                            max
+                        }
                     }
                 }
             `;
@@ -134,15 +120,9 @@ describe("aggregations-top_level-int", () => {
 
         expect(gqlResult.errors).toBeUndefined();
 
-        expect(gqlResult.data).toEqual({
-            [Movie.operations.connection]: {
-                aggregate: {
-                    node: {
-                        imdbRating: {
-                            max: 4,
-                        },
-                    },
-                },
+        expect((gqlResult.data as any)[Movie.operations.aggregate]).toEqual({
+            imdbRating: {
+                max: 4,
             },
         });
     });
@@ -167,14 +147,10 @@ describe("aggregations-top_level-int", () => {
 
         const query = `
                 {
-                    ${Movie.operations.connection}(where: {testString_EQ: "${testString}"}) {
-                        aggregate {
-                            node {
-                                imdbRating {
-                                        average
-                                    }
-                            }
-                        }   
+                    ${Movie.operations.aggregate}(where: {testString_EQ: "${testString}"}) {
+                        imdbRating {
+                            average
+                        }
                     }
                 }
             `;
@@ -187,15 +163,9 @@ describe("aggregations-top_level-int", () => {
 
         expect(gqlResult.errors).toBeUndefined();
 
-        expect(gqlResult.data).toEqual({
-            [Movie.operations.connection]: {
-                aggregate: {
-                    node: {
-                        imdbRating: {
-                            average: 2.5,
-                        },
-                    },
-                },
+        expect((gqlResult.data as any)[Movie.operations.aggregate]).toEqual({
+            imdbRating: {
+                average: 2.5,
             },
         });
     });
@@ -220,14 +190,10 @@ describe("aggregations-top_level-int", () => {
 
         const query = `
                 {
-                    ${Movie.operations.connection}(where: {testString_EQ: "${testString}"}) {
-                        aggregate {
-                            node {
-                                imdbRating {
-                                        sum
-                                    }
-                            }
-                        }   
+                    ${Movie.operations.aggregate}(where: {testString_EQ: "${testString}"}) {
+                        imdbRating {
+                            sum
+                        }
                     }
                 }
             `;
@@ -240,15 +206,9 @@ describe("aggregations-top_level-int", () => {
 
         expect(gqlResult.errors).toBeUndefined();
 
-        expect(gqlResult.data).toEqual({
-            [Movie.operations.connection]: {
-                aggregate: {
-                    node: {
-                        imdbRating: {
-                            sum: 10,
-                        },
-                    },
-                },
+        expect((gqlResult.data as any)[Movie.operations.aggregate]).toEqual({
+            imdbRating: {
+                sum: 10,
             },
         });
     });
@@ -273,16 +233,12 @@ describe("aggregations-top_level-int", () => {
 
         const query = `
                 {
-                    ${Movie.operations.connection}(where: {testString_EQ: "${testString}"}) {
-                        aggregate {
-                            node {
-                                imdbRating {
-                                        min
-                                        max
-                                        average
-                                        sum
-                                }
-                            }   
+                    ${Movie.operations.aggregate}(where: {testString_EQ: "${testString}"}) {
+                        imdbRating {
+                            min
+                            max
+                            average
+                            sum
                         }
                     }
                 }
@@ -296,18 +252,12 @@ describe("aggregations-top_level-int", () => {
 
         expect(gqlResult.errors).toBeUndefined();
 
-        expect(gqlResult.data).toEqual({
-            [Movie.operations.connection]: {
-                aggregate: {
-                    node: {
-                        imdbRating: {
-                            min: 1,
-                            max: 4,
-                            average: 2.5,
-                            sum: 10,
-                        },
-                    },
-                },
+        expect((gqlResult.data as any)[Movie.operations.aggregate]).toEqual({
+            imdbRating: {
+                min: 1,
+                max: 4,
+                average: 2.5,
+                sum: 10,
             },
         });
     });

--- a/packages/graphql/tests/integration/deprecations/aggregations/top-level/many.int.test.ts
+++ b/packages/graphql/tests/integration/deprecations/aggregations/top-level/many.int.test.ts
@@ -18,8 +18,8 @@
  */
 
 import { generate } from "randomstring";
-import type { UniqueType } from "../../../utils/graphql-types";
-import { TestHelper } from "../../../utils/tests-helper";
+import type { UniqueType } from "../../../../utils/graphql-types";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("aggregations-top_level-many", () => {
     const testHelper = new TestHelper();
@@ -67,29 +67,25 @@ describe("aggregations-top_level-many", () => {
 
         const query = `
                 {
-                    ${typeMovie.operations.connection}(where: { testId_EQ: "${testId}" }) {
-                        aggregate {
-                            node {
-                                id {
-                                        shortest
-                                        longest
-                                    }
-                                    title {
-                                        shortest
-                                        longest
-                                    }
-                                    imdbRating {
-                                        min
-                                        max
-                                        average
-                                    }
-                                    createdAt {
-                                        min
-                                        max
-                                    }
-                                }
-                            }
-                    }  
+                    ${typeMovie.operations.aggregate}(where: { testId_EQ: "${testId}" }) {
+                        id {
+                            shortest
+                            longest
+                        }
+                        title {
+                            shortest
+                            longest
+                        }
+                        imdbRating {
+                            min
+                            max
+                            average
+                        }
+                        createdAt {
+                            min
+                            max
+                        }
+                    }
                 }
             `;
 
@@ -101,29 +97,23 @@ describe("aggregations-top_level-many", () => {
 
         expect(gqlResult.errors).toBeUndefined();
 
-        expect(gqlResult.data).toEqual({
-            [typeMovie.operations.connection]: {
-                aggregate: {
-                    node: {
-                        id: {
-                            shortest: "1",
-                            longest: "4444",
-                        },
-                        title: {
-                            shortest: "1",
-                            longest: "4444",
-                        },
-                        imdbRating: {
-                            min: 1,
-                            max: 4,
-                            average: 2.5,
-                        },
-                        createdAt: {
-                            min: minDate.toISOString(),
-                            max: maxDate.toISOString(),
-                        },
-                    },
-                },
+        expect((gqlResult.data as any)[typeMovie.operations.aggregate]).toEqual({
+            id: {
+                shortest: "1",
+                longest: "4444",
+            },
+            title: {
+                shortest: "1",
+                longest: "4444",
+            },
+            imdbRating: {
+                min: 1,
+                max: 4,
+                average: 2.5,
+            },
+            createdAt: {
+                min: minDate.toISOString(),
+                max: maxDate.toISOString(),
             },
         });
     });

--- a/packages/graphql/tests/integration/deprecations/aggregations/top-level/string.int.test.ts
+++ b/packages/graphql/tests/integration/deprecations/aggregations/top-level/string.int.test.ts
@@ -18,8 +18,8 @@
  */
 
 import { generate } from "randomstring";
-import type { UniqueType } from "../../../utils/graphql-types";
-import { TestHelper } from "../../../utils/tests-helper";
+import type { UniqueType } from "../../../../utils/graphql-types";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("aggregations-top_level-string", () => {
     const testHelper = new TestHelper();
@@ -70,15 +70,11 @@ describe("aggregations-top_level-string", () => {
 
         const query = `
                 {
-                    ${typeMovie.operations.connection}(where: {testId_EQ: "${id}"}) {
-                    aggregate {
-                        node {    
-                    title {
+                    ${typeMovie.operations.aggregate}(where: {testId_EQ: "${id}"}) {
+                        title {
                             shortest
                         }
-                            }
-                        }
-                       }
+                    }
                 }
             `;
 
@@ -90,15 +86,9 @@ describe("aggregations-top_level-string", () => {
 
         expect(gqlResult.errors).toBeUndefined();
 
-        expect(gqlResult.data).toEqual({
-            [typeMovie.operations.connection]: {
-                aggregate: {
-                    node: {
-                        title: {
-                            shortest: titles[0],
-                        },
-                    },
-                },
+        expect((gqlResult.data as any)[typeMovie.operations.aggregate]).toEqual({
+            title: {
+                shortest: titles[0],
             },
         });
     });
@@ -132,15 +122,11 @@ describe("aggregations-top_level-string", () => {
 
         const query = `
                 {
-                    ${typeMovie.operations.connection}(where: {testId_EQ: "${id}"}) {
-                    aggregate {
-                        node {    
-                    title {
+                    ${typeMovie.operations.aggregate}(where: {testId_EQ: "${id}"}) {
+                        title {
                             longest
                         }
-                            }
-                        }
-                       }
+                    }
                 }
             `;
 
@@ -152,15 +138,9 @@ describe("aggregations-top_level-string", () => {
 
         expect(gqlResult.errors).toBeUndefined();
 
-        expect(gqlResult.data).toEqual({
-            [typeMovie.operations.connection]: {
-                aggregate: {
-                    node: {
-                        title: {
-                            longest: titles[3],
-                        },
-                    },
-                },
+        expect((gqlResult.data as any)[typeMovie.operations.aggregate]).toEqual({
+            title: {
+                longest: titles[3],
             },
         });
     });
@@ -194,15 +174,11 @@ describe("aggregations-top_level-string", () => {
 
         const query = `
                 {
-                    ${typeMovie.operations.connection}(where: {testId_EQ: "${id}"}) {
-                    aggregate {
-                        node {    
-                    title {
+                    ${typeMovie.operations.aggregate}(where: {testId_EQ: "${id}"}) {
+                        title {
                             shortest
                             longest
-                            }
-                            }
-                       }
+                        }
                     }
                 }
             `;
@@ -215,16 +191,10 @@ describe("aggregations-top_level-string", () => {
 
         expect(gqlResult.errors).toBeUndefined();
 
-        expect(gqlResult.data).toEqual({
-            [typeMovie.operations.connection]: {
-                aggregate: {
-                    node: {
-                        title: {
-                            shortest: titles[0],
-                            longest: titles[3],
-                        },
-                    },
-                },
+        expect((gqlResult.data as any)[typeMovie.operations.aggregate]).toEqual({
+            title: {
+                shortest: titles[0],
+                longest: titles[3],
             },
         });
     });

--- a/packages/graphql/tests/integration/deprecations/interfaces/aggregations/aggregation-interfaces-top-level-with-auth.int.test.ts
+++ b/packages/graphql/tests/integration/deprecations/interfaces/aggregations/aggregation-interfaces-top-level-with-auth.int.test.ts
@@ -18,8 +18,8 @@
  */
 
 import type { GraphQLError } from "graphql";
-import { createBearerToken } from "../../../utils/create-bearer-token";
-import { TestHelper } from "../../../utils/tests-helper";
+import { createBearerToken } from "../../../../utils/create-bearer-token";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("Top-level interface query fields with authorization", () => {
     const secret = "the-secret";
@@ -77,15 +77,11 @@ describe("Top-level interface query fields with authorization", () => {
     test("top level count and string fields", async () => {
         const query = `
             query {
-                productionsConnection {
-                    aggregate {
-                        node {
-                            count
-                            title {
-                                longest
-                                shortest
-                            }
-                        }
+                productionsAggregate {
+                    count
+                    title {
+                        longest
+                        shortest
                     }
                 }
             }
@@ -95,15 +91,11 @@ describe("Top-level interface query fields with authorization", () => {
         const queryResult = await testHelper.executeGraphQLWithToken(query, token);
         expect(queryResult.errors).toBeUndefined();
         expect(queryResult.data).toEqual({
-            productionsConnection: {
-                aggregate: {
-                    node: {
-                        count: 4,
-                        title: {
-                            longest: "The Matrix is a very interesting movie: The Documentary",
-                            shortest: "The Show",
-                        },
-                    },
+            productionsAggregate: {
+                count: 4,
+                title: {
+                    longest: "The Matrix is a very interesting movie: The Documentary",
+                    shortest: "The Show",
                 },
             },
         });
@@ -112,15 +104,11 @@ describe("Top-level interface query fields with authorization", () => {
     test("top level count and string fields with no roles should fail", async () => {
         const query = `
             query {
-                productionsConnection {
-                    aggregate  {
-                        node {
-                            count
-                            title {
-                                longest
-                                shortest
-                            }
-                        }
+                productionsAggregate {
+                    count
+                    title {
+                        longest
+                        shortest
                     }
                 }
             }
@@ -136,15 +124,11 @@ describe("Top-level interface query fields with authorization", () => {
     test("top level number fields", async () => {
         const query = `
             query {
-                productionsConnection {
-                    aggregate  {
-                        node {
-                            cost {
-                                max
-                                min
-                                average
-                            }
-                        }
+                productionsAggregate {
+                    cost {
+                        max
+                        min
+                        average
                     }
                 }
             }
@@ -154,15 +138,11 @@ describe("Top-level interface query fields with authorization", () => {
         const queryResult = await testHelper.executeGraphQLWithToken(query, token);
         expect(queryResult.errors).toBeUndefined();
         expect(queryResult.data).toEqual({
-            productionsConnection: {
-                aggregate: {
-                    node: {
-                        cost: {
-                            min: 1,
-                            max: 20,
-                            average: 8.25,
-                        },
-                    },
+            productionsAggregate: {
+                cost: {
+                    min: 1,
+                    max: 20,
+                    average: 8.25,
                 },
             },
         });
@@ -171,15 +151,11 @@ describe("Top-level interface query fields with authorization", () => {
     test("top level number fields with no roles should fail", async () => {
         const query = `
             query {
-                productionsConnection {
-                    aggregate  {
-                        node {
-                            cost {
-                                max
-                                min
-                                average
-                            }
-                        }
+                productionsAggregate {
+                    cost {
+                        max
+                        min
+                        average
                     }
                 }
             }

--- a/packages/graphql/tests/integration/deprecations/interfaces/aggregations/aggregation-interfaces-top-level.int.test.ts
+++ b/packages/graphql/tests/integration/deprecations/interfaces/aggregations/aggregation-interfaces-top-level.int.test.ts
@@ -17,8 +17,8 @@
  * limitations under the License.
  */
 
-import { createBearerToken } from "../../../utils/create-bearer-token";
-import { TestHelper } from "../../../utils/tests-helper";
+import { createBearerToken } from "../../../../utils/create-bearer-token";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("Top-level interface query fields", () => {
     const secret = "the-secret";
@@ -69,15 +69,11 @@ describe("Top-level interface query fields", () => {
     test("top level count and string fields", async () => {
         const query = `
             query {
-                productionsConnection {
-                    aggregate {
-                        node {
-                            count
-                            title {
-                                longest
-                                shortest
-                            }
-                        }
+                productionsAggregate {
+                    count
+                    title {
+                        longest
+                        shortest
                     }
                 }
             }
@@ -87,15 +83,11 @@ describe("Top-level interface query fields", () => {
         const queryResult = await testHelper.executeGraphQLWithToken(query, token);
         expect(queryResult.errors).toBeUndefined();
         expect(queryResult.data).toEqual({
-            productionsConnection: {
-                aggregate: {
-                    node: {
-                        count: 4,
-                        title: {
-                            longest: "The Matrix is a very interesting movie: The Documentary",
-                            shortest: "The Show",
-                        },
-                    },
+            productionsAggregate: {
+                count: 4,
+                title: {
+                    longest: "The Matrix is a very interesting movie: The Documentary",
+                    shortest: "The Show",
                 },
             },
         });
@@ -104,15 +96,11 @@ describe("Top-level interface query fields", () => {
     test("top level number fields", async () => {
         const query = `
             query {
-                productionsConnection {
-                    aggregate {
-                        node {
-                            cost {
-                                max
-                                min
-                                average
-                            }
-                        }
+                productionsAggregate {
+                    cost {
+                        max
+                        min
+                        average
                     }
                 }
             }
@@ -122,15 +110,11 @@ describe("Top-level interface query fields", () => {
         const queryResult = await testHelper.executeGraphQLWithToken(query, token);
         expect(queryResult.errors).toBeUndefined();
         expect(queryResult.data).toEqual({
-            productionsConnection: {
-                aggregate: {
-                    node: {
-                        cost: {
-                            min: 1,
-                            max: 20,
-                            average: 8.25,
-                        },
-                    },
+            productionsAggregate: {
+                cost: {
+                    min: 1,
+                    max: 20,
+                    average: 8.25,
                 },
             },
         });

--- a/packages/graphql/tests/schema/aggregations.test.ts
+++ b/packages/graphql/tests/schema/aggregations.test.ts
@@ -362,7 +362,7 @@ describe("Aggregations", () => {
 
             type Query {
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 
@@ -1223,10 +1223,10 @@ describe("Aggregations", () => {
 
             type Query {
               posts(limit: Int, offset: Int, options: PostOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PostSort!], where: PostWhere): [Post!]!
-              postsAggregate(where: PostWhere): PostAggregateSelection!
+              postsAggregate(where: PostWhere): PostAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"postsConnection\\\\\\"\\")
               postsConnection(after: String, first: Int, sort: [PostSort!], where: PostWhere): PostsConnection!
               users(limit: Int, offset: Int, options: UserOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [UserSort!], where: UserWhere): [User!]!
-              usersAggregate(where: UserWhere): UserAggregateSelection!
+              usersAggregate(where: UserWhere): UserAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"usersConnection\\\\\\"\\")
               usersConnection(after: String, first: Int, sort: [UserSort!], where: UserWhere): UsersConnection!
             }
 

--- a/packages/graphql/tests/schema/aggregations.test.ts
+++ b/packages/graphql/tests/schema/aggregations.test.ts
@@ -147,6 +147,25 @@ describe("Aggregations", () => {
               title: String
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              createdAt: DateTimeAggregateSelection!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              imdbRating: FloatAggregateSelection!
+              isbn: StringAggregateSelection!
+              screenTime: DurationAggregateSelection!
+              someBigInt: BigIntAggregateSelection!
+              someInt: IntAggregateSelection!
+              someLocalDateTime: LocalDateTimeAggregateSelection!
+              someLocalTime: LocalTimeAggregateSelection!
+              someTime: TimeAggregateSelection!
+              title: StringAggregateSelection!
+            }
+
             type MovieAggregateSelection {
               count: Int!
               createdAt: DateTimeAggregateSelection!
@@ -321,6 +340,7 @@ describe("Aggregations", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -837,6 +857,16 @@ describe("Aggregations", () => {
               title: String
             }
 
+            type PostAggregate {
+              node: PostAggregateNode!
+            }
+
+            type PostAggregateNode {
+              count: Int!
+              someID: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              title: StringAggregateSelection!
+            }
+
             type PostAggregateSelection {
               count: Int!
               someID: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -1185,6 +1215,7 @@ describe("Aggregations", () => {
             }
 
             type PostsConnection {
+              aggregate: PostAggregate!
               edges: [PostEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1251,6 +1282,24 @@ describe("Aggregations", () => {
               someLocalTime: LocalTime
               someString: String
               someTime: Time
+            }
+
+            type UserAggregate {
+              node: UserAggregateNode!
+            }
+
+            type UserAggregateNode {
+              count: Int!
+              someBigInt: BigIntAggregateSelection!
+              someDateTime: DateTimeAggregateSelection!
+              someDuration: DurationAggregateSelection!
+              someFloat: FloatAggregateSelection!
+              someID: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              someInt: IntAggregateSelection!
+              someLocalDateTime: LocalDateTimeAggregateSelection!
+              someLocalTime: LocalTimeAggregateSelection!
+              someString: StringAggregateSelection!
+              someTime: TimeAggregateSelection!
             }
 
             type UserAggregateSelection {
@@ -1420,6 +1469,7 @@ describe("Aggregations", () => {
             }
 
             type UsersConnection {
+              aggregate: UserAggregate!
               edges: [UserEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/array-methods.test.ts
+++ b/packages/graphql/tests/schema/array-methods.test.ts
@@ -208,6 +208,15 @@ describe("Arrays Methods", () => {
               where: ActorActedInConnectionWhere
             }
 
+            type ActorAggregate {
+              node: ActorAggregateNode!
+            }
+
+            type ActorAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
             type ActorAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -309,6 +318,7 @@ describe("Arrays Methods", () => {
             }
 
             type ActorsConnection {
+              aggregate: ActorAggregate!
               edges: [ActorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -473,6 +483,16 @@ describe("Arrays Methods", () => {
               where: MovieActorsConnectionWhere
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              averageRating: FloatAggregateSelection!
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+            }
+
             type MovieAggregateSelection {
               averageRating: FloatAggregateSelection!
               count: Int!
@@ -588,6 +608,7 @@ describe("Arrays Methods", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/array-methods.test.ts
+++ b/packages/graphql/tests/schema/array-methods.test.ts
@@ -633,10 +633,10 @@ describe("Arrays Methods", () => {
 
             type Query {
               actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
               actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 

--- a/packages/graphql/tests/schema/arrays.test.ts
+++ b/packages/graphql/tests/schema/arrays.test.ts
@@ -79,6 +79,16 @@ describe("Arrays", () => {
               ratings: [Float!]!
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              averageRating: FloatAggregateSelection!
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+            }
+
             type MovieAggregateSelection {
               averageRating: FloatAggregateSelection!
               count: Int!
@@ -151,6 +161,7 @@ describe("Arrays", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/arrays.test.ts
+++ b/packages/graphql/tests/schema/arrays.test.ts
@@ -183,7 +183,7 @@ describe("Arrays", () => {
 
             type Query {
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 

--- a/packages/graphql/tests/schema/authorization.test.ts
+++ b/packages/graphql/tests/schema/authorization.test.ts
@@ -103,6 +103,16 @@ describe("Authorization", () => {
               name: String!
             }
 
+            type PostAggregate {
+              node: PostAggregateNode!
+            }
+
+            type PostAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              name: StringAggregateSelection!
+            }
+
             type PostAggregateSelection {
               count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -288,6 +298,7 @@ describe("Authorization", () => {
             }
 
             type PostsConnection {
+              aggregate: PostAggregate!
               edges: [PostEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -341,6 +352,16 @@ describe("Authorization", () => {
               posts(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), limit: Int, offset: Int, options: UserOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [UserSort!], where: UserWhere): [User!]!
               postsAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: UserWhere): UserUserPostsAggregationSelection
               postsConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [UserPostsConnectionSort!], where: UserPostsConnectionWhere): UserPostsConnection!
+            }
+
+            type UserAggregate {
+              node: UserAggregateNode!
+            }
+
+            type UserAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              name: StringAggregateSelection!
             }
 
             type UserAggregateSelection {
@@ -562,6 +583,7 @@ describe("Authorization", () => {
             }
 
             type UsersConnection {
+              aggregate: UserAggregate!
               edges: [UserEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/authorization.test.ts
+++ b/packages/graphql/tests/schema/authorization.test.ts
@@ -306,10 +306,10 @@ describe("Authorization", () => {
 
             type Query {
               posts(limit: Int, offset: Int, options: PostOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PostSort!], where: PostWhere): [Post!]!
-              postsAggregate(where: PostWhere): PostAggregateSelection!
+              postsAggregate(where: PostWhere): PostAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"postsConnection\\\\\\"\\")
               postsConnection(after: String, first: Int, sort: [PostSort!], where: PostWhere): PostsConnection!
               users(limit: Int, offset: Int, options: UserOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [UserSort!], where: UserWhere): [User!]!
-              usersAggregate(where: UserWhere): UserAggregateSelection!
+              usersAggregate(where: UserWhere): UserAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"usersConnection\\\\\\"\\")
               usersConnection(after: String, first: Int, sort: [UserSort!], where: UserWhere): UsersConnection!
             }
 

--- a/packages/graphql/tests/schema/comments.test.ts
+++ b/packages/graphql/tests/schema/comments.test.ts
@@ -263,7 +263,7 @@ describe("Comments", () => {
 
             type Query {
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 
@@ -640,10 +640,10 @@ describe("Comments", () => {
 
                 type Query {
                   actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-                  actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+                  actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
                   actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                 }
 
@@ -1214,16 +1214,16 @@ describe("Comments", () => {
 
                 type Query {
                   actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-                  actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+                  actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
                   actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                   productions(limit: Int, offset: Int, options: ProductionOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ProductionSort!], where: ProductionWhere): [Production!]!
-                  productionsAggregate(where: ProductionWhere): ProductionAggregateSelection!
+                  productionsAggregate(where: ProductionWhere): ProductionAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"productionsConnection\\\\\\"\\")
                   productionsConnection(after: String, first: Int, sort: [ProductionSort!], where: ProductionWhere): ProductionsConnection!
                   series(limit: Int, offset: Int, options: SeriesOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [SeriesSort!], where: SeriesWhere): [Series!]!
-                  seriesAggregate(where: SeriesWhere): SeriesAggregateSelection!
+                  seriesAggregate(where: SeriesWhere): SeriesAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"seriesConnection\\\\\\"\\")
                   seriesConnection(after: String, first: Int, sort: [SeriesSort!], where: SeriesWhere): SeriesConnection!
                 }
 
@@ -1732,10 +1732,10 @@ describe("Comments", () => {
 
                 type Query {
                   genres(limit: Int, offset: Int, options: GenreOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [GenreSort!], where: GenreWhere): [Genre!]!
-                  genresAggregate(where: GenreWhere): GenreAggregateSelection!
+                  genresAggregate(where: GenreWhere): GenreAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"genresConnection\\\\\\"\\")
                   genresConnection(after: String, first: Int, sort: [GenreSort!], where: GenreWhere): GenresConnection!
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                   searches(limit: Int, offset: Int, options: QueryOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: SearchWhere): [Search!]!
                 }

--- a/packages/graphql/tests/schema/comments.test.ts
+++ b/packages/graphql/tests/schema/comments.test.ts
@@ -132,6 +132,17 @@ describe("Comments", () => {
               isActive: Boolean
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              actorCount: IntAggregateSelection!
+              averageRating: FloatAggregateSelection!
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+            }
+
             type MovieAggregateSelection {
               actorCount: IntAggregateSelection!
               averageRating: FloatAggregateSelection!
@@ -230,6 +241,7 @@ describe("Comments", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -306,6 +318,15 @@ describe("Comments", () => {
                   name: String
                 }
 
+                type ActorAggregate {
+                  node: ActorAggregateNode!
+                }
+
+                type ActorAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
+                }
+
                 type ActorAggregateSelection {
                   count: Int!
                   name: StringAggregateSelection!
@@ -358,6 +379,7 @@ describe("Comments", () => {
                 }
 
                 type ActorsConnection {
+                  aggregate: ActorAggregate!
                   edges: [ActorEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -505,6 +527,15 @@ describe("Comments", () => {
                   where: MovieActorsConnectionWhere
                 }
 
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+                }
+
                 type MovieAggregateSelection {
                   count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -584,6 +615,7 @@ describe("Comments", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -852,6 +884,15 @@ describe("Comments", () => {
                   where: ActorActedInConnectionWhere
                 }
 
+                type ActorAggregate {
+                  node: ActorAggregateNode!
+                }
+
+                type ActorAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
+                }
+
                 type ActorAggregateSelection {
                   count: Int!
                   name: StringAggregateSelection!
@@ -945,6 +986,7 @@ describe("Comments", () => {
                 }
 
                 type ActorsConnection {
+                  aggregate: ActorAggregate!
                   edges: [ActorEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -991,6 +1033,16 @@ describe("Comments", () => {
                 type Movie implements Production {
                   runtime: Int!
                   title: String!
+                }
+
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  runtime: IntAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 type MovieAggregateSelection {
@@ -1055,6 +1107,7 @@ describe("Comments", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -1082,6 +1135,15 @@ describe("Comments", () => {
 
                 interface Production {
                   title: String!
+                }
+
+                type ProductionAggregate {
+                  node: ProductionAggregateNode!
+                }
+
+                type ProductionAggregateNode {
+                  count: Int!
+                  title: StringAggregateSelection!
                 }
 
                 type ProductionAggregateSelection {
@@ -1144,6 +1206,7 @@ describe("Comments", () => {
                 }
 
                 type ProductionsConnection {
+                  aggregate: ProductionAggregate!
                   edges: [ProductionEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -1169,6 +1232,16 @@ describe("Comments", () => {
                   title: String!
                 }
 
+                type SeriesAggregate {
+                  node: SeriesAggregateNode!
+                }
+
+                type SeriesAggregateNode {
+                  count: Int!
+                  episodes: IntAggregateSelection!
+                  title: StringAggregateSelection!
+                }
+
                 type SeriesAggregateSelection {
                   count: Int!
                   episodes: IntAggregateSelection!
@@ -1176,6 +1249,7 @@ describe("Comments", () => {
                 }
 
                 type SeriesConnection {
+                  aggregate: SeriesAggregate!
                   edges: [SeriesEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -1329,6 +1403,15 @@ describe("Comments", () => {
                   id: ID
                 }
 
+                type GenreAggregate {
+                  node: GenreAggregateNode!
+                }
+
+                type GenreAggregateNode {
+                  count: Int!
+                  id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+                }
+
                 type GenreAggregateSelection {
                   count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -1381,6 +1464,7 @@ describe("Comments", () => {
                 }
 
                 type GenresConnection {
+                  aggregate: GenreAggregate!
                   edges: [GenreEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -1396,6 +1480,15 @@ describe("Comments", () => {
                   search(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), limit: Int, offset: Int, options: QueryOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: SearchWhere): [Search!]!
                   searchConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, where: MovieSearchConnectionWhere): MovieSearchConnection!
                   searchNoDirective: Search
+                }
+
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
                 }
 
                 type MovieAggregateSelection {
@@ -1614,6 +1707,7 @@ describe("Comments", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!

--- a/packages/graphql/tests/schema/connect-or-create-id.test.ts
+++ b/packages/graphql/tests/schema/connect-or-create-id.test.ts
@@ -51,6 +51,15 @@ describe("connect or create with id", () => {
               name: String!
             }
 
+            type ActorAggregate {
+              node: ActorAggregateNode!
+            }
+
+            type ActorAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
             type ActorAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -255,6 +264,7 @@ describe("connect or create with id", () => {
             }
 
             type ActorsConnection {
+              aggregate: ActorAggregate!
               edges: [ActorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -294,6 +304,16 @@ describe("connect or create with id", () => {
             type Movie {
               id: ID!
               title: String!
+            }
+
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              title: StringAggregateSelection!
             }
 
             type MovieAggregateSelection {
@@ -369,6 +389,7 @@ describe("connect or create with id", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -522,6 +543,17 @@ describe("connect or create with id", () => {
               creatorAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: UserWhere): PostUserCreatorAggregationSelection
               creatorConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [PostCreatorConnectionSort!], where: PostCreatorConnectionWhere): PostCreatorConnection!
               id: ID!
+            }
+
+            type PostAggregate {
+              node: PostAggregateNode!
+            }
+
+            type PostAggregateNode {
+              content: StringAggregateSelection!
+              count: Int!
+              createdAt: DateTimeAggregateSelection!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
             type PostAggregateSelection {
@@ -759,6 +791,7 @@ describe("connect or create with id", () => {
             }
 
             type PostsConnection {
+              aggregate: PostAggregate!
               edges: [PostEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -812,6 +845,16 @@ describe("connect or create with id", () => {
               posts(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), limit: Int, offset: Int, options: PostOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PostSort!], where: PostWhere): [Post!]!
               postsAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: PostWhere): UserPostPostsAggregationSelection
               postsConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [UserPostsConnectionSort!], where: UserPostsConnectionWhere): UserPostsConnection!
+            }
+
+            type UserAggregate {
+              node: UserAggregateNode!
+            }
+
+            type UserAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              name: StringAggregateSelection!
             }
 
             type UserAggregateSelection {
@@ -1065,6 +1108,7 @@ describe("connect or create with id", () => {
             }
 
             type UsersConnection {
+              aggregate: UserAggregate!
               edges: [UserEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/connect-or-create-id.test.ts
+++ b/packages/graphql/tests/schema/connect-or-create-id.test.ts
@@ -414,10 +414,10 @@ describe("connect or create with id", () => {
 
             type Query {
               actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
               actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 
@@ -799,10 +799,10 @@ describe("connect or create with id", () => {
 
             type Query {
               posts(limit: Int, offset: Int, options: PostOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PostSort!], where: PostWhere): [Post!]!
-              postsAggregate(where: PostWhere): PostAggregateSelection!
+              postsAggregate(where: PostWhere): PostAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"postsConnection\\\\\\"\\")
               postsConnection(after: String, first: Int, sort: [PostSort!], where: PostWhere): PostsConnection!
               users(limit: Int, offset: Int, options: UserOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [UserSort!], where: UserWhere): [User!]!
-              usersAggregate(where: UserWhere): UserAggregateSelection!
+              usersAggregate(where: UserWhere): UserAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"usersConnection\\\\\\"\\")
               usersConnection(after: String, first: Int, sort: [UserSort!], where: UserWhere): UsersConnection!
             }
 

--- a/packages/graphql/tests/schema/connect-or-create-unions.test.ts
+++ b/packages/graphql/tests/schema/connect-or-create-unions.test.ts
@@ -247,6 +247,15 @@ describe("Connect Or Create", () => {
               Series: [ActorActedInSeriesUpdateFieldInput!]
             }
 
+            type ActorAggregate {
+              node: ActorAggregateNode!
+            }
+
+            type ActorAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
             type ActorAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -325,6 +334,7 @@ describe("Connect Or Create", () => {
             }
 
             type ActorsConnection {
+              aggregate: ActorAggregate!
               edges: [ActorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -364,6 +374,16 @@ describe("Connect Or Create", () => {
             type Movie {
               isan: String!
               title: String!
+            }
+
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              isan: StringAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             type MovieAggregateSelection {
@@ -443,6 +463,7 @@ describe("Connect Or Create", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -499,6 +520,16 @@ describe("Connect Or Create", () => {
               title: String!
             }
 
+            type SeriesAggregate {
+              node: SeriesAggregateNode!
+            }
+
+            type SeriesAggregateNode {
+              count: Int!
+              isan: StringAggregateSelection!
+              title: StringAggregateSelection!
+            }
+
             type SeriesAggregateSelection {
               count: Int!
               isan: StringAggregateSelection!
@@ -514,6 +545,7 @@ describe("Connect Or Create", () => {
             }
 
             type SeriesConnection {
+              aggregate: SeriesAggregate!
               edges: [SeriesEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/connect-or-create-unions.test.ts
+++ b/packages/graphql/tests/schema/connect-or-create-unions.test.ts
@@ -498,14 +498,14 @@ describe("Connect Or Create", () => {
 
             type Query {
               actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
               actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
               productions(limit: Int, offset: Int, options: QueryOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: ProductionWhere): [Production!]!
               series(limit: Int, offset: Int, options: SeriesOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [SeriesSort!], where: SeriesWhere): [Series!]!
-              seriesAggregate(where: SeriesWhere): SeriesAggregateSelection!
+              seriesAggregate(where: SeriesWhere): SeriesAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"seriesConnection\\\\\\"\\")
               seriesConnection(after: String, first: Int, sort: [SeriesSort!], where: SeriesWhere): SeriesConnection!
             }
 

--- a/packages/graphql/tests/schema/connect-or-create.test.ts
+++ b/packages/graphql/tests/schema/connect-or-create.test.ts
@@ -51,6 +51,15 @@ describe("Connect Or Create", () => {
               name: String!
             }
 
+            type ActorAggregate {
+              node: ActorAggregateNode!
+            }
+
+            type ActorAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
             type ActorAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -260,6 +269,7 @@ describe("Connect Or Create", () => {
             }
 
             type ActorsConnection {
+              aggregate: ActorAggregate!
               edges: [ActorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -294,6 +304,16 @@ describe("Connect Or Create", () => {
             type Movie {
               isan: String!
               title: String!
+            }
+
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              isan: StringAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             type MovieAggregateSelection {
@@ -373,6 +393,7 @@ describe("Connect Or Create", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -558,6 +579,15 @@ describe("Connect Or Create", () => {
               moviesAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: MovieWhere): ActorMovieMoviesAggregationSelection
               moviesConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [ActorMoviesConnectionSort!], where: ActorMoviesConnectionWhere): ActorMoviesConnection!
               name: String!
+            }
+
+            type ActorAggregate {
+              node: ActorAggregateNode!
+            }
+
+            type ActorAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
             }
 
             type ActorAggregateSelection {
@@ -783,6 +813,7 @@ describe("Connect Or Create", () => {
             }
 
             type ActorsConnection {
+              aggregate: ActorAggregate!
               edges: [ActorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -824,6 +855,16 @@ describe("Connect Or Create", () => {
             type Movie {
               isan: String!
               title: String!
+            }
+
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              isan: StringAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             type MovieAggregateSelection {
@@ -903,6 +944,7 @@ describe("Connect Or Create", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/connect-or-create.test.ts
+++ b/packages/graphql/tests/schema/connect-or-create.test.ts
@@ -418,10 +418,10 @@ describe("Connect Or Create", () => {
 
             type Query {
               actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
               actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 
@@ -969,10 +969,10 @@ describe("Connect Or Create", () => {
 
             type Query {
               actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
               actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 

--- a/packages/graphql/tests/schema/connections/enums.test.ts
+++ b/packages/graphql/tests/schema/connections/enums.test.ts
@@ -91,6 +91,15 @@ describe("Enums", () => {
               name: String!
             }
 
+            type ActorAggregate {
+              node: ActorAggregateNode!
+            }
+
+            type ActorAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
             type ActorAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -294,6 +303,7 @@ describe("Enums", () => {
             }
 
             type ActorsConnection {
+              aggregate: ActorAggregate!
               edges: [ActorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -444,6 +454,15 @@ describe("Enums", () => {
               where: MovieActorsConnectionWhere
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              title: StringAggregateSelection!
+            }
+
             type MovieAggregateSelection {
               count: Int!
               title: StringAggregateSelection!
@@ -535,6 +554,7 @@ describe("Enums", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/connections/enums.test.ts
+++ b/packages/graphql/tests/schema/connections/enums.test.ts
@@ -579,10 +579,10 @@ describe("Enums", () => {
 
             type Query {
               actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
               actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 

--- a/packages/graphql/tests/schema/connections/interfaces.test.ts
+++ b/packages/graphql/tests/schema/connections/interfaces.test.ts
@@ -91,6 +91,15 @@ describe("Connection with interfaces", () => {
               moviesConnection(after: String, first: Int, sort: [CreatureMoviesConnectionSort!], where: CreatureMoviesConnectionWhere): CreatureMoviesConnection!
             }
 
+            type CreatureAggregate {
+              node: CreatureAggregateNode!
+            }
+
+            type CreatureAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+            }
+
             type CreatureAggregateSelection {
               count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -248,6 +257,7 @@ describe("Connection with interfaces", () => {
             }
 
             type CreaturesConnection {
+              aggregate: CreatureAggregate!
               edges: [CreatureEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -279,6 +289,16 @@ describe("Connection with interfaces", () => {
               directorConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [ProductionDirectorConnectionSort!], where: ProductionDirectorConnectionWhere): ProductionDirectorConnection!
               id: ID
               title: String!
+            }
+
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              title: StringAggregateSelection!
             }
 
             type MovieAggregateSelection {
@@ -446,6 +466,7 @@ describe("Connection with interfaces", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -472,6 +493,7 @@ describe("Connection with interfaces", () => {
             }
 
             type PeopleConnection {
+              aggregate: PersonAggregate!
               edges: [PersonEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -482,6 +504,15 @@ describe("Connection with interfaces", () => {
               movies(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), limit: Int, offset: Int, options: ProductionOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ProductionSort!], where: ProductionWhere): Production!
               moviesAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: ProductionWhere): PersonProductionMoviesAggregationSelection
               moviesConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [CreatureMoviesConnectionSort!], where: CreatureMoviesConnectionWhere): CreatureMoviesConnection!
+            }
+
+            type PersonAggregate {
+              node: PersonAggregateNode!
+            }
+
+            type PersonAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
             type PersonAggregateSelection {
@@ -619,6 +650,15 @@ describe("Connection with interfaces", () => {
               director(limit: Int, offset: Int, options: CreatureOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [CreatureSort!], where: CreatureWhere): [Creature!]!
               directorConnection(after: String, first: Int, sort: [ProductionDirectorConnectionSort!], where: ProductionDirectorConnectionWhere): ProductionDirectorConnection!
               id: ID
+            }
+
+            type ProductionAggregate {
+              node: ProductionAggregateNode!
+            }
+
+            type ProductionAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
             type ProductionAggregateSelection {
@@ -810,6 +850,7 @@ describe("Connection with interfaces", () => {
             }
 
             type ProductionsConnection {
+              aggregate: ProductionAggregate!
               edges: [ProductionEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -842,6 +883,17 @@ describe("Connection with interfaces", () => {
               title: String!
             }
 
+            type SeriesAggregate {
+              node: SeriesAggregateNode!
+            }
+
+            type SeriesAggregateNode {
+              count: Int!
+              episode: IntAggregateSelection!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              title: StringAggregateSelection!
+            }
+
             type SeriesAggregateSelection {
               count: Int!
               episode: IntAggregateSelection!
@@ -850,6 +902,7 @@ describe("Connection with interfaces", () => {
             }
 
             type SeriesConnection {
+              aggregate: SeriesAggregate!
               edges: [SeriesEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/connections/interfaces.test.ts
+++ b/packages/graphql/tests/schema/connections/interfaces.test.ts
@@ -858,19 +858,19 @@ describe("Connection with interfaces", () => {
 
             type Query {
               creatures(limit: Int, offset: Int, options: CreatureOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [CreatureSort!], where: CreatureWhere): [Creature!]!
-              creaturesAggregate(where: CreatureWhere): CreatureAggregateSelection!
+              creaturesAggregate(where: CreatureWhere): CreatureAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"creaturesConnection\\\\\\"\\")
               creaturesConnection(after: String, first: Int, sort: [CreatureSort!], where: CreatureWhere): CreaturesConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
               people(limit: Int, offset: Int, options: PersonOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonSort!], where: PersonWhere): [Person!]!
-              peopleAggregate(where: PersonWhere): PersonAggregateSelection!
+              peopleAggregate(where: PersonWhere): PersonAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"peopleConnection\\\\\\"\\")
               peopleConnection(after: String, first: Int, sort: [PersonSort!], where: PersonWhere): PeopleConnection!
               productions(limit: Int, offset: Int, options: ProductionOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ProductionSort!], where: ProductionWhere): [Production!]!
-              productionsAggregate(where: ProductionWhere): ProductionAggregateSelection!
+              productionsAggregate(where: ProductionWhere): ProductionAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"productionsConnection\\\\\\"\\")
               productionsConnection(after: String, first: Int, sort: [ProductionSort!], where: ProductionWhere): ProductionsConnection!
               series(limit: Int, offset: Int, options: SeriesOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [SeriesSort!], where: SeriesWhere): [Series!]!
-              seriesAggregate(where: SeriesWhere): SeriesAggregateSelection!
+              seriesAggregate(where: SeriesWhere): SeriesAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"seriesConnection\\\\\\"\\")
               seriesConnection(after: String, first: Int, sort: [SeriesSort!], where: SeriesWhere): SeriesConnection!
             }
 

--- a/packages/graphql/tests/schema/connections/sort.test.ts
+++ b/packages/graphql/tests/schema/connections/sort.test.ts
@@ -85,6 +85,15 @@ describe("Sort", () => {
               relatedToConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, where: Node1RelatedToConnectionWhere): Node1RelatedToConnection!
             }
 
+            type Node1Aggregate {
+              node: Node1AggregateNode!
+            }
+
+            type Node1AggregateNode {
+              count: Int!
+              property: StringAggregateSelection!
+            }
+
             type Node1AggregateSelection {
               count: Int!
               property: StringAggregateSelection!
@@ -251,6 +260,7 @@ describe("Sort", () => {
             }
 
             type Node1sConnection {
+              aggregate: Node1Aggregate!
               edges: [Node1Edge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -260,6 +270,14 @@ describe("Sort", () => {
               relatedTo(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), limit: Int, offset: Int, options: Node1Options @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [Node1Sort!], where: Node1Where): [Node1!]!
               relatedToAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: Node1Where): Node2Node1RelatedToAggregationSelection
               relatedToConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [Node2RelatedToConnectionSort!], where: Node2RelatedToConnectionWhere): Node2RelatedToConnection!
+            }
+
+            type Node2Aggregate {
+              node: Node2AggregateNode!
+            }
+
+            type Node2AggregateNode {
+              count: Int!
             }
 
             type Node2AggregateSelection {
@@ -438,6 +456,7 @@ describe("Sort", () => {
             }
 
             type Node2sConnection {
+              aggregate: Node2Aggregate!
               edges: [Node2Edge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/connections/sort.test.ts
+++ b/packages/graphql/tests/schema/connections/sort.test.ts
@@ -472,10 +472,10 @@ describe("Sort", () => {
 
             type Query {
               node1s(limit: Int, offset: Int, options: Node1Options @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [Node1Sort!], where: Node1Where): [Node1!]!
-              node1sAggregate(where: Node1Where): Node1AggregateSelection!
+              node1sAggregate(where: Node1Where): Node1AggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"node1sConnection\\\\\\"\\")
               node1sConnection(after: String, first: Int, sort: [Node1Sort!], where: Node1Where): Node1sConnection!
               node2s(limit: Int, offset: Int, options: Node2Options @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: Node2Where): [Node2!]!
-              node2sAggregate(where: Node2Where): Node2AggregateSelection!
+              node2sAggregate(where: Node2Where): Node2AggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"node2sConnection\\\\\\"\\")
               node2sConnection(after: String, first: Int, where: Node2Where): Node2sConnection!
             }
 

--- a/packages/graphql/tests/schema/connections/unions.test.ts
+++ b/packages/graphql/tests/schema/connections/unions.test.ts
@@ -841,13 +841,13 @@ describe("Unions", () => {
 
             type Query {
               authors(limit: Int, offset: Int, options: AuthorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [AuthorSort!], where: AuthorWhere): [Author!]!
-              authorsAggregate(where: AuthorWhere): AuthorAggregateSelection!
+              authorsAggregate(where: AuthorWhere): AuthorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"authorsConnection\\\\\\"\\")
               authorsConnection(after: String, first: Int, sort: [AuthorSort!], where: AuthorWhere): AuthorsConnection!
               books(limit: Int, offset: Int, options: BookOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [BookSort!], where: BookWhere): [Book!]!
-              booksAggregate(where: BookWhere): BookAggregateSelection!
+              booksAggregate(where: BookWhere): BookAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"booksConnection\\\\\\"\\")
               booksConnection(after: String, first: Int, sort: [BookSort!], where: BookWhere): BooksConnection!
               journals(limit: Int, offset: Int, options: JournalOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [JournalSort!], where: JournalWhere): [Journal!]!
-              journalsAggregate(where: JournalWhere): JournalAggregateSelection!
+              journalsAggregate(where: JournalWhere): JournalAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"journalsConnection\\\\\\"\\")
               journalsConnection(after: String, first: Int, sort: [JournalSort!], where: JournalWhere): JournalsConnection!
               publications(limit: Int, offset: Int, options: QueryOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: PublicationWhere): [Publication!]!
             }

--- a/packages/graphql/tests/schema/connections/unions.test.ts
+++ b/packages/graphql/tests/schema/connections/unions.test.ts
@@ -61,6 +61,15 @@ describe("Unions", () => {
               publicationsConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [AuthorPublicationsConnectionSort!], where: AuthorPublicationsConnectionWhere): AuthorPublicationsConnection!
             }
 
+            type AuthorAggregate {
+              node: AuthorAggregateNode!
+            }
+
+            type AuthorAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
             type AuthorAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -297,6 +306,7 @@ describe("Unions", () => {
             }
 
             type AuthorsConnection {
+              aggregate: AuthorAggregate!
               edges: [AuthorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -307,6 +317,15 @@ describe("Unions", () => {
               authorAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: AuthorWhere): BookAuthorAuthorAggregationSelection
               authorConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [BookAuthorConnectionSort!], where: BookAuthorConnectionWhere): BookAuthorConnection!
               title: String!
+            }
+
+            type BookAggregate {
+              node: BookAggregateNode!
+            }
+
+            type BookAggregateNode {
+              count: Int!
+              title: StringAggregateSelection!
             }
 
             type BookAggregateSelection {
@@ -518,6 +537,7 @@ describe("Unions", () => {
             }
 
             type BooksConnection {
+              aggregate: BookAggregate!
               edges: [BookEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -566,6 +586,15 @@ describe("Unions", () => {
               authorAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: AuthorWhere): JournalAuthorAuthorAggregationSelection
               authorConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [JournalAuthorConnectionSort!], where: JournalAuthorConnectionWhere): JournalAuthorConnection!
               subject: String!
+            }
+
+            type JournalAggregate {
+              node: JournalAggregateNode!
+            }
+
+            type JournalAggregateNode {
+              count: Int!
+              subject: StringAggregateSelection!
             }
 
             type JournalAggregateSelection {
@@ -777,6 +806,7 @@ describe("Unions", () => {
             }
 
             type JournalsConnection {
+              aggregate: JournalAggregate!
               edges: [JournalEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/custom-mutations.test.ts
+++ b/packages/graphql/tests/schema/custom-mutations.test.ts
@@ -92,6 +92,15 @@ describe("Custom-mutations", () => {
               id: ID
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+            }
+
             type MovieAggregateSelection {
               count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -140,6 +149,7 @@ describe("Custom-mutations", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/custom-mutations.test.ts
+++ b/packages/graphql/tests/schema/custom-mutations.test.ts
@@ -173,7 +173,7 @@ describe("Custom-mutations", () => {
 
             type Query {
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
               testCypherQuery(input: ExampleInput): String
               testQuery(input: ExampleInput): String

--- a/packages/graphql/tests/schema/directive-preserve.test.ts
+++ b/packages/graphql/tests/schema/directive-preserve.test.ts
@@ -76,6 +76,15 @@ describe("Directive-preserve", () => {
               id: ID @preservedFieldLevel(string: \\"str\\", int: 12, float: 1.2, boolean: true)
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+            }
+
             type MovieAggregateSelection {
               count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -124,6 +133,7 @@ describe("Directive-preserve", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -235,6 +245,15 @@ describe("Directive-preserve", () => {
               moviesAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: MovieWhere): GenreMovieMoviesAggregationSelection
               moviesConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [GenreMoviesConnectionSort!], where: GenreMoviesConnectionWhere): GenreMoviesConnection!
               name: String
+            }
+
+            type GenreAggregate {
+              node: GenreAggregateNode!
+            }
+
+            type GenreAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
             }
 
             type GenreAggregateSelection {
@@ -476,6 +495,7 @@ describe("Directive-preserve", () => {
             }
 
             type GenresConnection {
+              aggregate: GenreAggregate!
               edges: [GenreEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -495,6 +515,17 @@ describe("Directive-preserve", () => {
               imdbRating: Float
               title: String
               year: Int
+            }
+
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              imdbRating: FloatAggregateSelection!
+              title: StringAggregateSelection!
+              year: IntAggregateSelection!
             }
 
             type MovieAggregateSelection {
@@ -724,6 +755,7 @@ describe("Directive-preserve", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1001,6 +1033,15 @@ describe("Directive-preserve", () => {
               where: ActorActedInConnectionWhere
             }
 
+            type ActorAggregate {
+              node: ActorAggregateNode!
+            }
+
+            type ActorAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
             type ActorAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -1106,6 +1147,7 @@ describe("Directive-preserve", () => {
             }
 
             type ActorsConnection {
+              aggregate: ActorAggregate!
               edges: [ActorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1240,6 +1282,16 @@ describe("Directive-preserve", () => {
               where: ProductionActorsConnectionWhere
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              runtime: IntAggregateSelection!
+              title: StringAggregateSelection!
+            }
+
             type MovieAggregateSelection {
               count: Int!
               runtime: IntAggregateSelection!
@@ -1333,6 +1385,7 @@ describe("Directive-preserve", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1510,6 +1563,15 @@ describe("Directive-preserve", () => {
               where: ProductionActorsConnectionWhere
             }
 
+            type ProductionAggregate {
+              node: ProductionAggregateNode!
+            }
+
+            type ProductionAggregateNode {
+              count: Int!
+              title: StringAggregateSelection!
+            }
+
             type ProductionAggregateSelection {
               count: Int!
               title: StringAggregateSelection!
@@ -1608,6 +1670,7 @@ describe("Directive-preserve", () => {
             }
 
             type ProductionsConnection {
+              aggregate: ProductionAggregate!
               edges: [ProductionEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1719,6 +1782,16 @@ describe("Directive-preserve", () => {
               where: ProductionActorsConnectionWhere
             }
 
+            type SeriesAggregate {
+              node: SeriesAggregateNode!
+            }
+
+            type SeriesAggregateNode {
+              count: Int!
+              episodes: IntAggregateSelection!
+              title: StringAggregateSelection!
+            }
+
             type SeriesAggregateSelection {
               count: Int!
               episodes: IntAggregateSelection!
@@ -1726,6 +1799,7 @@ describe("Directive-preserve", () => {
             }
 
             type SeriesConnection {
+              aggregate: SeriesAggregate!
               edges: [SeriesEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -2066,6 +2140,15 @@ describe("Directive-preserve", () => {
               where: ActorActedInConnectionWhere
             }
 
+            type ActorAggregate {
+              node: ActorAggregateNode!
+            }
+
+            type ActorAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
             type ActorAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -2171,6 +2254,7 @@ describe("Directive-preserve", () => {
             }
 
             type ActorsConnection {
+              aggregate: ActorAggregate!
               edges: [ActorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -2340,6 +2424,16 @@ describe("Directive-preserve", () => {
               where: MovieActorsConnectionWhere
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              runtime: IntAggregateSelection!
+              title: StringAggregateSelection!
+            }
+
             type MovieAggregateSelection {
               count: Int!
               runtime: IntAggregateSelection!
@@ -2433,6 +2527,7 @@ describe("Directive-preserve", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -2461,6 +2556,15 @@ describe("Directive-preserve", () => {
             interface Production {
               actors: [Actor!]!
               title: String!
+            }
+
+            type ProductionAggregate {
+              node: ProductionAggregateNode!
+            }
+
+            type ProductionAggregateNode {
+              count: Int!
+              title: StringAggregateSelection!
             }
 
             type ProductionAggregateSelection {
@@ -2523,6 +2627,7 @@ describe("Directive-preserve", () => {
             }
 
             type ProductionsConnection {
+              aggregate: ProductionAggregate!
               edges: [ProductionEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -2669,6 +2774,16 @@ describe("Directive-preserve", () => {
               where: SeriesActorsConnectionWhere
             }
 
+            type SeriesAggregate {
+              node: SeriesAggregateNode!
+            }
+
+            type SeriesAggregateNode {
+              count: Int!
+              episodes: IntAggregateSelection!
+              title: StringAggregateSelection!
+            }
+
             type SeriesAggregateSelection {
               count: Int!
               episodes: IntAggregateSelection!
@@ -2676,6 +2791,7 @@ describe("Directive-preserve", () => {
             }
 
             type SeriesConnection {
+              aggregate: SeriesAggregate!
               edges: [SeriesEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -3004,6 +3120,15 @@ describe("Directive-preserve", () => {
               where: ActorActedInConnectionWhere
             }
 
+            type ActorAggregate {
+              node: ActorAggregateNode!
+            }
+
+            type ActorAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
             type ActorAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -3109,6 +3234,7 @@ describe("Directive-preserve", () => {
             }
 
             type ActorsConnection {
+              aggregate: ActorAggregate!
               edges: [ActorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -3278,6 +3404,16 @@ describe("Directive-preserve", () => {
               where: MovieActorsConnectionWhere
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              runtime: IntAggregateSelection!
+              title: StringAggregateSelection!
+            }
+
             type MovieAggregateSelection {
               count: Int!
               runtime: IntAggregateSelection!
@@ -3371,6 +3507,7 @@ describe("Directive-preserve", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -3399,6 +3536,15 @@ describe("Directive-preserve", () => {
             interface Production {
               actors: [Actor!]! @deprecated(reason: \\"Do not use\\")
               title: String!
+            }
+
+            type ProductionAggregate {
+              node: ProductionAggregateNode!
+            }
+
+            type ProductionAggregateNode {
+              count: Int!
+              title: StringAggregateSelection!
             }
 
             type ProductionAggregateSelection {
@@ -3461,6 +3607,7 @@ describe("Directive-preserve", () => {
             }
 
             type ProductionsConnection {
+              aggregate: ProductionAggregate!
               edges: [ProductionEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -3607,6 +3754,16 @@ describe("Directive-preserve", () => {
               where: SeriesActorsConnectionWhere
             }
 
+            type SeriesAggregate {
+              node: SeriesAggregateNode!
+            }
+
+            type SeriesAggregateNode {
+              count: Int!
+              episodes: IntAggregateSelection!
+              title: StringAggregateSelection!
+            }
+
             type SeriesAggregateSelection {
               count: Int!
               episodes: IntAggregateSelection!
@@ -3614,6 +3771,7 @@ describe("Directive-preserve", () => {
             }
 
             type SeriesConnection {
+              aggregate: SeriesAggregate!
               edges: [SeriesEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -3780,6 +3938,15 @@ describe("Directive-preserve", () => {
               postsAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: PostWhere): BlogPostPostsAggregationSelection
               postsConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [BlogPostsConnectionSort!], where: BlogPostsConnectionWhere): BlogPostsConnection!
               title: String
+            }
+
+            type BlogAggregate {
+              node: BlogAggregateNode!
+            }
+
+            type BlogAggregateNode {
+              count: Int!
+              title: StringAggregateSelection!
             }
 
             type BlogAggregateSelection {
@@ -3976,6 +4143,7 @@ describe("Directive-preserve", () => {
             }
 
             type BlogsConnection {
+              aggregate: BlogAggregate!
               edges: [BlogEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -4043,6 +4211,15 @@ describe("Directive-preserve", () => {
               content: String @deprecated(reason: \\"Do not use post.content\\")
             }
 
+            type PostAggregate {
+              node: PostAggregateNode!
+            }
+
+            type PostAggregateNode {
+              content: StringAggregateSelection!
+              count: Int!
+            }
+
             type PostAggregateSelection {
               content: StringAggregateSelection!
               count: Int!
@@ -4095,6 +4272,7 @@ describe("Directive-preserve", () => {
             }
 
             type PostsConnection {
+              aggregate: PostAggregate!
               edges: [PostEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -4161,6 +4339,15 @@ describe("Directive-preserve", () => {
               content(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), limit: Int, offset: Int, options: QueryOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: ContentWhere): [Content!]! @deprecated(reason: \\"Do not use user.content\\")
               contentConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, where: UserContentConnectionWhere): UserContentConnection! @deprecated(reason: \\"Do not use user.content\\")
               name: String
+            }
+
+            type UserAggregate {
+              node: UserAggregateNode!
+            }
+
+            type UserAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
             }
 
             type UserAggregateSelection {
@@ -4357,6 +4544,7 @@ describe("Directive-preserve", () => {
             }
 
             type UsersConnection {
+              aggregate: UserAggregate!
               edges: [UserEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/directive-preserve.test.ts
+++ b/packages/graphql/tests/schema/directive-preserve.test.ts
@@ -155,7 +155,7 @@ describe("Directive-preserve", () => {
 
             type Query {
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 
@@ -780,10 +780,10 @@ describe("Directive-preserve", () => {
 
             type Query {
               genres(limit: Int, offset: Int, options: GenreOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [GenreSort!], where: GenreWhere): [Genre!]!
-              genresAggregate(where: GenreWhere): GenreAggregateSelection!
+              genresAggregate(where: GenreWhere): GenreAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"genresConnection\\\\\\"\\")
               genresConnection(after: String, first: Int, sort: [GenreSort!], where: GenreWhere): GenresConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 
@@ -1678,16 +1678,16 @@ describe("Directive-preserve", () => {
 
             type Query {
               actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
               actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
               productions(limit: Int, offset: Int, options: ProductionOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ProductionSort!], where: ProductionWhere): [Production!]!
-              productionsAggregate(where: ProductionWhere): ProductionAggregateSelection!
+              productionsAggregate(where: ProductionWhere): ProductionAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"productionsConnection\\\\\\"\\")
               productionsConnection(after: String, first: Int, sort: [ProductionSort!], where: ProductionWhere): ProductionsConnection!
               series(limit: Int, offset: Int, options: SeriesOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [SeriesSort!], where: SeriesWhere): [Series!]!
-              seriesAggregate(where: SeriesWhere): SeriesAggregateSelection!
+              seriesAggregate(where: SeriesWhere): SeriesAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"seriesConnection\\\\\\"\\")
               seriesConnection(after: String, first: Int, sort: [SeriesSort!], where: SeriesWhere): SeriesConnection!
             }
 
@@ -2635,16 +2635,16 @@ describe("Directive-preserve", () => {
 
             type Query {
               actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
               actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
               productions(limit: Int, offset: Int, options: ProductionOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ProductionSort!], where: ProductionWhere): [Production!]!
-              productionsAggregate(where: ProductionWhere): ProductionAggregateSelection!
+              productionsAggregate(where: ProductionWhere): ProductionAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"productionsConnection\\\\\\"\\")
               productionsConnection(after: String, first: Int, sort: [ProductionSort!], where: ProductionWhere): ProductionsConnection!
               series(limit: Int, offset: Int, options: SeriesOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [SeriesSort!], where: SeriesWhere): [Series!]!
-              seriesAggregate(where: SeriesWhere): SeriesAggregateSelection!
+              seriesAggregate(where: SeriesWhere): SeriesAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"seriesConnection\\\\\\"\\")
               seriesConnection(after: String, first: Int, sort: [SeriesSort!], where: SeriesWhere): SeriesConnection!
             }
 
@@ -3615,16 +3615,16 @@ describe("Directive-preserve", () => {
 
             type Query {
               actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
               actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
               productions(limit: Int, offset: Int, options: ProductionOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ProductionSort!], where: ProductionWhere): [Production!]!
-              productionsAggregate(where: ProductionWhere): ProductionAggregateSelection!
+              productionsAggregate(where: ProductionWhere): ProductionAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"productionsConnection\\\\\\"\\")
               productionsConnection(after: String, first: Int, sort: [ProductionSort!], where: ProductionWhere): ProductionsConnection!
               series(limit: Int, offset: Int, options: SeriesOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [SeriesSort!], where: SeriesWhere): [Series!]!
-              seriesAggregate(where: SeriesWhere): SeriesAggregateSelection!
+              seriesAggregate(where: SeriesWhere): SeriesAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"seriesConnection\\\\\\"\\")
               seriesConnection(after: String, first: Int, sort: [SeriesSort!], where: SeriesWhere): SeriesConnection!
             }
 
@@ -4280,14 +4280,14 @@ describe("Directive-preserve", () => {
 
             type Query {
               blogs(limit: Int, offset: Int, options: BlogOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [BlogSort!], where: BlogWhere): [Blog!]!
-              blogsAggregate(where: BlogWhere): BlogAggregateSelection!
+              blogsAggregate(where: BlogWhere): BlogAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"blogsConnection\\\\\\"\\")
               blogsConnection(after: String, first: Int, sort: [BlogSort!], where: BlogWhere): BlogsConnection!
               contents(limit: Int, offset: Int, options: QueryOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: ContentWhere): [Content!]!
               posts(limit: Int, offset: Int, options: PostOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PostSort!], where: PostWhere): [Post!]!
-              postsAggregate(where: PostWhere): PostAggregateSelection!
+              postsAggregate(where: PostWhere): PostAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"postsConnection\\\\\\"\\")
               postsConnection(after: String, first: Int, sort: [PostSort!], where: PostWhere): PostsConnection!
               users(limit: Int, offset: Int, options: UserOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [UserSort!], where: UserWhere): [User!]!
-              usersAggregate(where: UserWhere): UserAggregateSelection!
+              usersAggregate(where: UserWhere): UserAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"usersConnection\\\\\\"\\")
               usersConnection(after: String, first: Int, sort: [UserSort!], where: UserWhere): UsersConnection!
             }
 

--- a/packages/graphql/tests/schema/directives/alias.test.ts
+++ b/packages/graphql/tests/schema/directives/alias.test.ts
@@ -537,10 +537,10 @@ describe("Alias", () => {
 
             type Query {
               actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
               actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 

--- a/packages/graphql/tests/schema/directives/alias.test.ts
+++ b/packages/graphql/tests/schema/directives/alias.test.ts
@@ -267,6 +267,16 @@ describe("Alias", () => {
               where: ActorActedInConnectionWhere
             }
 
+            type ActorAggregate {
+              node: ActorAggregateNode!
+            }
+
+            type ActorAggregateNode {
+              city: StringAggregateSelection!
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
             type ActorAggregateSelection {
               city: StringAggregateSelection!
               count: Int!
@@ -373,6 +383,7 @@ describe("Alias", () => {
             }
 
             type ActorsConnection {
+              aggregate: ActorAggregate!
               edges: [ActorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -421,6 +432,16 @@ describe("Alias", () => {
             type Movie {
               rating: Float
               title: String!
+            }
+
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              rating: FloatAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             type MovieAggregateSelection {
@@ -491,6 +512,7 @@ describe("Alias", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/directives/autogenerate.test.ts
+++ b/packages/graphql/tests/schema/directives/autogenerate.test.ts
@@ -70,6 +70,16 @@ describe("Autogenerate", () => {
               name: String!
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              name: StringAggregateSelection!
+            }
+
             type MovieAggregateSelection {
               count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -126,6 +136,7 @@ describe("Autogenerate", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/directives/autogenerate.test.ts
+++ b/packages/graphql/tests/schema/directives/autogenerate.test.ts
@@ -158,7 +158,7 @@ describe("Autogenerate", () => {
 
             type Query {
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 

--- a/packages/graphql/tests/schema/directives/customResolver.test.ts
+++ b/packages/graphql/tests/schema/directives/customResolver.test.ts
@@ -96,10 +96,10 @@ describe("@customResolver directive", () => {
 
             type Query {
               userInterfaces(limit: Int, offset: Int, options: UserInterfaceOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [UserInterfaceSort!], where: UserInterfaceWhere): [UserInterface!]!
-              userInterfacesAggregate(where: UserInterfaceWhere): UserInterfaceAggregateSelection!
+              userInterfacesAggregate(where: UserInterfaceWhere): UserInterfaceAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"userInterfacesConnection\\\\\\"\\")
               userInterfacesConnection(after: String, first: Int, sort: [UserInterfaceSort!], where: UserInterfaceWhere): UserInterfacesConnection!
               users(limit: Int, offset: Int, options: UserOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [UserSort!], where: UserWhere): [User!]!
-              usersAggregate(where: UserWhere): UserAggregateSelection!
+              usersAggregate(where: UserWhere): UserAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"usersConnection\\\\\\"\\")
               usersConnection(after: String, first: Int, sort: [UserSort!], where: UserWhere): UsersConnection!
             }
 

--- a/packages/graphql/tests/schema/directives/customResolver.test.ts
+++ b/packages/graphql/tests/schema/directives/customResolver.test.ts
@@ -139,6 +139,17 @@ describe("@customResolver directive", () => {
               username: String!
             }
 
+            type UserAggregate {
+              node: UserAggregateNode!
+            }
+
+            type UserAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              password: StringAggregateSelection!
+              username: StringAggregateSelection!
+            }
+
             type UserAggregateSelection {
               count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -159,6 +170,15 @@ describe("@customResolver directive", () => {
 
             interface UserInterface {
               customResolver: String
+            }
+
+            type UserInterfaceAggregate {
+              node: UserInterfaceAggregateNode!
+            }
+
+            type UserInterfaceAggregateNode {
+              count: Int!
+              customResolver: StringAggregateSelection!
             }
 
             type UserInterfaceAggregateSelection {
@@ -206,6 +226,7 @@ describe("@customResolver directive", () => {
             }
 
             type UserInterfacesConnection {
+              aggregate: UserInterfaceAggregate!
               edges: [UserInterfaceEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -263,6 +284,7 @@ describe("@customResolver directive", () => {
             }
 
             type UsersConnection {
+              aggregate: UserAggregate!
               edges: [UserEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/directives/cypher.test.ts
+++ b/packages/graphql/tests/schema/directives/cypher.test.ts
@@ -136,6 +136,15 @@ describe("Cypher", () => {
               name: String
             }
 
+            type ActorAggregate {
+              node: ActorAggregateNode!
+            }
+
+            type ActorAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
             type ActorAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -184,6 +193,7 @@ describe("Cypher", () => {
             }
 
             type ActorsConnection {
+              aggregate: ActorAggregate!
               edges: [ActorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -298,6 +308,15 @@ describe("Cypher", () => {
               list_of_custom_points: [Point]
               list_of_custom_strings: [String]
               list_of_custom_times: [Time]
+            }
+
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
             type MovieAggregateSelection {
@@ -497,6 +516,7 @@ describe("Cypher", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -632,6 +652,14 @@ describe("Cypher", () => {
               custom_cypher_string_list: [String]
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+            }
+
             type MovieAggregateSelection {
               count: Int!
             }
@@ -670,6 +698,7 @@ describe("Cypher", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -753,6 +782,14 @@ describe("Cypher", () => {
               custom_string_with_param(param: String): String
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+            }
+
             type MovieAggregateSelection {
               count: Int!
             }
@@ -799,6 +836,7 @@ describe("Cypher", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -894,6 +932,15 @@ describe("Cypher", () => {
               title: String
             }
 
+            type BlogAggregate {
+              node: BlogAggregateNode!
+            }
+
+            type BlogAggregateNode {
+              count: Int!
+              title: StringAggregateSelection!
+            }
+
             type BlogAggregateSelection {
               count: Int!
               title: StringAggregateSelection!
@@ -948,6 +995,7 @@ describe("Cypher", () => {
             }
 
             type BlogsConnection {
+              aggregate: BlogAggregate!
               edges: [BlogEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1007,6 +1055,15 @@ describe("Cypher", () => {
               content: String
             }
 
+            type PostAggregate {
+              node: PostAggregateNode!
+            }
+
+            type PostAggregateNode {
+              content: StringAggregateSelection!
+              count: Int!
+            }
+
             type PostAggregateSelection {
               content: StringAggregateSelection!
               count: Int!
@@ -1055,6 +1112,7 @@ describe("Cypher", () => {
             }
 
             type PostsConnection {
+              aggregate: PostAggregate!
               edges: [PostEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1174,6 +1232,15 @@ describe("Cypher", () => {
               name: String
             }
 
+            type ActorAggregate {
+              node: ActorAggregateNode!
+            }
+
+            type ActorAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
             type ActorAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -1228,6 +1295,7 @@ describe("Cypher", () => {
             }
 
             type ActorsConnection {
+              aggregate: ActorAggregate!
               edges: [ActorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1262,6 +1330,14 @@ describe("Cypher", () => {
             type Movie implements Production {
               actor: Actor
               actors: [Actor]
+            }
+
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
             }
 
             type MovieAggregateSelection {
@@ -1305,6 +1381,7 @@ describe("Cypher", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1330,6 +1407,14 @@ describe("Cypher", () => {
             interface Production {
               actor: Actor
               actors: [Actor]
+            }
+
+            type ProductionAggregate {
+              node: ProductionAggregateNode!
+            }
+
+            type ProductionAggregateNode {
+              count: Int!
             }
 
             type ProductionAggregateSelection {
@@ -1359,6 +1444,7 @@ describe("Cypher", () => {
             }
 
             type ProductionsConnection {
+              aggregate: ProductionAggregate!
               edges: [ProductionEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1469,6 +1555,15 @@ describe("Cypher", () => {
               name: String
             }
 
+            type ActorAggregate {
+              node: ActorAggregateNode!
+            }
+
+            type ActorAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
             type ActorAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -1523,6 +1618,7 @@ describe("Cypher", () => {
             }
 
             type ActorsConnection {
+              aggregate: ActorAggregate!
               edges: [ActorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1557,6 +1653,14 @@ describe("Cypher", () => {
             type Movie {
               actor: Actor
               actors: [Actor]
+            }
+
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
             }
 
             type MovieAggregateSelection {
@@ -1600,6 +1704,7 @@ describe("Cypher", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1707,6 +1812,15 @@ describe("Cypher", () => {
               totalScreenTime: Int!
             }
 
+            type ActorAggregate {
+              node: ActorAggregateNode!
+            }
+
+            type ActorAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
             type ActorAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -1763,6 +1877,7 @@ describe("Cypher", () => {
             }
 
             type ActorsConnection {
+              aggregate: ActorAggregate!
               edges: [ActorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1802,6 +1917,15 @@ describe("Cypher", () => {
             type Movie {
               actors(title: String): [Actor]
               id: ID
+            }
+
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
             type MovieAggregateSelection {
@@ -1852,6 +1976,7 @@ describe("Cypher", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1969,6 +2094,15 @@ describe("Cypher", () => {
               title: String
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              title: StringAggregateSelection!
+            }
+
             type MovieAggregateSelection {
               count: Int!
               title: StringAggregateSelection!
@@ -2060,6 +2194,7 @@ describe("Cypher", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/directives/cypher.test.ts
+++ b/packages/graphql/tests/schema/directives/cypher.test.ts
@@ -566,10 +566,10 @@ describe("Cypher", () => {
 
             type Query {
               actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
               actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 
@@ -720,7 +720,7 @@ describe("Cypher", () => {
 
             type Query {
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, where: MovieWhere): MoviesConnection!
             }
 
@@ -858,7 +858,7 @@ describe("Cypher", () => {
 
             type Query {
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 
@@ -1120,11 +1120,11 @@ describe("Cypher", () => {
 
             type Query {
               blogs(limit: Int, offset: Int, options: BlogOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [BlogSort!], where: BlogWhere): [Blog!]!
-              blogsAggregate(where: BlogWhere): BlogAggregateSelection!
+              blogsAggregate(where: BlogWhere): BlogAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"blogsConnection\\\\\\"\\")
               blogsConnection(after: String, first: Int, sort: [BlogSort!], where: BlogWhere): BlogsConnection!
               contents(limit: Int, offset: Int, options: QueryOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: ContentWhere): [Content!]!
               posts(limit: Int, offset: Int, options: PostOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PostSort!], where: PostWhere): [Post!]!
-              postsAggregate(where: PostWhere): PostAggregateSelection!
+              postsAggregate(where: PostWhere): PostAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"postsConnection\\\\\\"\\")
               postsConnection(after: String, first: Int, sort: [PostSort!], where: PostWhere): PostsConnection!
             }
 
@@ -1452,13 +1452,13 @@ describe("Cypher", () => {
 
             type Query {
               actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
               actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, where: MovieWhere): MoviesConnection!
               productions(limit: Int, offset: Int, options: ProductionOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: ProductionWhere): [Production!]!
-              productionsAggregate(where: ProductionWhere): ProductionAggregateSelection!
+              productionsAggregate(where: ProductionWhere): ProductionAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"productionsConnection\\\\\\"\\")
               productionsConnection(after: String, first: Int, where: ProductionWhere): ProductionsConnection!
             }
 
@@ -1729,10 +1729,10 @@ describe("Cypher", () => {
 
             type Query {
               actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
               actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, where: MovieWhere): MoviesConnection!
             }
 
@@ -2001,10 +2001,10 @@ describe("Cypher", () => {
 
             type Query {
               actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
               actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 
@@ -2216,7 +2216,7 @@ describe("Cypher", () => {
 
             type Query {
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 

--- a/packages/graphql/tests/schema/directives/default.test.ts
+++ b/packages/graphql/tests/schema/directives/default.test.ts
@@ -174,6 +174,21 @@ describe("@default directive", () => {
               verifiedDate: DateTime!
             }
 
+            type UserAggregate {
+              node: UserAggregateNode!
+            }
+
+            type UserAggregateNode {
+              count: Int!
+              fromInterface: StringAggregateSelection!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              name: StringAggregateSelection!
+              numberOfFriends: IntAggregateSelection!
+              rating: FloatAggregateSelection!
+              toBeOverridden: StringAggregateSelection!
+              verifiedDate: DateTimeAggregateSelection!
+            }
+
             type UserAggregateSelection {
               count: Int!
               fromInterface: StringAggregateSelection!
@@ -205,6 +220,16 @@ describe("@default directive", () => {
             interface UserInterface {
               fromInterface: String!
               toBeOverridden: String!
+            }
+
+            type UserInterfaceAggregate {
+              node: UserInterfaceAggregateNode!
+            }
+
+            type UserInterfaceAggregateNode {
+              count: Int!
+              fromInterface: StringAggregateSelection!
+              toBeOverridden: StringAggregateSelection!
             }
 
             type UserInterfaceAggregateSelection {
@@ -260,6 +285,7 @@ describe("@default directive", () => {
             }
 
             type UserInterfacesConnection {
+              aggregate: UserInterfaceAggregate!
               edges: [UserInterfaceEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -373,6 +399,7 @@ describe("@default directive", () => {
             }
 
             type UsersConnection {
+              aggregate: UserAggregate!
               edges: [UserEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/directives/default.test.ts
+++ b/packages/graphql/tests/schema/directives/default.test.ts
@@ -127,10 +127,10 @@ describe("@default directive", () => {
 
             type Query {
               userInterfaces(limit: Int, offset: Int, options: UserInterfaceOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [UserInterfaceSort!], where: UserInterfaceWhere): [UserInterface!]!
-              userInterfacesAggregate(where: UserInterfaceWhere): UserInterfaceAggregateSelection!
+              userInterfacesAggregate(where: UserInterfaceWhere): UserInterfaceAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"userInterfacesConnection\\\\\\"\\")
               userInterfacesConnection(after: String, first: Int, sort: [UserInterfaceSort!], where: UserInterfaceWhere): UserInterfacesConnection!
               users(limit: Int, offset: Int, options: UserOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [UserSort!], where: UserWhere): [User!]!
-              usersAggregate(where: UserWhere): UserAggregateSelection!
+              usersAggregate(where: UserWhere): UserAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"usersConnection\\\\\\"\\")
               usersConnection(after: String, first: Int, sort: [UserSort!], where: UserWhere): UsersConnection!
             }
 

--- a/packages/graphql/tests/schema/directives/filterable.test.ts
+++ b/packages/graphql/tests/schema/directives/filterable.test.ts
@@ -901,6 +901,16 @@ describe("@filterable directive", () => {
                       username: String!
                     }
 
+                    type ActorAggregate {
+                      node: ActorAggregateNode!
+                    }
+
+                    type ActorAggregateNode {
+                      count: Int!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
+                    }
+
                     type ActorAggregateSelection {
                       count: Int!
                       password: StringAggregateSelection!
@@ -1129,6 +1139,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorsConnection {
+                      aggregate: ActorAggregate!
                       edges: [ActorEdge!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -1297,6 +1308,15 @@ describe("@filterable directive", () => {
                       where: MovieActorsConnectionWhere
                     }
 
+                    type MovieAggregate {
+                      node: MovieAggregateNode!
+                    }
+
+                    type MovieAggregateNode {
+                      count: Int!
+                      title: StringAggregateSelection!
+                    }
+
                     type MovieAggregateSelection {
                       count: Int!
                       title: StringAggregateSelection!
@@ -1423,6 +1443,7 @@ describe("@filterable directive", () => {
                     }
 
                     type MoviesConnection {
+                      aggregate: MovieAggregate!
                       edges: [MovieEdge!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -1534,6 +1555,16 @@ describe("@filterable directive", () => {
                       username: String!
                     }
 
+                    type ActorAggregate {
+                      node: ActorAggregateNode!
+                    }
+
+                    type ActorAggregateNode {
+                      count: Int!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
+                    }
+
                     type ActorAggregateSelection {
                       count: Int!
                       password: StringAggregateSelection!
@@ -1784,6 +1815,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorsConnection {
+                      aggregate: ActorAggregate!
                       edges: [ActorEdge!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -1950,6 +1982,15 @@ describe("@filterable directive", () => {
                       disconnect: [MovieActorsDisconnectFieldInput!]
                       update: MovieActorsUpdateConnectionInput
                       where: MovieActorsConnectionWhere
+                    }
+
+                    type MovieAggregate {
+                      node: MovieAggregateNode!
+                    }
+
+                    type MovieAggregateNode {
+                      count: Int!
+                      title: StringAggregateSelection!
                     }
 
                     type MovieAggregateSelection {
@@ -2078,6 +2119,7 @@ describe("@filterable directive", () => {
                     }
 
                     type MoviesConnection {
+                      aggregate: MovieAggregate!
                       edges: [MovieEdge!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -2187,6 +2229,16 @@ describe("@filterable directive", () => {
                       moviesConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [ActorMoviesConnectionSort!], where: ActorMoviesConnectionWhere): ActorMoviesConnection!
                       password: String!
                       username: String!
+                    }
+
+                    type ActorAggregate {
+                      node: ActorAggregateNode!
+                    }
+
+                    type ActorAggregateNode {
+                      count: Int!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     type ActorAggregateSelection {
@@ -2439,6 +2491,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorsConnection {
+                      aggregate: ActorAggregate!
                       edges: [ActorEdge!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -2607,6 +2660,15 @@ describe("@filterable directive", () => {
                       where: MovieActorsConnectionWhere
                     }
 
+                    type MovieAggregate {
+                      node: MovieAggregateNode!
+                    }
+
+                    type MovieAggregateNode {
+                      count: Int!
+                      title: StringAggregateSelection!
+                    }
+
                     type MovieAggregateSelection {
                       count: Int!
                       title: StringAggregateSelection!
@@ -2715,6 +2777,7 @@ describe("@filterable directive", () => {
                     }
 
                     type MoviesConnection {
+                      aggregate: MovieAggregate!
                       edges: [MovieEdge!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -2829,6 +2892,16 @@ describe("@filterable directive", () => {
                       username: String!
                     }
 
+                    type ActorAggregate {
+                      node: ActorAggregateNode!
+                    }
+
+                    type ActorAggregateNode {
+                      count: Int!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
+                    }
+
                     type ActorAggregateSelection {
                       count: Int!
                       password: StringAggregateSelection!
@@ -3079,6 +3152,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorsConnection {
+                      aggregate: ActorAggregate!
                       edges: [ActorEdge!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -3196,6 +3270,15 @@ describe("@filterable directive", () => {
                       disconnect: [MovieActorsDisconnectFieldInput!]
                       update: MovieActorsUpdateConnectionInput
                       where: MovieActorsConnectionWhere
+                    }
+
+                    type MovieAggregate {
+                      node: MovieAggregateNode!
+                    }
+
+                    type MovieAggregateNode {
+                      count: Int!
+                      title: StringAggregateSelection!
                     }
 
                     type MovieAggregateSelection {
@@ -3323,6 +3406,7 @@ describe("@filterable directive", () => {
                     }
 
                     type MoviesConnection {
+                      aggregate: MovieAggregate!
                       edges: [MovieEdge!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -3436,6 +3520,16 @@ describe("@filterable directive", () => {
                       username: String!
                     }
 
+                    type ActorAggregate {
+                      node: ActorAggregateNode!
+                    }
+
+                    type ActorAggregateNode {
+                      count: Int!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
+                    }
+
                     type ActorAggregateSelection {
                       count: Int!
                       password: StringAggregateSelection!
@@ -3686,6 +3780,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorsConnection {
+                      aggregate: ActorAggregate!
                       edges: [ActorEdge!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -3854,6 +3949,15 @@ describe("@filterable directive", () => {
                       where: MovieActorsConnectionWhere
                     }
 
+                    type MovieAggregate {
+                      node: MovieAggregateNode!
+                    }
+
+                    type MovieAggregateNode {
+                      count: Int!
+                      title: StringAggregateSelection!
+                    }
+
                     type MovieAggregateSelection {
                       count: Int!
                       title: StringAggregateSelection!
@@ -3980,6 +4084,7 @@ describe("@filterable directive", () => {
                     }
 
                     type MoviesConnection {
+                      aggregate: MovieAggregate!
                       edges: [MovieEdge!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -4093,6 +4198,16 @@ describe("@filterable directive", () => {
                       username: String!
                     }
 
+                    type ActorAggregate {
+                      node: ActorAggregateNode!
+                    }
+
+                    type ActorAggregateNode {
+                      count: Int!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
+                    }
+
                     type ActorAggregateSelection {
                       count: Int!
                       password: StringAggregateSelection!
@@ -4343,6 +4458,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorsConnection {
+                      aggregate: ActorAggregate!
                       edges: [ActorEdge!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -4511,6 +4627,15 @@ describe("@filterable directive", () => {
                       where: MovieActorsConnectionWhere
                     }
 
+                    type MovieAggregate {
+                      node: MovieAggregateNode!
+                    }
+
+                    type MovieAggregateNode {
+                      count: Int!
+                      title: StringAggregateSelection!
+                    }
+
                     type MovieAggregateSelection {
                       count: Int!
                       title: StringAggregateSelection!
@@ -4613,6 +4738,7 @@ describe("@filterable directive", () => {
                     }
 
                     type MoviesConnection {
+                      aggregate: MovieAggregate!
                       edges: [MovieEdge!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -4724,6 +4850,16 @@ describe("@filterable directive", () => {
                       moviesConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [ActorMoviesConnectionSort!], where: ActorMoviesConnectionWhere): ActorMoviesConnection!
                       password: String!
                       username: String!
+                    }
+
+                    type ActorAggregate {
+                      node: ActorAggregateNode!
+                    }
+
+                    type ActorAggregateNode {
+                      count: Int!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     type ActorAggregateSelection {
@@ -4976,6 +5112,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorsConnection {
+                      aggregate: ActorAggregate!
                       edges: [ActorEdge!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -5093,6 +5230,15 @@ describe("@filterable directive", () => {
                       disconnect: [MovieActorsDisconnectFieldInput!]
                       update: MovieActorsUpdateConnectionInput
                       where: MovieActorsConnectionWhere
+                    }
+
+                    type MovieAggregate {
+                      node: MovieAggregateNode!
+                    }
+
+                    type MovieAggregateNode {
+                      count: Int!
+                      title: StringAggregateSelection!
                     }
 
                     type MovieAggregateSelection {
@@ -5220,6 +5366,7 @@ describe("@filterable directive", () => {
                     }
 
                     type MoviesConnection {
+                      aggregate: MovieAggregate!
                       edges: [MovieEdge!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -5338,6 +5485,16 @@ describe("@filterable directive", () => {
                       username: String!
                     }
 
+                    type ActorAggregate {
+                      node: ActorAggregateNode!
+                    }
+
+                    type ActorAggregateNode {
+                      count: Int!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
+                    }
+
                     type ActorAggregateSelection {
                       count: Int!
                       password: StringAggregateSelection!
@@ -5576,6 +5733,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorsConnection {
+                      aggregate: ActorAggregate!
                       edges: [ActorEdge!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -5676,6 +5834,15 @@ describe("@filterable directive", () => {
                       disconnect: [MovieActorsDisconnectFieldInput!]
                       update: MovieActorsUpdateConnectionInput
                       where: MovieActorsConnectionWhere
+                    }
+
+                    type MovieAggregate {
+                      node: MovieAggregateNode!
+                    }
+
+                    type MovieAggregateNode {
+                      count: Int!
+                      title: StringAggregateSelection!
                     }
 
                     type MovieAggregateSelection {
@@ -5812,6 +5979,7 @@ describe("@filterable directive", () => {
                     }
 
                     type MoviesConnection {
+                      aggregate: MovieAggregate!
                       edges: [MovieEdge!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -5835,6 +6003,7 @@ describe("@filterable directive", () => {
                     }
 
                     type PeopleConnection {
+                      aggregate: PersonAggregate!
                       edges: [PersonEdge!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -5842,6 +6011,15 @@ describe("@filterable directive", () => {
 
                     interface Person {
                       username: String!
+                    }
+
+                    type PersonAggregate {
+                      node: PersonAggregateNode!
+                    }
+
+                    type PersonAggregateNode {
+                      count: Int!
+                      username: StringAggregateSelection!
                     }
 
                     type PersonAggregateSelection {
@@ -6000,6 +6178,16 @@ describe("@filterable directive", () => {
                       username: String!
                     }
 
+                    type ActorAggregate {
+                      node: ActorAggregateNode!
+                    }
+
+                    type ActorAggregateNode {
+                      count: Int!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
+                    }
+
                     type ActorAggregateSelection {
                       count: Int!
                       password: StringAggregateSelection!
@@ -6238,6 +6426,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorsConnection {
+                      aggregate: ActorAggregate!
                       edges: [ActorEdge!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -6372,6 +6561,15 @@ describe("@filterable directive", () => {
                       disconnect: [MovieActorsDisconnectFieldInput!]
                       update: MovieActorsUpdateConnectionInput
                       where: MovieActorsConnectionWhere
+                    }
+
+                    type MovieAggregate {
+                      node: MovieAggregateNode!
+                    }
+
+                    type MovieAggregateNode {
+                      count: Int!
+                      title: StringAggregateSelection!
                     }
 
                     type MovieAggregateSelection {
@@ -6509,6 +6707,7 @@ describe("@filterable directive", () => {
                     }
 
                     type MoviesConnection {
+                      aggregate: MovieAggregate!
                       edges: [MovieEdge!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -6532,6 +6731,7 @@ describe("@filterable directive", () => {
                     }
 
                     type PeopleConnection {
+                      aggregate: PersonAggregate!
                       edges: [PersonEdge!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -6539,6 +6739,15 @@ describe("@filterable directive", () => {
 
                     interface Person {
                       username: String!
+                    }
+
+                    type PersonAggregate {
+                      node: PersonAggregateNode!
+                    }
+
+                    type PersonAggregateNode {
+                      count: Int!
+                      username: StringAggregateSelection!
                     }
 
                     type PersonAggregateSelection {
@@ -6697,6 +6906,16 @@ describe("@filterable directive", () => {
                       username: String!
                     }
 
+                    type ActorAggregate {
+                      node: ActorAggregateNode!
+                    }
+
+                    type ActorAggregateNode {
+                      count: Int!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
+                    }
+
                     type ActorAggregateSelection {
                       count: Int!
                       password: StringAggregateSelection!
@@ -6935,6 +7154,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorsConnection {
+                      aggregate: ActorAggregate!
                       edges: [ActorEdge!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -7035,6 +7255,15 @@ describe("@filterable directive", () => {
                       disconnect: [MovieActorsDisconnectFieldInput!]
                       update: MovieActorsUpdateConnectionInput
                       where: MovieActorsConnectionWhere
+                    }
+
+                    type MovieAggregate {
+                      node: MovieAggregateNode!
+                    }
+
+                    type MovieAggregateNode {
+                      count: Int!
+                      title: StringAggregateSelection!
                     }
 
                     type MovieAggregateSelection {
@@ -7171,6 +7400,7 @@ describe("@filterable directive", () => {
                     }
 
                     type MoviesConnection {
+                      aggregate: MovieAggregate!
                       edges: [MovieEdge!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -7194,6 +7424,7 @@ describe("@filterable directive", () => {
                     }
 
                     type PeopleConnection {
+                      aggregate: PersonAggregate!
                       edges: [PersonEdge!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -7201,6 +7432,15 @@ describe("@filterable directive", () => {
 
                     interface Person {
                       username: String!
+                    }
+
+                    type PersonAggregate {
+                      node: PersonAggregateNode!
+                    }
+
+                    type PersonAggregateNode {
+                      count: Int!
+                      username: StringAggregateSelection!
                     }
 
                     type PersonAggregateSelection {
@@ -7363,6 +7603,16 @@ describe("@filterable directive", () => {
                       username: String!
                     }
 
+                    type ActorAggregate {
+                      node: ActorAggregateNode!
+                    }
+
+                    type ActorAggregateNode {
+                      count: Int!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
+                    }
+
                     type ActorAggregateSelection {
                       count: Int!
                       password: StringAggregateSelection!
@@ -7613,6 +7863,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorsConnection {
+                      aggregate: ActorAggregate!
                       edges: [ActorEdge!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -7624,6 +7875,16 @@ describe("@filterable directive", () => {
                       moviesConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [AppearanceMoviesConnectionSort!], where: AppearanceMoviesConnectionWhere): AppearanceMoviesConnection!
                       password: String!
                       username: String!
+                    }
+
+                    type AppearanceAggregate {
+                      node: AppearanceAggregateNode!
+                    }
+
+                    type AppearanceAggregateNode {
+                      count: Int!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     type AppearanceAggregateSelection {
@@ -7876,6 +8137,7 @@ describe("@filterable directive", () => {
                     }
 
                     type AppearancesConnection {
+                      aggregate: AppearanceAggregate!
                       edges: [AppearanceEdge!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -8055,6 +8317,15 @@ describe("@filterable directive", () => {
                       Appearance: [MovieActorsAppearanceUpdateFieldInput!]
                     }
 
+                    type MovieAggregate {
+                      node: MovieAggregateNode!
+                    }
+
+                    type MovieAggregateNode {
+                      count: Int!
+                      title: StringAggregateSelection!
+                    }
+
                     type MovieAggregateSelection {
                       count: Int!
                       title: StringAggregateSelection!
@@ -8180,6 +8451,7 @@ describe("@filterable directive", () => {
                     }
 
                     type MoviesConnection {
+                      aggregate: MovieAggregate!
                       edges: [MovieEdge!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -8330,6 +8602,16 @@ describe("@filterable directive", () => {
                       username: String!
                     }
 
+                    type ActorAggregate {
+                      node: ActorAggregateNode!
+                    }
+
+                    type ActorAggregateNode {
+                      count: Int!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
+                    }
+
                     type ActorAggregateSelection {
                       count: Int!
                       password: StringAggregateSelection!
@@ -8580,6 +8862,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorsConnection {
+                      aggregate: ActorAggregate!
                       edges: [ActorEdge!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -8591,6 +8874,16 @@ describe("@filterable directive", () => {
                       moviesConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [AppearanceMoviesConnectionSort!], where: AppearanceMoviesConnectionWhere): AppearanceMoviesConnection!
                       password: String!
                       username: String!
+                    }
+
+                    type AppearanceAggregate {
+                      node: AppearanceAggregateNode!
+                    }
+
+                    type AppearanceAggregateNode {
+                      count: Int!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     type AppearanceAggregateSelection {
@@ -8843,6 +9136,7 @@ describe("@filterable directive", () => {
                     }
 
                     type AppearancesConnection {
+                      aggregate: AppearanceAggregate!
                       edges: [AppearanceEdge!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -9022,6 +9316,15 @@ describe("@filterable directive", () => {
                       Appearance: [MovieActorsAppearanceUpdateFieldInput!]
                     }
 
+                    type MovieAggregate {
+                      node: MovieAggregateNode!
+                    }
+
+                    type MovieAggregateNode {
+                      count: Int!
+                      title: StringAggregateSelection!
+                    }
+
                     type MovieAggregateSelection {
                       count: Int!
                       title: StringAggregateSelection!
@@ -9147,6 +9450,7 @@ describe("@filterable directive", () => {
                     }
 
                     type MoviesConnection {
+                      aggregate: MovieAggregate!
                       edges: [MovieEdge!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -9297,6 +9601,16 @@ describe("@filterable directive", () => {
                       username: String!
                     }
 
+                    type ActorAggregate {
+                      node: ActorAggregateNode!
+                    }
+
+                    type ActorAggregateNode {
+                      count: Int!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
+                    }
+
                     type ActorAggregateSelection {
                       count: Int!
                       password: StringAggregateSelection!
@@ -9547,6 +9861,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorsConnection {
+                      aggregate: ActorAggregate!
                       edges: [ActorEdge!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -9558,6 +9873,16 @@ describe("@filterable directive", () => {
                       moviesConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [AppearanceMoviesConnectionSort!], where: AppearanceMoviesConnectionWhere): AppearanceMoviesConnection!
                       password: String!
                       username: String!
+                    }
+
+                    type AppearanceAggregate {
+                      node: AppearanceAggregateNode!
+                    }
+
+                    type AppearanceAggregateNode {
+                      count: Int!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     type AppearanceAggregateSelection {
@@ -9810,6 +10135,7 @@ describe("@filterable directive", () => {
                     }
 
                     type AppearancesConnection {
+                      aggregate: AppearanceAggregate!
                       edges: [AppearanceEdge!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -9989,6 +10315,15 @@ describe("@filterable directive", () => {
                       Appearance: [MovieActorsAppearanceUpdateFieldInput!]
                     }
 
+                    type MovieAggregate {
+                      node: MovieAggregateNode!
+                    }
+
+                    type MovieAggregateNode {
+                      count: Int!
+                      title: StringAggregateSelection!
+                    }
+
                     type MovieAggregateSelection {
                       count: Int!
                       title: StringAggregateSelection!
@@ -10114,6 +10449,7 @@ describe("@filterable directive", () => {
                     }
 
                     type MoviesConnection {
+                      aggregate: MovieAggregate!
                       edges: [MovieEdge!]!
                       pageInfo: PageInfo!
                       totalCount: Int!

--- a/packages/graphql/tests/schema/directives/filterable.test.ts
+++ b/packages/graphql/tests/schema/directives/filterable.test.ts
@@ -1468,10 +1468,10 @@ describe("@filterable directive", () => {
 
                     type Query {
                       actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-                      actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+                      actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
                       actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
                       movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                      moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                      moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                       moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                     }
 
@@ -2144,10 +2144,10 @@ describe("@filterable directive", () => {
 
                     type Query {
                       actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-                      actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+                      actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
                       actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
                       movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                      moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                      moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                       moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                     }
 
@@ -2802,10 +2802,10 @@ describe("@filterable directive", () => {
 
                     type Query {
                       actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-                      actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+                      actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
                       actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
                       movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                      moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                      moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                       moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                     }
 
@@ -3431,10 +3431,10 @@ describe("@filterable directive", () => {
 
                     type Query {
                       actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-                      actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+                      actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
                       actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
                       movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                      moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                      moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                       moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                     }
 
@@ -4109,10 +4109,10 @@ describe("@filterable directive", () => {
 
                     type Query {
                       actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-                      actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+                      actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
                       actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
                       movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                      moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                      moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                       moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                     }
 
@@ -4763,10 +4763,10 @@ describe("@filterable directive", () => {
 
                     type Query {
                       actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-                      actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+                      actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
                       actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
                       movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                      moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                      moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                       moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                     }
 
@@ -5391,10 +5391,10 @@ describe("@filterable directive", () => {
 
                     type Query {
                       actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-                      actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+                      actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
                       actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
                       movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                      moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                      moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                       moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                     }
 
@@ -6081,13 +6081,13 @@ describe("@filterable directive", () => {
 
                     type Query {
                       actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-                      actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+                      actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
                       actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
                       movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                      moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                      moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                       moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                       people(limit: Int, offset: Int, options: PersonOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonSort!], where: PersonWhere): [Person!]!
-                      peopleAggregate(where: PersonWhere): PersonAggregateSelection!
+                      peopleAggregate(where: PersonWhere): PersonAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"peopleConnection\\\\\\"\\")
                       peopleConnection(after: String, first: Int, sort: [PersonSort!], where: PersonWhere): PeopleConnection!
                     }
 
@@ -6809,13 +6809,13 @@ describe("@filterable directive", () => {
 
                     type Query {
                       actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-                      actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+                      actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
                       actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
                       movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                      moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                      moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                       moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                       people(limit: Int, offset: Int, options: PersonOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonSort!], where: PersonWhere): [Person!]!
-                      peopleAggregate(where: PersonWhere): PersonAggregateSelection!
+                      peopleAggregate(where: PersonWhere): PersonAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"peopleConnection\\\\\\"\\")
                       peopleConnection(after: String, first: Int, sort: [PersonSort!], where: PersonWhere): PeopleConnection!
                     }
 
@@ -7502,13 +7502,13 @@ describe("@filterable directive", () => {
 
                     type Query {
                       actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-                      actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+                      actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
                       actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
                       movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                      moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                      moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                       moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                       people(limit: Int, offset: Int, options: PersonOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonSort!], where: PersonWhere): [Person!]!
-                      peopleAggregate(where: PersonWhere): PersonAggregateSelection!
+                      peopleAggregate(where: PersonWhere): PersonAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"peopleConnection\\\\\\"\\")
                       peopleConnection(after: String, first: Int, sort: [PersonSort!], where: PersonWhere): PeopleConnection!
                     }
 
@@ -8486,13 +8486,13 @@ describe("@filterable directive", () => {
 
                     type Query {
                       actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-                      actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+                      actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
                       actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
                       appearances(limit: Int, offset: Int, options: AppearanceOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [AppearanceSort!], where: AppearanceWhere): [Appearance!]!
-                      appearancesAggregate(where: AppearanceWhere): AppearanceAggregateSelection!
+                      appearancesAggregate(where: AppearanceWhere): AppearanceAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"appearancesConnection\\\\\\"\\")
                       appearancesConnection(after: String, first: Int, sort: [AppearanceSort!], where: AppearanceWhere): AppearancesConnection!
                       movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                      moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                      moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                       moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                       people(limit: Int, offset: Int, options: QueryOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: PersonWhere): [Person!]!
                     }
@@ -9485,13 +9485,13 @@ describe("@filterable directive", () => {
 
                     type Query {
                       actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-                      actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+                      actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
                       actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
                       appearances(limit: Int, offset: Int, options: AppearanceOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [AppearanceSort!], where: AppearanceWhere): [Appearance!]!
-                      appearancesAggregate(where: AppearanceWhere): AppearanceAggregateSelection!
+                      appearancesAggregate(where: AppearanceWhere): AppearanceAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"appearancesConnection\\\\\\"\\")
                       appearancesConnection(after: String, first: Int, sort: [AppearanceSort!], where: AppearanceWhere): AppearancesConnection!
                       movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                      moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                      moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                       moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                       people(limit: Int, offset: Int, options: QueryOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: PersonWhere): [Person!]!
                     }
@@ -10484,13 +10484,13 @@ describe("@filterable directive", () => {
 
                     type Query {
                       actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-                      actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+                      actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
                       actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
                       appearances(limit: Int, offset: Int, options: AppearanceOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [AppearanceSort!], where: AppearanceWhere): [Appearance!]!
-                      appearancesAggregate(where: AppearanceWhere): AppearanceAggregateSelection!
+                      appearancesAggregate(where: AppearanceWhere): AppearanceAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"appearancesConnection\\\\\\"\\")
                       appearancesConnection(after: String, first: Int, sort: [AppearanceSort!], where: AppearanceWhere): AppearancesConnection!
                       movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                      moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                      moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                       moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                       people(limit: Int, offset: Int, options: QueryOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: PersonWhere): [Person!]!
                     }

--- a/packages/graphql/tests/schema/directives/plural.test.ts
+++ b/packages/graphql/tests/schema/directives/plural.test.ts
@@ -79,7 +79,7 @@ describe("Plural option", () => {
 
             type Query {
               techs(limit: Int, offset: Int, options: TechOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [TechSort!], where: TechWhere): [Tech!]!
-              techsAggregate(where: TechWhere): TechAggregateSelection!
+              techsAggregate(where: TechWhere): TechAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"techsConnection\\\\\\"\\")
               techsConnection(after: String, first: Int, sort: [TechSort!], where: TechWhere): TechsConnection!
             }
 
@@ -249,7 +249,7 @@ describe("Plural option", () => {
 
             type Query {
               techs(limit: Int, offset: Int, options: TechOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [TechSort!], where: TechWhere): [Tech!]!
-              techsAggregate(where: TechWhere): TechAggregateSelection!
+              techsAggregate(where: TechWhere): TechAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"techsConnection\\\\\\"\\")
               techsConnection(after: String, first: Int, sort: [TechSort!], where: TechWhere): TechsConnection!
             }
 
@@ -419,7 +419,7 @@ describe("Plural option", () => {
 
             type Query {
               technologies(limit: Int, offset: Int, options: TechOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [TechSort!], where: TechWhere): [Tech!]!
-              technologiesAggregate(where: TechWhere): TechAggregateSelection!
+              technologiesAggregate(where: TechWhere): TechAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"technologiesConnection\\\\\\"\\")
               technologiesConnection(after: String, first: Int, sort: [TechSort!], where: TechWhere): TechnologiesConnection!
             }
 
@@ -589,7 +589,7 @@ describe("Plural option", () => {
 
             type Query {
               techs(limit: Int, offset: Int, options: TechsOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [TechsSort!], where: TechsWhere): [Techs!]!
-              techsAggregate(where: TechsWhere): TechsAggregateSelection!
+              techsAggregate(where: TechsWhere): TechsAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"techsConnection\\\\\\"\\")
               techsConnection(after: String, first: Int, sort: [TechsSort!], where: TechsWhere): TechsConnection!
             }
 
@@ -746,7 +746,7 @@ describe("Plural option", () => {
 
             type Query {
               techs(limit: Int, offset: Int, options: UserOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [UserSort!], where: UserWhere): [User!]!
-              techsAggregate(where: UserWhere): UserAggregateSelection!
+              techsAggregate(where: UserWhere): UserAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"techsConnection\\\\\\"\\")
               techsConnection(after: String, first: Int, sort: [UserSort!], where: UserWhere): TechsConnection!
             }
 
@@ -903,7 +903,7 @@ describe("Plural option", () => {
 
             type Query {
               users(limit: Int, offset: Int, options: UserOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [UserSort!], where: UserWhere): [User!]!
-              usersAggregate(where: UserWhere): UserAggregateSelection!
+              usersAggregate(where: UserWhere): UserAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"usersConnection\\\\\\"\\")
               usersConnection(after: String, first: Int, sort: [UserSort!], where: UserWhere): UsersConnection!
             }
 
@@ -1060,7 +1060,7 @@ describe("Plural option", () => {
 
             type Query {
               users(limit: Int, offset: Int, options: UsersOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [UsersSort!], where: UsersWhere): [Users!]!
-              usersAggregate(where: UsersWhere): UsersAggregateSelection!
+              usersAggregate(where: UsersWhere): UsersAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"usersConnection\\\\\\"\\")
               usersConnection(after: String, first: Int, sort: [UsersSort!], where: UsersWhere): UsersConnection!
             }
 

--- a/packages/graphql/tests/schema/directives/plural.test.ts
+++ b/packages/graphql/tests/schema/directives/plural.test.ts
@@ -101,6 +101,16 @@ describe("Plural option", () => {
               value: String
             }
 
+            type TechAggregate {
+              node: TechAggregateNode!
+            }
+
+            type TechAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+              value: StringAggregateSelection!
+            }
+
             type TechAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -160,6 +170,7 @@ describe("Plural option", () => {
             }
 
             type TechsConnection {
+              aggregate: TechAggregate!
               edges: [TechEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -260,6 +271,16 @@ describe("Plural option", () => {
               value: String
             }
 
+            type TechAggregate {
+              node: TechAggregateNode!
+            }
+
+            type TechAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+              value: StringAggregateSelection!
+            }
+
             type TechAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -319,6 +340,7 @@ describe("Plural option", () => {
             }
 
             type TechsConnection {
+              aggregate: TechAggregate!
               edges: [TechEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -419,6 +441,16 @@ describe("Plural option", () => {
               value: String
             }
 
+            type TechAggregate {
+              node: TechAggregateNode!
+            }
+
+            type TechAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+              value: StringAggregateSelection!
+            }
+
             type TechAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -478,6 +510,7 @@ describe("Plural option", () => {
             }
 
             type TechnologiesConnection {
+              aggregate: TechAggregate!
               edges: [TechEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -577,12 +610,22 @@ describe("Plural option", () => {
               value: String
             }
 
+            type TechsAggregate {
+              node: TechsAggregateNode!
+            }
+
+            type TechsAggregateNode {
+              count: Int!
+              value: StringAggregateSelection!
+            }
+
             type TechsAggregateSelection {
               count: Int!
               value: StringAggregateSelection!
             }
 
             type TechsConnection {
+              aggregate: TechsAggregate!
               edges: [TechsEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -721,6 +764,7 @@ describe("Plural option", () => {
             }
 
             type TechsConnection {
+              aggregate: UserAggregate!
               edges: [UserEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -743,6 +787,15 @@ describe("Plural option", () => {
 
             type User {
               value: String
+            }
+
+            type UserAggregate {
+              node: UserAggregateNode!
+            }
+
+            type UserAggregateNode {
+              count: Int!
+              value: StringAggregateSelection!
             }
 
             type UserAggregateSelection {
@@ -886,6 +939,15 @@ describe("Plural option", () => {
               value: String
             }
 
+            type UserAggregate {
+              node: UserAggregateNode!
+            }
+
+            type UserAggregateNode {
+              count: Int!
+              value: StringAggregateSelection!
+            }
+
             type UserAggregateSelection {
               count: Int!
               value: StringAggregateSelection!
@@ -934,6 +996,7 @@ describe("Plural option", () => {
             }
 
             type UsersConnection {
+              aggregate: UserAggregate!
               edges: [UserEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1033,12 +1096,22 @@ describe("Plural option", () => {
               value: String
             }
 
+            type UsersAggregate {
+              node: UsersAggregateNode!
+            }
+
+            type UsersAggregateNode {
+              count: Int!
+              value: StringAggregateSelection!
+            }
+
             type UsersAggregateSelection {
               count: Int!
               value: StringAggregateSelection!
             }
 
             type UsersConnection {
+              aggregate: UsersAggregate!
               edges: [UsersEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/directives/populatedBy.test.ts
+++ b/packages/graphql/tests/schema/directives/populatedBy.test.ts
@@ -304,7 +304,7 @@ describe("@populatedBy tests", () => {
 
                 type Query {
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                 }
 
@@ -527,7 +527,7 @@ describe("@populatedBy tests", () => {
 
                 type Query {
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                 }
 
@@ -1070,10 +1070,10 @@ describe("@populatedBy tests", () => {
 
                 type Query {
                   genres(limit: Int, offset: Int, options: GenreOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [GenreSort!], where: GenreWhere): [Genre!]!
-                  genresAggregate(where: GenreWhere): GenreAggregateSelection!
+                  genresAggregate(where: GenreWhere): GenreAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"genresConnection\\\\\\"\\")
                   genresConnection(after: String, first: Int, sort: [GenreSort!], where: GenreWhere): GenresConnection!
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                 }
 
@@ -1619,10 +1619,10 @@ describe("@populatedBy tests", () => {
 
                 type Query {
                   genres(limit: Int, offset: Int, options: GenreOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [GenreSort!], where: GenreWhere): [Genre!]!
-                  genresAggregate(where: GenreWhere): GenreAggregateSelection!
+                  genresAggregate(where: GenreWhere): GenreAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"genresConnection\\\\\\"\\")
                   genresConnection(after: String, first: Int, sort: [GenreSort!], where: GenreWhere): GenresConnection!
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                 }
 

--- a/packages/graphql/tests/schema/directives/populatedBy.test.ts
+++ b/packages/graphql/tests/schema/directives/populatedBy.test.ts
@@ -195,6 +195,18 @@ describe("@populatedBy tests", () => {
                   id: ID
                 }
 
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  callback1: StringAggregateSelection!
+                  callback2: StringAggregateSelection!
+                  callback3: StringAggregateSelection!
+                  count: Int!
+                  id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+                }
+
                 type MovieAggregateSelection {
                   callback1: StringAggregateSelection!
                   callback2: StringAggregateSelection!
@@ -270,6 +282,7 @@ describe("@populatedBy tests", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -400,6 +413,18 @@ describe("@populatedBy tests", () => {
                   id: ID
                 }
 
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  callback1: IntAggregateSelection!
+                  callback2: IntAggregateSelection!
+                  callback3: IntAggregateSelection!
+                  count: Int!
+                  id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+                }
+
                 type MovieAggregateSelection {
                   callback1: IntAggregateSelection!
                   callback2: IntAggregateSelection!
@@ -480,6 +505,7 @@ describe("@populatedBy tests", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -739,6 +765,15 @@ describe("@populatedBy tests", () => {
                   id: ID!
                 }
 
+                type GenreAggregate {
+                  node: GenreAggregateNode!
+                }
+
+                type GenreAggregateNode {
+                  count: Int!
+                  id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+                }
+
                 type GenreAggregateSelection {
                   count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -791,6 +826,7 @@ describe("@populatedBy tests", () => {
                 }
 
                 type GenresConnection {
+                  aggregate: GenreAggregate!
                   edges: [GenreEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -806,6 +842,15 @@ describe("@populatedBy tests", () => {
                   genresAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: GenreWhere): MovieGenreGenresAggregationSelection
                   genresConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [MovieGenresConnectionSort!], where: MovieGenresConnectionWhere): MovieGenresConnection!
                   id: ID
+                }
+
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
                 }
 
                 type MovieAggregateSelection {
@@ -1000,6 +1045,7 @@ describe("@populatedBy tests", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -1261,6 +1307,15 @@ describe("@populatedBy tests", () => {
                   id: ID!
                 }
 
+                type GenreAggregate {
+                  node: GenreAggregateNode!
+                }
+
+                type GenreAggregateNode {
+                  count: Int!
+                  id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+                }
+
                 type GenreAggregateSelection {
                   count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -1313,6 +1368,7 @@ describe("@populatedBy tests", () => {
                 }
 
                 type GenresConnection {
+                  aggregate: GenreAggregate!
                   edges: [GenreEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -1335,6 +1391,15 @@ describe("@populatedBy tests", () => {
                   genresAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: GenreWhere): MovieGenreGenresAggregationSelection
                   genresConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [MovieGenresConnectionSort!], where: MovieGenresConnectionWhere): MovieGenresConnection!
                   id: ID
+                }
+
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
                 }
 
                 type MovieAggregateSelection {
@@ -1529,6 +1594,7 @@ describe("@populatedBy tests", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!

--- a/packages/graphql/tests/schema/directives/private.test.ts
+++ b/packages/graphql/tests/schema/directives/private.test.ts
@@ -121,6 +121,15 @@ describe("@private directive", () => {
               id: ID
             }
 
+            type UserAggregate {
+              node: UserAggregateNode!
+            }
+
+            type UserAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+            }
+
             type UserAggregateSelection {
               count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -137,6 +146,15 @@ describe("@private directive", () => {
 
             interface UserInterface {
               id: ID
+            }
+
+            type UserInterfaceAggregate {
+              node: UserInterfaceAggregateNode!
+            }
+
+            type UserInterfaceAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
             type UserInterfaceAggregateSelection {
@@ -184,6 +202,7 @@ describe("@private directive", () => {
             }
 
             type UserInterfacesConnection {
+              aggregate: UserInterfaceAggregate!
               edges: [UserInterfaceEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -223,6 +242,7 @@ describe("@private directive", () => {
             }
 
             type UsersConnection {
+              aggregate: UserAggregate!
               edges: [UserEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -334,6 +354,16 @@ describe("@private directive", () => {
               private: String
             }
 
+            type UserAggregate {
+              node: UserAggregateNode!
+            }
+
+            type UserAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              private: StringAggregateSelection!
+            }
+
             type UserAggregateSelection {
               count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -352,6 +382,15 @@ describe("@private directive", () => {
 
             interface UserInterface {
               id: ID
+            }
+
+            type UserInterfaceAggregate {
+              node: UserInterfaceAggregateNode!
+            }
+
+            type UserInterfaceAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
             type UserInterfaceAggregateSelection {
@@ -399,6 +438,7 @@ describe("@private directive", () => {
             }
 
             type UserInterfacesConnection {
+              aggregate: UserInterfaceAggregate!
               edges: [UserInterfaceEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -447,6 +487,7 @@ describe("@private directive", () => {
             }
 
             type UsersConnection {
+              aggregate: UserAggregate!
               edges: [UserEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/directives/private.test.ts
+++ b/packages/graphql/tests/schema/directives/private.test.ts
@@ -87,10 +87,10 @@ describe("@private directive", () => {
 
             type Query {
               userInterfaces(limit: Int, offset: Int, options: UserInterfaceOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [UserInterfaceSort!], where: UserInterfaceWhere): [UserInterface!]!
-              userInterfacesAggregate(where: UserInterfaceWhere): UserInterfaceAggregateSelection!
+              userInterfacesAggregate(where: UserInterfaceWhere): UserInterfaceAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"userInterfacesConnection\\\\\\"\\")
               userInterfacesConnection(after: String, first: Int, sort: [UserInterfaceSort!], where: UserInterfaceWhere): UserInterfacesConnection!
               users(limit: Int, offset: Int, options: UserOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [UserSort!], where: UserWhere): [User!]!
-              usersAggregate(where: UserWhere): UserAggregateSelection!
+              usersAggregate(where: UserWhere): UserAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"usersConnection\\\\\\"\\")
               usersConnection(after: String, first: Int, sort: [UserSort!], where: UserWhere): UsersConnection!
             }
 
@@ -314,10 +314,10 @@ describe("@private directive", () => {
 
             type Query {
               userInterfaces(limit: Int, offset: Int, options: UserInterfaceOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [UserInterfaceSort!], where: UserInterfaceWhere): [UserInterface!]!
-              userInterfacesAggregate(where: UserInterfaceWhere): UserInterfaceAggregateSelection!
+              userInterfacesAggregate(where: UserInterfaceWhere): UserInterfaceAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"userInterfacesConnection\\\\\\"\\")
               userInterfacesConnection(after: String, first: Int, sort: [UserInterfaceSort!], where: UserInterfaceWhere): UserInterfacesConnection!
               users(limit: Int, offset: Int, options: UserOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [UserSort!], where: UserWhere): [User!]!
-              usersAggregate(where: UserWhere): UserAggregateSelection!
+              usersAggregate(where: UserWhere): UserAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"usersConnection\\\\\\"\\")
               usersConnection(after: String, first: Int, sort: [UserSort!], where: UserWhere): UsersConnection!
             }
 

--- a/packages/graphql/tests/schema/directives/relationship-aggregate.test.ts
+++ b/packages/graphql/tests/schema/directives/relationship-aggregate.test.ts
@@ -232,6 +232,16 @@ describe("@relationship directive, aggregate argument", () => {
                   username: String!
                 }
 
+                type ActorAggregate {
+                  node: ActorAggregateNode!
+                }
+
+                type ActorAggregateNode {
+                  count: Int!
+                  password: StringAggregateSelection!
+                  username: StringAggregateSelection!
+                }
+
                 type ActorAggregateSelection {
                   count: Int!
                   password: StringAggregateSelection!
@@ -295,6 +305,7 @@ describe("@relationship directive, aggregate argument", () => {
                 }
 
                 type ActorsConnection {
+                  aggregate: ActorAggregate!
                   edges: [ActorEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -441,6 +452,15 @@ describe("@relationship directive, aggregate argument", () => {
                   where: MovieActorsConnectionWhere
                 }
 
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  title: StringAggregateSelection!
+                }
+
                 type MovieAggregateSelection {
                   count: Int!
                   title: StringAggregateSelection!
@@ -520,6 +540,7 @@ describe("@relationship directive, aggregate argument", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -613,6 +634,16 @@ describe("@relationship directive, aggregate argument", () => {
                   username: String!
                 }
 
+                type ActorAggregate {
+                  node: ActorAggregateNode!
+                }
+
+                type ActorAggregateNode {
+                  count: Int!
+                  password: StringAggregateSelection!
+                  username: StringAggregateSelection!
+                }
+
                 type ActorAggregateSelection {
                   count: Int!
                   password: StringAggregateSelection!
@@ -676,6 +707,7 @@ describe("@relationship directive, aggregate argument", () => {
                 }
 
                 type ActorsConnection {
+                  aggregate: ActorAggregate!
                   edges: [ActorEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -833,6 +865,15 @@ describe("@relationship directive, aggregate argument", () => {
                   where: MovieActorsConnectionWhere
                 }
 
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  title: StringAggregateSelection!
+                }
+
                 type MovieAggregateSelection {
                   count: Int!
                   title: StringAggregateSelection!
@@ -912,6 +953,7 @@ describe("@relationship directive, aggregate argument", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -1011,6 +1053,16 @@ describe("@relationship directive, aggregate argument", () => {
                       username: String!
                     }
 
+                    type ActorAggregate {
+                      node: ActorAggregateNode!
+                    }
+
+                    type ActorAggregateNode {
+                      count: Int!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
+                    }
+
                     type ActorAggregateSelection {
                       count: Int!
                       password: StringAggregateSelection!
@@ -1070,6 +1122,7 @@ describe("@relationship directive, aggregate argument", () => {
                     }
 
                     type ActorsConnection {
+                      aggregate: ActorAggregate!
                       edges: [ActorEdge!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -1212,6 +1265,15 @@ describe("@relationship directive, aggregate argument", () => {
                       where: MovieActorsConnectionWhere
                     }
 
+                    type MovieAggregate {
+                      node: MovieAggregateNode!
+                    }
+
+                    type MovieAggregateNode {
+                      count: Int!
+                      title: StringAggregateSelection!
+                    }
+
                     type MovieAggregateSelection {
                       count: Int!
                       title: StringAggregateSelection!
@@ -1291,6 +1353,7 @@ describe("@relationship directive, aggregate argument", () => {
                     }
 
                     type MoviesConnection {
+                      aggregate: MovieAggregate!
                       edges: [MovieEdge!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -1314,6 +1377,7 @@ describe("@relationship directive, aggregate argument", () => {
                     }
 
                     type PeopleConnection {
+                      aggregate: PersonAggregate!
                       edges: [PersonEdge!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -1322,6 +1386,16 @@ describe("@relationship directive, aggregate argument", () => {
                     interface Person {
                       password: String!
                       username: String!
+                    }
+
+                    type PersonAggregate {
+                      node: PersonAggregateNode!
+                    }
+
+                    type PersonAggregateNode {
+                      count: Int!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     type PersonAggregateSelection {
@@ -1469,6 +1543,16 @@ describe("@relationship directive, aggregate argument", () => {
                       username: String!
                     }
 
+                    type ActorAggregate {
+                      node: ActorAggregateNode!
+                    }
+
+                    type ActorAggregateNode {
+                      count: Int!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
+                    }
+
                     type ActorAggregateSelection {
                       count: Int!
                       password: StringAggregateSelection!
@@ -1528,6 +1612,7 @@ describe("@relationship directive, aggregate argument", () => {
                     }
 
                     type ActorsConnection {
+                      aggregate: ActorAggregate!
                       edges: [ActorEdge!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -1671,6 +1756,15 @@ describe("@relationship directive, aggregate argument", () => {
                       where: MovieActorsConnectionWhere
                     }
 
+                    type MovieAggregate {
+                      node: MovieAggregateNode!
+                    }
+
+                    type MovieAggregateNode {
+                      count: Int!
+                      title: StringAggregateSelection!
+                    }
+
                     type MovieAggregateSelection {
                       count: Int!
                       title: StringAggregateSelection!
@@ -1760,6 +1854,7 @@ describe("@relationship directive, aggregate argument", () => {
                     }
 
                     type MoviesConnection {
+                      aggregate: MovieAggregate!
                       edges: [MovieEdge!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -1783,6 +1878,7 @@ describe("@relationship directive, aggregate argument", () => {
                     }
 
                     type PeopleConnection {
+                      aggregate: PersonAggregate!
                       edges: [PersonEdge!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -1791,6 +1887,16 @@ describe("@relationship directive, aggregate argument", () => {
                     interface Person {
                       password: String!
                       username: String!
+                    }
+
+                    type PersonAggregate {
+                      node: PersonAggregateNode!
+                    }
+
+                    type PersonAggregateNode {
+                      count: Int!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     type PersonAggregateSelection {
@@ -1942,6 +2048,16 @@ describe("@relationship directive, aggregate argument", () => {
                       username: String!
                     }
 
+                    type ActorAggregate {
+                      node: ActorAggregateNode!
+                    }
+
+                    type ActorAggregateNode {
+                      count: Int!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
+                    }
+
                     type ActorAggregateSelection {
                       count: Int!
                       password: StringAggregateSelection!
@@ -2005,6 +2121,7 @@ describe("@relationship directive, aggregate argument", () => {
                     }
 
                     type ActorsConnection {
+                      aggregate: ActorAggregate!
                       edges: [ActorEdge!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -2167,6 +2284,15 @@ describe("@relationship directive, aggregate argument", () => {
                       Person: [MovieActorsPersonUpdateFieldInput!]
                     }
 
+                    type MovieAggregate {
+                      node: MovieAggregateNode!
+                    }
+
+                    type MovieAggregateNode {
+                      count: Int!
+                      title: StringAggregateSelection!
+                    }
+
                     type MovieAggregateSelection {
                       count: Int!
                       title: StringAggregateSelection!
@@ -2245,6 +2371,7 @@ describe("@relationship directive, aggregate argument", () => {
                     }
 
                     type MoviesConnection {
+                      aggregate: MovieAggregate!
                       edges: [MovieEdge!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -2271,6 +2398,7 @@ describe("@relationship directive, aggregate argument", () => {
                     }
 
                     type PeopleConnection {
+                      aggregate: PersonAggregate!
                       edges: [PersonEdge!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -2278,6 +2406,15 @@ describe("@relationship directive, aggregate argument", () => {
 
                     type Person {
                       name: String!
+                    }
+
+                    type PersonAggregate {
+                      node: PersonAggregateNode!
+                    }
+
+                    type PersonAggregateNode {
+                      count: Int!
+                      name: StringAggregateSelection!
                     }
 
                     type PersonAggregateSelection {
@@ -2422,6 +2559,16 @@ describe("@relationship directive, aggregate argument", () => {
                       username: String!
                     }
 
+                    type ActorAggregate {
+                      node: ActorAggregateNode!
+                    }
+
+                    type ActorAggregateNode {
+                      count: Int!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
+                    }
+
                     type ActorAggregateSelection {
                       count: Int!
                       password: StringAggregateSelection!
@@ -2485,6 +2632,7 @@ describe("@relationship directive, aggregate argument", () => {
                     }
 
                     type ActorsConnection {
+                      aggregate: ActorAggregate!
                       edges: [ActorEdge!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -2647,6 +2795,15 @@ describe("@relationship directive, aggregate argument", () => {
                       Person: [MovieActorsPersonUpdateFieldInput!]
                     }
 
+                    type MovieAggregate {
+                      node: MovieAggregateNode!
+                    }
+
+                    type MovieAggregateNode {
+                      count: Int!
+                      title: StringAggregateSelection!
+                    }
+
                     type MovieAggregateSelection {
                       count: Int!
                       title: StringAggregateSelection!
@@ -2725,6 +2882,7 @@ describe("@relationship directive, aggregate argument", () => {
                     }
 
                     type MoviesConnection {
+                      aggregate: MovieAggregate!
                       edges: [MovieEdge!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -2751,6 +2909,7 @@ describe("@relationship directive, aggregate argument", () => {
                     }
 
                     type PeopleConnection {
+                      aggregate: PersonAggregate!
                       edges: [PersonEdge!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -2758,6 +2917,15 @@ describe("@relationship directive, aggregate argument", () => {
 
                     type Person {
                       name: String!
+                    }
+
+                    type PersonAggregate {
+                      node: PersonAggregateNode!
+                    }
+
+                    type PersonAggregateNode {
+                      count: Int!
+                      name: StringAggregateSelection!
                     }
 
                     type PersonAggregateSelection {

--- a/packages/graphql/tests/schema/directives/relationship-aggregate.test.ts
+++ b/packages/graphql/tests/schema/directives/relationship-aggregate.test.ts
@@ -565,10 +565,10 @@ describe("@relationship directive, aggregate argument", () => {
 
                 type Query {
                   actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-                  actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+                  actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
                   actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                 }
 
@@ -978,10 +978,10 @@ describe("@relationship directive, aggregate argument", () => {
 
                 type Query {
                   actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-                  actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+                  actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
                   actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                 }
 
@@ -1467,13 +1467,13 @@ describe("@relationship directive, aggregate argument", () => {
 
                     type Query {
                       actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-                      actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+                      actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
                       actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
                       movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                      moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                      moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                       moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                       people(limit: Int, offset: Int, options: PersonOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonSort!], where: PersonWhere): [Person!]!
-                      peopleAggregate(where: PersonWhere): PersonAggregateSelection!
+                      peopleAggregate(where: PersonWhere): PersonAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"peopleConnection\\\\\\"\\")
                       peopleConnection(after: String, first: Int, sort: [PersonSort!], where: PersonWhere): PeopleConnection!
                     }
 
@@ -1968,13 +1968,13 @@ describe("@relationship directive, aggregate argument", () => {
 
                     type Query {
                       actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-                      actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+                      actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
                       actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
                       movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                      moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                      moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                       moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                       people(limit: Int, offset: Int, options: PersonOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonSort!], where: PersonWhere): [Person!]!
-                      peopleAggregate(where: PersonWhere): PersonAggregateSelection!
+                      peopleAggregate(where: PersonWhere): PersonAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"peopleConnection\\\\\\"\\")
                       peopleConnection(after: String, first: Int, sort: [PersonSort!], where: PersonWhere): PeopleConnection!
                     }
 
@@ -2470,14 +2470,14 @@ describe("@relationship directive, aggregate argument", () => {
 
                     type Query {
                       actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-                      actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+                      actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
                       actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
                       castMembers(limit: Int, offset: Int, options: QueryOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: CastMemberWhere): [CastMember!]!
                       movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                      moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                      moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                       moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                       people(limit: Int, offset: Int, options: PersonOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonSort!], where: PersonWhere): [Person!]!
-                      peopleAggregate(where: PersonWhere): PersonAggregateSelection!
+                      peopleAggregate(where: PersonWhere): PersonAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"peopleConnection\\\\\\"\\")
                       peopleConnection(after: String, first: Int, sort: [PersonSort!], where: PersonWhere): PeopleConnection!
                     }
 
@@ -2981,14 +2981,14 @@ describe("@relationship directive, aggregate argument", () => {
 
                     type Query {
                       actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-                      actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+                      actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
                       actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
                       castMembers(limit: Int, offset: Int, options: QueryOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: CastMemberWhere): [CastMember!]!
                       movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                      moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                      moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                       moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                       people(limit: Int, offset: Int, options: PersonOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonSort!], where: PersonWhere): [Person!]!
-                      peopleAggregate(where: PersonWhere): PersonAggregateSelection!
+                      peopleAggregate(where: PersonWhere): PersonAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"peopleConnection\\\\\\"\\")
                       peopleConnection(after: String, first: Int, sort: [PersonSort!], where: PersonWhere): PeopleConnection!
                     }
 

--- a/packages/graphql/tests/schema/directives/relationship-nested-operations.test.ts
+++ b/packages/graphql/tests/schema/directives/relationship-nested-operations.test.ts
@@ -327,10 +327,10 @@ describe("Relationship nested operations", () => {
 
                 type Query {
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                   people(limit: Int, offset: Int, options: PersonOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonSort!], where: PersonWhere): [Person!]!
-                  peopleAggregate(where: PersonWhere): PersonAggregateSelection!
+                  peopleAggregate(where: PersonWhere): PersonAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"peopleConnection\\\\\\"\\")
                   peopleConnection(after: String, first: Int, sort: [PersonSort!], where: PersonWhere): PeopleConnection!
                 }
 
@@ -681,10 +681,10 @@ describe("Relationship nested operations", () => {
 
                 type Query {
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                   people(limit: Int, offset: Int, options: PersonOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonSort!], where: PersonWhere): [Person!]!
-                  peopleAggregate(where: PersonWhere): PersonAggregateSelection!
+                  peopleAggregate(where: PersonWhere): PersonAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"peopleConnection\\\\\\"\\")
                   peopleConnection(after: String, first: Int, sort: [PersonSort!], where: PersonWhere): PeopleConnection!
                 }
 
@@ -1043,10 +1043,10 @@ describe("Relationship nested operations", () => {
 
                 type Query {
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                   people(limit: Int, offset: Int, options: PersonOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonSort!], where: PersonWhere): [Person!]!
-                  peopleAggregate(where: PersonWhere): PersonAggregateSelection!
+                  peopleAggregate(where: PersonWhere): PersonAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"peopleConnection\\\\\\"\\")
                   peopleConnection(after: String, first: Int, sort: [PersonSort!], where: PersonWhere): PeopleConnection!
                 }
 
@@ -1392,10 +1392,10 @@ describe("Relationship nested operations", () => {
 
                 type Query {
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                   people(limit: Int, offset: Int, options: PersonOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonSort!], where: PersonWhere): [Person!]!
-                  peopleAggregate(where: PersonWhere): PersonAggregateSelection!
+                  peopleAggregate(where: PersonWhere): PersonAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"peopleConnection\\\\\\"\\")
                   peopleConnection(after: String, first: Int, sort: [PersonSort!], where: PersonWhere): PeopleConnection!
                 }
 
@@ -1745,10 +1745,10 @@ describe("Relationship nested operations", () => {
 
                 type Query {
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                   people(limit: Int, offset: Int, options: PersonOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonSort!], where: PersonWhere): [Person!]!
-                  peopleAggregate(where: PersonWhere): PersonAggregateSelection!
+                  peopleAggregate(where: PersonWhere): PersonAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"peopleConnection\\\\\\"\\")
                   peopleConnection(after: String, first: Int, sort: [PersonSort!], where: PersonWhere): PeopleConnection!
                 }
 
@@ -2094,10 +2094,10 @@ describe("Relationship nested operations", () => {
 
                 type Query {
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                   people(limit: Int, offset: Int, options: PersonOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonSort!], where: PersonWhere): [Person!]!
-                  peopleAggregate(where: PersonWhere): PersonAggregateSelection!
+                  peopleAggregate(where: PersonWhere): PersonAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"peopleConnection\\\\\\"\\")
                   peopleConnection(after: String, first: Int, sort: [PersonSort!], where: PersonWhere): PeopleConnection!
                 }
 
@@ -2434,10 +2434,10 @@ describe("Relationship nested operations", () => {
 
                 type Query {
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                   people(limit: Int, offset: Int, options: PersonOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonSort!], where: PersonWhere): [Person!]!
-                  peopleAggregate(where: PersonWhere): PersonAggregateSelection!
+                  peopleAggregate(where: PersonWhere): PersonAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"peopleConnection\\\\\\"\\")
                   peopleConnection(after: String, first: Int, sort: [PersonSort!], where: PersonWhere): PeopleConnection!
                 }
 
@@ -2829,10 +2829,10 @@ describe("Relationship nested operations", () => {
 
                 type Query {
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                   people(limit: Int, offset: Int, options: PersonOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonSort!], where: PersonWhere): [Person!]!
-                  peopleAggregate(where: PersonWhere): PersonAggregateSelection!
+                  peopleAggregate(where: PersonWhere): PersonAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"peopleConnection\\\\\\"\\")
                   peopleConnection(after: String, first: Int, sort: [PersonSort!], where: PersonWhere): PeopleConnection!
                 }
 
@@ -3320,10 +3320,10 @@ describe("Relationship nested operations", () => {
 
                 type Query {
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                   people(limit: Int, offset: Int, options: PersonOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonSort!], where: PersonWhere): [Person!]!
-                  peopleAggregate(where: PersonWhere): PersonAggregateSelection!
+                  peopleAggregate(where: PersonWhere): PersonAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"peopleConnection\\\\\\"\\")
                   peopleConnection(after: String, first: Int, sort: [PersonSort!], where: PersonWhere): PeopleConnection!
                 }
 
@@ -3778,10 +3778,10 @@ describe("Relationship nested operations", () => {
 
                 type Query {
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                   people(limit: Int, offset: Int, options: PersonOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonSort!], where: PersonWhere): [Person!]!
-                  peopleAggregate(where: PersonWhere): PersonAggregateSelection!
+                  peopleAggregate(where: PersonWhere): PersonAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"peopleConnection\\\\\\"\\")
                   peopleConnection(after: String, first: Int, sort: [PersonSort!], where: PersonWhere): PeopleConnection!
                 }
 
@@ -4175,14 +4175,14 @@ describe("Relationship nested operations", () => {
 
                 type Query {
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                   people(limit: Int, offset: Int, options: QueryOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: PersonWhere): [Person!]!
                   personOnes(limit: Int, offset: Int, options: PersonOneOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonOneSort!], where: PersonOneWhere): [PersonOne!]!
-                  personOnesAggregate(where: PersonOneWhere): PersonOneAggregateSelection!
+                  personOnesAggregate(where: PersonOneWhere): PersonOneAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"personOnesConnection\\\\\\"\\")
                   personOnesConnection(after: String, first: Int, sort: [PersonOneSort!], where: PersonOneWhere): PersonOnesConnection!
                   personTwos(limit: Int, offset: Int, options: PersonTwoOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonTwoSort!], where: PersonTwoWhere): [PersonTwo!]!
-                  personTwosAggregate(where: PersonTwoWhere): PersonTwoAggregateSelection!
+                  personTwosAggregate(where: PersonTwoWhere): PersonTwoAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"personTwosConnection\\\\\\"\\")
                   personTwosConnection(after: String, first: Int, sort: [PersonTwoSort!], where: PersonTwoWhere): PersonTwosConnection!
                 }
 
@@ -4618,14 +4618,14 @@ describe("Relationship nested operations", () => {
 
                 type Query {
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                   people(limit: Int, offset: Int, options: QueryOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: PersonWhere): [Person!]!
                   personOnes(limit: Int, offset: Int, options: PersonOneOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonOneSort!], where: PersonOneWhere): [PersonOne!]!
-                  personOnesAggregate(where: PersonOneWhere): PersonOneAggregateSelection!
+                  personOnesAggregate(where: PersonOneWhere): PersonOneAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"personOnesConnection\\\\\\"\\")
                   personOnesConnection(after: String, first: Int, sort: [PersonOneSort!], where: PersonOneWhere): PersonOnesConnection!
                   personTwos(limit: Int, offset: Int, options: PersonTwoOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonTwoSort!], where: PersonTwoWhere): [PersonTwo!]!
-                  personTwosAggregate(where: PersonTwoWhere): PersonTwoAggregateSelection!
+                  personTwosAggregate(where: PersonTwoWhere): PersonTwoAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"personTwosConnection\\\\\\"\\")
                   personTwosConnection(after: String, first: Int, sort: [PersonTwoSort!], where: PersonTwoWhere): PersonTwosConnection!
                 }
 
@@ -5069,14 +5069,14 @@ describe("Relationship nested operations", () => {
 
                 type Query {
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                   people(limit: Int, offset: Int, options: QueryOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: PersonWhere): [Person!]!
                   personOnes(limit: Int, offset: Int, options: PersonOneOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonOneSort!], where: PersonOneWhere): [PersonOne!]!
-                  personOnesAggregate(where: PersonOneWhere): PersonOneAggregateSelection!
+                  personOnesAggregate(where: PersonOneWhere): PersonOneAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"personOnesConnection\\\\\\"\\")
                   personOnesConnection(after: String, first: Int, sort: [PersonOneSort!], where: PersonOneWhere): PersonOnesConnection!
                   personTwos(limit: Int, offset: Int, options: PersonTwoOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonTwoSort!], where: PersonTwoWhere): [PersonTwo!]!
-                  personTwosAggregate(where: PersonTwoWhere): PersonTwoAggregateSelection!
+                  personTwosAggregate(where: PersonTwoWhere): PersonTwoAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"personTwosConnection\\\\\\"\\")
                   personTwosConnection(after: String, first: Int, sort: [PersonTwoSort!], where: PersonTwoWhere): PersonTwosConnection!
                 }
 
@@ -5498,14 +5498,14 @@ describe("Relationship nested operations", () => {
 
                 type Query {
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                   people(limit: Int, offset: Int, options: QueryOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: PersonWhere): [Person!]!
                   personOnes(limit: Int, offset: Int, options: PersonOneOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonOneSort!], where: PersonOneWhere): [PersonOne!]!
-                  personOnesAggregate(where: PersonOneWhere): PersonOneAggregateSelection!
+                  personOnesAggregate(where: PersonOneWhere): PersonOneAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"personOnesConnection\\\\\\"\\")
                   personOnesConnection(after: String, first: Int, sort: [PersonOneSort!], where: PersonOneWhere): PersonOnesConnection!
                   personTwos(limit: Int, offset: Int, options: PersonTwoOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonTwoSort!], where: PersonTwoWhere): [PersonTwo!]!
-                  personTwosAggregate(where: PersonTwoWhere): PersonTwoAggregateSelection!
+                  personTwosAggregate(where: PersonTwoWhere): PersonTwoAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"personTwosConnection\\\\\\"\\")
                   personTwosConnection(after: String, first: Int, sort: [PersonTwoSort!], where: PersonTwoWhere): PersonTwosConnection!
                 }
 
@@ -5936,14 +5936,14 @@ describe("Relationship nested operations", () => {
 
                 type Query {
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                   people(limit: Int, offset: Int, options: QueryOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: PersonWhere): [Person!]!
                   personOnes(limit: Int, offset: Int, options: PersonOneOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonOneSort!], where: PersonOneWhere): [PersonOne!]!
-                  personOnesAggregate(where: PersonOneWhere): PersonOneAggregateSelection!
+                  personOnesAggregate(where: PersonOneWhere): PersonOneAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"personOnesConnection\\\\\\"\\")
                   personOnesConnection(after: String, first: Int, sort: [PersonOneSort!], where: PersonOneWhere): PersonOnesConnection!
                   personTwos(limit: Int, offset: Int, options: PersonTwoOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonTwoSort!], where: PersonTwoWhere): [PersonTwo!]!
-                  personTwosAggregate(where: PersonTwoWhere): PersonTwoAggregateSelection!
+                  personTwosAggregate(where: PersonTwoWhere): PersonTwoAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"personTwosConnection\\\\\\"\\")
                   personTwosConnection(after: String, first: Int, sort: [PersonTwoSort!], where: PersonTwoWhere): PersonTwosConnection!
                 }
 
@@ -6365,14 +6365,14 @@ describe("Relationship nested operations", () => {
 
                 type Query {
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                   people(limit: Int, offset: Int, options: QueryOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: PersonWhere): [Person!]!
                   personOnes(limit: Int, offset: Int, options: PersonOneOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonOneSort!], where: PersonOneWhere): [PersonOne!]!
-                  personOnesAggregate(where: PersonOneWhere): PersonOneAggregateSelection!
+                  personOnesAggregate(where: PersonOneWhere): PersonOneAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"personOnesConnection\\\\\\"\\")
                   personOnesConnection(after: String, first: Int, sort: [PersonOneSort!], where: PersonOneWhere): PersonOnesConnection!
                   personTwos(limit: Int, offset: Int, options: PersonTwoOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonTwoSort!], where: PersonTwoWhere): [PersonTwo!]!
-                  personTwosAggregate(where: PersonTwoWhere): PersonTwoAggregateSelection!
+                  personTwosAggregate(where: PersonTwoWhere): PersonTwoAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"personTwosConnection\\\\\\"\\")
                   personTwosConnection(after: String, first: Int, sort: [PersonTwoSort!], where: PersonTwoWhere): PersonTwosConnection!
                 }
 
@@ -6771,14 +6771,14 @@ describe("Relationship nested operations", () => {
 
                 type Query {
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                   people(limit: Int, offset: Int, options: QueryOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: PersonWhere): [Person!]!
                   personOnes(limit: Int, offset: Int, options: PersonOneOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonOneSort!], where: PersonOneWhere): [PersonOne!]!
-                  personOnesAggregate(where: PersonOneWhere): PersonOneAggregateSelection!
+                  personOnesAggregate(where: PersonOneWhere): PersonOneAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"personOnesConnection\\\\\\"\\")
                   personOnesConnection(after: String, first: Int, sort: [PersonOneSort!], where: PersonOneWhere): PersonOnesConnection!
                   personTwos(limit: Int, offset: Int, options: PersonTwoOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonTwoSort!], where: PersonTwoWhere): [PersonTwo!]!
-                  personTwosAggregate(where: PersonTwoWhere): PersonTwoAggregateSelection!
+                  personTwosAggregate(where: PersonTwoWhere): PersonTwoAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"personTwosConnection\\\\\\"\\")
                   personTwosConnection(after: String, first: Int, sort: [PersonTwoSort!], where: PersonTwoWhere): PersonTwosConnection!
                 }
 
@@ -7273,14 +7273,14 @@ describe("Relationship nested operations", () => {
 
                 type Query {
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                   people(limit: Int, offset: Int, options: QueryOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: PersonWhere): [Person!]!
                   personOnes(limit: Int, offset: Int, options: PersonOneOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonOneSort!], where: PersonOneWhere): [PersonOne!]!
-                  personOnesAggregate(where: PersonOneWhere): PersonOneAggregateSelection!
+                  personOnesAggregate(where: PersonOneWhere): PersonOneAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"personOnesConnection\\\\\\"\\")
                   personOnesConnection(after: String, first: Int, sort: [PersonOneSort!], where: PersonOneWhere): PersonOnesConnection!
                   personTwos(limit: Int, offset: Int, options: PersonTwoOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonTwoSort!], where: PersonTwoWhere): [PersonTwo!]!
-                  personTwosAggregate(where: PersonTwoWhere): PersonTwoAggregateSelection!
+                  personTwosAggregate(where: PersonTwoWhere): PersonTwoAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"personTwosConnection\\\\\\"\\")
                   personTwosConnection(after: String, first: Int, sort: [PersonTwoSort!], where: PersonTwoWhere): PersonTwosConnection!
                 }
 
@@ -7856,14 +7856,14 @@ describe("Relationship nested operations", () => {
 
                 type Query {
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                   people(limit: Int, offset: Int, options: QueryOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: PersonWhere): [Person!]!
                   personOnes(limit: Int, offset: Int, options: PersonOneOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonOneSort!], where: PersonOneWhere): [PersonOne!]!
-                  personOnesAggregate(where: PersonOneWhere): PersonOneAggregateSelection!
+                  personOnesAggregate(where: PersonOneWhere): PersonOneAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"personOnesConnection\\\\\\"\\")
                   personOnesConnection(after: String, first: Int, sort: [PersonOneSort!], where: PersonOneWhere): PersonOnesConnection!
                   personTwos(limit: Int, offset: Int, options: PersonTwoOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonTwoSort!], where: PersonTwoWhere): [PersonTwo!]!
-                  personTwosAggregate(where: PersonTwoWhere): PersonTwoAggregateSelection!
+                  personTwosAggregate(where: PersonTwoWhere): PersonTwoAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"personTwosConnection\\\\\\"\\")
                   personTwosConnection(after: String, first: Int, sort: [PersonTwoSort!], where: PersonTwoWhere): PersonTwosConnection!
                 }
 
@@ -8380,14 +8380,14 @@ describe("Relationship nested operations", () => {
 
                 type Query {
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                   people(limit: Int, offset: Int, options: QueryOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: PersonWhere): [Person!]!
                   personOnes(limit: Int, offset: Int, options: PersonOneOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonOneSort!], where: PersonOneWhere): [PersonOne!]!
-                  personOnesAggregate(where: PersonOneWhere): PersonOneAggregateSelection!
+                  personOnesAggregate(where: PersonOneWhere): PersonOneAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"personOnesConnection\\\\\\"\\")
                   personOnesConnection(after: String, first: Int, sort: [PersonOneSort!], where: PersonOneWhere): PersonOnesConnection!
                   personTwos(limit: Int, offset: Int, options: PersonTwoOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonTwoSort!], where: PersonTwoWhere): [PersonTwo!]!
-                  personTwosAggregate(where: PersonTwoWhere): PersonTwoAggregateSelection!
+                  personTwosAggregate(where: PersonTwoWhere): PersonTwoAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"personTwosConnection\\\\\\"\\")
                   personTwosConnection(after: String, first: Int, sort: [PersonTwoSort!], where: PersonTwoWhere): PersonTwosConnection!
                 }
 
@@ -8899,16 +8899,16 @@ describe("Relationship nested operations", () => {
 
                 type Query {
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                   people(limit: Int, offset: Int, options: PersonOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonSort!], where: PersonWhere): [Person!]!
-                  peopleAggregate(where: PersonWhere): PersonAggregateSelection!
+                  peopleAggregate(where: PersonWhere): PersonAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"peopleConnection\\\\\\"\\")
                   peopleConnection(after: String, first: Int, sort: [PersonSort!], where: PersonWhere): PeopleConnection!
                   personOnes(limit: Int, offset: Int, options: PersonOneOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonOneSort!], where: PersonOneWhere): [PersonOne!]!
-                  personOnesAggregate(where: PersonOneWhere): PersonOneAggregateSelection!
+                  personOnesAggregate(where: PersonOneWhere): PersonOneAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"personOnesConnection\\\\\\"\\")
                   personOnesConnection(after: String, first: Int, sort: [PersonOneSort!], where: PersonOneWhere): PersonOnesConnection!
                   personTwos(limit: Int, offset: Int, options: PersonTwoOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonTwoSort!], where: PersonTwoWhere): [PersonTwo!]!
-                  personTwosAggregate(where: PersonTwoWhere): PersonTwoAggregateSelection!
+                  personTwosAggregate(where: PersonTwoWhere): PersonTwoAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"personTwosConnection\\\\\\"\\")
                   personTwosConnection(after: String, first: Int, sort: [PersonTwoSort!], where: PersonTwoWhere): PersonTwosConnection!
                 }
 
@@ -9427,16 +9427,16 @@ describe("Relationship nested operations", () => {
 
                 type Query {
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                   people(limit: Int, offset: Int, options: PersonOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonSort!], where: PersonWhere): [Person!]!
-                  peopleAggregate(where: PersonWhere): PersonAggregateSelection!
+                  peopleAggregate(where: PersonWhere): PersonAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"peopleConnection\\\\\\"\\")
                   peopleConnection(after: String, first: Int, sort: [PersonSort!], where: PersonWhere): PeopleConnection!
                   personOnes(limit: Int, offset: Int, options: PersonOneOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonOneSort!], where: PersonOneWhere): [PersonOne!]!
-                  personOnesAggregate(where: PersonOneWhere): PersonOneAggregateSelection!
+                  personOnesAggregate(where: PersonOneWhere): PersonOneAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"personOnesConnection\\\\\\"\\")
                   personOnesConnection(after: String, first: Int, sort: [PersonOneSort!], where: PersonOneWhere): PersonOnesConnection!
                   personTwos(limit: Int, offset: Int, options: PersonTwoOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonTwoSort!], where: PersonTwoWhere): [PersonTwo!]!
-                  personTwosAggregate(where: PersonTwoWhere): PersonTwoAggregateSelection!
+                  personTwosAggregate(where: PersonTwoWhere): PersonTwoAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"personTwosConnection\\\\\\"\\")
                   personTwosConnection(after: String, first: Int, sort: [PersonTwoSort!], where: PersonTwoWhere): PersonTwosConnection!
                 }
 
@@ -9954,16 +9954,16 @@ describe("Relationship nested operations", () => {
 
                 type Query {
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                   people(limit: Int, offset: Int, options: PersonOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonSort!], where: PersonWhere): [Person!]!
-                  peopleAggregate(where: PersonWhere): PersonAggregateSelection!
+                  peopleAggregate(where: PersonWhere): PersonAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"peopleConnection\\\\\\"\\")
                   peopleConnection(after: String, first: Int, sort: [PersonSort!], where: PersonWhere): PeopleConnection!
                   personOnes(limit: Int, offset: Int, options: PersonOneOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonOneSort!], where: PersonOneWhere): [PersonOne!]!
-                  personOnesAggregate(where: PersonOneWhere): PersonOneAggregateSelection!
+                  personOnesAggregate(where: PersonOneWhere): PersonOneAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"personOnesConnection\\\\\\"\\")
                   personOnesConnection(after: String, first: Int, sort: [PersonOneSort!], where: PersonOneWhere): PersonOnesConnection!
                   personTwos(limit: Int, offset: Int, options: PersonTwoOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonTwoSort!], where: PersonTwoWhere): [PersonTwo!]!
-                  personTwosAggregate(where: PersonTwoWhere): PersonTwoAggregateSelection!
+                  personTwosAggregate(where: PersonTwoWhere): PersonTwoAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"personTwosConnection\\\\\\"\\")
                   personTwosConnection(after: String, first: Int, sort: [PersonTwoSort!], where: PersonTwoWhere): PersonTwosConnection!
                 }
 
@@ -10477,16 +10477,16 @@ describe("Relationship nested operations", () => {
 
                 type Query {
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                   people(limit: Int, offset: Int, options: PersonOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonSort!], where: PersonWhere): [Person!]!
-                  peopleAggregate(where: PersonWhere): PersonAggregateSelection!
+                  peopleAggregate(where: PersonWhere): PersonAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"peopleConnection\\\\\\"\\")
                   peopleConnection(after: String, first: Int, sort: [PersonSort!], where: PersonWhere): PeopleConnection!
                   personOnes(limit: Int, offset: Int, options: PersonOneOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonOneSort!], where: PersonOneWhere): [PersonOne!]!
-                  personOnesAggregate(where: PersonOneWhere): PersonOneAggregateSelection!
+                  personOnesAggregate(where: PersonOneWhere): PersonOneAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"personOnesConnection\\\\\\"\\")
                   personOnesConnection(after: String, first: Int, sort: [PersonOneSort!], where: PersonOneWhere): PersonOnesConnection!
                   personTwos(limit: Int, offset: Int, options: PersonTwoOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonTwoSort!], where: PersonTwoWhere): [PersonTwo!]!
-                  personTwosAggregate(where: PersonTwoWhere): PersonTwoAggregateSelection!
+                  personTwosAggregate(where: PersonTwoWhere): PersonTwoAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"personTwosConnection\\\\\\"\\")
                   personTwosConnection(after: String, first: Int, sort: [PersonTwoSort!], where: PersonTwoWhere): PersonTwosConnection!
                 }
 
@@ -10999,16 +10999,16 @@ describe("Relationship nested operations", () => {
 
                 type Query {
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                   people(limit: Int, offset: Int, options: PersonOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonSort!], where: PersonWhere): [Person!]!
-                  peopleAggregate(where: PersonWhere): PersonAggregateSelection!
+                  peopleAggregate(where: PersonWhere): PersonAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"peopleConnection\\\\\\"\\")
                   peopleConnection(after: String, first: Int, sort: [PersonSort!], where: PersonWhere): PeopleConnection!
                   personOnes(limit: Int, offset: Int, options: PersonOneOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonOneSort!], where: PersonOneWhere): [PersonOne!]!
-                  personOnesAggregate(where: PersonOneWhere): PersonOneAggregateSelection!
+                  personOnesAggregate(where: PersonOneWhere): PersonOneAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"personOnesConnection\\\\\\"\\")
                   personOnesConnection(after: String, first: Int, sort: [PersonOneSort!], where: PersonOneWhere): PersonOnesConnection!
                   personTwos(limit: Int, offset: Int, options: PersonTwoOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonTwoSort!], where: PersonTwoWhere): [PersonTwo!]!
-                  personTwosAggregate(where: PersonTwoWhere): PersonTwoAggregateSelection!
+                  personTwosAggregate(where: PersonTwoWhere): PersonTwoAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"personTwosConnection\\\\\\"\\")
                   personTwosConnection(after: String, first: Int, sort: [PersonTwoSort!], where: PersonTwoWhere): PersonTwosConnection!
                 }
 
@@ -11517,16 +11517,16 @@ describe("Relationship nested operations", () => {
 
                 type Query {
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                   people(limit: Int, offset: Int, options: PersonOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonSort!], where: PersonWhere): [Person!]!
-                  peopleAggregate(where: PersonWhere): PersonAggregateSelection!
+                  peopleAggregate(where: PersonWhere): PersonAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"peopleConnection\\\\\\"\\")
                   peopleConnection(after: String, first: Int, sort: [PersonSort!], where: PersonWhere): PeopleConnection!
                   personOnes(limit: Int, offset: Int, options: PersonOneOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonOneSort!], where: PersonOneWhere): [PersonOne!]!
-                  personOnesAggregate(where: PersonOneWhere): PersonOneAggregateSelection!
+                  personOnesAggregate(where: PersonOneWhere): PersonOneAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"personOnesConnection\\\\\\"\\")
                   personOnesConnection(after: String, first: Int, sort: [PersonOneSort!], where: PersonOneWhere): PersonOnesConnection!
                   personTwos(limit: Int, offset: Int, options: PersonTwoOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonTwoSort!], where: PersonTwoWhere): [PersonTwo!]!
-                  personTwosAggregate(where: PersonTwoWhere): PersonTwoAggregateSelection!
+                  personTwosAggregate(where: PersonTwoWhere): PersonTwoAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"personTwosConnection\\\\\\"\\")
                   personTwosConnection(after: String, first: Int, sort: [PersonTwoSort!], where: PersonTwoWhere): PersonTwosConnection!
                 }
 
@@ -12183,16 +12183,16 @@ describe("Relationship nested operations", () => {
 
                 type Query {
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                   people(limit: Int, offset: Int, options: PersonOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonSort!], where: PersonWhere): [Person!]!
-                  peopleAggregate(where: PersonWhere): PersonAggregateSelection!
+                  peopleAggregate(where: PersonWhere): PersonAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"peopleConnection\\\\\\"\\")
                   peopleConnection(after: String, first: Int, sort: [PersonSort!], where: PersonWhere): PeopleConnection!
                   personOnes(limit: Int, offset: Int, options: PersonOneOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonOneSort!], where: PersonOneWhere): [PersonOne!]!
-                  personOnesAggregate(where: PersonOneWhere): PersonOneAggregateSelection!
+                  personOnesAggregate(where: PersonOneWhere): PersonOneAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"personOnesConnection\\\\\\"\\")
                   personOnesConnection(after: String, first: Int, sort: [PersonOneSort!], where: PersonOneWhere): PersonOnesConnection!
                   personTwos(limit: Int, offset: Int, options: PersonTwoOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonTwoSort!], where: PersonTwoWhere): [PersonTwo!]!
-                  personTwosAggregate(where: PersonTwoWhere): PersonTwoAggregateSelection!
+                  personTwosAggregate(where: PersonTwoWhere): PersonTwoAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"personTwosConnection\\\\\\"\\")
                   personTwosConnection(after: String, first: Int, sort: [PersonTwoSort!], where: PersonTwoWhere): PersonTwosConnection!
                 }
 
@@ -12825,16 +12825,16 @@ describe("Relationship nested operations", () => {
 
                 type Query {
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                   people(limit: Int, offset: Int, options: PersonOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonSort!], where: PersonWhere): [Person!]!
-                  peopleAggregate(where: PersonWhere): PersonAggregateSelection!
+                  peopleAggregate(where: PersonWhere): PersonAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"peopleConnection\\\\\\"\\")
                   peopleConnection(after: String, first: Int, sort: [PersonSort!], where: PersonWhere): PeopleConnection!
                   personOnes(limit: Int, offset: Int, options: PersonOneOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonOneSort!], where: PersonOneWhere): [PersonOne!]!
-                  personOnesAggregate(where: PersonOneWhere): PersonOneAggregateSelection!
+                  personOnesAggregate(where: PersonOneWhere): PersonOneAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"personOnesConnection\\\\\\"\\")
                   personOnesConnection(after: String, first: Int, sort: [PersonOneSort!], where: PersonOneWhere): PersonOnesConnection!
                   personTwos(limit: Int, offset: Int, options: PersonTwoOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonTwoSort!], where: PersonTwoWhere): [PersonTwo!]!
-                  personTwosAggregate(where: PersonTwoWhere): PersonTwoAggregateSelection!
+                  personTwosAggregate(where: PersonTwoWhere): PersonTwoAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"personTwosConnection\\\\\\"\\")
                   personTwosConnection(after: String, first: Int, sort: [PersonTwoSort!], where: PersonTwoWhere): PersonTwosConnection!
                 }
 

--- a/packages/graphql/tests/schema/directives/relationship-nested-operations.test.ts
+++ b/packages/graphql/tests/schema/directives/relationship-nested-operations.test.ts
@@ -144,6 +144,15 @@ describe("Relationship nested operations", () => {
                   node: Person!
                 }
 
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+                }
+
                 type MovieAggregateSelection {
                   count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -226,6 +235,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -249,6 +259,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PeopleConnection {
+                  aggregate: PersonAggregate!
                   edges: [PersonEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -256,6 +267,15 @@ describe("Relationship nested operations", () => {
 
                 type Person {
                   name: String
+                }
+
+                type PersonAggregate {
+                  node: PersonAggregateNode!
+                }
+
+                type PersonAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
                 }
 
                 type PersonAggregateSelection {
@@ -476,6 +496,15 @@ describe("Relationship nested operations", () => {
                   where: MovieActorsConnectionWhere
                 }
 
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+                }
+
                 type MovieAggregateSelection {
                   count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -560,6 +589,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -583,6 +613,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PeopleConnection {
+                  aggregate: PersonAggregate!
                   edges: [PersonEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -590,6 +621,15 @@ describe("Relationship nested operations", () => {
 
                 type Person {
                   name: String
+                }
+
+                type PersonAggregate {
+                  node: PersonAggregateNode!
+                }
+
+                type PersonAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
                 }
 
                 type PersonAggregateSelection {
@@ -814,6 +854,15 @@ describe("Relationship nested operations", () => {
                   where: MovieActorsConnectionWhere
                 }
 
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+                }
+
                 type MovieAggregateSelection {
                   count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -898,6 +947,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -921,6 +971,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PeopleConnection {
+                  aggregate: PersonAggregate!
                   edges: [PersonEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -928,6 +979,15 @@ describe("Relationship nested operations", () => {
 
                 type Person {
                   name: String
+                }
+
+                type PersonAggregate {
+                  node: PersonAggregateNode!
+                }
+
+                type PersonAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
                 }
 
                 type PersonAggregateSelection {
@@ -1148,6 +1208,15 @@ describe("Relationship nested operations", () => {
                   where: MovieActorsConnectionWhere
                 }
 
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+                }
+
                 type MovieAggregateSelection {
                   count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -1231,6 +1300,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -1254,6 +1324,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PeopleConnection {
+                  aggregate: PersonAggregate!
                   edges: [PersonEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -1261,6 +1332,15 @@ describe("Relationship nested operations", () => {
 
                 type Person {
                   name: String
+                }
+
+                type PersonAggregate {
+                  node: PersonAggregateNode!
+                }
+
+                type PersonAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
                 }
 
                 type PersonAggregateSelection {
@@ -1477,6 +1557,15 @@ describe("Relationship nested operations", () => {
                   where: MovieActorsConnectionWhere
                 }
 
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+                }
+
                 type MovieAggregateSelection {
                   count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -1564,6 +1653,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -1587,6 +1677,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PeopleConnection {
+                  aggregate: PersonAggregate!
                   edges: [PersonEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -1594,6 +1685,15 @@ describe("Relationship nested operations", () => {
 
                 type Person {
                   name: String
+                }
+
+                type PersonAggregate {
+                  node: PersonAggregateNode!
+                }
+
+                type PersonAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
                 }
 
                 type PersonAggregateSelection {
@@ -1810,6 +1910,15 @@ describe("Relationship nested operations", () => {
                   where: MovieActorsConnectionWhere
                 }
 
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+                }
+
                 type MovieAggregateSelection {
                   count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -1893,6 +2002,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -1916,6 +2026,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PeopleConnection {
+                  aggregate: PersonAggregate!
                   edges: [PersonEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -1923,6 +2034,15 @@ describe("Relationship nested operations", () => {
 
                 type Person {
                   name: String
+                }
+
+                type PersonAggregate {
+                  node: PersonAggregateNode!
+                }
+
+                type PersonAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
                 }
 
                 type PersonAggregateSelection {
@@ -2131,6 +2251,15 @@ describe("Relationship nested operations", () => {
                   node: Person!
                 }
 
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+                }
+
                 type MovieAggregateSelection {
                   count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -2213,6 +2342,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -2236,6 +2366,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PeopleConnection {
+                  aggregate: PersonAggregate!
                   edges: [PersonEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -2243,6 +2374,15 @@ describe("Relationship nested operations", () => {
 
                 type Person {
                   name: String
+                }
+
+                type PersonAggregate {
+                  node: PersonAggregateNode!
+                }
+
+                type PersonAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
                 }
 
                 type PersonAggregateSelection {
@@ -2480,6 +2620,15 @@ describe("Relationship nested operations", () => {
                   where: MovieActorsConnectionWhere
                 }
 
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+                }
+
                 type MovieAggregateSelection {
                   count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -2565,6 +2714,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -2588,6 +2738,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PeopleConnection {
+                  aggregate: PersonAggregate!
                   edges: [PersonEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -2596,6 +2747,16 @@ describe("Relationship nested operations", () => {
                 type Person {
                   id: ID!
                   name: String
+                }
+
+                type PersonAggregate {
+                  node: PersonAggregateNode!
+                }
+
+                type PersonAggregateNode {
+                  count: Int!
+                  id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+                  name: StringAggregateSelection!
                 }
 
                 type PersonAggregateSelection {
@@ -2866,6 +3027,15 @@ describe("Relationship nested operations", () => {
                   where: MovieActorsConnectionWhere
                 }
 
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+                }
+
                 type MovieAggregateSelection {
                   count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -3054,6 +3224,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -3077,6 +3248,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PeopleConnection {
+                  aggregate: PersonAggregate!
                   edges: [PersonEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -3084,6 +3256,15 @@ describe("Relationship nested operations", () => {
 
                 type Person {
                   name: String
+                }
+
+                type PersonAggregate {
+                  node: PersonAggregateNode!
+                }
+
+                type PersonAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
                 }
 
                 type PersonAggregateSelection {
@@ -3312,6 +3493,15 @@ describe("Relationship nested operations", () => {
                   where: MovieActorsConnectionWhere
                 }
 
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+                }
+
                 type MovieAggregateSelection {
                   count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -3496,6 +3686,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -3519,6 +3710,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PeopleConnection {
+                  aggregate: PersonAggregate!
                   edges: [PersonEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -3526,6 +3718,15 @@ describe("Relationship nested operations", () => {
 
                 type Person {
                   name: String
+                }
+
+                type PersonAggregate {
+                  node: PersonAggregateNode!
+                }
+
+                type PersonAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
                 }
 
                 type PersonAggregateSelection {
@@ -3724,6 +3925,15 @@ describe("Relationship nested operations", () => {
                   node: Person!
                 }
 
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+                }
+
                 type MovieAggregateSelection {
                   count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -3796,6 +4006,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -3825,6 +4036,15 @@ describe("Relationship nested operations", () => {
 
                 type PersonOne {
                   name: String
+                }
+
+                type PersonOneAggregate {
+                  node: PersonOneAggregateNode!
+                }
+
+                type PersonOneAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
                 }
 
                 type PersonOneAggregateSelection {
@@ -3875,6 +4095,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonOnesConnection {
+                  aggregate: PersonOneAggregate!
                   edges: [PersonOneEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -3882,6 +4103,15 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwo {
                   nameTwo: String
+                }
+
+                type PersonTwoAggregate {
+                  node: PersonTwoAggregateNode!
+                }
+
+                type PersonTwoAggregateNode {
+                  count: Int!
+                  nameTwo: StringAggregateSelection!
                 }
 
                 type PersonTwoAggregateSelection {
@@ -3932,6 +4162,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonTwosConnection {
+                  aggregate: PersonTwoAggregate!
                   edges: [PersonTwoEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -4135,6 +4366,15 @@ describe("Relationship nested operations", () => {
                   PersonTwo: [MovieActorsPersonTwoUpdateFieldInput!]
                 }
 
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+                }
+
                 type MovieAggregateSelection {
                   count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -4209,6 +4449,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -4238,6 +4479,15 @@ describe("Relationship nested operations", () => {
 
                 type PersonOne {
                   name: String
+                }
+
+                type PersonOneAggregate {
+                  node: PersonOneAggregateNode!
+                }
+
+                type PersonOneAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
                 }
 
                 type PersonOneAggregateSelection {
@@ -4288,6 +4538,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonOnesConnection {
+                  aggregate: PersonOneAggregate!
                   edges: [PersonOneEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -4295,6 +4546,15 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwo {
                   nameTwo: String
+                }
+
+                type PersonTwoAggregate {
+                  node: PersonTwoAggregateNode!
+                }
+
+                type PersonTwoAggregateNode {
+                  count: Int!
+                  nameTwo: StringAggregateSelection!
                 }
 
                 type PersonTwoAggregateSelection {
@@ -4345,6 +4605,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonTwosConnection {
+                  aggregate: PersonTwoAggregate!
                   edges: [PersonTwoEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -4548,6 +4809,15 @@ describe("Relationship nested operations", () => {
                   PersonTwo: [MovieActorsPersonTwoUpdateFieldInput!]
                 }
 
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+                }
+
                 type MovieAggregateSelection {
                   count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -4622,6 +4892,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -4651,6 +4922,15 @@ describe("Relationship nested operations", () => {
 
                 type PersonOne {
                   name: String
+                }
+
+                type PersonOneAggregate {
+                  node: PersonOneAggregateNode!
+                }
+
+                type PersonOneAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
                 }
 
                 type PersonOneAggregateSelection {
@@ -4705,6 +4985,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonOnesConnection {
+                  aggregate: PersonOneAggregate!
                   edges: [PersonOneEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -4712,6 +4993,15 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwo {
                   nameTwo: String
+                }
+
+                type PersonTwoAggregate {
+                  node: PersonTwoAggregateNode!
+                }
+
+                type PersonTwoAggregateNode {
+                  count: Int!
+                  nameTwo: StringAggregateSelection!
                 }
 
                 type PersonTwoAggregateSelection {
@@ -4766,6 +5056,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonTwosConnection {
+                  aggregate: PersonTwoAggregate!
                   edges: [PersonTwoEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -4956,6 +5247,15 @@ describe("Relationship nested operations", () => {
                   PersonTwo: [MovieActorsPersonTwoUpdateFieldInput!]
                 }
 
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+                }
+
                 type MovieAggregateSelection {
                   count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -5029,6 +5329,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -5058,6 +5359,15 @@ describe("Relationship nested operations", () => {
 
                 type PersonOne {
                   name: String
+                }
+
+                type PersonOneAggregate {
+                  node: PersonOneAggregateNode!
+                }
+
+                type PersonOneAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
                 }
 
                 type PersonOneAggregateSelection {
@@ -5108,6 +5418,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonOnesConnection {
+                  aggregate: PersonOneAggregate!
                   edges: [PersonOneEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -5115,6 +5426,15 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwo {
                   nameTwo: String
+                }
+
+                type PersonTwoAggregate {
+                  node: PersonTwoAggregateNode!
+                }
+
+                type PersonTwoAggregateNode {
+                  count: Int!
+                  nameTwo: StringAggregateSelection!
                 }
 
                 type PersonTwoAggregateSelection {
@@ -5165,6 +5485,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonTwosConnection {
+                  aggregate: PersonTwoAggregate!
                   edges: [PersonTwoEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -5360,6 +5681,15 @@ describe("Relationship nested operations", () => {
                   PersonTwo: [MovieActorsPersonTwoUpdateFieldInput!]
                 }
 
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+                }
+
                 type MovieAggregateSelection {
                   count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -5437,6 +5767,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -5466,6 +5797,15 @@ describe("Relationship nested operations", () => {
 
                 type PersonOne {
                   name: String
+                }
+
+                type PersonOneAggregate {
+                  node: PersonOneAggregateNode!
+                }
+
+                type PersonOneAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
                 }
 
                 type PersonOneAggregateSelection {
@@ -5516,6 +5856,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonOnesConnection {
+                  aggregate: PersonOneAggregate!
                   edges: [PersonOneEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -5523,6 +5864,15 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwo {
                   nameTwo: String
+                }
+
+                type PersonTwoAggregate {
+                  node: PersonTwoAggregateNode!
+                }
+
+                type PersonTwoAggregateNode {
+                  count: Int!
+                  nameTwo: StringAggregateSelection!
                 }
 
                 type PersonTwoAggregateSelection {
@@ -5573,6 +5923,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonTwosConnection {
+                  aggregate: PersonTwoAggregate!
                   edges: [PersonTwoEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -5763,6 +6114,15 @@ describe("Relationship nested operations", () => {
                   PersonTwo: [MovieActorsPersonTwoUpdateFieldInput!]
                 }
 
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+                }
+
                 type MovieAggregateSelection {
                   count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -5836,6 +6196,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -5865,6 +6226,15 @@ describe("Relationship nested operations", () => {
 
                 type PersonOne {
                   name: String
+                }
+
+                type PersonOneAggregate {
+                  node: PersonOneAggregateNode!
+                }
+
+                type PersonOneAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
                 }
 
                 type PersonOneAggregateSelection {
@@ -5915,6 +6285,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonOnesConnection {
+                  aggregate: PersonOneAggregate!
                   edges: [PersonOneEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -5922,6 +6293,15 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwo {
                   nameTwo: String
+                }
+
+                type PersonTwoAggregate {
+                  node: PersonTwoAggregateNode!
+                }
+
+                type PersonTwoAggregateNode {
+                  count: Int!
+                  nameTwo: StringAggregateSelection!
                 }
 
                 type PersonTwoAggregateSelection {
@@ -5972,6 +6352,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonTwosConnection {
+                  aggregate: PersonTwoAggregate!
                   edges: [PersonTwoEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -6140,6 +6521,15 @@ describe("Relationship nested operations", () => {
                   node: Person!
                 }
 
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+                }
+
                 type MovieAggregateSelection {
                   count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -6212,6 +6602,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -6241,6 +6632,15 @@ describe("Relationship nested operations", () => {
 
                 type PersonOne {
                   name: String
+                }
+
+                type PersonOneAggregate {
+                  node: PersonOneAggregateNode!
+                }
+
+                type PersonOneAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
                 }
 
                 type PersonOneAggregateSelection {
@@ -6291,6 +6691,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonOnesConnection {
+                  aggregate: PersonOneAggregate!
                   edges: [PersonOneEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -6298,6 +6699,15 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwo {
                   nameTwo: String
+                }
+
+                type PersonTwoAggregate {
+                  node: PersonTwoAggregateNode!
+                }
+
+                type PersonTwoAggregateNode {
+                  count: Int!
+                  nameTwo: StringAggregateSelection!
                 }
 
                 type PersonTwoAggregateSelection {
@@ -6348,6 +6758,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonTwosConnection {
+                  aggregate: PersonTwoAggregate!
                   edges: [PersonTwoEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -6564,6 +6975,15 @@ describe("Relationship nested operations", () => {
                   PersonTwo: [MovieActorsPersonTwoUpdateFieldInput!]
                 }
 
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+                }
+
                 type MovieAggregateSelection {
                   count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -6638,6 +7058,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -6668,6 +7089,16 @@ describe("Relationship nested operations", () => {
                 type PersonOne {
                   id: ID!
                   name: String
+                }
+
+                type PersonOneAggregate {
+                  node: PersonOneAggregateNode!
+                }
+
+                type PersonOneAggregateNode {
+                  count: Int!
+                  id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+                  name: StringAggregateSelection!
                 }
 
                 type PersonOneAggregateSelection {
@@ -6739,6 +7170,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonOnesConnection {
+                  aggregate: PersonOneAggregate!
                   edges: [PersonOneEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -6747,6 +7179,16 @@ describe("Relationship nested operations", () => {
                 type PersonTwo {
                   id: ID!
                   nameTwo: String
+                }
+
+                type PersonTwoAggregate {
+                  node: PersonTwoAggregateNode!
+                }
+
+                type PersonTwoAggregateNode {
+                  count: Int!
+                  id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+                  nameTwo: StringAggregateSelection!
                 }
 
                 type PersonTwoAggregateSelection {
@@ -6818,6 +7260,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonTwosConnection {
+                  aggregate: PersonTwoAggregate!
                   edges: [PersonTwoEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -7071,6 +7514,15 @@ describe("Relationship nested operations", () => {
                   PersonTwo: [MovieActorsPersonTwoUpdateFieldInput!]
                 }
 
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+                }
+
                 type MovieAggregateSelection {
                   count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -7227,6 +7679,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -7256,6 +7709,15 @@ describe("Relationship nested operations", () => {
 
                 type PersonOne {
                   name: String
+                }
+
+                type PersonOneAggregate {
+                  node: PersonOneAggregateNode!
+                }
+
+                type PersonOneAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
                 }
 
                 type PersonOneAggregateSelection {
@@ -7310,6 +7772,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonOnesConnection {
+                  aggregate: PersonOneAggregate!
                   edges: [PersonOneEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -7317,6 +7780,15 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwo {
                   nameTwo: String
+                }
+
+                type PersonTwoAggregate {
+                  node: PersonTwoAggregateNode!
+                }
+
+                type PersonTwoAggregateNode {
+                  count: Int!
+                  nameTwo: StringAggregateSelection!
                 }
 
                 type PersonTwoAggregateSelection {
@@ -7371,6 +7843,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonTwosConnection {
+                  aggregate: PersonTwoAggregate!
                   edges: [PersonTwoEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -7577,6 +8050,15 @@ describe("Relationship nested operations", () => {
                   PersonTwo: [MovieActorsPersonTwoUpdateFieldInput!]
                 }
 
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+                }
+
                 type MovieAggregateSelection {
                   count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -7729,6 +8211,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -7758,6 +8241,15 @@ describe("Relationship nested operations", () => {
 
                 type PersonOne {
                   name: String
+                }
+
+                type PersonOneAggregate {
+                  node: PersonOneAggregateNode!
+                }
+
+                type PersonOneAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
                 }
 
                 type PersonOneAggregateSelection {
@@ -7808,6 +8300,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonOnesConnection {
+                  aggregate: PersonOneAggregate!
                   edges: [PersonOneEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -7815,6 +8308,15 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwo {
                   nameTwo: String
+                }
+
+                type PersonTwoAggregate {
+                  node: PersonTwoAggregateNode!
+                }
+
+                type PersonTwoAggregateNode {
+                  count: Int!
+                  nameTwo: StringAggregateSelection!
                 }
 
                 type PersonTwoAggregateSelection {
@@ -7865,6 +8367,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonTwosConnection {
+                  aggregate: PersonTwoAggregate!
                   edges: [PersonTwoEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -8069,6 +8572,15 @@ describe("Relationship nested operations", () => {
                   node: Person!
                 }
 
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+                }
+
                 type MovieAggregateSelection {
                   count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -8151,6 +8663,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -8177,6 +8690,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PeopleConnection {
+                  aggregate: PersonAggregate!
                   edges: [PersonEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -8184,6 +8698,15 @@ describe("Relationship nested operations", () => {
 
                 interface Person {
                   name: String
+                }
+
+                type PersonAggregate {
+                  node: PersonAggregateNode!
+                }
+
+                type PersonAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
                 }
 
                 type PersonAggregateSelection {
@@ -8204,6 +8727,15 @@ describe("Relationship nested operations", () => {
                 type PersonOne implements Person {
                   name: String
                   someExtraProp: [Int!]!
+                }
+
+                type PersonOneAggregate {
+                  node: PersonOneAggregateNode!
+                }
+
+                type PersonOneAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
                 }
 
                 type PersonOneAggregateSelection {
@@ -8262,6 +8794,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonOnesConnection {
+                  aggregate: PersonOneAggregate!
                   edges: [PersonOneEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -8285,6 +8818,15 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwo implements Person {
                   name: String
+                }
+
+                type PersonTwoAggregate {
+                  node: PersonTwoAggregateNode!
+                }
+
+                type PersonTwoAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
                 }
 
                 type PersonTwoAggregateSelection {
@@ -8335,6 +8877,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonTwosConnection {
+                  aggregate: PersonTwoAggregate!
                   edges: [PersonTwoEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -8550,6 +9093,15 @@ describe("Relationship nested operations", () => {
                   where: MovieActorsConnectionWhere
                 }
 
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+                }
+
                 type MovieAggregateSelection {
                   count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -8634,6 +9186,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -8660,6 +9213,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PeopleConnection {
+                  aggregate: PersonAggregate!
                   edges: [PersonEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -8667,6 +9221,15 @@ describe("Relationship nested operations", () => {
 
                 interface Person {
                   name: String
+                }
+
+                type PersonAggregate {
+                  node: PersonAggregateNode!
+                }
+
+                type PersonAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
                 }
 
                 type PersonAggregateSelection {
@@ -8692,6 +9255,15 @@ describe("Relationship nested operations", () => {
                 type PersonOne implements Person {
                   name: String
                   someExtraProp: [Int!]!
+                }
+
+                type PersonOneAggregate {
+                  node: PersonOneAggregateNode!
+                }
+
+                type PersonOneAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
                 }
 
                 type PersonOneAggregateSelection {
@@ -8750,6 +9322,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonOnesConnection {
+                  aggregate: PersonOneAggregate!
                   edges: [PersonOneEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -8773,6 +9346,15 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwo implements Person {
                   name: String
+                }
+
+                type PersonTwoAggregate {
+                  node: PersonTwoAggregateNode!
+                }
+
+                type PersonTwoAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
                 }
 
                 type PersonTwoAggregateSelection {
@@ -8823,6 +9405,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonTwosConnection {
+                  aggregate: PersonTwoAggregate!
                   edges: [PersonTwoEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -9038,6 +9621,15 @@ describe("Relationship nested operations", () => {
                   where: MovieActorsConnectionWhere
                 }
 
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+                }
+
                 type MovieAggregateSelection {
                   count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -9122,6 +9714,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -9148,6 +9741,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PeopleConnection {
+                  aggregate: PersonAggregate!
                   edges: [PersonEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -9155,6 +9749,15 @@ describe("Relationship nested operations", () => {
 
                 interface Person {
                   name: String
+                }
+
+                type PersonAggregate {
+                  node: PersonAggregateNode!
+                }
+
+                type PersonAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
                 }
 
                 type PersonAggregateSelection {
@@ -9179,6 +9782,15 @@ describe("Relationship nested operations", () => {
                 type PersonOne implements Person {
                   name: String
                   someExtraProp: [Int!]!
+                }
+
+                type PersonOneAggregate {
+                  node: PersonOneAggregateNode!
+                }
+
+                type PersonOneAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
                 }
 
                 type PersonOneAggregateSelection {
@@ -9237,6 +9849,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonOnesConnection {
+                  aggregate: PersonOneAggregate!
                   edges: [PersonOneEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -9260,6 +9873,15 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwo implements Person {
                   name: String
+                }
+
+                type PersonTwoAggregate {
+                  node: PersonTwoAggregateNode!
+                }
+
+                type PersonTwoAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
                 }
 
                 type PersonTwoAggregateSelection {
@@ -9310,6 +9932,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonTwosConnection {
+                  aggregate: PersonTwoAggregate!
                   edges: [PersonTwoEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -9521,6 +10144,15 @@ describe("Relationship nested operations", () => {
                   where: MovieActorsConnectionWhere
                 }
 
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+                }
+
                 type MovieAggregateSelection {
                   count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -9604,6 +10236,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -9630,6 +10263,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PeopleConnection {
+                  aggregate: PersonAggregate!
                   edges: [PersonEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -9637,6 +10271,15 @@ describe("Relationship nested operations", () => {
 
                 interface Person {
                   name: String
+                }
+
+                type PersonAggregate {
+                  node: PersonAggregateNode!
+                }
+
+                type PersonAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
                 }
 
                 type PersonAggregateSelection {
@@ -9657,6 +10300,15 @@ describe("Relationship nested operations", () => {
                 type PersonOne implements Person {
                   name: String
                   someExtraProp: [Int!]!
+                }
+
+                type PersonOneAggregate {
+                  node: PersonOneAggregateNode!
+                }
+
+                type PersonOneAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
                 }
 
                 type PersonOneAggregateSelection {
@@ -9715,6 +10367,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonOnesConnection {
+                  aggregate: PersonOneAggregate!
                   edges: [PersonOneEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -9738,6 +10391,15 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwo implements Person {
                   name: String
+                }
+
+                type PersonTwoAggregate {
+                  node: PersonTwoAggregateNode!
+                }
+
+                type PersonTwoAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
                 }
 
                 type PersonTwoAggregateSelection {
@@ -9788,6 +10450,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonTwosConnection {
+                  aggregate: PersonTwoAggregate!
                   edges: [PersonTwoEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -10004,6 +10667,15 @@ describe("Relationship nested operations", () => {
                   where: MovieActorsConnectionWhere
                 }
 
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+                }
+
                 type MovieAggregateSelection {
                   count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -10091,6 +10763,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -10117,6 +10790,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PeopleConnection {
+                  aggregate: PersonAggregate!
                   edges: [PersonEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -10124,6 +10798,15 @@ describe("Relationship nested operations", () => {
 
                 interface Person {
                   name: String
+                }
+
+                type PersonAggregate {
+                  node: PersonAggregateNode!
+                }
+
+                type PersonAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
                 }
 
                 type PersonAggregateSelection {
@@ -10144,6 +10827,15 @@ describe("Relationship nested operations", () => {
                 type PersonOne implements Person {
                   name: String
                   someExtraProp: [Int!]!
+                }
+
+                type PersonOneAggregate {
+                  node: PersonOneAggregateNode!
+                }
+
+                type PersonOneAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
                 }
 
                 type PersonOneAggregateSelection {
@@ -10202,6 +10894,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonOnesConnection {
+                  aggregate: PersonOneAggregate!
                   edges: [PersonOneEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -10225,6 +10918,15 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwo implements Person {
                   name: String
+                }
+
+                type PersonTwoAggregate {
+                  node: PersonTwoAggregateNode!
+                }
+
+                type PersonTwoAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
                 }
 
                 type PersonTwoAggregateSelection {
@@ -10275,6 +10977,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonTwosConnection {
+                  aggregate: PersonTwoAggregate!
                   edges: [PersonTwoEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -10486,6 +11189,15 @@ describe("Relationship nested operations", () => {
                   where: MovieActorsConnectionWhere
                 }
 
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+                }
+
                 type MovieAggregateSelection {
                   count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -10569,6 +11281,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -10595,6 +11308,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PeopleConnection {
+                  aggregate: PersonAggregate!
                   edges: [PersonEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -10602,6 +11316,15 @@ describe("Relationship nested operations", () => {
 
                 interface Person {
                   name: String
+                }
+
+                type PersonAggregate {
+                  node: PersonAggregateNode!
+                }
+
+                type PersonAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
                 }
 
                 type PersonAggregateSelection {
@@ -10622,6 +11345,15 @@ describe("Relationship nested operations", () => {
                 type PersonOne implements Person {
                   name: String
                   someExtraProp: [Int!]!
+                }
+
+                type PersonOneAggregate {
+                  node: PersonOneAggregateNode!
+                }
+
+                type PersonOneAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
                 }
 
                 type PersonOneAggregateSelection {
@@ -10680,6 +11412,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonOnesConnection {
+                  aggregate: PersonOneAggregate!
                   edges: [PersonOneEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -10703,6 +11436,15 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwo implements Person {
                   name: String
+                }
+
+                type PersonTwoAggregate {
+                  node: PersonTwoAggregateNode!
+                }
+
+                type PersonTwoAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
                 }
 
                 type PersonTwoAggregateSelection {
@@ -10753,6 +11495,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonTwosConnection {
+                  aggregate: PersonTwoAggregate!
                   edges: [PersonTwoEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -10993,6 +11736,15 @@ describe("Relationship nested operations", () => {
                   where: MovieActorsConnectionWhere
                 }
 
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+                }
+
                 type MovieAggregateSelection {
                   count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -11181,6 +11933,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -11207,6 +11960,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PeopleConnection {
+                  aggregate: PersonAggregate!
                   edges: [PersonEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -11214,6 +11968,15 @@ describe("Relationship nested operations", () => {
 
                 interface Person {
                   name: String
+                }
+
+                type PersonAggregate {
+                  node: PersonAggregateNode!
+                }
+
+                type PersonAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
                 }
 
                 type PersonAggregateSelection {
@@ -11243,6 +12006,15 @@ describe("Relationship nested operations", () => {
                 type PersonOne implements Person {
                   name: String
                   someExtraProp: [Int!]!
+                }
+
+                type PersonOneAggregate {
+                  node: PersonOneAggregateNode!
+                }
+
+                type PersonOneAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
                 }
 
                 type PersonOneAggregateSelection {
@@ -11301,6 +12073,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonOnesConnection {
+                  aggregate: PersonOneAggregate!
                   edges: [PersonOneEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -11324,6 +12097,15 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwo implements Person {
                   name: String
+                }
+
+                type PersonTwoAggregate {
+                  node: PersonTwoAggregateNode!
+                }
+
+                type PersonTwoAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
                 }
 
                 type PersonTwoAggregateSelection {
@@ -11374,6 +12156,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonTwosConnection {
+                  aggregate: PersonTwoAggregate!
                   edges: [PersonTwoEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -11604,6 +12387,15 @@ describe("Relationship nested operations", () => {
                   where: MovieActorsConnectionWhere
                 }
 
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+                }
+
                 type MovieAggregateSelection {
                   count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -11792,6 +12584,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -11818,6 +12611,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PeopleConnection {
+                  aggregate: PersonAggregate!
                   edges: [PersonEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -11825,6 +12619,15 @@ describe("Relationship nested operations", () => {
 
                 interface Person {
                   name: String
+                }
+
+                type PersonAggregate {
+                  node: PersonAggregateNode!
+                }
+
+                type PersonAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
                 }
 
                 type PersonAggregateSelection {
@@ -11850,6 +12653,15 @@ describe("Relationship nested operations", () => {
                 type PersonOne implements Person {
                   name: String
                   someExtraProp: [Int!]!
+                }
+
+                type PersonOneAggregate {
+                  node: PersonOneAggregateNode!
+                }
+
+                type PersonOneAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
                 }
 
                 type PersonOneAggregateSelection {
@@ -11908,6 +12720,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonOnesConnection {
+                  aggregate: PersonOneAggregate!
                   edges: [PersonOneEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -11931,6 +12744,15 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwo implements Person {
                   name: String
+                }
+
+                type PersonTwoAggregate {
+                  node: PersonTwoAggregateNode!
+                }
+
+                type PersonTwoAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
                 }
 
                 type PersonTwoAggregateSelection {
@@ -11981,6 +12803,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonTwosConnection {
+                  aggregate: PersonTwoAggregate!
                   edges: [PersonTwoEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!

--- a/packages/graphql/tests/schema/directives/relationship-properties.test.ts
+++ b/packages/graphql/tests/schema/directives/relationship-properties.test.ts
@@ -139,6 +139,15 @@ describe("Relationship-properties", () => {
               name: String!
             }
 
+            type ActorAggregate {
+              node: ActorAggregateNode!
+            }
+
+            type ActorAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
             type ActorAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -348,6 +357,7 @@ describe("Relationship-properties", () => {
             }
 
             type ActorsConnection {
+              aggregate: ActorAggregate!
               edges: [ActorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -514,6 +524,15 @@ describe("Relationship-properties", () => {
               where: MovieActorsConnectionWhere
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              title: StringAggregateSelection!
+            }
+
             type MovieAggregateSelection {
               count: Int!
               title: StringAggregateSelection!
@@ -605,6 +624,7 @@ describe("Relationship-properties", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -805,6 +825,15 @@ describe("Relationship-properties", () => {
               name: String!
             }
 
+            type ActorAggregate {
+              node: ActorAggregateNode!
+            }
+
+            type ActorAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
             type ActorAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -1016,6 +1045,7 @@ describe("Relationship-properties", () => {
             }
 
             type ActorsConnection {
+              aggregate: ActorAggregate!
               edges: [ActorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1194,6 +1224,15 @@ describe("Relationship-properties", () => {
               where: MovieActorsConnectionWhere
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              title: StringAggregateSelection!
+            }
+
             type MovieAggregateSelection {
               count: Int!
               title: StringAggregateSelection!
@@ -1285,6 +1324,7 @@ describe("Relationship-properties", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1442,6 +1482,15 @@ describe("Relationship-properties", () => {
               moviesAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: MovieWhere): ActorMovieMoviesAggregationSelection
               moviesConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [ActorMoviesConnectionSort!], where: ActorMoviesConnectionWhere): ActorMoviesConnection!
               name: String!
+            }
+
+            type ActorAggregate {
+              node: ActorAggregateNode!
+            }
+
+            type ActorAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
             }
 
             type ActorAggregateSelection {
@@ -1651,6 +1700,7 @@ describe("Relationship-properties", () => {
             }
 
             type ActorsConnection {
+              aggregate: ActorAggregate!
               edges: [ActorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1818,6 +1868,15 @@ describe("Relationship-properties", () => {
               where: MovieActorsConnectionWhere
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              title: StringAggregateSelection!
+            }
+
             type MovieAggregateSelection {
               count: Int!
               title: StringAggregateSelection!
@@ -1909,6 +1968,7 @@ describe("Relationship-properties", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/directives/relationship-properties.test.ts
+++ b/packages/graphql/tests/schema/directives/relationship-properties.test.ts
@@ -649,10 +649,10 @@ describe("Relationship-properties", () => {
 
             type Query {
               actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
               actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 
@@ -1349,10 +1349,10 @@ describe("Relationship-properties", () => {
 
             type Query {
               actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
               actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 
@@ -1993,10 +1993,10 @@ describe("Relationship-properties", () => {
 
             type Query {
               actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
               actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 

--- a/packages/graphql/tests/schema/directives/relationship.test.ts
+++ b/packages/graphql/tests/schema/directives/relationship.test.ts
@@ -47,6 +47,15 @@ describe("Relationship", () => {
               name: String
             }
 
+            type ActorAggregate {
+              node: ActorAggregateNode!
+            }
+
+            type ActorAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
             type ActorAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -99,6 +108,7 @@ describe("Relationship", () => {
             }
 
             type ActorsConnection {
+              aggregate: ActorAggregate!
               edges: [ActorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -245,6 +255,15 @@ describe("Relationship", () => {
               where: MovieActorsConnectionWhere
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+            }
+
             type MovieAggregateSelection {
               count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -324,6 +343,7 @@ describe("Relationship", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -416,6 +436,15 @@ describe("Relationship", () => {
               moviesAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: MovieWhere): ActorMovieMoviesAggregationSelection
               moviesConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [ActorMoviesConnectionSort!], where: ActorMoviesConnectionWhere): ActorMoviesConnection!
               name: String
+            }
+
+            type ActorAggregate {
+              node: ActorAggregateNode!
+            }
+
+            type ActorAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
             }
 
             type ActorAggregateSelection {
@@ -610,6 +639,7 @@ describe("Relationship", () => {
             }
 
             type ActorsConnection {
+              aggregate: ActorAggregate!
               edges: [ActorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -759,6 +789,15 @@ describe("Relationship", () => {
               where: MovieActorsConnectionWhere
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+            }
+
             type MovieAggregateSelection {
               count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -850,6 +889,7 @@ describe("Relationship", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/directives/relationship.test.ts
+++ b/packages/graphql/tests/schema/directives/relationship.test.ts
@@ -368,10 +368,10 @@ describe("Relationship", () => {
 
             type Query {
               actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
               actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 
@@ -914,10 +914,10 @@ describe("Relationship", () => {
 
             type Query {
               actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
               actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 

--- a/packages/graphql/tests/schema/directives/selectable.test.ts
+++ b/packages/graphql/tests/schema/directives/selectable.test.ts
@@ -155,7 +155,7 @@ describe("@selectable", () => {
 
             type Query {
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 
@@ -319,7 +319,7 @@ describe("@selectable", () => {
 
             type Query {
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 
@@ -482,7 +482,7 @@ describe("@selectable", () => {
 
             type Query {
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 
@@ -697,7 +697,7 @@ describe("@selectable", () => {
 
             type Query {
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 
@@ -1092,10 +1092,10 @@ describe("@selectable", () => {
 
                 type Query {
                   actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-                  actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+                  actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
                   actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                 }
 
@@ -1504,10 +1504,10 @@ describe("@selectable", () => {
 
                 type Query {
                   actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-                  actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+                  actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
                   actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                 }
 
@@ -1920,14 +1920,14 @@ describe("@selectable", () => {
 
                 type Query {
                   actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-                  actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+                  actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
                   actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                   productions(limit: Int, offset: Int, options: QueryOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: ProductionWhere): [Production!]!
                   series(limit: Int, offset: Int, options: SeriesOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [SeriesSort!], where: SeriesWhere): [Series!]!
-                  seriesAggregate(where: SeriesWhere): SeriesAggregateSelection!
+                  seriesAggregate(where: SeriesWhere): SeriesAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"seriesConnection\\\\\\"\\")
                   seriesConnection(after: String, first: Int, sort: [SeriesSort!], where: SeriesWhere): SeriesConnection!
                 }
 
@@ -2445,14 +2445,14 @@ describe("@selectable", () => {
 
                 type Query {
                   actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-                  actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+                  actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
                   actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                   productions(limit: Int, offset: Int, options: QueryOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: ProductionWhere): [Production!]!
                   series(limit: Int, offset: Int, options: SeriesOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [SeriesSort!], where: SeriesWhere): [Series!]!
-                  seriesAggregate(where: SeriesWhere): SeriesAggregateSelection!
+                  seriesAggregate(where: SeriesWhere): SeriesAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"seriesConnection\\\\\\"\\")
                   seriesConnection(after: String, first: Int, sort: [SeriesSort!], where: SeriesWhere): SeriesConnection!
                 }
 
@@ -3043,16 +3043,16 @@ describe("@selectable", () => {
 
                 type Query {
                   actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-                  actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+                  actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
                   actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                   productions(limit: Int, offset: Int, options: ProductionOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ProductionSort!], where: ProductionWhere): [Production!]!
-                  productionsAggregate(where: ProductionWhere): ProductionAggregateSelection!
+                  productionsAggregate(where: ProductionWhere): ProductionAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"productionsConnection\\\\\\"\\")
                   productionsConnection(after: String, first: Int, sort: [ProductionSort!], where: ProductionWhere): ProductionsConnection!
                   series(limit: Int, offset: Int, options: SeriesOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [SeriesSort!], where: SeriesWhere): [Series!]!
-                  seriesAggregate(where: SeriesWhere): SeriesAggregateSelection!
+                  seriesAggregate(where: SeriesWhere): SeriesAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"seriesConnection\\\\\\"\\")
                   seriesConnection(after: String, first: Int, sort: [SeriesSort!], where: SeriesWhere): SeriesConnection!
                 }
 
@@ -3647,16 +3647,16 @@ describe("@selectable", () => {
 
                 type Query {
                   actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-                  actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+                  actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
                   actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                   productions(limit: Int, offset: Int, options: ProductionOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ProductionSort!], where: ProductionWhere): [Production!]!
-                  productionsAggregate(where: ProductionWhere): ProductionAggregateSelection!
+                  productionsAggregate(where: ProductionWhere): ProductionAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"productionsConnection\\\\\\"\\")
                   productionsConnection(after: String, first: Int, sort: [ProductionSort!], where: ProductionWhere): ProductionsConnection!
                   series(limit: Int, offset: Int, options: SeriesOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [SeriesSort!], where: SeriesWhere): [Series!]!
-                  seriesAggregate(where: SeriesWhere): SeriesAggregateSelection!
+                  seriesAggregate(where: SeriesWhere): SeriesAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"seriesConnection\\\\\\"\\")
                   seriesConnection(after: String, first: Int, sort: [SeriesSort!], where: SeriesWhere): SeriesConnection!
                 }
 

--- a/packages/graphql/tests/schema/directives/selectable.test.ts
+++ b/packages/graphql/tests/schema/directives/selectable.test.ts
@@ -64,6 +64,16 @@ describe("@selectable", () => {
               title: String!
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              description: StringAggregateSelection!
+              title: StringAggregateSelection!
+            }
+
             type MovieAggregateSelection {
               count: Int!
               description: StringAggregateSelection!
@@ -123,6 +133,7 @@ describe("@selectable", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -219,6 +230,15 @@ describe("@selectable", () => {
               title: String!
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              title: StringAggregateSelection!
+            }
+
             type MovieAggregateSelection {
               count: Int!
               title: StringAggregateSelection!
@@ -277,6 +297,7 @@ describe("@selectable", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -372,6 +393,15 @@ describe("@selectable", () => {
               title: String!
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              title: StringAggregateSelection!
+            }
+
             type MovieAggregateSelection {
               count: Int!
               title: StringAggregateSelection!
@@ -430,6 +460,7 @@ describe("@selectable", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -534,6 +565,16 @@ describe("@selectable", () => {
               title: String!
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              description: StringAggregateSelection!
+              title: StringAggregateSelection!
+            }
+
             type MovieAggregateSelection {
               count: Int!
               description: StringAggregateSelection!
@@ -634,6 +675,7 @@ describe("@selectable", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -817,6 +859,15 @@ describe("@selectable", () => {
                   where: ActorActedInConnectionWhere
                 }
 
+                type ActorAggregate {
+                  node: ActorAggregateNode!
+                }
+
+                type ActorAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
+                }
+
                 type ActorAggregateSelection {
                   count: Int!
                   name: StringAggregateSelection!
@@ -906,6 +957,7 @@ describe("@selectable", () => {
                 }
 
                 type ActorsConnection {
+                  aggregate: ActorAggregate!
                   edges: [ActorEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -940,6 +992,16 @@ describe("@selectable", () => {
                 type Movie {
                   description: String
                   title: String!
+                }
+
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 type MovieAggregateSelection {
@@ -1005,6 +1067,7 @@ describe("@selectable", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -1208,6 +1271,15 @@ describe("@selectable", () => {
                   where: ActorActedInConnectionWhere
                 }
 
+                type ActorAggregate {
+                  node: ActorAggregateNode!
+                }
+
+                type ActorAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
+                }
+
                 type ActorAggregateSelection {
                   count: Int!
                   name: StringAggregateSelection!
@@ -1297,6 +1369,7 @@ describe("@selectable", () => {
                 }
 
                 type ActorsConnection {
+                  aggregate: ActorAggregate!
                   edges: [ActorEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -1331,6 +1404,16 @@ describe("@selectable", () => {
                 type Movie {
                   description: String
                   title: String!
+                }
+
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 type MovieAggregateSelection {
@@ -1396,6 +1479,7 @@ describe("@selectable", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -1599,6 +1683,15 @@ describe("@selectable", () => {
                   Series: [ActorActedInSeriesUpdateFieldInput!]
                 }
 
+                type ActorAggregate {
+                  node: ActorAggregateNode!
+                }
+
+                type ActorAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
+                }
+
                 type ActorAggregateSelection {
                   count: Int!
                   name: StringAggregateSelection!
@@ -1677,6 +1770,7 @@ describe("@selectable", () => {
                 }
 
                 type ActorsConnection {
+                  aggregate: ActorAggregate!
                   edges: [ActorEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -1716,6 +1810,16 @@ describe("@selectable", () => {
                 type Movie {
                   description: String
                   title: String!
+                }
+
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 type MovieAggregateSelection {
@@ -1781,6 +1885,7 @@ describe("@selectable", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -1837,6 +1942,16 @@ describe("@selectable", () => {
                   name: String!
                 }
 
+                type SeriesAggregate {
+                  node: SeriesAggregateNode!
+                }
+
+                type SeriesAggregateNode {
+                  count: Int!
+                  description: StringAggregateSelection!
+                  name: StringAggregateSelection!
+                }
+
                 type SeriesAggregateSelection {
                   count: Int!
                   description: StringAggregateSelection!
@@ -1848,6 +1963,7 @@ describe("@selectable", () => {
                 }
 
                 type SeriesConnection {
+                  aggregate: SeriesAggregate!
                   edges: [SeriesEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -2092,6 +2208,15 @@ describe("@selectable", () => {
                   Series: [ActorActedInSeriesUpdateFieldInput!]
                 }
 
+                type ActorAggregate {
+                  node: ActorAggregateNode!
+                }
+
+                type ActorAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
+                }
+
                 type ActorAggregateSelection {
                   count: Int!
                   name: StringAggregateSelection!
@@ -2170,6 +2295,7 @@ describe("@selectable", () => {
                 }
 
                 type ActorsConnection {
+                  aggregate: ActorAggregate!
                   edges: [ActorEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -2209,6 +2335,16 @@ describe("@selectable", () => {
                 type Movie {
                   description: String
                   title: String!
+                }
+
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 type MovieAggregateSelection {
@@ -2274,6 +2410,7 @@ describe("@selectable", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -2330,6 +2467,16 @@ describe("@selectable", () => {
                   name: String!
                 }
 
+                type SeriesAggregate {
+                  node: SeriesAggregateNode!
+                }
+
+                type SeriesAggregateNode {
+                  count: Int!
+                  description: StringAggregateSelection!
+                  name: StringAggregateSelection!
+                }
+
                 type SeriesAggregateSelection {
                   count: Int!
                   description: StringAggregateSelection!
@@ -2341,6 +2488,7 @@ describe("@selectable", () => {
                 }
 
                 type SeriesConnection {
+                  aggregate: SeriesAggregate!
                   edges: [SeriesEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -2567,6 +2715,15 @@ describe("@selectable", () => {
                   where: ActorActedInConnectionWhere
                 }
 
+                type ActorAggregate {
+                  node: ActorAggregateNode!
+                }
+
+                type ActorAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
+                }
+
                 type ActorAggregateSelection {
                   count: Int!
                   name: StringAggregateSelection!
@@ -2656,6 +2813,7 @@ describe("@selectable", () => {
                 }
 
                 type ActorsConnection {
+                  aggregate: ActorAggregate!
                   edges: [ActorEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -2695,6 +2853,16 @@ describe("@selectable", () => {
                 type Movie implements Production {
                   description: String
                   title: String!
+                }
+
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 type MovieAggregateSelection {
@@ -2756,6 +2924,7 @@ describe("@selectable", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -2784,6 +2953,16 @@ describe("@selectable", () => {
                 interface Production {
                   description: String
                   title: String!
+                }
+
+                type ProductionAggregate {
+                  node: ProductionAggregateNode!
+                }
+
+                type ProductionAggregateNode {
+                  count: Int!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 type ProductionAggregateSelection {
@@ -2856,6 +3035,7 @@ describe("@selectable", () => {
                 }
 
                 type ProductionsConnection {
+                  aggregate: ProductionAggregate!
                   edges: [ProductionEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -2881,6 +3061,16 @@ describe("@selectable", () => {
                   title: String!
                 }
 
+                type SeriesAggregate {
+                  node: SeriesAggregateNode!
+                }
+
+                type SeriesAggregateNode {
+                  count: Int!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
+                }
+
                 type SeriesAggregateSelection {
                   count: Int!
                   description: StringAggregateSelection!
@@ -2888,6 +3078,7 @@ describe("@selectable", () => {
                 }
 
                 type SeriesConnection {
+                  aggregate: SeriesAggregate!
                   edges: [SeriesEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -3128,6 +3319,15 @@ describe("@selectable", () => {
                   where: ActorActedInConnectionWhere
                 }
 
+                type ActorAggregate {
+                  node: ActorAggregateNode!
+                }
+
+                type ActorAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
+                }
+
                 type ActorAggregateSelection {
                   count: Int!
                   name: StringAggregateSelection!
@@ -3217,6 +3417,7 @@ describe("@selectable", () => {
                 }
 
                 type ActorsConnection {
+                  aggregate: ActorAggregate!
                   edges: [ActorEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -3256,6 +3457,16 @@ describe("@selectable", () => {
                 type Movie implements Production {
                   description: String
                   title: String!
+                }
+
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 type MovieAggregateSelection {
@@ -3317,6 +3528,7 @@ describe("@selectable", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -3345,6 +3557,16 @@ describe("@selectable", () => {
                 interface Production {
                   description: String
                   title: String!
+                }
+
+                type ProductionAggregate {
+                  node: ProductionAggregateNode!
+                }
+
+                type ProductionAggregateNode {
+                  count: Int!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 type ProductionAggregateSelection {
@@ -3417,6 +3639,7 @@ describe("@selectable", () => {
                 }
 
                 type ProductionsConnection {
+                  aggregate: ProductionAggregate!
                   edges: [ProductionEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -3442,6 +3665,16 @@ describe("@selectable", () => {
                   title: String!
                 }
 
+                type SeriesAggregate {
+                  node: SeriesAggregateNode!
+                }
+
+                type SeriesAggregateNode {
+                  count: Int!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
+                }
+
                 type SeriesAggregateSelection {
                   count: Int!
                   description: StringAggregateSelection!
@@ -3449,6 +3682,7 @@ describe("@selectable", () => {
                 }
 
                 type SeriesConnection {
+                  aggregate: SeriesAggregate!
                   edges: [SeriesEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!

--- a/packages/graphql/tests/schema/directives/settable.test.ts
+++ b/packages/graphql/tests/schema/directives/settable.test.ts
@@ -65,6 +65,16 @@ describe("@settable", () => {
               title: String!
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              description: StringAggregateSelection!
+              title: StringAggregateSelection!
+            }
+
             type MovieAggregateSelection {
               count: Int!
               description: StringAggregateSelection!
@@ -123,6 +133,7 @@ describe("@settable", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -219,6 +230,16 @@ describe("@settable", () => {
               title: String!
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              description: StringAggregateSelection!
+              title: StringAggregateSelection!
+            }
+
             type MovieAggregateSelection {
               count: Int!
               description: StringAggregateSelection!
@@ -276,6 +297,7 @@ describe("@settable", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -381,6 +403,16 @@ describe("@settable", () => {
               title: String!
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              description: StringAggregateSelection!
+              title: StringAggregateSelection!
+            }
+
             type MovieAggregateSelection {
               count: Int!
               description: StringAggregateSelection!
@@ -479,6 +511,7 @@ describe("@settable", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -674,6 +707,15 @@ describe("@settable", () => {
                   where: ActorActedInConnectionWhere
                 }
 
+                type ActorAggregate {
+                  node: ActorAggregateNode!
+                }
+
+                type ActorAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
+                }
+
                 type ActorAggregateSelection {
                   count: Int!
                   name: StringAggregateSelection!
@@ -762,6 +804,7 @@ describe("@settable", () => {
                 }
 
                 type ActorsConnection {
+                  aggregate: ActorAggregate!
                   edges: [ActorEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -796,6 +839,16 @@ describe("@settable", () => {
                 type Movie {
                   description: String
                   title: String!
+                }
+
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 type MovieAggregateSelection {
@@ -861,6 +914,7 @@ describe("@settable", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -1048,6 +1102,15 @@ describe("@settable", () => {
                   node: Movie!
                 }
 
+                type ActorAggregate {
+                  node: ActorAggregateNode!
+                }
+
+                type ActorAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
+                }
+
                 type ActorAggregateSelection {
                   count: Int!
                   name: StringAggregateSelection!
@@ -1136,6 +1199,7 @@ describe("@settable", () => {
                 }
 
                 type ActorsConnection {
+                  aggregate: ActorAggregate!
                   edges: [ActorEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -1170,6 +1234,16 @@ describe("@settable", () => {
                 type Movie {
                   description: String
                   title: String!
+                }
+
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 type MovieAggregateSelection {
@@ -1235,6 +1309,7 @@ describe("@settable", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -1428,6 +1503,15 @@ describe("@settable", () => {
                   node: Movie!
                 }
 
+                type ActorAggregate {
+                  node: ActorAggregateNode!
+                }
+
+                type ActorAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
+                }
+
                 type ActorAggregateSelection {
                   count: Int!
                   name: StringAggregateSelection!
@@ -1528,6 +1612,7 @@ describe("@settable", () => {
                 }
 
                 type ActorsConnection {
+                  aggregate: ActorAggregate!
                   edges: [ActorEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -1673,6 +1758,16 @@ describe("@settable", () => {
                   where: MovieActorsConnectionWhere
                 }
 
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
+                }
+
                 type MovieAggregateSelection {
                   count: Int!
                   description: StringAggregateSelection!
@@ -1775,6 +1870,7 @@ describe("@settable", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -1976,6 +2072,15 @@ describe("@settable", () => {
                   where: ActorActedInConnectionWhere
                 }
 
+                type ActorAggregate {
+                  node: ActorAggregateNode!
+                }
+
+                type ActorAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
+                }
+
                 type ActorAggregateSelection {
                   count: Int!
                   name: StringAggregateSelection!
@@ -2076,6 +2181,7 @@ describe("@settable", () => {
                 }
 
                 type ActorsConnection {
+                  aggregate: ActorAggregate!
                   edges: [ActorEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -2221,6 +2327,16 @@ describe("@settable", () => {
                   where: MovieActorsConnectionWhere
                 }
 
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
+                }
+
                 type MovieAggregateSelection {
                   count: Int!
                   description: StringAggregateSelection!
@@ -2323,6 +2439,7 @@ describe("@settable", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -2523,6 +2640,15 @@ describe("@settable", () => {
                   Series: [ActorActedInSeriesUpdateFieldInput!]
                 }
 
+                type ActorAggregate {
+                  node: ActorAggregateNode!
+                }
+
+                type ActorAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
+                }
+
                 type ActorAggregateSelection {
                   count: Int!
                   name: StringAggregateSelection!
@@ -2600,6 +2726,7 @@ describe("@settable", () => {
                 }
 
                 type ActorsConnection {
+                  aggregate: ActorAggregate!
                   edges: [ActorEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -2639,6 +2766,16 @@ describe("@settable", () => {
                 type Movie {
                   description: String
                   title: String!
+                }
+
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 type MovieAggregateSelection {
@@ -2704,6 +2841,7 @@ describe("@settable", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -2760,6 +2898,16 @@ describe("@settable", () => {
                   name: String!
                 }
 
+                type SeriesAggregate {
+                  node: SeriesAggregateNode!
+                }
+
+                type SeriesAggregateNode {
+                  count: Int!
+                  description: StringAggregateSelection!
+                  name: StringAggregateSelection!
+                }
+
                 type SeriesAggregateSelection {
                   count: Int!
                   description: StringAggregateSelection!
@@ -2771,6 +2919,7 @@ describe("@settable", () => {
                 }
 
                 type SeriesConnection {
+                  aggregate: SeriesAggregate!
                   edges: [SeriesEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -2977,6 +3126,15 @@ describe("@settable", () => {
                   create: [ActorActedInSeriesCreateFieldInput!]
                 }
 
+                type ActorAggregate {
+                  node: ActorAggregateNode!
+                }
+
+                type ActorAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
+                }
+
                 type ActorAggregateSelection {
                   count: Int!
                   name: StringAggregateSelection!
@@ -3054,6 +3212,7 @@ describe("@settable", () => {
                 }
 
                 type ActorsConnection {
+                  aggregate: ActorAggregate!
                   edges: [ActorEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -3093,6 +3252,16 @@ describe("@settable", () => {
                 type Movie {
                   description: String
                   title: String!
+                }
+
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 type MovieAggregateSelection {
@@ -3158,6 +3327,7 @@ describe("@settable", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -3214,6 +3384,16 @@ describe("@settable", () => {
                   name: String!
                 }
 
+                type SeriesAggregate {
+                  node: SeriesAggregateNode!
+                }
+
+                type SeriesAggregateNode {
+                  count: Int!
+                  description: StringAggregateSelection!
+                  name: StringAggregateSelection!
+                }
+
                 type SeriesAggregateSelection {
                   count: Int!
                   description: StringAggregateSelection!
@@ -3225,6 +3405,7 @@ describe("@settable", () => {
                 }
 
                 type SeriesConnection {
+                  aggregate: SeriesAggregate!
                   edges: [SeriesEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -3451,6 +3632,15 @@ describe("@settable", () => {
                   create: [ActorActedInSeriesCreateFieldInput!]
                 }
 
+                type ActorAggregate {
+                  node: ActorAggregateNode!
+                }
+
+                type ActorAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
+                }
+
                 type ActorAggregateSelection {
                   count: Int!
                   name: StringAggregateSelection!
@@ -3540,6 +3730,7 @@ describe("@settable", () => {
                 }
 
                 type ActorsConnection {
+                  aggregate: ActorAggregate!
                   edges: [ActorEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -3690,6 +3881,16 @@ describe("@settable", () => {
                   where: MovieActorsConnectionWhere
                 }
 
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
+                }
+
                 type MovieAggregateSelection {
                   count: Int!
                   description: StringAggregateSelection!
@@ -3792,6 +3993,7 @@ describe("@settable", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -3848,6 +4050,16 @@ describe("@settable", () => {
                   name: String!
                 }
 
+                type SeriesAggregate {
+                  node: SeriesAggregateNode!
+                }
+
+                type SeriesAggregateNode {
+                  count: Int!
+                  description: StringAggregateSelection!
+                  name: StringAggregateSelection!
+                }
+
                 type SeriesAggregateSelection {
                   count: Int!
                   description: StringAggregateSelection!
@@ -3859,6 +4071,7 @@ describe("@settable", () => {
                 }
 
                 type SeriesConnection {
+                  aggregate: SeriesAggregate!
                   edges: [SeriesEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -4101,6 +4314,15 @@ describe("@settable", () => {
                   Series: [ActorActedInSeriesUpdateFieldInput!]
                 }
 
+                type ActorAggregate {
+                  node: ActorAggregateNode!
+                }
+
+                type ActorAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
+                }
+
                 type ActorAggregateSelection {
                   count: Int!
                   name: StringAggregateSelection!
@@ -4190,6 +4412,7 @@ describe("@settable", () => {
                 }
 
                 type ActorsConnection {
+                  aggregate: ActorAggregate!
                   edges: [ActorEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -4340,6 +4563,16 @@ describe("@settable", () => {
                   where: MovieActorsConnectionWhere
                 }
 
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
+                }
+
                 type MovieAggregateSelection {
                   count: Int!
                   description: StringAggregateSelection!
@@ -4442,6 +4675,7 @@ describe("@settable", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -4498,6 +4732,16 @@ describe("@settable", () => {
                   name: String!
                 }
 
+                type SeriesAggregate {
+                  node: SeriesAggregateNode!
+                }
+
+                type SeriesAggregateNode {
+                  count: Int!
+                  description: StringAggregateSelection!
+                  name: StringAggregateSelection!
+                }
+
                 type SeriesAggregateSelection {
                   count: Int!
                   description: StringAggregateSelection!
@@ -4509,6 +4753,7 @@ describe("@settable", () => {
                 }
 
                 type SeriesConnection {
+                  aggregate: SeriesAggregate!
                   edges: [SeriesEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -4747,6 +4992,15 @@ describe("@settable", () => {
                   where: ActorActedInConnectionWhere
                 }
 
+                type ActorAggregate {
+                  node: ActorAggregateNode!
+                }
+
+                type ActorAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
+                }
+
                 type ActorAggregateSelection {
                   count: Int!
                   name: StringAggregateSelection!
@@ -4835,6 +5089,7 @@ describe("@settable", () => {
                 }
 
                 type ActorsConnection {
+                  aggregate: ActorAggregate!
                   edges: [ActorEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -4874,6 +5129,16 @@ describe("@settable", () => {
                 type Movie implements Production {
                   description: String
                   title: String!
+                }
+
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 type MovieAggregateSelection {
@@ -4935,6 +5200,7 @@ describe("@settable", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -4963,6 +5229,16 @@ describe("@settable", () => {
                 interface Production {
                   description: String
                   title: String!
+                }
+
+                type ProductionAggregate {
+                  node: ProductionAggregateNode!
+                }
+
+                type ProductionAggregateNode {
+                  count: Int!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 type ProductionAggregateSelection {
@@ -5035,6 +5311,7 @@ describe("@settable", () => {
                 }
 
                 type ProductionsConnection {
+                  aggregate: ProductionAggregate!
                   edges: [ProductionEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -5060,6 +5337,16 @@ describe("@settable", () => {
                   title: String!
                 }
 
+                type SeriesAggregate {
+                  node: SeriesAggregateNode!
+                }
+
+                type SeriesAggregateNode {
+                  count: Int!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
+                }
+
                 type SeriesAggregateSelection {
                   count: Int!
                   description: StringAggregateSelection!
@@ -5067,6 +5354,7 @@ describe("@settable", () => {
                 }
 
                 type SeriesConnection {
+                  aggregate: SeriesAggregate!
                   edges: [SeriesEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -5291,6 +5579,15 @@ describe("@settable", () => {
                   node: Production!
                 }
 
+                type ActorAggregate {
+                  node: ActorAggregateNode!
+                }
+
+                type ActorAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
+                }
+
                 type ActorAggregateSelection {
                   count: Int!
                   name: StringAggregateSelection!
@@ -5379,6 +5676,7 @@ describe("@settable", () => {
                 }
 
                 type ActorsConnection {
+                  aggregate: ActorAggregate!
                   edges: [ActorEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -5418,6 +5716,16 @@ describe("@settable", () => {
                 type Movie implements Production {
                   description: String
                   title: String!
+                }
+
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 type MovieAggregateSelection {
@@ -5479,6 +5787,7 @@ describe("@settable", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -5507,6 +5816,16 @@ describe("@settable", () => {
                 interface Production {
                   description: String
                   title: String!
+                }
+
+                type ProductionAggregate {
+                  node: ProductionAggregateNode!
+                }
+
+                type ProductionAggregateNode {
+                  count: Int!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 type ProductionAggregateSelection {
@@ -5572,6 +5891,7 @@ describe("@settable", () => {
                 }
 
                 type ProductionsConnection {
+                  aggregate: ProductionAggregate!
                   edges: [ProductionEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -5597,6 +5917,16 @@ describe("@settable", () => {
                   title: String!
                 }
 
+                type SeriesAggregate {
+                  node: SeriesAggregateNode!
+                }
+
+                type SeriesAggregateNode {
+                  count: Int!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
+                }
+
                 type SeriesAggregateSelection {
                   count: Int!
                   description: StringAggregateSelection!
@@ -5604,6 +5934,7 @@ describe("@settable", () => {
                 }
 
                 type SeriesConnection {
+                  aggregate: SeriesAggregate!
                   edges: [SeriesEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -5836,6 +6167,15 @@ describe("@settable", () => {
                   node: Production!
                 }
 
+                type ActorAggregate {
+                  node: ActorAggregateNode!
+                }
+
+                type ActorAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
+                }
+
                 type ActorAggregateSelection {
                   count: Int!
                   name: StringAggregateSelection!
@@ -5936,6 +6276,7 @@ describe("@settable", () => {
                 }
 
                 type ActorsConnection {
+                  aggregate: ActorAggregate!
                   edges: [ActorEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -6054,6 +6395,16 @@ describe("@settable", () => {
                   where: ProductionActorsConnectionWhere
                 }
 
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
+                }
+
                 type MovieAggregateSelection {
                   count: Int!
                   description: StringAggregateSelection!
@@ -6144,6 +6495,7 @@ describe("@settable", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -6251,6 +6603,16 @@ describe("@settable", () => {
                   node: Actor!
                 }
 
+                type ProductionAggregate {
+                  node: ProductionAggregateNode!
+                }
+
+                type ProductionAggregateNode {
+                  count: Int!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
+                }
+
                 type ProductionAggregateSelection {
                   count: Int!
                   description: StringAggregateSelection!
@@ -6351,6 +6713,7 @@ describe("@settable", () => {
                 }
 
                 type ProductionsConnection {
+                  aggregate: ProductionAggregate!
                   edges: [ProductionEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -6453,6 +6816,16 @@ describe("@settable", () => {
                   where: ProductionActorsConnectionWhere
                 }
 
+                type SeriesAggregate {
+                  node: SeriesAggregateNode!
+                }
+
+                type SeriesAggregateNode {
+                  count: Int!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
+                }
+
                 type SeriesAggregateSelection {
                   count: Int!
                   description: StringAggregateSelection!
@@ -6460,6 +6833,7 @@ describe("@settable", () => {
                 }
 
                 type SeriesConnection {
+                  aggregate: SeriesAggregate!
                   edges: [SeriesEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -6731,6 +7105,15 @@ describe("@settable", () => {
                   where: ActorActedInConnectionWhere
                 }
 
+                type ActorAggregate {
+                  node: ActorAggregateNode!
+                }
+
+                type ActorAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
+                }
+
                 type ActorAggregateSelection {
                   count: Int!
                   name: StringAggregateSelection!
@@ -6831,6 +7214,7 @@ describe("@settable", () => {
                 }
 
                 type ActorsConnection {
+                  aggregate: ActorAggregate!
                   edges: [ActorEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -6949,6 +7333,16 @@ describe("@settable", () => {
                   where: ProductionActorsConnectionWhere
                 }
 
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
+                }
+
                 type MovieAggregateSelection {
                   count: Int!
                   description: StringAggregateSelection!
@@ -7039,6 +7433,7 @@ describe("@settable", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -7163,6 +7558,16 @@ describe("@settable", () => {
                   where: ProductionActorsConnectionWhere
                 }
 
+                type ProductionAggregate {
+                  node: ProductionAggregateNode!
+                }
+
+                type ProductionAggregateNode {
+                  count: Int!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
+                }
+
                 type ProductionAggregateSelection {
                   count: Int!
                   description: StringAggregateSelection!
@@ -7271,6 +7676,7 @@ describe("@settable", () => {
                 }
 
                 type ProductionsConnection {
+                  aggregate: ProductionAggregate!
                   edges: [ProductionEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -7373,6 +7779,16 @@ describe("@settable", () => {
                   where: ProductionActorsConnectionWhere
                 }
 
+                type SeriesAggregate {
+                  node: SeriesAggregateNode!
+                }
+
+                type SeriesAggregateNode {
+                  count: Int!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
+                }
+
                 type SeriesAggregateSelection {
                   count: Int!
                   description: StringAggregateSelection!
@@ -7380,6 +7796,7 @@ describe("@settable", () => {
                 }
 
                 type SeriesConnection {
+                  aggregate: SeriesAggregate!
                   edges: [SeriesEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!

--- a/packages/graphql/tests/schema/directives/settable.test.ts
+++ b/packages/graphql/tests/schema/directives/settable.test.ts
@@ -155,7 +155,7 @@ describe("@settable", () => {
 
             type Query {
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 
@@ -319,7 +319,7 @@ describe("@settable", () => {
 
             type Query {
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 
@@ -533,7 +533,7 @@ describe("@settable", () => {
 
             type Query {
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 
@@ -939,10 +939,10 @@ describe("@settable", () => {
 
                 type Query {
                   actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-                  actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+                  actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
                   actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                 }
 
@@ -1334,10 +1334,10 @@ describe("@settable", () => {
 
                 type Query {
                   actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-                  actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+                  actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
                   actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                 }
 
@@ -1895,10 +1895,10 @@ describe("@settable", () => {
 
                 type Query {
                   actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-                  actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+                  actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
                   actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                 }
 
@@ -2464,10 +2464,10 @@ describe("@settable", () => {
 
                 type Query {
                   actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-                  actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+                  actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
                   actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                 }
 
@@ -2876,14 +2876,14 @@ describe("@settable", () => {
 
                 type Query {
                   actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-                  actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+                  actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
                   actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                   productions(limit: Int, offset: Int, options: QueryOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: ProductionWhere): [Production!]!
                   series(limit: Int, offset: Int, options: SeriesOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [SeriesSort!], where: SeriesWhere): [Series!]!
-                  seriesAggregate(where: SeriesWhere): SeriesAggregateSelection!
+                  seriesAggregate(where: SeriesWhere): SeriesAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"seriesConnection\\\\\\"\\")
                   seriesConnection(after: String, first: Int, sort: [SeriesSort!], where: SeriesWhere): SeriesConnection!
                 }
 
@@ -3362,14 +3362,14 @@ describe("@settable", () => {
 
                 type Query {
                   actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-                  actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+                  actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
                   actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                   productions(limit: Int, offset: Int, options: QueryOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: ProductionWhere): [Production!]!
                   series(limit: Int, offset: Int, options: SeriesOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [SeriesSort!], where: SeriesWhere): [Series!]!
-                  seriesAggregate(where: SeriesWhere): SeriesAggregateSelection!
+                  seriesAggregate(where: SeriesWhere): SeriesAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"seriesConnection\\\\\\"\\")
                   seriesConnection(after: String, first: Int, sort: [SeriesSort!], where: SeriesWhere): SeriesConnection!
                 }
 
@@ -4028,14 +4028,14 @@ describe("@settable", () => {
 
                 type Query {
                   actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-                  actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+                  actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
                   actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                   productions(limit: Int, offset: Int, options: QueryOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: ProductionWhere): [Production!]!
                   series(limit: Int, offset: Int, options: SeriesOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [SeriesSort!], where: SeriesWhere): [Series!]!
-                  seriesAggregate(where: SeriesWhere): SeriesAggregateSelection!
+                  seriesAggregate(where: SeriesWhere): SeriesAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"seriesConnection\\\\\\"\\")
                   seriesConnection(after: String, first: Int, sort: [SeriesSort!], where: SeriesWhere): SeriesConnection!
                 }
 
@@ -4710,14 +4710,14 @@ describe("@settable", () => {
 
                 type Query {
                   actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-                  actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+                  actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
                   actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                   productions(limit: Int, offset: Int, options: QueryOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: ProductionWhere): [Production!]!
                   series(limit: Int, offset: Int, options: SeriesOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [SeriesSort!], where: SeriesWhere): [Series!]!
-                  seriesAggregate(where: SeriesWhere): SeriesAggregateSelection!
+                  seriesAggregate(where: SeriesWhere): SeriesAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"seriesConnection\\\\\\"\\")
                   seriesConnection(after: String, first: Int, sort: [SeriesSort!], where: SeriesWhere): SeriesConnection!
                 }
 
@@ -5319,16 +5319,16 @@ describe("@settable", () => {
 
                 type Query {
                   actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-                  actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+                  actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
                   actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                   productions(limit: Int, offset: Int, options: ProductionOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ProductionSort!], where: ProductionWhere): [Production!]!
-                  productionsAggregate(where: ProductionWhere): ProductionAggregateSelection!
+                  productionsAggregate(where: ProductionWhere): ProductionAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"productionsConnection\\\\\\"\\")
                   productionsConnection(after: String, first: Int, sort: [ProductionSort!], where: ProductionWhere): ProductionsConnection!
                   series(limit: Int, offset: Int, options: SeriesOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [SeriesSort!], where: SeriesWhere): [Series!]!
-                  seriesAggregate(where: SeriesWhere): SeriesAggregateSelection!
+                  seriesAggregate(where: SeriesWhere): SeriesAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"seriesConnection\\\\\\"\\")
                   seriesConnection(after: String, first: Int, sort: [SeriesSort!], where: SeriesWhere): SeriesConnection!
                 }
 
@@ -5899,16 +5899,16 @@ describe("@settable", () => {
 
                 type Query {
                   actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-                  actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+                  actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
                   actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                   productions(limit: Int, offset: Int, options: ProductionOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ProductionSort!], where: ProductionWhere): [Production!]!
-                  productionsAggregate(where: ProductionWhere): ProductionAggregateSelection!
+                  productionsAggregate(where: ProductionWhere): ProductionAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"productionsConnection\\\\\\"\\")
                   productionsConnection(after: String, first: Int, sort: [ProductionSort!], where: ProductionWhere): ProductionsConnection!
                   series(limit: Int, offset: Int, options: SeriesOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [SeriesSort!], where: SeriesWhere): [Series!]!
-                  seriesAggregate(where: SeriesWhere): SeriesAggregateSelection!
+                  seriesAggregate(where: SeriesWhere): SeriesAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"seriesConnection\\\\\\"\\")
                   seriesConnection(after: String, first: Int, sort: [SeriesSort!], where: SeriesWhere): SeriesConnection!
                 }
 
@@ -6721,16 +6721,16 @@ describe("@settable", () => {
 
                 type Query {
                   actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-                  actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+                  actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
                   actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                   productions(limit: Int, offset: Int, options: ProductionOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ProductionSort!], where: ProductionWhere): [Production!]!
-                  productionsAggregate(where: ProductionWhere): ProductionAggregateSelection!
+                  productionsAggregate(where: ProductionWhere): ProductionAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"productionsConnection\\\\\\"\\")
                   productionsConnection(after: String, first: Int, sort: [ProductionSort!], where: ProductionWhere): ProductionsConnection!
                   series(limit: Int, offset: Int, options: SeriesOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [SeriesSort!], where: SeriesWhere): [Series!]!
-                  seriesAggregate(where: SeriesWhere): SeriesAggregateSelection!
+                  seriesAggregate(where: SeriesWhere): SeriesAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"seriesConnection\\\\\\"\\")
                   seriesConnection(after: String, first: Int, sort: [SeriesSort!], where: SeriesWhere): SeriesConnection!
                 }
 
@@ -7684,16 +7684,16 @@ describe("@settable", () => {
 
                 type Query {
                   actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-                  actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+                  actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
                   actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                   productions(limit: Int, offset: Int, options: ProductionOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ProductionSort!], where: ProductionWhere): [Production!]!
-                  productionsAggregate(where: ProductionWhere): ProductionAggregateSelection!
+                  productionsAggregate(where: ProductionWhere): ProductionAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"productionsConnection\\\\\\"\\")
                   productionsConnection(after: String, first: Int, sort: [ProductionSort!], where: ProductionWhere): ProductionsConnection!
                   series(limit: Int, offset: Int, options: SeriesOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [SeriesSort!], where: SeriesWhere): [Series!]!
-                  seriesAggregate(where: SeriesWhere): SeriesAggregateSelection!
+                  seriesAggregate(where: SeriesWhere): SeriesAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"seriesConnection\\\\\\"\\")
                   seriesConnection(after: String, first: Int, sort: [SeriesSort!], where: SeriesWhere): SeriesConnection!
                 }
 

--- a/packages/graphql/tests/schema/directives/timestamps.test.ts
+++ b/packages/graphql/tests/schema/directives/timestamps.test.ts
@@ -80,6 +80,17 @@ describe("Timestamps", () => {
               updatedAt: DateTime!
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              createdAt: DateTimeAggregateSelection!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              updatedAt: DateTimeAggregateSelection!
+            }
+
             type MovieAggregateSelection {
               count: Int!
               createdAt: DateTimeAggregateSelection!
@@ -149,6 +160,7 @@ describe("Timestamps", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/directives/timestamps.test.ts
+++ b/packages/graphql/tests/schema/directives/timestamps.test.ts
@@ -182,7 +182,7 @@ describe("Timestamps", () => {
 
             type Query {
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 

--- a/packages/graphql/tests/schema/enum.test.ts
+++ b/packages/graphql/tests/schema/enum.test.ts
@@ -69,6 +69,14 @@ describe("Enum", () => {
               status: Status
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+            }
+
             type MovieAggregateSelection {
               count: Int!
             }
@@ -113,6 +121,7 @@ describe("Enum", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/enum.test.ts
+++ b/packages/graphql/tests/schema/enum.test.ts
@@ -143,7 +143,7 @@ describe("Enum", () => {
 
             type Query {
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 

--- a/packages/graphql/tests/schema/extend.test.ts
+++ b/packages/graphql/tests/schema/extend.test.ts
@@ -164,7 +164,7 @@ describe("Extend", () => {
 
             type Query {
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 

--- a/packages/graphql/tests/schema/extend.test.ts
+++ b/packages/graphql/tests/schema/extend.test.ts
@@ -73,6 +73,16 @@ describe("Extend", () => {
               name: String
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              name: StringAggregateSelection!
+            }
+
             type MovieAggregateSelection {
               count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -132,6 +142,7 @@ describe("Extend", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/federation.test.ts
+++ b/packages/graphql/tests/schema/federation.test.ts
@@ -312,10 +312,10 @@ describe("Apollo Federation", () => {
             type Query {
               _service: _Service!
               posts(limit: Int, offset: Int, options: PostOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PostSort!], where: PostWhere): [Post!]!
-              postsAggregate(where: PostWhere): PostAggregateSelection!
+              postsAggregate(where: PostWhere): PostAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"postsConnection\\\\\\"\\")
               postsConnection(after: String, first: Int, sort: [PostSort!], where: PostWhere): PostsConnection!
               users(limit: Int, offset: Int, options: UserOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [UserSort!], where: UserWhere): [User!]! @shareable
-              usersAggregate(where: UserWhere): UserAggregateSelection! @shareable
+              usersAggregate(where: UserWhere): UserAggregateSelection! @shareable @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"usersConnection\\\\\\"\\")
               usersConnection(after: String, first: Int, sort: [UserSort!], where: UserWhere): UsersConnection! @shareable
             }
 
@@ -868,10 +868,10 @@ describe("Apollo Federation", () => {
               _entities(representations: [_Any!]!): [_Entity]!
               _service: _Service!
               posts(limit: Int, offset: Int, options: PostOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PostSort!], where: PostWhere): [Post!]!
-              postsAggregate(where: PostWhere): PostAggregateSelection!
+              postsAggregate(where: PostWhere): PostAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"postsConnection\\\\\\"\\")
               postsConnection(after: String, first: Int, sort: [PostSort!], where: PostWhere): PostsConnection!
               users(limit: Int, offset: Int, options: UserOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [UserSort!], where: UserWhere): [User!]!
-              usersAggregate(where: UserWhere): UserAggregateSelection!
+              usersAggregate(where: UserWhere): UserAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"usersConnection\\\\\\"\\")
               usersConnection(after: String, first: Int, sort: [UserSort!], where: UserWhere): UsersConnection!
             }
 

--- a/packages/graphql/tests/schema/federation.test.ts
+++ b/packages/graphql/tests/schema/federation.test.ts
@@ -119,6 +119,15 @@ describe("Apollo Federation", () => {
               content: String!
             }
 
+            type PostAggregate {
+              node: PostAggregateNode!
+            }
+
+            type PostAggregateNode {
+              content: StringAggregateSelection!
+              count: Int!
+            }
+
             type PostAggregateSelection {
               content: StringAggregateSelection!
               count: Int!
@@ -294,6 +303,7 @@ describe("Apollo Federation", () => {
             }
 
             type PostsConnection {
+              aggregate: PostAggregate!
               edges: [PostEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -347,6 +357,15 @@ describe("Apollo Federation", () => {
               posts(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), limit: Int, offset: Int, options: PostOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PostSort!], where: PostWhere): [Post!]!
               postsAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: PostWhere): UserPostPostsAggregationSelection
               postsConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [UserPostsConnectionSort!], where: UserPostsConnectionWhere): UserPostsConnection!
+            }
+
+            type UserAggregate @shareable {
+              node: UserAggregateNode!
+            }
+
+            type UserAggregateNode @shareable {
+              count: Int!
+              name: StringAggregateSelection!
             }
 
             type UserAggregateSelection @shareable {
@@ -546,6 +565,7 @@ describe("Apollo Federation", () => {
             }
 
             type UsersConnection @shareable {
+              aggregate: UserAggregate!
               edges: [UserEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -667,6 +687,15 @@ describe("Apollo Federation", () => {
               authorAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: UserWhere): PostUserAuthorAggregationSelection
               authorConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [PostAuthorConnectionSort!], where: PostAuthorConnectionWhere): PostAuthorConnection!
               content: String!
+            }
+
+            type PostAggregate {
+              node: PostAggregateNode!
+            }
+
+            type PostAggregateNode {
+              content: StringAggregateSelection!
+              count: Int!
             }
 
             type PostAggregateSelection {
@@ -829,6 +858,7 @@ describe("Apollo Federation", () => {
             }
 
             type PostsConnection {
+              aggregate: PostAggregate!
               edges: [PostEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -880,6 +910,15 @@ describe("Apollo Federation", () => {
 
             type User @key(fields: \\"name\\", resolvable: false) {
               name: String!
+            }
+
+            type UserAggregate {
+              node: UserAggregateNode!
+            }
+
+            type UserAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
             }
 
             type UserAggregateSelection {
@@ -934,6 +973,7 @@ describe("Apollo Federation", () => {
             }
 
             type UsersConnection {
+              aggregate: UserAggregate!
               edges: [UserEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/fulltext.test.ts
+++ b/packages/graphql/tests/schema/fulltext.test.ts
@@ -217,7 +217,7 @@ describe("@fulltext schema", () => {
                 \\"\\"\\"
                 fulltext: MovieFulltext
                 where: MovieWhere
-              ): MovieAggregateSelection!
+              ): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(
                 after: String
                 first: Int

--- a/packages/graphql/tests/schema/fulltext.test.ts
+++ b/packages/graphql/tests/schema/fulltext.test.ts
@@ -79,6 +79,16 @@ describe("@fulltext schema", () => {
               title: String
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              description: StringAggregateSelection!
+              title: StringAggregateSelection!
+            }
+
             type MovieAggregateSelection {
               count: Int!
               description: StringAggregateSelection!
@@ -169,6 +179,7 @@ describe("@fulltext schema", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/global-node.test.ts
+++ b/packages/graphql/tests/schema/global-node.test.ts
@@ -71,6 +71,16 @@ describe("Node Interface Types", () => {
               title: String!
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              imdb: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              title: StringAggregateSelection!
+            }
+
             type MovieAggregateSelection {
               count: Int!
               imdb: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -131,6 +141,7 @@ describe("Node Interface Types", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/global-node.test.ts
+++ b/packages/graphql/tests/schema/global-node.test.ts
@@ -169,7 +169,7 @@ describe("Node Interface Types", () => {
 
             type Query {
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
               \\"\\"\\"Fetches an object given its ID\\"\\"\\"
               node(

--- a/packages/graphql/tests/schema/inheritance.test.ts
+++ b/packages/graphql/tests/schema/inheritance.test.ts
@@ -65,6 +65,15 @@ describe("inheritance", () => {
               name: String
             }
 
+            type ActorAggregate {
+              node: ActorAggregateNode!
+            }
+
+            type ActorAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
             type ActorAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -233,6 +242,7 @@ describe("inheritance", () => {
             }
 
             type ActorsConnection {
+              aggregate: ActorAggregate!
               edges: [ActorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -343,6 +353,7 @@ describe("inheritance", () => {
             }
 
             type PeopleConnection {
+              aggregate: PersonAggregate!
               edges: [PersonEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -352,6 +363,15 @@ describe("inheritance", () => {
               friends(limit: Int, offset: Int, options: PersonOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonSort!], where: PersonWhere): [Person!]! @customDirectiveField
               friendsConnection(after: String, first: Int, sort: [PersonFriendsConnectionSort!], where: PersonFriendsConnectionWhere): PersonFriendsConnection!
               name: String @customDirectiveField
+            }
+
+            type PersonAggregate {
+              node: PersonAggregateNode!
+            }
+
+            type PersonAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
             }
 
             type PersonAggregateSelection {

--- a/packages/graphql/tests/schema/inheritance.test.ts
+++ b/packages/graphql/tests/schema/inheritance.test.ts
@@ -608,10 +608,10 @@ describe("inheritance", () => {
 
             type Query {
               actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
               actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
               people(limit: Int, offset: Int, options: PersonOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonSort!], where: PersonWhere): [Person!]!
-              peopleAggregate(where: PersonWhere): PersonAggregateSelection!
+              peopleAggregate(where: PersonWhere): PersonAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"peopleConnection\\\\\\"\\")
               peopleConnection(after: String, first: Int, sort: [PersonSort!], where: PersonWhere): PeopleConnection!
             }
 

--- a/packages/graphql/tests/schema/inputs.test.ts
+++ b/packages/graphql/tests/schema/inputs.test.ts
@@ -159,7 +159,7 @@ describe("Inputs", () => {
 
             type Query {
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
               name(input: NodeInput): String
             }

--- a/packages/graphql/tests/schema/inputs.test.ts
+++ b/packages/graphql/tests/schema/inputs.test.ts
@@ -76,6 +76,15 @@ describe("Inputs", () => {
               id: ID
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+            }
+
             type MovieAggregateSelection {
               count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -124,6 +133,7 @@ describe("Inputs", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/interface-relationships.test.ts
+++ b/packages/graphql/tests/schema/interface-relationships.test.ts
@@ -223,6 +223,15 @@ describe("Interface Relationships", () => {
               where: ActorActedInConnectionWhere
             }
 
+            type ActorAggregate {
+              node: ActorAggregateNode!
+            }
+
+            type ActorAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
             type ActorAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -316,6 +325,7 @@ describe("Interface Relationships", () => {
             }
 
             type ActorsConnection {
+              aggregate: ActorAggregate!
               edges: [ActorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -362,6 +372,16 @@ describe("Interface Relationships", () => {
             type Movie implements Production {
               runtime: Int!
               title: String!
+            }
+
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              runtime: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             type MovieAggregateSelection {
@@ -426,6 +446,7 @@ describe("Interface Relationships", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -453,6 +474,15 @@ describe("Interface Relationships", () => {
 
             interface Production {
               title: String!
+            }
+
+            type ProductionAggregate {
+              node: ProductionAggregateNode!
+            }
+
+            type ProductionAggregateNode {
+              count: Int!
+              title: StringAggregateSelection!
             }
 
             type ProductionAggregateSelection {
@@ -515,6 +545,7 @@ describe("Interface Relationships", () => {
             }
 
             type ProductionsConnection {
+              aggregate: ProductionAggregate!
               edges: [ProductionEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -540,6 +571,16 @@ describe("Interface Relationships", () => {
               title: String!
             }
 
+            type SeriesAggregate {
+              node: SeriesAggregateNode!
+            }
+
+            type SeriesAggregateNode {
+              count: Int!
+              episodes: IntAggregateSelection!
+              title: StringAggregateSelection!
+            }
+
             type SeriesAggregateSelection {
               count: Int!
               episodes: IntAggregateSelection!
@@ -547,6 +588,7 @@ describe("Interface Relationships", () => {
             }
 
             type SeriesConnection {
+              aggregate: SeriesAggregate!
               edges: [SeriesEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -861,6 +903,15 @@ describe("Interface Relationships", () => {
               where: ActorActedInConnectionWhere
             }
 
+            type ActorAggregate {
+              node: ActorAggregateNode!
+            }
+
+            type ActorAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
             type ActorAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -966,6 +1017,7 @@ describe("Interface Relationships", () => {
             }
 
             type ActorsConnection {
+              aggregate: ActorAggregate!
               edges: [ActorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1012,6 +1064,15 @@ describe("Interface Relationships", () => {
               series(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), limit: Int, offset: Int, options: SeriesOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [SeriesSort!], where: SeriesWhere): Series!
               seriesAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: SeriesWhere): EpisodeSeriesSeriesAggregationSelection
               seriesConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [EpisodeSeriesConnectionSort!], where: EpisodeSeriesConnectionWhere): EpisodeSeriesConnection!
+            }
+
+            type EpisodeAggregate {
+              node: EpisodeAggregateNode!
+            }
+
+            type EpisodeAggregateNode {
+              count: Int!
+              runtime: IntAggregateSelection!
             }
 
             type EpisodeAggregateSelection {
@@ -1213,6 +1274,7 @@ describe("Interface Relationships", () => {
             }
 
             type EpisodesConnection {
+              aggregate: EpisodeAggregate!
               edges: [EpisodeEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1316,6 +1378,16 @@ describe("Interface Relationships", () => {
               where: ProductionActorsConnectionWhere
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              runtime: IntAggregateSelection!
+              title: StringAggregateSelection!
+            }
+
             type MovieAggregateSelection {
               count: Int!
               runtime: IntAggregateSelection!
@@ -1409,6 +1481,7 @@ describe("Interface Relationships", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1589,6 +1662,15 @@ describe("Interface Relationships", () => {
               where: ProductionActorsConnectionWhere
             }
 
+            type ProductionAggregate {
+              node: ProductionAggregateNode!
+            }
+
+            type ProductionAggregateNode {
+              count: Int!
+              title: StringAggregateSelection!
+            }
+
             type ProductionAggregateSelection {
               count: Int!
               title: StringAggregateSelection!
@@ -1687,6 +1769,7 @@ describe("Interface Relationships", () => {
             }
 
             type ProductionsConnection {
+              aggregate: ProductionAggregate!
               edges: [ProductionEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1804,6 +1887,16 @@ describe("Interface Relationships", () => {
               where: ProductionActorsConnectionWhere
             }
 
+            type SeriesAggregate {
+              node: SeriesAggregateNode!
+            }
+
+            type SeriesAggregateNode {
+              count: Int!
+              episodeCount: IntAggregateSelection!
+              title: StringAggregateSelection!
+            }
+
             type SeriesAggregateSelection {
               count: Int!
               episodeCount: IntAggregateSelection!
@@ -1820,6 +1913,7 @@ describe("Interface Relationships", () => {
             }
 
             type SeriesConnection {
+              aggregate: SeriesAggregate!
               edges: [SeriesEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -2317,6 +2411,15 @@ describe("Interface Relationships", () => {
               where: ActorActedInConnectionWhere
             }
 
+            type ActorAggregate {
+              node: ActorAggregateNode!
+            }
+
+            type ActorAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
             type ActorAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -2422,6 +2525,7 @@ describe("Interface Relationships", () => {
             }
 
             type ActorsConnection {
+              aggregate: ActorAggregate!
               edges: [ActorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -2468,6 +2572,15 @@ describe("Interface Relationships", () => {
               series(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), limit: Int, offset: Int, options: SeriesOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [SeriesSort!], where: SeriesWhere): Series!
               seriesAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: SeriesWhere): EpisodeSeriesSeriesAggregationSelection
               seriesConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [EpisodeSeriesConnectionSort!], where: EpisodeSeriesConnectionWhere): EpisodeSeriesConnection!
+            }
+
+            type EpisodeAggregate {
+              node: EpisodeAggregateNode!
+            }
+
+            type EpisodeAggregateNode {
+              count: Int!
+              runtime: IntAggregateSelection!
             }
 
             type EpisodeAggregateSelection {
@@ -2669,6 +2782,7 @@ describe("Interface Relationships", () => {
             }
 
             type EpisodesConnection {
+              aggregate: EpisodeAggregate!
               edges: [EpisodeEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -2772,6 +2886,16 @@ describe("Interface Relationships", () => {
               where: ProductionActorsConnectionWhere
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              runtime: IntAggregateSelection!
+              title: StringAggregateSelection!
+            }
+
             type MovieAggregateSelection {
               count: Int!
               runtime: IntAggregateSelection!
@@ -2865,6 +2989,7 @@ describe("Interface Relationships", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -3065,6 +3190,15 @@ describe("Interface Relationships", () => {
               where: ProductionActorsConnectionWhere
             }
 
+            type ProductionAggregate {
+              node: ProductionAggregateNode!
+            }
+
+            type ProductionAggregateNode {
+              count: Int!
+              title: StringAggregateSelection!
+            }
+
             type ProductionAggregateSelection {
               count: Int!
               title: StringAggregateSelection!
@@ -3163,6 +3297,7 @@ describe("Interface Relationships", () => {
             }
 
             type ProductionsConnection {
+              aggregate: ProductionAggregate!
               edges: [ProductionEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -3280,6 +3415,16 @@ describe("Interface Relationships", () => {
               where: ProductionActorsConnectionWhere
             }
 
+            type SeriesAggregate {
+              node: SeriesAggregateNode!
+            }
+
+            type SeriesAggregateNode {
+              count: Int!
+              episodeCount: IntAggregateSelection!
+              title: StringAggregateSelection!
+            }
+
             type SeriesAggregateSelection {
               count: Int!
               episodeCount: IntAggregateSelection!
@@ -3296,6 +3441,7 @@ describe("Interface Relationships", () => {
             }
 
             type SeriesConnection {
+              aggregate: SeriesAggregate!
               edges: [SeriesEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -3729,6 +3875,15 @@ describe("Interface Relationships", () => {
               interface2Connection(after: String, first: Int, sort: [Interface1Interface2ConnectionSort!], where: Interface1Interface2ConnectionWhere): Interface1Interface2Connection!
             }
 
+            type Interface1Aggregate {
+              node: Interface1AggregateNode!
+            }
+
+            type Interface1AggregateNode {
+              count: Int!
+              field1: StringAggregateSelection!
+            }
+
             type Interface1AggregateSelection {
               count: Int!
               field1: StringAggregateSelection!
@@ -3920,6 +4075,7 @@ describe("Interface Relationships", () => {
             }
 
             type Interface1sConnection {
+              aggregate: Interface1Aggregate!
               edges: [Interface1Edge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -3927,6 +4083,15 @@ describe("Interface Relationships", () => {
 
             interface Interface2 {
               field2: String
+            }
+
+            type Interface2Aggregate {
+              node: Interface2AggregateNode!
+            }
+
+            type Interface2AggregateNode {
+              count: Int!
+              field2: StringAggregateSelection!
             }
 
             type Interface2AggregateSelection {
@@ -3989,6 +4154,7 @@ describe("Interface Relationships", () => {
             }
 
             type Interface2sConnection {
+              aggregate: Interface2Aggregate!
               edges: [Interface2Edge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -4064,6 +4230,15 @@ describe("Interface Relationships", () => {
               interface1Connection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [Type1Interface1ConnectionSort!], where: Type1Interface1ConnectionWhere): Type1Interface1Connection!
             }
 
+            type Type1Aggregate {
+              node: Type1AggregateNode!
+            }
+
+            type Type1AggregateNode {
+              count: Int!
+              field1: StringAggregateSelection!
+            }
+
             type Type1AggregateSelection {
               count: Int!
               field1: StringAggregateSelection!
@@ -4090,6 +4265,10 @@ describe("Interface Relationships", () => {
               interface2Connection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [Interface1Interface2ConnectionSort!], where: Interface1Interface2ConnectionWhere): Interface1Interface2Connection!
             }
 
+            type Type1Interface1Aggregate {
+              node: Type1Interface1AggregateNode!
+            }
+
             input Type1Interface1AggregateInput {
               AND: [Type1Interface1AggregateInput!]
               NOT: Type1Interface1AggregateInput
@@ -4101,6 +4280,11 @@ describe("Interface Relationships", () => {
               count_LT: Int
               count_LTE: Int
               node: Type1Interface1NodeAggregationWhereInput
+            }
+
+            type Type1Interface1AggregateNode {
+              count: Int!
+              field1: StringAggregateSelection!
             }
 
             type Type1Interface1AggregateSelection {
@@ -4356,6 +4540,7 @@ describe("Interface Relationships", () => {
             }
 
             type Type1Interface1sConnection {
+              aggregate: Type1Interface1Aggregate!
               edges: [Type1Interface1Edge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -4363,6 +4548,15 @@ describe("Interface Relationships", () => {
 
             type Type1Interface2 implements Interface2 {
               field2: String!
+            }
+
+            type Type1Interface2Aggregate {
+              node: Type1Interface2AggregateNode!
+            }
+
+            type Type1Interface2AggregateNode {
+              count: Int!
+              field2: StringAggregateSelection!
             }
 
             type Type1Interface2AggregateSelection {
@@ -4413,6 +4607,7 @@ describe("Interface Relationships", () => {
             }
 
             type Type1Interface2sConnection {
+              aggregate: Type1Interface2Aggregate!
               edges: [Type1Interface2Edge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -4478,6 +4673,7 @@ describe("Interface Relationships", () => {
             }
 
             type Type1sConnection {
+              aggregate: Type1Aggregate!
               edges: [Type1Edge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -4488,6 +4684,15 @@ describe("Interface Relationships", () => {
               interface2(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), limit: Int, offset: Int, options: Interface2Options @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [Interface2Sort!], where: Interface2Where): [Interface2!]!
               interface2Aggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: Interface2Where): Type2Interface1Interface2Interface2AggregationSelection
               interface2Connection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [Interface1Interface2ConnectionSort!], where: Interface1Interface2ConnectionWhere): Interface1Interface2Connection!
+            }
+
+            type Type2Interface1Aggregate {
+              node: Type2Interface1AggregateNode!
+            }
+
+            type Type2Interface1AggregateNode {
+              count: Int!
+              field1: StringAggregateSelection!
             }
 
             type Type2Interface1AggregateSelection {
@@ -4654,6 +4859,7 @@ describe("Interface Relationships", () => {
             }
 
             type Type2Interface1sConnection {
+              aggregate: Type2Interface1Aggregate!
               edges: [Type2Interface1Edge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -4661,6 +4867,15 @@ describe("Interface Relationships", () => {
 
             type Type2Interface2 implements Interface2 {
               field2: String!
+            }
+
+            type Type2Interface2Aggregate {
+              node: Type2Interface2AggregateNode!
+            }
+
+            type Type2Interface2AggregateNode {
+              count: Int!
+              field2: StringAggregateSelection!
             }
 
             type Type2Interface2AggregateSelection {
@@ -4711,6 +4926,7 @@ describe("Interface Relationships", () => {
             }
 
             type Type2Interface2sConnection {
+              aggregate: Type2Interface2Aggregate!
               edges: [Type2Interface2Edge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -4858,6 +5074,15 @@ describe("Interface Relationships", () => {
               field1: String!
               interface2(limit: Int, offset: Int, options: Interface2Options @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [Interface2Sort!], where: Interface2Where): [Interface2!]!
               interface2Connection(after: String, first: Int, sort: [Interface1Interface2ConnectionSort!], where: Interface1Interface2ConnectionWhere): Interface1Interface2Connection!
+            }
+
+            type Interface1Aggregate {
+              node: Interface1AggregateNode!
+            }
+
+            type Interface1AggregateNode {
+              count: Int!
+              field1: StringAggregateSelection!
             }
 
             type Interface1AggregateSelection {
@@ -5105,6 +5330,7 @@ describe("Interface Relationships", () => {
             }
 
             type Interface1sConnection {
+              aggregate: Interface1Aggregate!
               edges: [Interface1Edge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -5112,6 +5338,15 @@ describe("Interface Relationships", () => {
 
             interface Interface2 {
               field2: String
+            }
+
+            type Interface2Aggregate {
+              node: Interface2AggregateNode!
+            }
+
+            type Interface2AggregateNode {
+              count: Int!
+              field2: StringAggregateSelection!
             }
 
             type Interface2AggregateSelection {
@@ -5174,6 +5409,7 @@ describe("Interface Relationships", () => {
             }
 
             type Interface2sConnection {
+              aggregate: Interface2Aggregate!
               edges: [Interface2Edge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -5312,6 +5548,15 @@ describe("Interface Relationships", () => {
               interface1Connection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [Type1Interface1ConnectionSort!], where: Type1Interface1ConnectionWhere): Type1Interface1Connection!
             }
 
+            type Type1Aggregate {
+              node: Type1AggregateNode!
+            }
+
+            type Type1AggregateNode {
+              count: Int!
+              field1: StringAggregateSelection!
+            }
+
             type Type1AggregateSelection {
               count: Int!
               field1: StringAggregateSelection!
@@ -5338,6 +5583,10 @@ describe("Interface Relationships", () => {
               interface2Connection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [Interface1Interface2ConnectionSort!], where: Interface1Interface2ConnectionWhere): Interface1Interface2Connection!
             }
 
+            type Type1Interface1Aggregate {
+              node: Type1Interface1AggregateNode!
+            }
+
             input Type1Interface1AggregateInput {
               AND: [Type1Interface1AggregateInput!]
               NOT: Type1Interface1AggregateInput
@@ -5349,6 +5598,11 @@ describe("Interface Relationships", () => {
               count_LT: Int
               count_LTE: Int
               node: Type1Interface1NodeAggregationWhereInput
+            }
+
+            type Type1Interface1AggregateNode {
+              count: Int!
+              field1: StringAggregateSelection!
             }
 
             type Type1Interface1AggregateSelection {
@@ -5613,6 +5867,7 @@ describe("Interface Relationships", () => {
             }
 
             type Type1Interface1sConnection {
+              aggregate: Type1Interface1Aggregate!
               edges: [Type1Interface1Edge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -5620,6 +5875,15 @@ describe("Interface Relationships", () => {
 
             type Type1Interface2 implements Interface2 {
               field2: String!
+            }
+
+            type Type1Interface2Aggregate {
+              node: Type1Interface2AggregateNode!
+            }
+
+            type Type1Interface2AggregateNode {
+              count: Int!
+              field2: StringAggregateSelection!
             }
 
             type Type1Interface2AggregateSelection {
@@ -5670,6 +5934,7 @@ describe("Interface Relationships", () => {
             }
 
             type Type1Interface2sConnection {
+              aggregate: Type1Interface2Aggregate!
               edges: [Type1Interface2Edge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -5735,6 +6000,7 @@ describe("Interface Relationships", () => {
             }
 
             type Type1sConnection {
+              aggregate: Type1Aggregate!
               edges: [Type1Edge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -5745,6 +6011,15 @@ describe("Interface Relationships", () => {
               interface2(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), limit: Int, offset: Int, options: Interface2Options @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [Interface2Sort!], where: Interface2Where): [Interface2!]!
               interface2Aggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: Interface2Where): Type2Interface1Interface2Interface2AggregationSelection
               interface2Connection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [Interface1Interface2ConnectionSort!], where: Interface1Interface2ConnectionWhere): Interface1Interface2Connection!
+            }
+
+            type Type2Interface1Aggregate {
+              node: Type2Interface1AggregateNode!
+            }
+
+            type Type2Interface1AggregateNode {
+              count: Int!
+              field1: StringAggregateSelection!
             }
 
             type Type2Interface1AggregateSelection {
@@ -5920,6 +6195,7 @@ describe("Interface Relationships", () => {
             }
 
             type Type2Interface1sConnection {
+              aggregate: Type2Interface1Aggregate!
               edges: [Type2Interface1Edge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -5927,6 +6203,15 @@ describe("Interface Relationships", () => {
 
             type Type2Interface2 implements Interface2 {
               field2: String!
+            }
+
+            type Type2Interface2Aggregate {
+              node: Type2Interface2AggregateNode!
+            }
+
+            type Type2Interface2AggregateNode {
+              count: Int!
+              field2: StringAggregateSelection!
             }
 
             type Type2Interface2AggregateSelection {
@@ -5977,6 +6262,7 @@ describe("Interface Relationships", () => {
             }
 
             type Type2Interface2sConnection {
+              aggregate: Type2Interface2Aggregate!
               edges: [Type2Interface2Edge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -6130,6 +6416,15 @@ describe("Interface Relationships", () => {
               field1: String!
               interface2(limit: Int, offset: Int, options: Interface2Options @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [Interface2Sort!], where: Interface2Where): [Interface2!]!
               interface2Connection(after: String, first: Int, sort: [Interface1Interface2ConnectionSort!], where: Interface1Interface2ConnectionWhere): Interface1Interface2Connection!
+            }
+
+            type Interface1Aggregate {
+              node: Interface1AggregateNode!
+            }
+
+            type Interface1AggregateNode {
+              count: Int!
+              field1: StringAggregateSelection!
             }
 
             type Interface1AggregateSelection {
@@ -6397,6 +6692,7 @@ describe("Interface Relationships", () => {
             }
 
             type Interface1sConnection {
+              aggregate: Interface1Aggregate!
               edges: [Interface1Edge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -6404,6 +6700,15 @@ describe("Interface Relationships", () => {
 
             interface Interface2 {
               field2: String
+            }
+
+            type Interface2Aggregate {
+              node: Interface2AggregateNode!
+            }
+
+            type Interface2AggregateNode {
+              count: Int!
+              field2: StringAggregateSelection!
             }
 
             type Interface2AggregateSelection {
@@ -6466,6 +6771,7 @@ describe("Interface Relationships", () => {
             }
 
             type Interface2sConnection {
+              aggregate: Interface2Aggregate!
               edges: [Interface2Edge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -6541,6 +6847,15 @@ describe("Interface Relationships", () => {
               interface1Connection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [Type1Interface1ConnectionSort!], where: Type1Interface1ConnectionWhere): Type1Interface1Connection!
             }
 
+            type Type1Aggregate {
+              node: Type1AggregateNode!
+            }
+
+            type Type1AggregateNode {
+              count: Int!
+              field1: StringAggregateSelection!
+            }
+
             type Type1AggregateSelection {
               count: Int!
               field1: StringAggregateSelection!
@@ -6567,6 +6882,10 @@ describe("Interface Relationships", () => {
               interface2Connection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [Interface1Interface2ConnectionSort!], where: Interface1Interface2ConnectionWhere): Interface1Interface2Connection!
             }
 
+            type Type1Interface1Aggregate {
+              node: Type1Interface1AggregateNode!
+            }
+
             input Type1Interface1AggregateInput {
               AND: [Type1Interface1AggregateInput!]
               NOT: Type1Interface1AggregateInput
@@ -6578,6 +6897,11 @@ describe("Interface Relationships", () => {
               count_LT: Int
               count_LTE: Int
               node: Type1Interface1NodeAggregationWhereInput
+            }
+
+            type Type1Interface1AggregateNode {
+              count: Int!
+              field1: StringAggregateSelection!
             }
 
             type Type1Interface1AggregateSelection {
@@ -6842,6 +7166,7 @@ describe("Interface Relationships", () => {
             }
 
             type Type1Interface1sConnection {
+              aggregate: Type1Interface1Aggregate!
               edges: [Type1Interface1Edge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -6849,6 +7174,15 @@ describe("Interface Relationships", () => {
 
             type Type1Interface2 implements Interface2 {
               field2: String!
+            }
+
+            type Type1Interface2Aggregate {
+              node: Type1Interface2AggregateNode!
+            }
+
+            type Type1Interface2AggregateNode {
+              count: Int!
+              field2: StringAggregateSelection!
             }
 
             type Type1Interface2AggregateSelection {
@@ -6899,6 +7233,7 @@ describe("Interface Relationships", () => {
             }
 
             type Type1Interface2sConnection {
+              aggregate: Type1Interface2Aggregate!
               edges: [Type1Interface2Edge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -7026,6 +7361,7 @@ describe("Interface Relationships", () => {
             }
 
             type Type1sConnection {
+              aggregate: Type1Aggregate!
               edges: [Type1Edge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -7036,6 +7372,15 @@ describe("Interface Relationships", () => {
               interface2(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), limit: Int, offset: Int, options: Interface2Options @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [Interface2Sort!], where: Interface2Where): [Interface2!]!
               interface2Aggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: Interface2Where): Type2Interface1Interface2Interface2AggregationSelection
               interface2Connection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [Interface1Interface2ConnectionSort!], where: Interface1Interface2ConnectionWhere): Interface1Interface2Connection!
+            }
+
+            type Type2Interface1Aggregate {
+              node: Type2Interface1AggregateNode!
+            }
+
+            type Type2Interface1AggregateNode {
+              count: Int!
+              field1: StringAggregateSelection!
             }
 
             type Type2Interface1AggregateSelection {
@@ -7211,6 +7556,7 @@ describe("Interface Relationships", () => {
             }
 
             type Type2Interface1sConnection {
+              aggregate: Type2Interface1Aggregate!
               edges: [Type2Interface1Edge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -7218,6 +7564,15 @@ describe("Interface Relationships", () => {
 
             type Type2Interface2 implements Interface2 {
               field2: String!
+            }
+
+            type Type2Interface2Aggregate {
+              node: Type2Interface2AggregateNode!
+            }
+
+            type Type2Interface2AggregateNode {
+              count: Int!
+              field2: StringAggregateSelection!
             }
 
             type Type2Interface2AggregateSelection {
@@ -7268,6 +7623,7 @@ describe("Interface Relationships", () => {
             }
 
             type Type2Interface2sConnection {
+              aggregate: Type2Interface2Aggregate!
               edges: [Type2Interface2Edge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -7424,6 +7780,16 @@ describe("Interface Relationships", () => {
               post(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), limit: Int, offset: Int, options: PostOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PostSort!], where: PostWhere): Post!
               postAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: PostWhere): CommentPostPostAggregationSelection
               postConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [CommentPostConnectionSort!], where: CommentPostConnectionWhere): CommentPostConnection!
+            }
+
+            type CommentAggregate {
+              node: CommentAggregateNode!
+            }
+
+            type CommentAggregateNode {
+              content: StringAggregateSelection!
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
             type CommentAggregateSelection {
@@ -7716,6 +8082,7 @@ describe("Interface Relationships", () => {
             }
 
             type CommentsConnection {
+              aggregate: CommentAggregate!
               edges: [CommentEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -7726,6 +8093,16 @@ describe("Interface Relationships", () => {
               creator(limit: Int, offset: Int, options: UserOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [UserSort!], where: UserWhere): User!
               creatorConnection(after: String, first: Int, sort: [ContentCreatorConnectionSort!], where: ContentCreatorConnectionWhere): ContentCreatorConnection!
               id: ID
+            }
+
+            type ContentAggregate {
+              node: ContentAggregateNode!
+            }
+
+            type ContentAggregateNode {
+              content: StringAggregateSelection!
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
             type ContentAggregateSelection {
@@ -7916,6 +8293,7 @@ describe("Interface Relationships", () => {
             }
 
             type ContentsConnection {
+              aggregate: ContentAggregate!
               edges: [ContentEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -7986,6 +8364,16 @@ describe("Interface Relationships", () => {
               creatorAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: UserWhere): PostUserCreatorAggregationSelection
               creatorConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [ContentCreatorConnectionSort!], where: ContentCreatorConnectionWhere): ContentCreatorConnection!
               id: ID
+            }
+
+            type PostAggregate {
+              node: PostAggregateNode!
+            }
+
+            type PostAggregateNode {
+              content: StringAggregateSelection!
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
             type PostAggregateSelection {
@@ -8300,6 +8688,7 @@ describe("Interface Relationships", () => {
             }
 
             type PostsConnection {
+              aggregate: PostAggregate!
               edges: [PostEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -8364,6 +8753,16 @@ describe("Interface Relationships", () => {
               contentConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [UserContentConnectionSort!], where: UserContentConnectionWhere): UserContentConnection!
               id: ID
               name: String
+            }
+
+            type UserAggregate {
+              node: UserAggregateNode!
+            }
+
+            type UserAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              name: StringAggregateSelection!
             }
 
             type UserAggregateSelection {
@@ -8581,6 +8980,7 @@ describe("Interface Relationships", () => {
             }
 
             type UsersConnection {
+              aggregate: UserAggregate!
               edges: [UserEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -8805,6 +9205,15 @@ describe("Interface Relationships", () => {
               where: ActorActedInConnectionWhere
             }
 
+            type ActorAggregate {
+              node: ActorAggregateNode!
+            }
+
+            type ActorAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
             type ActorAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -8910,6 +9319,7 @@ describe("Interface Relationships", () => {
             }
 
             type ActorsConnection {
+              aggregate: ActorAggregate!
               edges: [ActorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -9044,6 +9454,16 @@ describe("Interface Relationships", () => {
               where: ShowActorsConnectionWhere
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              runtime: IntAggregateSelection!
+              title: StringAggregateSelection!
+            }
+
             type MovieAggregateSelection {
               count: Int!
               runtime: IntAggregateSelection!
@@ -9137,6 +9557,7 @@ describe("Interface Relationships", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -9165,6 +9586,15 @@ describe("Interface Relationships", () => {
             interface Production {
               actors: [Actor!]!
               title: String!
+            }
+
+            type ProductionAggregate {
+              node: ProductionAggregateNode!
+            }
+
+            type ProductionAggregateNode {
+              count: Int!
+              title: StringAggregateSelection!
             }
 
             type ProductionAggregateSelection {
@@ -9213,6 +9643,7 @@ describe("Interface Relationships", () => {
             }
 
             type ProductionsConnection {
+              aggregate: ProductionAggregate!
               edges: [ProductionEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -9327,6 +9758,16 @@ describe("Interface Relationships", () => {
               where: ShowActorsConnectionWhere
             }
 
+            type SeriesAggregate {
+              node: SeriesAggregateNode!
+            }
+
+            type SeriesAggregateNode {
+              count: Int!
+              episodeCount: IntAggregateSelection!
+              title: StringAggregateSelection!
+            }
+
             type SeriesAggregateSelection {
               count: Int!
               episodeCount: IntAggregateSelection!
@@ -9334,6 +9775,7 @@ describe("Interface Relationships", () => {
             }
 
             type SeriesConnection {
+              aggregate: SeriesAggregate!
               edges: [SeriesEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -9597,6 +10039,15 @@ describe("Interface Relationships", () => {
               where: ShowActorsConnectionWhere
             }
 
+            type ShowAggregate {
+              node: ShowAggregateNode!
+            }
+
+            type ShowAggregateNode {
+              count: Int!
+              title: StringAggregateSelection!
+            }
+
             type ShowAggregateSelection {
               count: Int!
               title: StringAggregateSelection!
@@ -9695,6 +10146,7 @@ describe("Interface Relationships", () => {
             }
 
             type ShowsConnection {
+              aggregate: ShowAggregate!
               edges: [ShowEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/interface-relationships.test.ts
+++ b/packages/graphql/tests/schema/interface-relationships.test.ts
@@ -553,16 +553,16 @@ describe("Interface Relationships", () => {
 
             type Query {
               actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
               actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
               productions(limit: Int, offset: Int, options: ProductionOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ProductionSort!], where: ProductionWhere): [Production!]!
-              productionsAggregate(where: ProductionWhere): ProductionAggregateSelection!
+              productionsAggregate(where: ProductionWhere): ProductionAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"productionsConnection\\\\\\"\\")
               productionsConnection(after: String, first: Int, sort: [ProductionSort!], where: ProductionWhere): ProductionsConnection!
               series(limit: Int, offset: Int, options: SeriesOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [SeriesSort!], where: SeriesWhere): [Series!]!
-              seriesAggregate(where: SeriesWhere): SeriesAggregateSelection!
+              seriesAggregate(where: SeriesWhere): SeriesAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"seriesConnection\\\\\\"\\")
               seriesConnection(after: String, first: Int, sort: [SeriesSort!], where: SeriesWhere): SeriesConnection!
             }
 
@@ -1777,19 +1777,19 @@ describe("Interface Relationships", () => {
 
             type Query {
               actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
               actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
               episodes(limit: Int, offset: Int, options: EpisodeOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [EpisodeSort!], where: EpisodeWhere): [Episode!]!
-              episodesAggregate(where: EpisodeWhere): EpisodeAggregateSelection!
+              episodesAggregate(where: EpisodeWhere): EpisodeAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"episodesConnection\\\\\\"\\")
               episodesConnection(after: String, first: Int, sort: [EpisodeSort!], where: EpisodeWhere): EpisodesConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
               productions(limit: Int, offset: Int, options: ProductionOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ProductionSort!], where: ProductionWhere): [Production!]!
-              productionsAggregate(where: ProductionWhere): ProductionAggregateSelection!
+              productionsAggregate(where: ProductionWhere): ProductionAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"productionsConnection\\\\\\"\\")
               productionsConnection(after: String, first: Int, sort: [ProductionSort!], where: ProductionWhere): ProductionsConnection!
               series(limit: Int, offset: Int, options: SeriesOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [SeriesSort!], where: SeriesWhere): [Series!]!
-              seriesAggregate(where: SeriesWhere): SeriesAggregateSelection!
+              seriesAggregate(where: SeriesWhere): SeriesAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"seriesConnection\\\\\\"\\")
               seriesConnection(after: String, first: Int, sort: [SeriesSort!], where: SeriesWhere): SeriesConnection!
             }
 
@@ -3305,19 +3305,19 @@ describe("Interface Relationships", () => {
 
             type Query {
               actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
               actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
               episodes(limit: Int, offset: Int, options: EpisodeOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [EpisodeSort!], where: EpisodeWhere): [Episode!]!
-              episodesAggregate(where: EpisodeWhere): EpisodeAggregateSelection!
+              episodesAggregate(where: EpisodeWhere): EpisodeAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"episodesConnection\\\\\\"\\")
               episodesConnection(after: String, first: Int, sort: [EpisodeSort!], where: EpisodeWhere): EpisodesConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
               productions(limit: Int, offset: Int, options: ProductionOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ProductionSort!], where: ProductionWhere): [Production!]!
-              productionsAggregate(where: ProductionWhere): ProductionAggregateSelection!
+              productionsAggregate(where: ProductionWhere): ProductionAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"productionsConnection\\\\\\"\\")
               productionsConnection(after: String, first: Int, sort: [ProductionSort!], where: ProductionWhere): ProductionsConnection!
               series(limit: Int, offset: Int, options: SeriesOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [SeriesSort!], where: SeriesWhere): [Series!]!
-              seriesAggregate(where: SeriesWhere): SeriesAggregateSelection!
+              seriesAggregate(where: SeriesWhere): SeriesAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"seriesConnection\\\\\\"\\")
               seriesConnection(after: String, first: Int, sort: [SeriesSort!], where: SeriesWhere): SeriesConnection!
             }
 
@@ -4188,25 +4188,25 @@ describe("Interface Relationships", () => {
 
             type Query {
               interface1s(limit: Int, offset: Int, options: Interface1Options @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [Interface1Sort!], where: Interface1Where): [Interface1!]!
-              interface1sAggregate(where: Interface1Where): Interface1AggregateSelection!
+              interface1sAggregate(where: Interface1Where): Interface1AggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"interface1sConnection\\\\\\"\\")
               interface1sConnection(after: String, first: Int, sort: [Interface1Sort!], where: Interface1Where): Interface1sConnection!
               interface2s(limit: Int, offset: Int, options: Interface2Options @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [Interface2Sort!], where: Interface2Where): [Interface2!]!
-              interface2sAggregate(where: Interface2Where): Interface2AggregateSelection!
+              interface2sAggregate(where: Interface2Where): Interface2AggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"interface2sConnection\\\\\\"\\")
               interface2sConnection(after: String, first: Int, sort: [Interface2Sort!], where: Interface2Where): Interface2sConnection!
               type1Interface1s(limit: Int, offset: Int, options: Type1Interface1Options @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [Type1Interface1Sort!], where: Type1Interface1Where): [Type1Interface1!]!
-              type1Interface1sAggregate(where: Type1Interface1Where): Type1Interface1AggregateSelection!
+              type1Interface1sAggregate(where: Type1Interface1Where): Type1Interface1AggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"type1Interface1sConnection\\\\\\"\\")
               type1Interface1sConnection(after: String, first: Int, sort: [Type1Interface1Sort!], where: Type1Interface1Where): Type1Interface1sConnection!
               type1Interface2s(limit: Int, offset: Int, options: Type1Interface2Options @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [Type1Interface2Sort!], where: Type1Interface2Where): [Type1Interface2!]!
-              type1Interface2sAggregate(where: Type1Interface2Where): Type1Interface2AggregateSelection!
+              type1Interface2sAggregate(where: Type1Interface2Where): Type1Interface2AggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"type1Interface2sConnection\\\\\\"\\")
               type1Interface2sConnection(after: String, first: Int, sort: [Type1Interface2Sort!], where: Type1Interface2Where): Type1Interface2sConnection!
               type1s(limit: Int, offset: Int, options: Type1Options @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [Type1Sort!], where: Type1Where): [Type1!]!
-              type1sAggregate(where: Type1Where): Type1AggregateSelection!
+              type1sAggregate(where: Type1Where): Type1AggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"type1sConnection\\\\\\"\\")
               type1sConnection(after: String, first: Int, sort: [Type1Sort!], where: Type1Where): Type1sConnection!
               type2Interface1s(limit: Int, offset: Int, options: Type2Interface1Options @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [Type2Interface1Sort!], where: Type2Interface1Where): [Type2Interface1!]!
-              type2Interface1sAggregate(where: Type2Interface1Where): Type2Interface1AggregateSelection!
+              type2Interface1sAggregate(where: Type2Interface1Where): Type2Interface1AggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"type2Interface1sConnection\\\\\\"\\")
               type2Interface1sConnection(after: String, first: Int, sort: [Type2Interface1Sort!], where: Type2Interface1Where): Type2Interface1sConnection!
               type2Interface2s(limit: Int, offset: Int, options: Type2Interface2Options @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [Type2Interface2Sort!], where: Type2Interface2Where): [Type2Interface2!]!
-              type2Interface2sAggregate(where: Type2Interface2Where): Type2Interface2AggregateSelection!
+              type2Interface2sAggregate(where: Type2Interface2Where): Type2Interface2AggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"type2Interface2sConnection\\\\\\"\\")
               type2Interface2sConnection(after: String, first: Int, sort: [Type2Interface2Sort!], where: Type2Interface2Where): Type2Interface2sConnection!
             }
 
@@ -5506,25 +5506,25 @@ describe("Interface Relationships", () => {
 
             type Query {
               interface1s(limit: Int, offset: Int, options: Interface1Options @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [Interface1Sort!], where: Interface1Where): [Interface1!]!
-              interface1sAggregate(where: Interface1Where): Interface1AggregateSelection!
+              interface1sAggregate(where: Interface1Where): Interface1AggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"interface1sConnection\\\\\\"\\")
               interface1sConnection(after: String, first: Int, sort: [Interface1Sort!], where: Interface1Where): Interface1sConnection!
               interface2s(limit: Int, offset: Int, options: Interface2Options @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [Interface2Sort!], where: Interface2Where): [Interface2!]!
-              interface2sAggregate(where: Interface2Where): Interface2AggregateSelection!
+              interface2sAggregate(where: Interface2Where): Interface2AggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"interface2sConnection\\\\\\"\\")
               interface2sConnection(after: String, first: Int, sort: [Interface2Sort!], where: Interface2Where): Interface2sConnection!
               type1Interface1s(limit: Int, offset: Int, options: Type1Interface1Options @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [Type1Interface1Sort!], where: Type1Interface1Where): [Type1Interface1!]!
-              type1Interface1sAggregate(where: Type1Interface1Where): Type1Interface1AggregateSelection!
+              type1Interface1sAggregate(where: Type1Interface1Where): Type1Interface1AggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"type1Interface1sConnection\\\\\\"\\")
               type1Interface1sConnection(after: String, first: Int, sort: [Type1Interface1Sort!], where: Type1Interface1Where): Type1Interface1sConnection!
               type1Interface2s(limit: Int, offset: Int, options: Type1Interface2Options @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [Type1Interface2Sort!], where: Type1Interface2Where): [Type1Interface2!]!
-              type1Interface2sAggregate(where: Type1Interface2Where): Type1Interface2AggregateSelection!
+              type1Interface2sAggregate(where: Type1Interface2Where): Type1Interface2AggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"type1Interface2sConnection\\\\\\"\\")
               type1Interface2sConnection(after: String, first: Int, sort: [Type1Interface2Sort!], where: Type1Interface2Where): Type1Interface2sConnection!
               type1s(limit: Int, offset: Int, options: Type1Options @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [Type1Sort!], where: Type1Where): [Type1!]!
-              type1sAggregate(where: Type1Where): Type1AggregateSelection!
+              type1sAggregate(where: Type1Where): Type1AggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"type1sConnection\\\\\\"\\")
               type1sConnection(after: String, first: Int, sort: [Type1Sort!], where: Type1Where): Type1sConnection!
               type2Interface1s(limit: Int, offset: Int, options: Type2Interface1Options @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [Type2Interface1Sort!], where: Type2Interface1Where): [Type2Interface1!]!
-              type2Interface1sAggregate(where: Type2Interface1Where): Type2Interface1AggregateSelection!
+              type2Interface1sAggregate(where: Type2Interface1Where): Type2Interface1AggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"type2Interface1sConnection\\\\\\"\\")
               type2Interface1sConnection(after: String, first: Int, sort: [Type2Interface1Sort!], where: Type2Interface1Where): Type2Interface1sConnection!
               type2Interface2s(limit: Int, offset: Int, options: Type2Interface2Options @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [Type2Interface2Sort!], where: Type2Interface2Where): [Type2Interface2!]!
-              type2Interface2sAggregate(where: Type2Interface2Where): Type2Interface2AggregateSelection!
+              type2Interface2sAggregate(where: Type2Interface2Where): Type2Interface2AggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"type2Interface2sConnection\\\\\\"\\")
               type2Interface2sConnection(after: String, first: Int, sort: [Type2Interface2Sort!], where: Type2Interface2Where): Type2Interface2sConnection!
             }
 
@@ -6805,25 +6805,25 @@ describe("Interface Relationships", () => {
 
             type Query {
               interface1s(limit: Int, offset: Int, options: Interface1Options @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [Interface1Sort!], where: Interface1Where): [Interface1!]!
-              interface1sAggregate(where: Interface1Where): Interface1AggregateSelection!
+              interface1sAggregate(where: Interface1Where): Interface1AggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"interface1sConnection\\\\\\"\\")
               interface1sConnection(after: String, first: Int, sort: [Interface1Sort!], where: Interface1Where): Interface1sConnection!
               interface2s(limit: Int, offset: Int, options: Interface2Options @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [Interface2Sort!], where: Interface2Where): [Interface2!]!
-              interface2sAggregate(where: Interface2Where): Interface2AggregateSelection!
+              interface2sAggregate(where: Interface2Where): Interface2AggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"interface2sConnection\\\\\\"\\")
               interface2sConnection(after: String, first: Int, sort: [Interface2Sort!], where: Interface2Where): Interface2sConnection!
               type1Interface1s(limit: Int, offset: Int, options: Type1Interface1Options @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [Type1Interface1Sort!], where: Type1Interface1Where): [Type1Interface1!]!
-              type1Interface1sAggregate(where: Type1Interface1Where): Type1Interface1AggregateSelection!
+              type1Interface1sAggregate(where: Type1Interface1Where): Type1Interface1AggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"type1Interface1sConnection\\\\\\"\\")
               type1Interface1sConnection(after: String, first: Int, sort: [Type1Interface1Sort!], where: Type1Interface1Where): Type1Interface1sConnection!
               type1Interface2s(limit: Int, offset: Int, options: Type1Interface2Options @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [Type1Interface2Sort!], where: Type1Interface2Where): [Type1Interface2!]!
-              type1Interface2sAggregate(where: Type1Interface2Where): Type1Interface2AggregateSelection!
+              type1Interface2sAggregate(where: Type1Interface2Where): Type1Interface2AggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"type1Interface2sConnection\\\\\\"\\")
               type1Interface2sConnection(after: String, first: Int, sort: [Type1Interface2Sort!], where: Type1Interface2Where): Type1Interface2sConnection!
               type1s(limit: Int, offset: Int, options: Type1Options @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [Type1Sort!], where: Type1Where): [Type1!]!
-              type1sAggregate(where: Type1Where): Type1AggregateSelection!
+              type1sAggregate(where: Type1Where): Type1AggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"type1sConnection\\\\\\"\\")
               type1sConnection(after: String, first: Int, sort: [Type1Sort!], where: Type1Where): Type1sConnection!
               type2Interface1s(limit: Int, offset: Int, options: Type2Interface1Options @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [Type2Interface1Sort!], where: Type2Interface1Where): [Type2Interface1!]!
-              type2Interface1sAggregate(where: Type2Interface1Where): Type2Interface1AggregateSelection!
+              type2Interface1sAggregate(where: Type2Interface1Where): Type2Interface1AggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"type2Interface1sConnection\\\\\\"\\")
               type2Interface1sConnection(after: String, first: Int, sort: [Type2Interface1Sort!], where: Type2Interface1Where): Type2Interface1sConnection!
               type2Interface2s(limit: Int, offset: Int, options: Type2Interface2Options @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [Type2Interface2Sort!], where: Type2Interface2Where): [Type2Interface2!]!
-              type2Interface2sAggregate(where: Type2Interface2Where): Type2Interface2AggregateSelection!
+              type2Interface2sAggregate(where: Type2Interface2Where): Type2Interface2AggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"type2Interface2sConnection\\\\\\"\\")
               type2Interface2sConnection(after: String, first: Int, sort: [Type2Interface2Sort!], where: Type2Interface2Where): Type2Interface2sConnection!
             }
 
@@ -8696,16 +8696,16 @@ describe("Interface Relationships", () => {
 
             type Query {
               comments(limit: Int, offset: Int, options: CommentOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [CommentSort!], where: CommentWhere): [Comment!]!
-              commentsAggregate(where: CommentWhere): CommentAggregateSelection!
+              commentsAggregate(where: CommentWhere): CommentAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"commentsConnection\\\\\\"\\")
               commentsConnection(after: String, first: Int, sort: [CommentSort!], where: CommentWhere): CommentsConnection!
               contents(limit: Int, offset: Int, options: ContentOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ContentSort!], where: ContentWhere): [Content!]!
-              contentsAggregate(where: ContentWhere): ContentAggregateSelection!
+              contentsAggregate(where: ContentWhere): ContentAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"contentsConnection\\\\\\"\\")
               contentsConnection(after: String, first: Int, sort: [ContentSort!], where: ContentWhere): ContentsConnection!
               posts(limit: Int, offset: Int, options: PostOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PostSort!], where: PostWhere): [Post!]!
-              postsAggregate(where: PostWhere): PostAggregateSelection!
+              postsAggregate(where: PostWhere): PostAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"postsConnection\\\\\\"\\")
               postsConnection(after: String, first: Int, sort: [PostSort!], where: PostWhere): PostsConnection!
               users(limit: Int, offset: Int, options: UserOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [UserSort!], where: UserWhere): [User!]!
-              usersAggregate(where: UserWhere): UserAggregateSelection!
+              usersAggregate(where: UserWhere): UserAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"usersConnection\\\\\\"\\")
               usersConnection(after: String, first: Int, sort: [UserSort!], where: UserWhere): UsersConnection!
             }
 
@@ -9651,19 +9651,19 @@ describe("Interface Relationships", () => {
 
             type Query {
               actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
               actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
               productions(limit: Int, offset: Int, options: ProductionOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ProductionSort!], where: ProductionWhere): [Production!]!
-              productionsAggregate(where: ProductionWhere): ProductionAggregateSelection!
+              productionsAggregate(where: ProductionWhere): ProductionAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"productionsConnection\\\\\\"\\")
               productionsConnection(after: String, first: Int, sort: [ProductionSort!], where: ProductionWhere): ProductionsConnection!
               series(limit: Int, offset: Int, options: SeriesOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [SeriesSort!], where: SeriesWhere): [Series!]!
-              seriesAggregate(where: SeriesWhere): SeriesAggregateSelection!
+              seriesAggregate(where: SeriesWhere): SeriesAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"seriesConnection\\\\\\"\\")
               seriesConnection(after: String, first: Int, sort: [SeriesSort!], where: SeriesWhere): SeriesConnection!
               shows(limit: Int, offset: Int, options: ShowOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ShowSort!], where: ShowWhere): [Show!]!
-              showsAggregate(where: ShowWhere): ShowAggregateSelection!
+              showsAggregate(where: ShowWhere): ShowAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"showsConnection\\\\\\"\\")
               showsConnection(after: String, first: Int, sort: [ShowSort!], where: ShowWhere): ShowsConnection!
             }
 

--- a/packages/graphql/tests/schema/interfaces.test.ts
+++ b/packages/graphql/tests/schema/interfaces.test.ts
@@ -438,10 +438,10 @@ describe("Interfaces", () => {
 
             type Query {
               movieNodes(limit: Int, offset: Int, options: MovieNodeOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieNodeSort!], where: MovieNodeWhere): [MovieNode!]!
-              movieNodesAggregate(where: MovieNodeWhere): MovieNodeAggregateSelection!
+              movieNodesAggregate(where: MovieNodeWhere): MovieNodeAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"movieNodesConnection\\\\\\"\\")
               movieNodesConnection(after: String, first: Int, sort: [MovieNodeSort!], where: MovieNodeWhere): MovieNodesConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 
@@ -888,10 +888,10 @@ describe("Interfaces", () => {
 
             type Query {
               movieNodes(limit: Int, offset: Int, options: MovieNodeOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieNodeSort!], where: MovieNodeWhere): [MovieNode!]!
-              movieNodesAggregate(where: MovieNodeWhere): MovieNodeAggregateSelection!
+              movieNodesAggregate(where: MovieNodeWhere): MovieNodeAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"movieNodesConnection\\\\\\"\\")
               movieNodesConnection(after: String, first: Int, sort: [MovieNodeSort!], where: MovieNodeWhere): MovieNodesConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 

--- a/packages/graphql/tests/schema/interfaces.test.ts
+++ b/packages/graphql/tests/schema/interfaces.test.ts
@@ -89,6 +89,15 @@ describe("Interfaces", () => {
               nodes: [MovieNode]
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+            }
+
             type MovieAggregateSelection {
               count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -194,6 +203,15 @@ describe("Interfaces", () => {
               id: ID
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
               moviesConnection(after: String, first: Int, sort: [MovieNodeMoviesConnectionSort!], where: MovieNodeMoviesConnectionWhere): MovieNodeMoviesConnection!
+            }
+
+            type MovieNodeAggregate {
+              node: MovieNodeAggregateNode!
+            }
+
+            type MovieNodeAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
             type MovieNodeAggregateSelection {
@@ -327,6 +345,7 @@ describe("Interfaces", () => {
             }
 
             type MovieNodesConnection {
+              aggregate: MovieNodeAggregate!
               edges: [MovieNodeEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -397,6 +416,7 @@ describe("Interfaces", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -519,6 +539,15 @@ describe("Interfaces", () => {
               nodes: [MovieNode]
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+            }
+
             type MovieAggregateSelection {
               count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -624,6 +653,15 @@ describe("Interfaces", () => {
               id: ID
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
               moviesConnection(after: String, first: Int, sort: [MovieNodeMoviesConnectionSort!], where: MovieNodeMoviesConnectionWhere): MovieNodeMoviesConnection!
+            }
+
+            type MovieNodeAggregate {
+              node: MovieNodeAggregateNode!
+            }
+
+            type MovieNodeAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
             type MovieNodeAggregateSelection {
@@ -757,6 +795,7 @@ describe("Interfaces", () => {
             }
 
             type MovieNodesConnection {
+              aggregate: MovieNodeAggregate!
               edges: [MovieNodeEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -827,6 +866,7 @@ describe("Interfaces", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/issues/1038.test.ts
+++ b/packages/graphql/tests/schema/issues/1038.test.ts
@@ -249,10 +249,10 @@ describe("https://github.com/neo4j/graphql/issues/1038", () => {
 
             type Query {
               awsAccounts(limit: Int, offset: Int, options: AWSAccountOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [AWSAccountSort!], where: AWSAccountWhere): [AWSAccount!]!
-              awsAccountsAggregate(where: AWSAccountWhere): AWSAccountAggregateSelection!
+              awsAccountsAggregate(where: AWSAccountWhere): AWSAccountAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"awsAccountsConnection\\\\\\"\\")
               awsAccountsConnection(after: String, first: Int, sort: [AWSAccountSort!], where: AWSAccountWhere): AwsAccountsConnection!
               dnsZones(limit: Int, offset: Int, options: DNSZoneOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [DNSZoneSort!], where: DNSZoneWhere): [DNSZone!]!
-              dnsZonesAggregate(where: DNSZoneWhere): DNSZoneAggregateSelection!
+              dnsZonesAggregate(where: DNSZoneWhere): DNSZoneAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"dnsZonesConnection\\\\\\"\\")
               dnsZonesConnection(after: String, first: Int, sort: [DNSZoneSort!], where: DNSZoneWhere): DnsZonesConnection!
             }
 

--- a/packages/graphql/tests/schema/issues/1038.test.ts
+++ b/packages/graphql/tests/schema/issues/1038.test.ts
@@ -49,6 +49,16 @@ describe("https://github.com/neo4j/graphql/issues/1038", () => {
               code: String
             }
 
+            type AWSAccountAggregate {
+              node: AWSAccountAggregateNode!
+            }
+
+            type AWSAccountAggregateNode {
+              accountName: StringAggregateSelection!
+              code: StringAggregateSelection!
+              count: Int!
+            }
+
             type AWSAccountAggregateSelection {
               accountName: StringAggregateSelection!
               code: StringAggregateSelection!
@@ -108,6 +118,7 @@ describe("https://github.com/neo4j/graphql/issues/1038", () => {
             }
 
             type AwsAccountsConnection {
+              aggregate: AWSAccountAggregate!
               edges: [AWSAccountEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -134,6 +145,16 @@ describe("https://github.com/neo4j/graphql/issues/1038", () => {
             type DNSZone {
               awsId: String
               zoneType: String
+            }
+
+            type DNSZoneAggregate {
+              node: DNSZoneAggregateNode!
+            }
+
+            type DNSZoneAggregateNode {
+              awsId: StringAggregateSelection!
+              count: Int!
+              zoneType: StringAggregateSelection!
             }
 
             type DNSZoneAggregateSelection {
@@ -203,6 +224,7 @@ describe("https://github.com/neo4j/graphql/issues/1038", () => {
             }
 
             type DnsZonesConnection {
+              aggregate: DNSZoneAggregate!
               edges: [DNSZoneEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/issues/1182.test.ts
+++ b/packages/graphql/tests/schema/issues/1182.test.ts
@@ -54,6 +54,17 @@ describe("https://github.com/neo4j/graphql/issues/1182", () => {
               name: String!
             }
 
+            type ActorAggregate {
+              node: ActorAggregateNode!
+            }
+
+            type ActorAggregateNode {
+              count: Int!
+              dob: DateTimeAggregateSelection!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              name: StringAggregateSelection!
+            }
+
             type ActorAggregateSelection {
               count: Int!
               dob: DateTimeAggregateSelection!
@@ -153,6 +164,7 @@ describe("https://github.com/neo4j/graphql/issues/1182", () => {
             }
 
             type ActorsConnection {
+              aggregate: ActorAggregate!
               edges: [ActorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -341,6 +353,16 @@ describe("https://github.com/neo4j/graphql/issues/1182", () => {
               where: MovieActorsConnectionWhere
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              title: StringAggregateSelection!
+            }
+
             type MovieAggregateSelection {
               count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -428,6 +450,7 @@ describe("https://github.com/neo4j/graphql/issues/1182", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/issues/1182.test.ts
+++ b/packages/graphql/tests/schema/issues/1182.test.ts
@@ -500,10 +500,10 @@ describe("https://github.com/neo4j/graphql/issues/1182", () => {
 
             type Query {
               actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
               actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 

--- a/packages/graphql/tests/schema/issues/1575.test.ts
+++ b/packages/graphql/tests/schema/issues/1575.test.ts
@@ -180,7 +180,7 @@ describe("https://github.com/neo4j/graphql/issues/1575", () => {
 
             type Query {
               foos(limit: Int, offset: Int, options: FooOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [FooSort!], where: FooWhere): [Foo!]!
-              foosAggregate(where: FooWhere): FooAggregateSelection!
+              foosAggregate(where: FooWhere): FooAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"foosConnection\\\\\\"\\")
               foosConnection(after: String, first: Int, sort: [FooSort!], where: FooWhere): FoosConnection!
             }
 

--- a/packages/graphql/tests/schema/issues/1575.test.ts
+++ b/packages/graphql/tests/schema/issues/1575.test.ts
@@ -64,6 +64,14 @@ describe("https://github.com/neo4j/graphql/issues/1575", () => {
               point: Point
             }
 
+            type FooAggregate {
+              node: FooAggregateNode!
+            }
+
+            type FooAggregateNode {
+              count: Int!
+            }
+
             type FooAggregateSelection {
               count: Int!
             }
@@ -125,6 +133,7 @@ describe("https://github.com/neo4j/graphql/issues/1575", () => {
             }
 
             type FoosConnection {
+              aggregate: FooAggregate!
               edges: [FooEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/issues/1614.test.ts
+++ b/packages/graphql/tests/schema/issues/1614.test.ts
@@ -370,10 +370,10 @@ describe("https://github.com/neo4j/graphql/issues/1614", () => {
 
             type Query {
               crewMembers(limit: Int, offset: Int, options: CrewMemberOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: CrewMemberWhere): [CrewMember!]!
-              crewMembersAggregate(where: CrewMemberWhere): CrewMemberAggregateSelection!
+              crewMembersAggregate(where: CrewMemberWhere): CrewMemberAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"crewMembersConnection\\\\\\"\\")
               crewMembersConnection(after: String, first: Int, where: CrewMemberWhere): CrewMembersConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 

--- a/packages/graphql/tests/schema/issues/1614.test.ts
+++ b/packages/graphql/tests/schema/issues/1614.test.ts
@@ -77,6 +77,14 @@ describe("https://github.com/neo4j/graphql/issues/1614", () => {
               moviesConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [CrewMemberMoviesConnectionSort!], where: CrewMemberMoviesConnectionWhere): CrewMemberMoviesConnection!
             }
 
+            type CrewMemberAggregate {
+              node: CrewMemberAggregateNode!
+            }
+
+            type CrewMemberAggregateNode {
+              count: Int!
+            }
+
             type CrewMemberAggregateSelection {
               count: Int!
             }
@@ -222,6 +230,7 @@ describe("https://github.com/neo4j/graphql/issues/1614", () => {
             }
 
             type CrewMembersConnection {
+              aggregate: CrewMemberAggregate!
               edges: [CrewMemberEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -273,6 +282,15 @@ describe("https://github.com/neo4j/graphql/issues/1614", () => {
 
             type Movie {
               name: String!
+            }
+
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
             }
 
             type MovieAggregateSelection {
@@ -327,6 +345,7 @@ describe("https://github.com/neo4j/graphql/issues/1614", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/issues/162.test.ts
+++ b/packages/graphql/tests/schema/issues/162.test.ts
@@ -113,13 +113,13 @@ describe("162", () => {
 
             type Query {
               tigerJawLevel2Part1s(limit: Int, offset: Int, options: TigerJawLevel2Part1Options @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [TigerJawLevel2Part1Sort!], where: TigerJawLevel2Part1Where): [TigerJawLevel2Part1!]!
-              tigerJawLevel2Part1sAggregate(where: TigerJawLevel2Part1Where): TigerJawLevel2Part1AggregateSelection!
+              tigerJawLevel2Part1sAggregate(where: TigerJawLevel2Part1Where): TigerJawLevel2Part1AggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"tigerJawLevel2Part1sConnection\\\\\\"\\")
               tigerJawLevel2Part1sConnection(after: String, first: Int, sort: [TigerJawLevel2Part1Sort!], where: TigerJawLevel2Part1Where): TigerJawLevel2Part1sConnection!
               tigerJawLevel2s(limit: Int, offset: Int, options: TigerJawLevel2Options @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [TigerJawLevel2Sort!], where: TigerJawLevel2Where): [TigerJawLevel2!]!
-              tigerJawLevel2sAggregate(where: TigerJawLevel2Where): TigerJawLevel2AggregateSelection!
+              tigerJawLevel2sAggregate(where: TigerJawLevel2Where): TigerJawLevel2AggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"tigerJawLevel2sConnection\\\\\\"\\")
               tigerJawLevel2sConnection(after: String, first: Int, sort: [TigerJawLevel2Sort!], where: TigerJawLevel2Where): TigerJawLevel2sConnection!
               tigers(limit: Int, offset: Int, options: TigerOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [TigerSort!], where: TigerWhere): [Tiger!]!
-              tigersAggregate(where: TigerWhere): TigerAggregateSelection!
+              tigersAggregate(where: TigerWhere): TigerAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"tigersConnection\\\\\\"\\")
               tigersConnection(after: String, first: Int, sort: [TigerSort!], where: TigerWhere): TigersConnection!
             }
 

--- a/packages/graphql/tests/schema/issues/162.test.ts
+++ b/packages/graphql/tests/schema/issues/162.test.ts
@@ -135,6 +135,15 @@ describe("162", () => {
               x: Int
             }
 
+            type TigerAggregate {
+              node: TigerAggregateNode!
+            }
+
+            type TigerAggregateNode {
+              count: Int!
+              x: IntAggregateSelection!
+            }
+
             type TigerAggregateSelection {
               count: Int!
               x: IntAggregateSelection!
@@ -158,6 +167,15 @@ describe("162", () => {
               part1(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), limit: Int, offset: Int, options: TigerJawLevel2Part1Options @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [TigerJawLevel2Part1Sort!], where: TigerJawLevel2Part1Where): TigerJawLevel2Part1!
               part1Aggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: TigerJawLevel2Part1Where): TigerJawLevel2TigerJawLevel2Part1Part1AggregationSelection
               part1Connection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [TigerJawLevel2Part1ConnectionSort!], where: TigerJawLevel2Part1ConnectionWhere): TigerJawLevel2Part1Connection!
+            }
+
+            type TigerJawLevel2Aggregate {
+              node: TigerJawLevel2AggregateNode!
+            }
+
+            type TigerJawLevel2AggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
             type TigerJawLevel2AggregateSelection {
@@ -195,6 +213,10 @@ describe("162", () => {
               tigerConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [TigerJawLevel2Part1TigerConnectionSort!], where: TigerJawLevel2Part1TigerConnectionWhere): TigerJawLevel2Part1TigerConnection!
             }
 
+            type TigerJawLevel2Part1Aggregate {
+              node: TigerJawLevel2Part1AggregateNode!
+            }
+
             input TigerJawLevel2Part1AggregateInput {
               AND: [TigerJawLevel2Part1AggregateInput!]
               NOT: TigerJawLevel2Part1AggregateInput
@@ -206,6 +228,11 @@ describe("162", () => {
               count_LT: Int
               count_LTE: Int
               node: TigerJawLevel2Part1NodeAggregationWhereInput
+            }
+
+            type TigerJawLevel2Part1AggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
             type TigerJawLevel2Part1AggregateSelection {
@@ -464,6 +491,7 @@ describe("162", () => {
             }
 
             type TigerJawLevel2Part1sConnection {
+              aggregate: TigerJawLevel2Part1Aggregate!
               edges: [TigerJawLevel2Part1Edge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -507,6 +535,7 @@ describe("162", () => {
             }
 
             type TigerJawLevel2sConnection {
+              aggregate: TigerJawLevel2Aggregate!
               edges: [TigerJawLevel2Edge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -549,6 +578,7 @@ describe("162", () => {
             }
 
             type TigersConnection {
+              aggregate: TigerAggregate!
               edges: [TigerEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/issues/200.test.ts
+++ b/packages/graphql/tests/schema/issues/200.test.ts
@@ -182,7 +182,7 @@ describe("200", () => {
 
             type Query {
               categories(limit: Int, offset: Int, options: CategoryOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [CategorySort!], where: CategoryWhere): [Category!]!
-              categoriesAggregate(where: CategoryWhere): CategoryAggregateSelection!
+              categoriesAggregate(where: CategoryWhere): CategoryAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"categoriesConnection\\\\\\"\\")
               categoriesConnection(after: String, first: Int, sort: [CategorySort!], where: CategoryWhere): CategoriesConnection!
             }
 

--- a/packages/graphql/tests/schema/issues/200.test.ts
+++ b/packages/graphql/tests/schema/issues/200.test.ts
@@ -42,6 +42,7 @@ describe("200", () => {
             }
 
             type CategoriesConnection {
+              aggregate: CategoryAggregate!
               edges: [CategoryEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -52,6 +53,17 @@ describe("200", () => {
               description: String!
               exampleImageLocations: [String!]
               name: String!
+            }
+
+            type CategoryAggregate {
+              node: CategoryAggregateNode!
+            }
+
+            type CategoryAggregateNode {
+              categoryId: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              count: Int!
+              description: StringAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             type CategoryAggregateSelection {

--- a/packages/graphql/tests/schema/issues/2187.test.ts
+++ b/packages/graphql/tests/schema/issues/2187.test.ts
@@ -621,10 +621,10 @@ describe("https://github.com/neo4j/graphql/issues/2187", () => {
 
             type Query {
               genres(limit: Int, offset: Int, options: GenreOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [GenreSort!], where: GenreWhere): [Genre!]!
-              genresAggregate(where: GenreWhere): GenreAggregateSelection!
+              genresAggregate(where: GenreWhere): GenreAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"genresConnection\\\\\\"\\")
               genresConnection(after: String, first: Int, sort: [GenreSort!], where: GenreWhere): GenresConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 

--- a/packages/graphql/tests/schema/issues/2187.test.ts
+++ b/packages/graphql/tests/schema/issues/2187.test.ts
@@ -88,6 +88,15 @@ describe("https://github.com/neo4j/graphql/issues/2187", () => {
               name: String
             }
 
+            type GenreAggregate {
+              node: GenreAggregateNode!
+            }
+
+            type GenreAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
             type GenreAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -327,6 +336,7 @@ describe("https://github.com/neo4j/graphql/issues/2187", () => {
             }
 
             type GenresConnection {
+              aggregate: GenreAggregate!
               edges: [GenreEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -346,6 +356,17 @@ describe("https://github.com/neo4j/graphql/issues/2187", () => {
               imdbRating: Float
               title: String @deprecated(reason: \\"Do not use title\\")
               year: Int
+            }
+
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              imdbRating: FloatAggregateSelection!
+              title: StringAggregateSelection!
+              year: IntAggregateSelection!
             }
 
             type MovieAggregateSelection {
@@ -575,6 +596,7 @@ describe("https://github.com/neo4j/graphql/issues/2187", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/issues/2377.test.ts
+++ b/packages/graphql/tests/schema/issues/2377.test.ts
@@ -140,10 +140,10 @@ describe("https://github.com/neo4j/graphql/issues/2377", () => {
 
             type Query {
               resourceEntities(limit: Int, offset: Int, options: ResourceEntityOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ResourceEntitySort!], where: ResourceEntityWhere): [ResourceEntity!]!
-              resourceEntitiesAggregate(where: ResourceEntityWhere): ResourceEntityAggregateSelection!
+              resourceEntitiesAggregate(where: ResourceEntityWhere): ResourceEntityAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"resourceEntitiesConnection\\\\\\"\\")
               resourceEntitiesConnection(after: String, first: Int, sort: [ResourceEntitySort!], where: ResourceEntityWhere): ResourceEntitiesConnection!
               resources(limit: Int, offset: Int, options: ResourceOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ResourceSort!], where: ResourceWhere): [Resource!]!
-              resourcesAggregate(where: ResourceWhere): ResourceAggregateSelection!
+              resourcesAggregate(where: ResourceWhere): ResourceAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"resourcesConnection\\\\\\"\\")
               resourcesConnection(after: String, first: Int, sort: [ResourceSort!], where: ResourceWhere): ResourcesConnection!
             }
 

--- a/packages/graphql/tests/schema/issues/2377.test.ts
+++ b/packages/graphql/tests/schema/issues/2377.test.ts
@@ -165,6 +165,18 @@ describe("https://github.com/neo4j/graphql/issues/2377", () => {
               updatedAt: DateTime!
             }
 
+            type ResourceAggregate {
+              node: ResourceAggregateNode!
+            }
+
+            type ResourceAggregateNode {
+              count: Int!
+              createdAt: DateTimeAggregateSelection!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              name: StringAggregateSelection!
+              updatedAt: DateTimeAggregateSelection!
+            }
+
             type ResourceAggregateSelection {
               count: Int!
               createdAt: DateTimeAggregateSelection!
@@ -348,6 +360,7 @@ describe("https://github.com/neo4j/graphql/issues/2377", () => {
             }
 
             type ResourceEntitiesConnection {
+              aggregate: ResourceEntityAggregate!
               edges: [ResourceEntityEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -361,6 +374,16 @@ describe("https://github.com/neo4j/graphql/issues/2377", () => {
               tags: [Tag!]
               \\"\\"\\"Allowed resource types (enums)\\"\\"\\"
               type: ResourceType!
+            }
+
+            type ResourceEntityAggregate {
+              node: ResourceEntityAggregateNode!
+            }
+
+            type ResourceEntityAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              name: StringAggregateSelection!
             }
 
             type ResourceEntityAggregateSelection {
@@ -568,6 +591,7 @@ describe("https://github.com/neo4j/graphql/issues/2377", () => {
             }
 
             type ResourcesConnection {
+              aggregate: ResourceAggregate!
               edges: [ResourceEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/issues/2969.test.ts
+++ b/packages/graphql/tests/schema/issues/2969.test.ts
@@ -303,10 +303,10 @@ describe("https://github.com/neo4j/graphql/issues/2969", () => {
 
             type Query {
               posts(limit: Int, offset: Int, options: PostOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PostSort!], where: PostWhere): [Post!]!
-              postsAggregate(where: PostWhere): PostAggregateSelection!
+              postsAggregate(where: PostWhere): PostAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"postsConnection\\\\\\"\\")
               postsConnection(after: String, first: Int, sort: [PostSort!], where: PostWhere): PostsConnection!
               users(limit: Int, offset: Int, options: UserOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [UserSort!], where: UserWhere): [User!]!
-              usersAggregate(where: UserWhere): UserAggregateSelection!
+              usersAggregate(where: UserWhere): UserAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"usersConnection\\\\\\"\\")
               usersConnection(after: String, first: Int, sort: [UserSort!], where: UserWhere): UsersConnection!
             }
 

--- a/packages/graphql/tests/schema/issues/2969.test.ts
+++ b/packages/graphql/tests/schema/issues/2969.test.ts
@@ -100,6 +100,15 @@ describe("https://github.com/neo4j/graphql/issues/2969", () => {
               content: String!
             }
 
+            type PostAggregate {
+              node: PostAggregateNode!
+            }
+
+            type PostAggregateNode {
+              content: StringAggregateSelection!
+              count: Int!
+            }
+
             type PostAggregateSelection {
               content: StringAggregateSelection!
               count: Int!
@@ -286,6 +295,7 @@ describe("https://github.com/neo4j/graphql/issues/2969", () => {
             }
 
             type PostsConnection {
+              aggregate: PostAggregate!
               edges: [PostEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -339,6 +349,16 @@ describe("https://github.com/neo4j/graphql/issues/2969", () => {
               posts(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), limit: Int, offset: Int, options: PostOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PostSort!], where: PostWhere): [Post!]!
               postsAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: PostWhere): UserPostPostsAggregationSelection
               postsConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [UserPostsConnectionSort!], where: UserPostsConnectionWhere): UserPostsConnection!
+            }
+
+            type UserAggregate {
+              node: UserAggregateNode!
+            }
+
+            type UserAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              name: StringAggregateSelection!
             }
 
             type UserAggregateSelection {
@@ -549,6 +569,7 @@ describe("https://github.com/neo4j/graphql/issues/2969", () => {
             }
 
             type UsersConnection {
+              aggregate: UserAggregate!
               edges: [UserEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/issues/2981.test.ts
+++ b/packages/graphql/tests/schema/issues/2981.test.ts
@@ -769,14 +769,14 @@ describe("https://github.com/neo4j/graphql/issues/2981", () => {
 
             type Query {
               bookTitleEns(limit: Int, offset: Int, options: BookTitle_ENOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [BookTitle_ENSort!], where: BookTitle_ENWhere): [BookTitle_EN!]!
-              bookTitleEnsAggregate(where: BookTitle_ENWhere): BookTitle_ENAggregateSelection!
+              bookTitleEnsAggregate(where: BookTitle_ENWhere): BookTitle_ENAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"bookTitleEnsConnection\\\\\\"\\")
               bookTitleEnsConnection(after: String, first: Int, sort: [BookTitle_ENSort!], where: BookTitle_ENWhere): BookTitleEnsConnection!
               bookTitleSvs(limit: Int, offset: Int, options: BookTitle_SVOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [BookTitle_SVSort!], where: BookTitle_SVWhere): [BookTitle_SV!]!
-              bookTitleSvsAggregate(where: BookTitle_SVWhere): BookTitle_SVAggregateSelection!
+              bookTitleSvsAggregate(where: BookTitle_SVWhere): BookTitle_SVAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"bookTitleSvsConnection\\\\\\"\\")
               bookTitleSvsConnection(after: String, first: Int, sort: [BookTitle_SVSort!], where: BookTitle_SVWhere): BookTitleSvsConnection!
               bookTitles(limit: Int, offset: Int, options: QueryOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: BookTitleWhere): [BookTitle!]!
               books(limit: Int, offset: Int, options: BookOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [BookSort!], where: BookWhere): [Book!]!
-              booksAggregate(where: BookWhere): BookAggregateSelection!
+              booksAggregate(where: BookWhere): BookAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"booksConnection\\\\\\"\\")
               booksConnection(after: String, first: Int, sort: [BookSort!], where: BookWhere): BooksConnection!
             }
 

--- a/packages/graphql/tests/schema/issues/2981.test.ts
+++ b/packages/graphql/tests/schema/issues/2981.test.ts
@@ -59,6 +59,16 @@ describe("https://github.com/neo4j/graphql/issues/2981", () => {
               translatedTitleConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, where: BookTranslatedTitleConnectionWhere): BookTranslatedTitleConnection!
             }
 
+            type BookAggregate {
+              node: BookAggregateNode!
+            }
+
+            type BookAggregateNode {
+              count: Int!
+              isbn: StringAggregateSelection!
+              originalTitle: StringAggregateSelection!
+            }
+
             type BookAggregateSelection {
               count: Int!
               isbn: StringAggregateSelection!
@@ -112,12 +122,14 @@ describe("https://github.com/neo4j/graphql/issues/2981", () => {
             union BookTitle = BookTitle_EN | BookTitle_SV
 
             type BookTitleEnsConnection {
+              aggregate: BookTitle_ENAggregate!
               edges: [BookTitle_ENEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
             }
 
             type BookTitleSvsConnection {
+              aggregate: BookTitle_SVAggregate!
               edges: [BookTitle_SVEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -133,6 +145,15 @@ describe("https://github.com/neo4j/graphql/issues/2981", () => {
               bookAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: BookWhere): BookTitle_ENBookBookAggregationSelection
               bookConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [BookTitle_ENBookConnectionSort!], where: BookTitle_ENBookConnectionWhere): BookTitle_ENBookConnection!
               value: String!
+            }
+
+            type BookTitle_ENAggregate {
+              node: BookTitle_ENAggregateNode!
+            }
+
+            type BookTitle_ENAggregateNode {
+              count: Int!
+              value: StringAggregateSelection!
             }
 
             type BookTitle_ENAggregateSelection {
@@ -330,6 +351,15 @@ describe("https://github.com/neo4j/graphql/issues/2981", () => {
               bookAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: BookWhere): BookTitle_SVBookBookAggregationSelection
               bookConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [BookTitle_SVBookConnectionSort!], where: BookTitle_SVBookConnectionWhere): BookTitle_SVBookConnection!
               value: String!
+            }
+
+            type BookTitle_SVAggregate {
+              node: BookTitle_SVAggregateNode!
+            }
+
+            type BookTitle_SVAggregateNode {
+              count: Int!
+              value: StringAggregateSelection!
             }
 
             type BookTitle_SVAggregateSelection {
@@ -680,6 +710,7 @@ describe("https://github.com/neo4j/graphql/issues/2981", () => {
             }
 
             type BooksConnection {
+              aggregate: BookAggregate!
               edges: [BookEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/issues/2993.test.ts
+++ b/packages/graphql/tests/schema/issues/2993.test.ts
@@ -149,6 +149,16 @@ describe("https://github.com/neo4j/graphql/issues/2993", () => {
               userName: String!
             }
 
+            type ProfileAggregate {
+              node: ProfileAggregateNode!
+            }
+
+            type ProfileAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              userName: StringAggregateSelection!
+            }
+
             type ProfileAggregateSelection {
               count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -217,6 +227,7 @@ describe("https://github.com/neo4j/graphql/issues/2993", () => {
             }
 
             type ProfilesConnection {
+              aggregate: ProfileAggregate!
               edges: [ProfileEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -265,6 +276,16 @@ describe("https://github.com/neo4j/graphql/issues/2993", () => {
               followingConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [UserFollowingConnectionSort!], where: UserFollowingConnectionWhere): UserFollowingConnection!
               id: ID!
               userName: String!
+            }
+
+            type UserAggregate {
+              node: UserAggregateNode!
+            }
+
+            type UserAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              userName: StringAggregateSelection!
             }
 
             type UserAggregateSelection {
@@ -474,6 +495,7 @@ describe("https://github.com/neo4j/graphql/issues/2993", () => {
             }
 
             type UsersConnection {
+              aggregate: UserAggregate!
               edges: [UserEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/issues/2993.test.ts
+++ b/packages/graphql/tests/schema/issues/2993.test.ts
@@ -235,10 +235,10 @@ describe("https://github.com/neo4j/graphql/issues/2993", () => {
 
             type Query {
               profiles(limit: Int, offset: Int, options: ProfileOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ProfileSort!], where: ProfileWhere): [Profile!]!
-              profilesAggregate(where: ProfileWhere): ProfileAggregateSelection!
+              profilesAggregate(where: ProfileWhere): ProfileAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"profilesConnection\\\\\\"\\")
               profilesConnection(after: String, first: Int, sort: [ProfileSort!], where: ProfileWhere): ProfilesConnection!
               users(limit: Int, offset: Int, options: UserOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [UserSort!], where: UserWhere): [User!]!
-              usersAggregate(where: UserWhere): UserAggregateSelection!
+              usersAggregate(where: UserWhere): UserAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"usersConnection\\\\\\"\\")
               usersConnection(after: String, first: Int, sort: [UserSort!], where: UserWhere): UsersConnection!
             }
 

--- a/packages/graphql/tests/schema/issues/3428.test.ts
+++ b/packages/graphql/tests/schema/issues/3428.test.ts
@@ -148,6 +148,15 @@ describe("Relationship nested operations", () => {
               node: Person!
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+            }
+
             type MovieAggregateSelection {
               count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -231,6 +240,7 @@ describe("Relationship nested operations", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -254,6 +264,7 @@ describe("Relationship nested operations", () => {
             }
 
             type PeopleConnection {
+              aggregate: PersonAggregate!
               edges: [PersonEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -262,6 +273,16 @@ describe("Relationship nested operations", () => {
             type Person {
               id: ID!
               name: String
+            }
+
+            type PersonAggregate {
+              node: PersonAggregateNode!
+            }
+
+            type PersonAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              name: StringAggregateSelection!
             }
 
             type PersonAggregateSelection {
@@ -461,6 +482,15 @@ describe("Relationship nested operations", () => {
               node: Person!
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+            }
+
             type MovieAggregateSelection {
               count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -533,6 +563,7 @@ describe("Relationship nested operations", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -562,6 +593,15 @@ describe("Relationship nested operations", () => {
 
             type PersonOne {
               name: String
+            }
+
+            type PersonOneAggregate {
+              node: PersonOneAggregateNode!
+            }
+
+            type PersonOneAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
             }
 
             type PersonOneAggregateSelection {
@@ -612,6 +652,7 @@ describe("Relationship nested operations", () => {
             }
 
             type PersonOnesConnection {
+              aggregate: PersonOneAggregate!
               edges: [PersonOneEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -619,6 +660,15 @@ describe("Relationship nested operations", () => {
 
             type PersonTwo {
               nameTwo: String
+            }
+
+            type PersonTwoAggregate {
+              node: PersonTwoAggregateNode!
+            }
+
+            type PersonTwoAggregateNode {
+              count: Int!
+              nameTwo: StringAggregateSelection!
             }
 
             type PersonTwoAggregateSelection {
@@ -669,6 +719,7 @@ describe("Relationship nested operations", () => {
             }
 
             type PersonTwosConnection {
+              aggregate: PersonTwoAggregate!
               edges: [PersonTwoEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/issues/3428.test.ts
+++ b/packages/graphql/tests/schema/issues/3428.test.ts
@@ -342,10 +342,10 @@ describe("Relationship nested operations", () => {
 
             type Query {
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
               people(limit: Int, offset: Int, options: PersonOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonSort!], where: PersonWhere): [Person!]!
-              peopleAggregate(where: PersonWhere): PersonAggregateSelection!
+              peopleAggregate(where: PersonWhere): PersonAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"peopleConnection\\\\\\"\\")
               peopleConnection(after: String, first: Int, sort: [PersonSort!], where: PersonWhere): PeopleConnection!
             }
 
@@ -732,14 +732,14 @@ describe("Relationship nested operations", () => {
 
             type Query {
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
               people(limit: Int, offset: Int, options: QueryOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: PersonWhere): [Person!]!
               personOnes(limit: Int, offset: Int, options: PersonOneOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonOneSort!], where: PersonOneWhere): [PersonOne!]!
-              personOnesAggregate(where: PersonOneWhere): PersonOneAggregateSelection!
+              personOnesAggregate(where: PersonOneWhere): PersonOneAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"personOnesConnection\\\\\\"\\")
               personOnesConnection(after: String, first: Int, sort: [PersonOneSort!], where: PersonOneWhere): PersonOnesConnection!
               personTwos(limit: Int, offset: Int, options: PersonTwoOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonTwoSort!], where: PersonTwoWhere): [PersonTwo!]!
-              personTwosAggregate(where: PersonTwoWhere): PersonTwoAggregateSelection!
+              personTwosAggregate(where: PersonTwoWhere): PersonTwoAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"personTwosConnection\\\\\\"\\")
               personTwosConnection(after: String, first: Int, sort: [PersonTwoSort!], where: PersonTwoWhere): PersonTwosConnection!
             }
 

--- a/packages/graphql/tests/schema/issues/3439.test.ts
+++ b/packages/graphql/tests/schema/issues/3439.test.ts
@@ -818,19 +818,19 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
 
             type Query {
               genres(limit: Int, offset: Int, options: GenreOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [GenreSort!], where: GenreWhere): [Genre!]!
-              genresAggregate(where: GenreWhere): GenreAggregateSelection!
+              genresAggregate(where: GenreWhere): GenreAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"genresConnection\\\\\\"\\")
               genresConnection(after: String, first: Int, sort: [GenreSort!], where: GenreWhere): GenresConnection!
               iNodes(limit: Int, offset: Int, options: INodeOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [INodeSort!], where: INodeWhere): [INode!]!
-              iNodesAggregate(where: INodeWhere): INodeAggregateSelection!
+              iNodesAggregate(where: INodeWhere): INodeAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"iNodesConnection\\\\\\"\\")
               iNodesConnection(after: String, first: Int, sort: [INodeSort!], where: INodeWhere): INodesConnection!
               iProducts(limit: Int, offset: Int, options: IProductOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [IProductSort!], where: IProductWhere): [IProduct!]!
-              iProductsAggregate(where: IProductWhere): IProductAggregateSelection!
+              iProductsAggregate(where: IProductWhere): IProductAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"iProductsConnection\\\\\\"\\")
               iProductsConnection(after: String, first: Int, sort: [IProductSort!], where: IProductWhere): IProductsConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
               series(limit: Int, offset: Int, options: SeriesOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [SeriesSort!], where: SeriesWhere): [Series!]!
-              seriesAggregate(where: SeriesWhere): SeriesAggregateSelection!
+              seriesAggregate(where: SeriesWhere): SeriesAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"seriesConnection\\\\\\"\\")
               seriesConnection(after: String, first: Int, sort: [SeriesSort!], where: SeriesWhere): SeriesConnection!
             }
 
@@ -1861,16 +1861,16 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
 
             type Query {
               genres(limit: Int, offset: Int, options: GenreOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [GenreSort!], where: GenreWhere): [Genre!]!
-              genresAggregate(where: GenreWhere): GenreAggregateSelection!
+              genresAggregate(where: GenreWhere): GenreAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"genresConnection\\\\\\"\\")
               genresConnection(after: String, first: Int, sort: [GenreSort!], where: GenreWhere): GenresConnection!
               iProducts(limit: Int, offset: Int, options: IProductOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [IProductSort!], where: IProductWhere): [IProduct!]!
-              iProductsAggregate(where: IProductWhere): IProductAggregateSelection!
+              iProductsAggregate(where: IProductWhere): IProductAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"iProductsConnection\\\\\\"\\")
               iProductsConnection(after: String, first: Int, sort: [IProductSort!], where: IProductWhere): IProductsConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
               series(limit: Int, offset: Int, options: SeriesOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [SeriesSort!], where: SeriesWhere): [Series!]!
-              seriesAggregate(where: SeriesWhere): SeriesAggregateSelection!
+              seriesAggregate(where: SeriesWhere): SeriesAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"seriesConnection\\\\\\"\\")
               seriesConnection(after: String, first: Int, sort: [SeriesSort!], where: SeriesWhere): SeriesConnection!
             }
 
@@ -3153,16 +3153,16 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
 
             type Query {
               genres(limit: Int, offset: Int, options: GenreOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [GenreSort!], where: GenreWhere): [Genre!]!
-              genresAggregate(where: GenreWhere): GenreAggregateSelection!
+              genresAggregate(where: GenreWhere): GenreAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"genresConnection\\\\\\"\\")
               genresConnection(after: String, first: Int, sort: [GenreSort!], where: GenreWhere): GenresConnection!
               iProducts(limit: Int, offset: Int, options: IProductOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [IProductSort!], where: IProductWhere): [IProduct!]!
-              iProductsAggregate(where: IProductWhere): IProductAggregateSelection!
+              iProductsAggregate(where: IProductWhere): IProductAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"iProductsConnection\\\\\\"\\")
               iProductsConnection(after: String, first: Int, sort: [IProductSort!], where: IProductWhere): IProductsConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
               series(limit: Int, offset: Int, options: SeriesOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [SeriesSort!], where: SeriesWhere): [Series!]!
-              seriesAggregate(where: SeriesWhere): SeriesAggregateSelection!
+              seriesAggregate(where: SeriesWhere): SeriesAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"seriesConnection\\\\\\"\\")
               seriesConnection(after: String, first: Int, sort: [SeriesSort!], where: SeriesWhere): SeriesConnection!
             }
 
@@ -4501,19 +4501,19 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
 
             type Query {
               genres(limit: Int, offset: Int, options: GenreOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [GenreSort!], where: GenreWhere): [Genre!]!
-              genresAggregate(where: GenreWhere): GenreAggregateSelection!
+              genresAggregate(where: GenreWhere): GenreAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"genresConnection\\\\\\"\\")
               genresConnection(after: String, first: Int, sort: [GenreSort!], where: GenreWhere): GenresConnection!
               iProducts(limit: Int, offset: Int, options: IProductOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [IProductSort!], where: IProductWhere): [IProduct!]!
-              iProductsAggregate(where: IProductWhere): IProductAggregateSelection!
+              iProductsAggregate(where: IProductWhere): IProductAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"iProductsConnection\\\\\\"\\")
               iProductsConnection(after: String, first: Int, sort: [IProductSort!], where: IProductWhere): IProductsConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
               ratings(limit: Int, offset: Int, options: RatingOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [RatingSort!], where: RatingWhere): [Rating!]!
-              ratingsAggregate(where: RatingWhere): RatingAggregateSelection!
+              ratingsAggregate(where: RatingWhere): RatingAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"ratingsConnection\\\\\\"\\")
               ratingsConnection(after: String, first: Int, sort: [RatingSort!], where: RatingWhere): RatingsConnection!
               series(limit: Int, offset: Int, options: SeriesOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [SeriesSort!], where: SeriesWhere): [Series!]!
-              seriesAggregate(where: SeriesWhere): SeriesAggregateSelection!
+              seriesAggregate(where: SeriesWhere): SeriesAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"seriesConnection\\\\\\"\\")
               seriesConnection(after: String, first: Int, sort: [SeriesSort!], where: SeriesWhere): SeriesConnection!
               uGenres(limit: Int, offset: Int, options: QueryOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: UGenreWhere): [UGenre!]!
             }

--- a/packages/graphql/tests/schema/issues/3439.test.ts
+++ b/packages/graphql/tests/schema/issues/3439.test.ts
@@ -119,6 +119,15 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               productConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [GenreProductConnectionSort!], where: GenreProductConnectionWhere): GenreProductConnection!
             }
 
+            type GenreAggregate {
+              node: GenreAggregateNode!
+            }
+
+            type GenreAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
             type GenreAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -373,6 +382,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type GenresConnection {
+              aggregate: GenreAggregate!
               edges: [GenreEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -380,6 +390,15 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
 
             interface INode {
               id: String!
+            }
+
+            type INodeAggregate {
+              node: INodeAggregateNode!
+            }
+
+            type INodeAggregateNode {
+              count: Int!
+              id: StringAggregateSelection!
             }
 
             type INodeAggregateSelection {
@@ -428,6 +447,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type INodesConnection {
+              aggregate: INodeAggregate!
               edges: [INodeEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -437,6 +457,16 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               genre: Genre!
               id: String!
               name: String!
+            }
+
+            type IProductAggregate {
+              node: IProductAggregateNode!
+            }
+
+            type IProductAggregateNode {
+              count: Int!
+              id: StringAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             type IProductAggregateSelection {
@@ -509,6 +539,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type IProductsConnection {
+              aggregate: IProductAggregate!
               edges: [IProductEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -520,6 +551,16 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               genreConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [MovieGenreConnectionSort!], where: MovieGenreConnectionWhere): MovieGenreConnection!
               id: String!
               name: String!
+            }
+
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              id: StringAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             type MovieAggregateSelection {
@@ -749,6 +790,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -800,6 +842,16 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               name: String!
             }
 
+            type SeriesAggregate {
+              node: SeriesAggregateNode!
+            }
+
+            type SeriesAggregateNode {
+              count: Int!
+              id: StringAggregateSelection!
+              name: StringAggregateSelection!
+            }
+
             type SeriesAggregateSelection {
               count: Int!
               id: StringAggregateSelection!
@@ -807,6 +859,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type SeriesConnection {
+              aggregate: SeriesAggregate!
               edges: [SeriesEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1174,6 +1227,15 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               productConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [GenreProductConnectionSort!], where: GenreProductConnectionWhere): GenreProductConnection!
             }
 
+            type GenreAggregate {
+              node: GenreAggregateNode!
+            }
+
+            type GenreAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
             type GenreAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -1428,6 +1490,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type GenresConnection {
+              aggregate: GenreAggregate!
               edges: [GenreEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1437,6 +1500,16 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               genre: Genre!
               id: String!
               name: String!
+            }
+
+            type IProductAggregate {
+              node: IProductAggregateNode!
+            }
+
+            type IProductAggregateNode {
+              count: Int!
+              id: StringAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             type IProductAggregateSelection {
@@ -1509,6 +1582,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type IProductsConnection {
+              aggregate: IProductAggregate!
               edges: [IProductEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1520,6 +1594,16 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               genreConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [MovieGenreConnectionSort!], where: MovieGenreConnectionWhere): MovieGenreConnection!
               id: String!
               name: String!
+            }
+
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              id: StringAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             type MovieAggregateSelection {
@@ -1749,6 +1833,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1797,6 +1882,16 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               name: String!
             }
 
+            type SeriesAggregate {
+              node: SeriesAggregateNode!
+            }
+
+            type SeriesAggregateNode {
+              count: Int!
+              id: StringAggregateSelection!
+              name: StringAggregateSelection!
+            }
+
             type SeriesAggregateSelection {
               count: Int!
               id: StringAggregateSelection!
@@ -1804,6 +1899,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type SeriesConnection {
+              aggregate: SeriesAggregate!
               edges: [SeriesEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -2179,6 +2275,15 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               productConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [GenreProductConnectionSort!], where: GenreProductConnectionWhere): GenreProductConnection!
             }
 
+            type GenreAggregate {
+              node: GenreAggregateNode!
+            }
+
+            type GenreAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
             type GenreAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -2436,6 +2541,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type GenresConnection {
+              aggregate: GenreAggregate!
               edges: [GenreEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -2446,6 +2552,16 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               genreConnection(after: String, first: Int, sort: [IProductGenreConnectionSort!], where: IProductGenreConnectionWhere): IProductGenreConnection!
               id: String!
               name: String!
+            }
+
+            type IProductAggregate {
+              node: IProductAggregateNode!
+            }
+
+            type IProductAggregateNode {
+              count: Int!
+              id: StringAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             type IProductAggregateSelection {
@@ -2711,6 +2827,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type IProductsConnection {
+              aggregate: IProductAggregate!
               edges: [IProductEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -2729,6 +2846,16 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               genreConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [IProductGenreConnectionSort!], where: IProductGenreConnectionWhere): IProductGenreConnection!
               id: String!
               name: String!
+            }
+
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              id: StringAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             type MovieAggregateSelection {
@@ -2998,6 +3125,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -3046,6 +3174,16 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               name: String!
             }
 
+            type SeriesAggregate {
+              node: SeriesAggregateNode!
+            }
+
+            type SeriesAggregateNode {
+              count: Int!
+              id: StringAggregateSelection!
+              name: StringAggregateSelection!
+            }
+
             type SeriesAggregateSelection {
               count: Int!
               id: StringAggregateSelection!
@@ -3053,6 +3191,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type SeriesConnection {
+              aggregate: SeriesAggregate!
               edges: [SeriesEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -3480,6 +3619,15 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               productConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [GenreProductConnectionSort!], where: GenreProductConnectionWhere): GenreProductConnection!
             }
 
+            type GenreAggregate {
+              node: GenreAggregateNode!
+            }
+
+            type GenreAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
             type GenreAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -3737,6 +3885,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type GenresConnection {
+              aggregate: GenreAggregate!
               edges: [GenreEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -3747,6 +3896,16 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               genreConnection(after: String, first: Int, sort: [IProductGenreConnectionSort!], where: IProductGenreConnectionWhere): IProductGenreConnection!
               id: String!
               name: String!
+            }
+
+            type IProductAggregate {
+              node: IProductAggregateNode!
+            }
+
+            type IProductAggregateNode {
+              count: Int!
+              id: StringAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             type IProductAggregateSelection {
@@ -4037,6 +4196,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type IProductsConnection {
+              aggregate: IProductAggregate!
               edges: [IProductEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -4054,6 +4214,16 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               genreConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [IProductGenreConnectionSort!], where: IProductGenreConnectionWhere): IProductGenreConnection!
               id: String!
               name: String!
+            }
+
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              id: StringAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             type MovieAggregateSelection {
@@ -4300,6 +4470,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -4358,6 +4529,15 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               product(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), limit: Int, offset: Int, options: IProductOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [IProductSort!], where: IProductWhere): [IProduct!]!
               productAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: IProductWhere): RatingIProductProductAggregationSelection
               productConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [RatingProductConnectionSort!], where: RatingProductConnectionWhere): RatingProductConnection!
+            }
+
+            type RatingAggregate {
+              node: RatingAggregateNode!
+            }
+
+            type RatingAggregateNode {
+              count: Int!
+              number: IntAggregateSelection!
             }
 
             type RatingAggregateSelection {
@@ -4621,6 +4801,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type RatingsConnection {
+              aggregate: RatingAggregate!
               edges: [RatingEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -4633,6 +4814,16 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               name: String!
             }
 
+            type SeriesAggregate {
+              node: SeriesAggregateNode!
+            }
+
+            type SeriesAggregateNode {
+              count: Int!
+              id: StringAggregateSelection!
+              name: StringAggregateSelection!
+            }
+
             type SeriesAggregateSelection {
               count: Int!
               id: StringAggregateSelection!
@@ -4640,6 +4831,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type SeriesConnection {
+              aggregate: SeriesAggregate!
               edges: [SeriesEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/issues/3537.test.ts
+++ b/packages/graphql/tests/schema/issues/3537.test.ts
@@ -335,6 +335,16 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
               username: String!
             }
 
+            type ActorAggregate {
+              node: ActorAggregateNode!
+            }
+
+            type ActorAggregateNode {
+              count: Int!
+              password: StringAggregateSelection!
+              username: StringAggregateSelection!
+            }
+
             type ActorAggregateSelection {
               count: Int!
               password: StringAggregateSelection!
@@ -382,6 +392,7 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
             }
 
             type ActorsConnection {
+              aggregate: ActorAggregate!
               edges: [ActorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -389,6 +400,15 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
 
             type Movie {
               title: String
+            }
+
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              title: StringAggregateSelection!
             }
 
             type MovieAggregateSelection {
@@ -430,6 +450,7 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -540,6 +561,16 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
               username: String!
             }
 
+            type ActorAggregate {
+              node: ActorAggregateNode!
+            }
+
+            type ActorAggregateNode {
+              count: Int!
+              password: StringAggregateSelection!
+              username: StringAggregateSelection!
+            }
+
             type ActorAggregateSelection {
               count: Int!
               password: StringAggregateSelection!
@@ -629,6 +660,7 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
             }
 
             type ActorsConnection {
+              aggregate: ActorAggregate!
               edges: [ActorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -670,6 +702,15 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
 
             type Movie {
               title: String
+            }
+
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              title: StringAggregateSelection!
             }
 
             type MovieAggregateSelection {
@@ -743,6 +784,7 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/issues/3537.test.ts
+++ b/packages/graphql/tests/schema/issues/3537.test.ts
@@ -467,10 +467,10 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
             type Query {
               _service: _Service!
               actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
               actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 
@@ -810,10 +810,10 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
             type Query {
               _service: _Service!
               actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
               actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 

--- a/packages/graphql/tests/schema/issues/3541.test.ts
+++ b/packages/graphql/tests/schema/issues/3541.test.ts
@@ -69,6 +69,15 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
               name: String!
             }
 
+            type ActorAggregate {
+              node: ActorAggregateNode!
+            }
+
+            type ActorAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
             type ActorAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -108,6 +117,7 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
             }
 
             type ActorsConnection {
+              aggregate: ActorAggregate!
               edges: [ActorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -185,6 +195,15 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
               node: Actor!
             }
 
+            type MovieAggregate @shareable {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode @shareable {
+              count: Int!
+              title: StringAggregateSelection!
+            }
+
             type MovieAggregateSelection @shareable {
               count: Int!
               title: StringAggregateSelection!
@@ -249,6 +268,7 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
             }
 
             type MoviesConnection @shareable {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -359,6 +379,15 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
               name: String!
             }
 
+            type ActorAggregate {
+              node: ActorAggregateNode!
+            }
+
+            type ActorAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
             type ActorAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -411,6 +440,7 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
             }
 
             type ActorsConnection {
+              aggregate: ActorAggregate!
               edges: [ActorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/issues/3541.test.ts
+++ b/packages/graphql/tests/schema/issues/3541.test.ts
@@ -286,10 +286,10 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
               _entities(representations: [_Any!]!): [_Entity]!
               _service: _Service!
               actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
               actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]! @shareable
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @shareable
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @shareable @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection! @shareable
             }
 
@@ -665,7 +665,7 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
               _entities(representations: [_Any!]!): [_Entity]!
               _service: _Service!
               actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
               actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
             }
 

--- a/packages/graphql/tests/schema/issues/3698.test.ts
+++ b/packages/graphql/tests/schema/issues/3698.test.ts
@@ -770,13 +770,13 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
 
             type Query {
               genres(limit: Int, offset: Int, options: GenreOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [GenreSort!], where: GenreWhere): [Genre!]!
-              genresAggregate(where: GenreWhere): GenreAggregateSelection!
+              genresAggregate(where: GenreWhere): GenreAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"genresConnection\\\\\\"\\")
               genresConnection(after: String, first: Int, sort: [GenreSort!], where: GenreWhere): GenresConnection!
               iProducts(limit: Int, offset: Int, options: IProductOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [IProductSort!], where: IProductWhere): [IProduct!]!
-              iProductsAggregate(where: IProductWhere): IProductAggregateSelection!
+              iProductsAggregate(where: IProductWhere): IProductAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"iProductsConnection\\\\\\"\\")
               iProductsConnection(after: String, first: Int, sort: [IProductSort!], where: IProductWhere): IProductsConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 
@@ -1659,13 +1659,13 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
 
             type Query {
               genres(limit: Int, offset: Int, options: GenreOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [GenreSort!], where: GenreWhere): [Genre!]!
-              genresAggregate(where: GenreWhere): GenreAggregateSelection!
+              genresAggregate(where: GenreWhere): GenreAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"genresConnection\\\\\\"\\")
               genresConnection(after: String, first: Int, sort: [GenreSort!], where: GenreWhere): GenresConnection!
               iProducts(limit: Int, offset: Int, options: IProductOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [IProductSort!], where: IProductWhere): [IProduct!]!
-              iProductsAggregate(where: IProductWhere): IProductAggregateSelection!
+              iProductsAggregate(where: IProductWhere): IProductAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"iProductsConnection\\\\\\"\\")
               iProductsConnection(after: String, first: Int, sort: [IProductSort!], where: IProductWhere): IProductsConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 
@@ -2566,16 +2566,16 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
 
             type Query {
               genres(limit: Int, offset: Int, options: GenreOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [GenreSort!], where: GenreWhere): [Genre!]!
-              genresAggregate(where: GenreWhere): GenreAggregateSelection!
+              genresAggregate(where: GenreWhere): GenreAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"genresConnection\\\\\\"\\")
               genresConnection(after: String, first: Int, sort: [GenreSort!], where: GenreWhere): GenresConnection!
               iProducts(limit: Int, offset: Int, options: IProductOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [IProductSort!], where: IProductWhere): [IProduct!]!
-              iProductsAggregate(where: IProductWhere): IProductAggregateSelection!
+              iProductsAggregate(where: IProductWhere): IProductAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"iProductsConnection\\\\\\"\\")
               iProductsConnection(after: String, first: Int, sort: [IProductSort!], where: IProductWhere): IProductsConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
               series(limit: Int, offset: Int, options: SeriesOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [SeriesSort!], where: SeriesWhere): [Series!]!
-              seriesAggregate(where: SeriesWhere): SeriesAggregateSelection!
+              seriesAggregate(where: SeriesWhere): SeriesAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"seriesConnection\\\\\\"\\")
               seriesConnection(after: String, first: Int, sort: [SeriesSort!], where: SeriesWhere): SeriesConnection!
             }
 

--- a/packages/graphql/tests/schema/issues/3698.test.ts
+++ b/packages/graphql/tests/schema/issues/3698.test.ts
@@ -112,6 +112,15 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
               productConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [GenreProductConnectionSort!], where: GenreProductConnectionWhere): GenreProductConnection!
             }
 
+            type GenreAggregate {
+              node: GenreAggregateNode!
+            }
+
+            type GenreAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
             type GenreAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -382,6 +391,7 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
             }
 
             type GenresConnection {
+              aggregate: GenreAggregate!
               edges: [GenreEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -392,6 +402,17 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
               id: String!
               info: String!
               name: String!
+            }
+
+            type IProductAggregate {
+              node: IProductAggregateNode!
+            }
+
+            type IProductAggregateNode {
+              count: Int!
+              id: StringAggregateSelection!
+              info: StringAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             type IProductAggregateSelection {
@@ -472,6 +493,7 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
             }
 
             type IProductsConnection {
+              aggregate: IProductAggregate!
               edges: [IProductEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -484,6 +506,16 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
               id: String!
               info: String!
               name: String!
+            }
+
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              id: StringAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             type MovieAggregateSelection {
@@ -713,6 +745,7 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -876,6 +909,15 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
               product(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), limit: Int, offset: Int, options: IProductOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [IProductSort!], where: IProductWhere): [IProduct!]!
               productAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: IProductWhere): GenreIProductProductAggregationSelection
               productConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [GenreProductConnectionSort!], where: GenreProductConnectionWhere): GenreProductConnection!
+            }
+
+            type GenreAggregate {
+              node: GenreAggregateNode!
+            }
+
+            type GenreAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
             }
 
             type GenreAggregateSelection {
@@ -1151,6 +1193,7 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
             }
 
             type GenresConnection {
+              aggregate: GenreAggregate!
               edges: [GenreEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1162,6 +1205,17 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
               id: String!
               info: String!
               name: String!
+            }
+
+            type IProductAggregate {
+              node: IProductAggregateNode!
+            }
+
+            type IProductAggregateNode {
+              count: Int!
+              id: StringAggregateSelection!
+              info: StringAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             type IProductAggregateSelection {
@@ -1360,6 +1414,7 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
             }
 
             type IProductsConnection {
+              aggregate: IProductAggregate!
               edges: [IProductEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1372,6 +1427,16 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
               id: String!
               info: String!
               name: String!
+            }
+
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              id: StringAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             type MovieAggregateSelection {
@@ -1569,6 +1634,7 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1745,6 +1811,15 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
               product(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), limit: Int, offset: Int, options: IProductOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [IProductSort!], where: IProductWhere): [IProduct!]!
               productAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: IProductWhere): GenreIProductProductAggregationSelection
               productConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [GenreProductConnectionSort!], where: GenreProductConnectionWhere): GenreProductConnection!
+            }
+
+            type GenreAggregate {
+              node: GenreAggregateNode!
+            }
+
+            type GenreAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
             }
 
             type GenreAggregateSelection {
@@ -2020,6 +2095,7 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
             }
 
             type GenresConnection {
+              aggregate: GenreAggregate!
               edges: [GenreEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -2031,6 +2107,17 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
               id: String!
               info: String!
               name: String!
+            }
+
+            type IProductAggregate {
+              node: IProductAggregateNode!
+            }
+
+            type IProductAggregateNode {
+              count: Int!
+              id: StringAggregateSelection!
+              info: StringAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             type IProductAggregateSelection {
@@ -2231,6 +2318,7 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
             }
 
             type IProductsConnection {
+              aggregate: IProductAggregate!
               edges: [IProductEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -2243,6 +2331,16 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
               id: String!
               info: String!
               name: String!
+            }
+
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              id: StringAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             type MovieAggregateSelection {
@@ -2440,6 +2538,7 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -2489,6 +2588,17 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
               name: String!
             }
 
+            type SeriesAggregate {
+              node: SeriesAggregateNode!
+            }
+
+            type SeriesAggregateNode {
+              count: Int!
+              id: StringAggregateSelection!
+              info: StringAggregateSelection!
+              name: StringAggregateSelection!
+            }
+
             type SeriesAggregateSelection {
               count: Int!
               id: StringAggregateSelection!
@@ -2497,6 +2607,7 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
             }
 
             type SeriesConnection {
+              aggregate: SeriesAggregate!
               edges: [SeriesEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/issues/3816.test.ts
+++ b/packages/graphql/tests/schema/issues/3816.test.ts
@@ -78,6 +78,15 @@ describe("https://github.com/neo4j/graphql/issues/3816", () => {
               name: String!
             }
 
+            type GenreAggregate {
+              node: GenreAggregateNode!
+            }
+
+            type GenreAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
             type GenreAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -274,6 +283,7 @@ describe("https://github.com/neo4j/graphql/issues/3816", () => {
             }
 
             type GenresConnection {
+              aggregate: GenreAggregate!
               edges: [GenreEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -284,6 +294,15 @@ describe("https://github.com/neo4j/graphql/issues/3816", () => {
               genreAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: GenreWhere): MovieGenreGenreAggregationSelection
               genreConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [MovieGenreConnectionSort!], where: MovieGenreConnectionWhere): MovieGenreConnection!
               name: String!
+            }
+
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
             }
 
             type MovieAggregateSelection {
@@ -440,6 +459,7 @@ describe("https://github.com/neo4j/graphql/issues/3816", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -559,6 +579,15 @@ describe("https://github.com/neo4j/graphql/issues/3816", () => {
               moviesAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: MovieWhere): GenreMovieMoviesAggregationSelection
               moviesConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [GenreMoviesConnectionSort!], where: GenreMoviesConnectionWhere): GenreMoviesConnection!
               name: String!
+            }
+
+            type GenreAggregate {
+              node: GenreAggregateNode!
+            }
+
+            type GenreAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
             }
 
             type GenreAggregateSelection {
@@ -743,6 +772,7 @@ describe("https://github.com/neo4j/graphql/issues/3816", () => {
             }
 
             type GenresConnection {
+              aggregate: GenreAggregate!
               edges: [GenreEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -753,6 +783,15 @@ describe("https://github.com/neo4j/graphql/issues/3816", () => {
               genreAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: GenreWhere): MovieGenreGenreAggregationSelection
               genreConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [MovieGenreConnectionSort!], where: MovieGenreConnectionWhere): MovieGenreConnection!
               name: String!
+            }
+
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
             }
 
             type MovieAggregateSelection {
@@ -875,6 +914,7 @@ describe("https://github.com/neo4j/graphql/issues/3816", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/issues/3816.test.ts
+++ b/packages/graphql/tests/schema/issues/3816.test.ts
@@ -484,10 +484,10 @@ describe("https://github.com/neo4j/graphql/issues/3816", () => {
 
             type Query {
               genres(limit: Int, offset: Int, options: GenreOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [GenreSort!], where: GenreWhere): [Genre!]!
-              genresAggregate(where: GenreWhere): GenreAggregateSelection!
+              genresAggregate(where: GenreWhere): GenreAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"genresConnection\\\\\\"\\")
               genresConnection(after: String, first: Int, sort: [GenreSort!], where: GenreWhere): GenresConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 
@@ -939,10 +939,10 @@ describe("https://github.com/neo4j/graphql/issues/3816", () => {
 
             type Query {
               genres(limit: Int, offset: Int, options: GenreOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [GenreSort!], where: GenreWhere): [Genre!]!
-              genresAggregate(where: GenreWhere): GenreAggregateSelection!
+              genresAggregate(where: GenreWhere): GenreAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"genresConnection\\\\\\"\\")
               genresConnection(after: String, first: Int, sort: [GenreSort!], where: GenreWhere): GenresConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 

--- a/packages/graphql/tests/schema/issues/3817.test.ts
+++ b/packages/graphql/tests/schema/issues/3817.test.ts
@@ -406,7 +406,7 @@ describe("3817", () => {
 
             type Query {
               people(limit: Int, offset: Int, options: PersonOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonSort!], where: PersonWhere): [Person!]!
-              peopleAggregate(where: PersonWhere): PersonAggregateSelection!
+              peopleAggregate(where: PersonWhere): PersonAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"peopleConnection\\\\\\"\\")
               peopleConnection(after: String, first: Int, sort: [PersonSort!], where: PersonWhere): PeopleConnection!
             }
 

--- a/packages/graphql/tests/schema/issues/3817.test.ts
+++ b/packages/graphql/tests/schema/issues/3817.test.ts
@@ -157,6 +157,7 @@ describe("3817", () => {
             }
 
             type PeopleConnection {
+              aggregate: PersonAggregate!
               edges: [PersonEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -167,6 +168,15 @@ describe("3817", () => {
               friendsAggregate(where: PersonWhere): PersonPersonFriendsAggregationSelection
               friendsConnection(after: String, first: Int, sort: [PersonFriendsConnectionSort!], where: PersonFriendsConnectionWhere): PersonFriendsConnection!
               id: ID!
+            }
+
+            type PersonAggregate {
+              node: PersonAggregateNode!
+            }
+
+            type PersonAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
             type PersonAggregateSelection {

--- a/packages/graphql/tests/schema/issues/4511.test.ts
+++ b/packages/graphql/tests/schema/issues/4511.test.ts
@@ -92,6 +92,14 @@ describe("https://github.com/neo4j/graphql/issues/4511", () => {
               moviesConnection(after: String, first: Int, sort: [CreatureMoviesConnectionSort!], where: CreatureMoviesConnectionWhere): CreatureMoviesConnection!
             }
 
+            type CreatureAggregate {
+              node: CreatureAggregateNode!
+            }
+
+            type CreatureAggregateNode {
+              count: Int!
+            }
+
             type CreatureAggregateSelection {
               count: Int!
             }
@@ -229,6 +237,7 @@ describe("https://github.com/neo4j/graphql/issues/4511", () => {
             }
 
             type CreaturesConnection {
+              aggregate: CreatureAggregate!
               edges: [CreatureEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -268,6 +277,16 @@ describe("https://github.com/neo4j/graphql/issues/4511", () => {
               directorConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, where: ProductionDirectorConnectionWhere): ProductionDirectorConnection!
               id: ID
               title: String!
+            }
+
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              title: StringAggregateSelection!
             }
 
             type MovieAggregateSelection {
@@ -391,6 +410,7 @@ describe("https://github.com/neo4j/graphql/issues/4511", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -417,6 +437,7 @@ describe("https://github.com/neo4j/graphql/issues/4511", () => {
             }
 
             type PeopleConnection {
+              aggregate: PersonAggregate!
               edges: [PersonEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -426,6 +447,14 @@ describe("https://github.com/neo4j/graphql/issues/4511", () => {
               movies(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), limit: Int, offset: Int, options: ProductionOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ProductionSort!], where: ProductionWhere): Production!
               moviesAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: ProductionWhere): PersonProductionMoviesAggregationSelection
               moviesConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [CreatureMoviesConnectionSort!], where: CreatureMoviesConnectionWhere): CreatureMoviesConnection!
+            }
+
+            type PersonAggregate {
+              node: PersonAggregateNode!
+            }
+
+            type PersonAggregateNode {
+              count: Int!
             }
 
             type PersonAggregateSelection {
@@ -557,6 +586,15 @@ describe("https://github.com/neo4j/graphql/issues/4511", () => {
               director(limit: Int, offset: Int, options: CreatureOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: CreatureWhere): Creature!
               directorConnection(after: String, first: Int, where: ProductionDirectorConnectionWhere): ProductionDirectorConnection!
               id: ID
+            }
+
+            type ProductionAggregate {
+              node: ProductionAggregateNode!
+            }
+
+            type ProductionAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
             type ProductionAggregateSelection {
@@ -697,6 +735,7 @@ describe("https://github.com/neo4j/graphql/issues/4511", () => {
             }
 
             type ProductionsConnection {
+              aggregate: ProductionAggregate!
               edges: [ProductionEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -729,6 +768,17 @@ describe("https://github.com/neo4j/graphql/issues/4511", () => {
               title: String!
             }
 
+            type SeriesAggregate {
+              node: SeriesAggregateNode!
+            }
+
+            type SeriesAggregateNode {
+              count: Int!
+              episode: IntAggregateSelection!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              title: StringAggregateSelection!
+            }
+
             type SeriesAggregateSelection {
               count: Int!
               episode: IntAggregateSelection!
@@ -737,6 +787,7 @@ describe("https://github.com/neo4j/graphql/issues/4511", () => {
             }
 
             type SeriesConnection {
+              aggregate: SeriesAggregate!
               edges: [SeriesEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/issues/4511.test.ts
+++ b/packages/graphql/tests/schema/issues/4511.test.ts
@@ -743,19 +743,19 @@ describe("https://github.com/neo4j/graphql/issues/4511", () => {
 
             type Query {
               creatures(limit: Int, offset: Int, options: CreatureOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: CreatureWhere): [Creature!]!
-              creaturesAggregate(where: CreatureWhere): CreatureAggregateSelection!
+              creaturesAggregate(where: CreatureWhere): CreatureAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"creaturesConnection\\\\\\"\\")
               creaturesConnection(after: String, first: Int, where: CreatureWhere): CreaturesConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
               people(limit: Int, offset: Int, options: PersonOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: PersonWhere): [Person!]!
-              peopleAggregate(where: PersonWhere): PersonAggregateSelection!
+              peopleAggregate(where: PersonWhere): PersonAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"peopleConnection\\\\\\"\\")
               peopleConnection(after: String, first: Int, where: PersonWhere): PeopleConnection!
               productions(limit: Int, offset: Int, options: ProductionOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ProductionSort!], where: ProductionWhere): [Production!]!
-              productionsAggregate(where: ProductionWhere): ProductionAggregateSelection!
+              productionsAggregate(where: ProductionWhere): ProductionAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"productionsConnection\\\\\\"\\")
               productionsConnection(after: String, first: Int, sort: [ProductionSort!], where: ProductionWhere): ProductionsConnection!
               series(limit: Int, offset: Int, options: SeriesOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [SeriesSort!], where: SeriesWhere): [Series!]!
-              seriesAggregate(where: SeriesWhere): SeriesAggregateSelection!
+              seriesAggregate(where: SeriesWhere): SeriesAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"seriesConnection\\\\\\"\\")
               seriesConnection(after: String, first: Int, sort: [SeriesSort!], where: SeriesWhere): SeriesConnection!
             }
 

--- a/packages/graphql/tests/schema/issues/4615.test.ts
+++ b/packages/graphql/tests/schema/issues/4615.test.ts
@@ -636,16 +636,16 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
 
             type Query {
               actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
               actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
               series(limit: Int, offset: Int, options: SeriesOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [SeriesSort!], where: SeriesWhere): [Series!]!
-              seriesAggregate(where: SeriesWhere): SeriesAggregateSelection!
+              seriesAggregate(where: SeriesWhere): SeriesAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"seriesConnection\\\\\\"\\")
               seriesConnection(after: String, first: Int, sort: [SeriesSort!], where: SeriesWhere): SeriesConnection!
               shows(limit: Int, offset: Int, options: ShowOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ShowSort!], where: ShowWhere): [Show!]!
-              showsAggregate(where: ShowWhere): ShowAggregateSelection!
+              showsAggregate(where: ShowWhere): ShowAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"showsConnection\\\\\\"\\")
               showsConnection(after: String, first: Int, sort: [ShowSort!], where: ShowWhere): ShowsConnection!
             }
 

--- a/packages/graphql/tests/schema/issues/4615.test.ts
+++ b/packages/graphql/tests/schema/issues/4615.test.ts
@@ -234,6 +234,15 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
               where: ActorActedInConnectionWhere
             }
 
+            type ActorAggregate {
+              node: ActorAggregateNode!
+            }
+
+            type ActorAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
             type ActorAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -339,6 +348,7 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
             }
 
             type ActorsConnection {
+              aggregate: ActorAggregate!
               edges: [ActorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -482,6 +492,17 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
               where: ShowActorsConnectionWhere
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              release: DateTimeAggregateSelection!
+              runtime: IntAggregateSelection!
+              title: StringAggregateSelection!
+            }
+
             type MovieAggregateSelection {
               count: Int!
               release: DateTimeAggregateSelection!
@@ -587,6 +608,7 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -718,6 +740,16 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
               where: ShowActorsConnectionWhere
             }
 
+            type SeriesAggregate {
+              node: SeriesAggregateNode!
+            }
+
+            type SeriesAggregateNode {
+              count: Int!
+              episodes: IntAggregateSelection!
+              title: StringAggregateSelection!
+            }
+
             type SeriesAggregateSelection {
               count: Int!
               episodes: IntAggregateSelection!
@@ -725,6 +757,7 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
             }
 
             type SeriesConnection {
+              aggregate: SeriesAggregate!
               edges: [SeriesEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -968,6 +1001,15 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
               where: ShowActorsConnectionWhere
             }
 
+            type ShowAggregate {
+              node: ShowAggregateNode!
+            }
+
+            type ShowAggregateNode {
+              count: Int!
+              title: StringAggregateSelection!
+            }
+
             type ShowAggregateSelection {
               count: Int!
               title: StringAggregateSelection!
@@ -1066,6 +1108,7 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
             }
 
             type ShowsConnection {
+              aggregate: ShowAggregate!
               edges: [ShowEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/issues/5428.test.ts
+++ b/packages/graphql/tests/schema/issues/5428.test.ts
@@ -77,7 +77,7 @@ describe("https://github.com/neo4j/graphql/issues/5428", () => {
 
             type Query {
               test(limit: Int, offset: Int, options: TestOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [TestSort!], where: TestWhere): [Test!]!
-              testAggregate(where: TestWhere): TestAggregateSelection!
+              testAggregate(where: TestWhere): TestAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"testConnection\\\\\\"\\")
               testConnection(after: String, first: Int, sort: [TestSort!], where: TestWhere): TestConnection!
             }
 

--- a/packages/graphql/tests/schema/issues/5428.test.ts
+++ b/packages/graphql/tests/schema/issues/5428.test.ts
@@ -98,12 +98,22 @@ describe("https://github.com/neo4j/graphql/issues/5428", () => {
               Name: String
             }
 
+            type TestAggregate {
+              node: TestAggregateNode!
+            }
+
+            type TestAggregateNode {
+              Name: StringAggregateSelection!
+              count: Int!
+            }
+
             type TestAggregateSelection {
               Name: StringAggregateSelection!
               count: Int!
             }
 
             type TestConnection {
+              aggregate: TestAggregate!
               edges: [TestEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/issues/5631.test.ts
+++ b/packages/graphql/tests/schema/issues/5631.test.ts
@@ -63,6 +63,14 @@ describe("https://github.com/neo4j/graphql/issues/5631", () => {
               custom_string_with_zero_param: String!
             }
 
+            type ActorAggregate {
+              node: ActorAggregateNode!
+            }
+
+            type ActorAggregateNode {
+              count: Int!
+            }
+
             type ActorAggregateSelection {
               count: Int!
             }
@@ -116,6 +124,7 @@ describe("https://github.com/neo4j/graphql/issues/5631", () => {
             }
 
             type ActorsConnection {
+              aggregate: ActorAggregate!
               edges: [ActorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -151,6 +160,14 @@ describe("https://github.com/neo4j/graphql/issues/5631", () => {
               custom_actor_with_zero_param: Actor
               custom_actors_with_params(title: String): [Actor]
               custom_string_with_non_nullable_param(param: String!): String!
+            }
+
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
             }
 
             type MovieAggregateSelection {
@@ -189,6 +206,7 @@ describe("https://github.com/neo4j/graphql/issues/5631", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/issues/5631.test.ts
+++ b/packages/graphql/tests/schema/issues/5631.test.ts
@@ -231,10 +231,10 @@ describe("https://github.com/neo4j/graphql/issues/5631", () => {
 
             type Query {
               actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
               actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, where: MovieWhere): MoviesConnection!
             }
 

--- a/packages/graphql/tests/schema/issues/609.test.ts
+++ b/packages/graphql/tests/schema/issues/609.test.ts
@@ -63,6 +63,15 @@ describe("609", () => {
               deprecatedField: String @deprecated
             }
 
+            type DeprecatedAggregate {
+              node: DeprecatedAggregateNode!
+            }
+
+            type DeprecatedAggregateNode {
+              count: Int!
+              deprecatedField: StringAggregateSelection!
+            }
+
             type DeprecatedAggregateSelection {
               count: Int!
               deprecatedField: StringAggregateSelection!
@@ -111,6 +120,7 @@ describe("609", () => {
             }
 
             type DeprecatedsConnection {
+              aggregate: DeprecatedAggregate!
               edges: [DeprecatedEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/issues/609.test.ts
+++ b/packages/graphql/tests/schema/issues/609.test.ts
@@ -142,7 +142,7 @@ describe("609", () => {
 
             type Query {
               deprecateds(limit: Int, offset: Int, options: DeprecatedOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [DeprecatedSort!], where: DeprecatedWhere): [Deprecated!]!
-              deprecatedsAggregate(where: DeprecatedWhere): DeprecatedAggregateSelection!
+              deprecatedsAggregate(where: DeprecatedWhere): DeprecatedAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"deprecatedsConnection\\\\\\"\\")
               deprecatedsConnection(after: String, first: Int, sort: [DeprecatedSort!], where: DeprecatedWhere): DeprecatedsConnection!
             }
 

--- a/packages/graphql/tests/schema/issues/872.test.ts
+++ b/packages/graphql/tests/schema/issues/872.test.ts
@@ -653,13 +653,13 @@ describe("https://github.com/neo4j/graphql/issues/872", () => {
 
             type Query {
               actor2s(limit: Int, offset: Int, options: Actor2Options @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [Actor2Sort!], where: Actor2Where): [Actor2!]!
-              actor2sAggregate(where: Actor2Where): Actor2AggregateSelection!
+              actor2sAggregate(where: Actor2Where): Actor2AggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actor2sConnection\\\\\\"\\")
               actor2sConnection(after: String, first: Int, sort: [Actor2Sort!], where: Actor2Where): Actor2sConnection!
               actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
               actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 

--- a/packages/graphql/tests/schema/issues/872.test.ts
+++ b/packages/graphql/tests/schema/issues/872.test.ts
@@ -63,6 +63,15 @@ describe("https://github.com/neo4j/graphql/issues/872", () => {
               name: String!
             }
 
+            type Actor2Aggregate {
+              node: Actor2AggregateNode!
+            }
+
+            type Actor2AggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
             type Actor2AggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -267,9 +276,19 @@ describe("https://github.com/neo4j/graphql/issues/872", () => {
             }
 
             type Actor2sConnection {
+              aggregate: Actor2Aggregate!
               edges: [Actor2Edge!]!
               pageInfo: PageInfo!
               totalCount: Int!
+            }
+
+            type ActorAggregate {
+              node: ActorAggregateNode!
+            }
+
+            type ActorAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
             }
 
             type ActorAggregateSelection {
@@ -476,6 +495,7 @@ describe("https://github.com/neo4j/graphql/issues/872", () => {
             }
 
             type ActorsConnection {
+              aggregate: ActorAggregate!
               edges: [ActorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -520,6 +540,16 @@ describe("https://github.com/neo4j/graphql/issues/872", () => {
             type Movie {
               id: ID!
               title: String!
+            }
+
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              title: StringAggregateSelection!
             }
 
             type MovieAggregateSelection {
@@ -595,6 +625,7 @@ describe("https://github.com/neo4j/graphql/issues/872", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/lowercase-type-names.test.ts
+++ b/packages/graphql/tests/schema/lowercase-type-names.test.ts
@@ -51,6 +51,7 @@ describe("lower case type names", () => {
             }
 
             type ActorsConnection {
+              aggregate: actorAggregate!
               edges: [actorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -98,6 +99,7 @@ describe("lower case type names", () => {
             }
 
             type MoviesConnection {
+              aggregate: movieAggregate!
               edges: [movieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -169,6 +171,17 @@ describe("lower case type names", () => {
               moviesConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [actorMoviesConnectionSort!], where: actorMoviesConnectionWhere): actorMoviesConnection!
               name: String
               year: Int
+            }
+
+            type actorAggregate {
+              node: actorAggregateNode!
+            }
+
+            type actorAggregateNode {
+              count: Int!
+              createdAt: DateTimeAggregateSelection!
+              name: StringAggregateSelection!
+              year: IntAggregateSelection!
             }
 
             type actorAggregateSelection {
@@ -576,6 +589,18 @@ describe("lower case type names", () => {
               disconnect: [movieActorsDisconnectFieldInput!]
               update: movieActorsUpdateConnectionInput
               where: movieActorsConnectionWhere
+            }
+
+            type movieAggregate {
+              node: movieAggregateNode!
+            }
+
+            type movieAggregateNode {
+              count: Int!
+              createdAt: DateTimeAggregateSelection!
+              name: StringAggregateSelection!
+              testId: StringAggregateSelection!
+              year: IntAggregateSelection!
             }
 
             type movieAggregateSelection {

--- a/packages/graphql/tests/schema/lowercase-type-names.test.ts
+++ b/packages/graphql/tests/schema/lowercase-type-names.test.ts
@@ -124,10 +124,10 @@ describe("lower case type names", () => {
 
             type Query {
               actors(limit: Int, offset: Int, options: actorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [actorSort!], where: actorWhere): [actor!]!
-              actorsAggregate(where: actorWhere): actorAggregateSelection!
+              actorsAggregate(where: actorWhere): actorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
               actorsConnection(after: String, first: Int, sort: [actorSort!], where: actorWhere): ActorsConnection!
               movies(limit: Int, offset: Int, options: movieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [movieSort!], where: movieWhere): [movie!]!
-              moviesAggregate(where: movieWhere): movieAggregateSelection!
+              moviesAggregate(where: movieWhere): movieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [movieSort!], where: movieWhere): MoviesConnection!
             }
 

--- a/packages/graphql/tests/schema/math.test.ts
+++ b/packages/graphql/tests/schema/math.test.ts
@@ -170,7 +170,7 @@ describe("Algebraic", () => {
 
             type Query {
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 
@@ -351,7 +351,7 @@ describe("Algebraic", () => {
 
             type Query {
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 
@@ -530,7 +530,7 @@ describe("Algebraic", () => {
 
             type Query {
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 
@@ -1085,10 +1085,10 @@ describe("Algebraic", () => {
 
             type Query {
               directors(limit: Int, offset: Int, options: DirectorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [DirectorSort!], where: DirectorWhere): [Director!]!
-              directorsAggregate(where: DirectorWhere): DirectorAggregateSelection!
+              directorsAggregate(where: DirectorWhere): DirectorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"directorsConnection\\\\\\"\\")
               directorsConnection(after: String, first: Int, sort: [DirectorSort!], where: DirectorWhere): DirectorsConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 
@@ -1729,13 +1729,13 @@ describe("Algebraic", () => {
 
             type Query {
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
               people(limit: Int, offset: Int, options: PersonOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonSort!], where: PersonWhere): [Person!]!
-              peopleAggregate(where: PersonWhere): PersonAggregateSelection!
+              peopleAggregate(where: PersonWhere): PersonAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"peopleConnection\\\\\\"\\")
               peopleConnection(after: String, first: Int, sort: [PersonSort!], where: PersonWhere): PeopleConnection!
               productions(limit: Int, offset: Int, options: ProductionOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ProductionSort!], where: ProductionWhere): [Production!]!
-              productionsAggregate(where: ProductionWhere): ProductionAggregateSelection!
+              productionsAggregate(where: ProductionWhere): ProductionAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"productionsConnection\\\\\\"\\")
               productionsConnection(after: String, first: Int, sort: [ProductionSort!], where: ProductionWhere): ProductionsConnection!
             }
 
@@ -2389,10 +2389,10 @@ describe("Algebraic", () => {
 
             type Query {
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
               people(limit: Int, offset: Int, options: PersonOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonSort!], where: PersonWhere): [Person!]!
-              peopleAggregate(where: PersonWhere): PersonAggregateSelection!
+              peopleAggregate(where: PersonWhere): PersonAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"peopleConnection\\\\\\"\\")
               peopleConnection(after: String, first: Int, sort: [PersonSort!], where: PersonWhere): PeopleConnection!
             }
 

--- a/packages/graphql/tests/schema/math.test.ts
+++ b/packages/graphql/tests/schema/math.test.ts
@@ -76,6 +76,16 @@ describe("Algebraic", () => {
               viewers: Int!
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              viewers: IntAggregateSelection!
+            }
+
             type MovieAggregateSelection {
               count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -138,6 +148,7 @@ describe("Algebraic", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -246,6 +257,16 @@ describe("Algebraic", () => {
               viewers: BigInt!
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              viewers: BigIntAggregateSelection!
+            }
+
             type MovieAggregateSelection {
               count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -308,6 +329,7 @@ describe("Algebraic", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -412,6 +434,16 @@ describe("Algebraic", () => {
               viewers: Float!
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              viewers: FloatAggregateSelection!
+            }
+
             type MovieAggregateSelection {
               count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -476,6 +508,7 @@ describe("Algebraic", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -578,6 +611,15 @@ describe("Algebraic", () => {
               directsAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: MovieWhere): DirectorMovieDirectsAggregationSelection
               directsConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [DirectorDirectsConnectionSort!], where: DirectorDirectsConnectionWhere): DirectorDirectsConnection!
               lastName: String!
+            }
+
+            type DirectorAggregate {
+              node: DirectorAggregateNode!
+            }
+
+            type DirectorAggregateNode {
+              count: Int!
+              lastName: StringAggregateSelection!
             }
 
             type DirectorAggregateSelection {
@@ -793,6 +835,7 @@ describe("Algebraic", () => {
             }
 
             type DirectorsConnection {
+              aggregate: DirectorAggregate!
               edges: [DirectorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -816,6 +859,16 @@ describe("Algebraic", () => {
               directedByConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [MovieDirectedByConnectionSort!], where: MovieDirectedByConnectionWhere): MovieDirectedByConnection!
               id: ID
               viewers: Int!
+            }
+
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              viewers: IntAggregateSelection!
             }
 
             type MovieAggregateSelection {
@@ -1007,6 +1060,7 @@ describe("Algebraic", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1142,6 +1196,16 @@ describe("Algebraic", () => {
               workers(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), limit: Int, offset: Int, options: PersonOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonSort!], where: PersonWhere): [Person!]!
               workersAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: PersonWhere): MoviePersonWorkersAggregationSelection
               workersConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [MovieWorkersConnectionSort!], where: MovieWorkersConnectionWhere): MovieWorkersConnection!
+            }
+
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              viewers: IntAggregateSelection!
             }
 
             type MovieAggregateSelection {
@@ -1343,6 +1407,7 @@ describe("Algebraic", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1366,6 +1431,7 @@ describe("Algebraic", () => {
             }
 
             type PeopleConnection {
+              aggregate: PersonAggregate!
               edges: [PersonEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1376,6 +1442,15 @@ describe("Algebraic", () => {
               worksInProduction(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), limit: Int, offset: Int, options: ProductionOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ProductionSort!], where: ProductionWhere): [Production!]!
               worksInProductionAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: ProductionWhere): PersonProductionWorksInProductionAggregationSelection
               worksInProductionConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [PersonWorksInProductionConnectionSort!], where: PersonWorksInProductionConnectionWhere): PersonWorksInProductionConnection!
+            }
+
+            type PersonAggregate {
+              node: PersonAggregateNode!
+            }
+
+            type PersonAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
             }
 
             type PersonAggregateSelection {
@@ -1576,6 +1651,15 @@ describe("Algebraic", () => {
               viewers: Int!
             }
 
+            type ProductionAggregate {
+              node: ProductionAggregateNode!
+            }
+
+            type ProductionAggregateNode {
+              count: Int!
+              viewers: IntAggregateSelection!
+            }
+
             type ProductionAggregateSelection {
               count: Int!
               viewers: IntAggregateSelection!
@@ -1637,6 +1721,7 @@ describe("Algebraic", () => {
             }
 
             type ProductionsConnection {
+              aggregate: ProductionAggregate!
               edges: [ProductionEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1934,6 +2019,15 @@ describe("Algebraic", () => {
               where: MovieActorsConnectionWhere
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              title: StringAggregateSelection!
+            }
+
             type MovieAggregateSelection {
               count: Int!
               title: StringAggregateSelection!
@@ -2039,6 +2133,7 @@ describe("Algebraic", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -2062,6 +2157,7 @@ describe("Algebraic", () => {
             }
 
             type PeopleConnection {
+              aggregate: PersonAggregate!
               edges: [PersonEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -2176,6 +2272,15 @@ describe("Algebraic", () => {
               disconnect: [PersonActedInMoviesDisconnectFieldInput!]
               update: PersonActedInMoviesUpdateConnectionInput
               where: PersonActedInMoviesConnectionWhere
+            }
+
+            type PersonAggregate {
+              node: PersonAggregateNode!
+            }
+
+            type PersonAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
             }
 
             type PersonAggregateSelection {

--- a/packages/graphql/tests/schema/nested-aggregation-on-type.test.ts
+++ b/packages/graphql/tests/schema/nested-aggregation-on-type.test.ts
@@ -240,6 +240,15 @@ describe("nested aggregation on interface", () => {
               where: ActorActedInConnectionWhere
             }
 
+            type ActorAggregate {
+              node: ActorAggregateNode!
+            }
+
+            type ActorAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
             type ActorAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -335,6 +344,7 @@ describe("nested aggregation on interface", () => {
             }
 
             type ActorsConnection {
+              aggregate: ActorAggregate!
               edges: [ActorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -384,6 +394,17 @@ describe("nested aggregation on interface", () => {
               cost: Float!
               runtime: Int!
               title: String!
+            }
+
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              cost: FloatAggregateSelection!
+              count: Int!
+              runtime: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             type MovieAggregateSelection {
@@ -468,6 +489,7 @@ describe("nested aggregation on interface", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/nested-aggregation-on-type.test.ts
+++ b/packages/graphql/tests/schema/nested-aggregation-on-type.test.ts
@@ -514,10 +514,10 @@ describe("nested aggregation on interface", () => {
 
             type Query {
               actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
               actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 

--- a/packages/graphql/tests/schema/null.test.ts
+++ b/packages/graphql/tests/schema/null.test.ts
@@ -342,7 +342,7 @@ describe("Null", () => {
 
             type Query {
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 

--- a/packages/graphql/tests/schema/null.test.ts
+++ b/packages/graphql/tests/schema/null.test.ts
@@ -114,6 +114,19 @@ describe("Null", () => {
               names: [String!]!
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              actorCount: IntAggregateSelection!
+              averageRating: FloatAggregateSelection!
+              count: Int!
+              createdAt: DateTimeAggregateSelection!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              name: StringAggregateSelection!
+            }
+
             type MovieAggregateSelection {
               actorCount: IntAggregateSelection!
               averageRating: FloatAggregateSelection!
@@ -282,6 +295,7 @@ describe("Null", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/pluralize-consistency.test.ts
+++ b/packages/graphql/tests/schema/pluralize-consistency.test.ts
@@ -109,12 +109,14 @@ describe("Pluralize consistency", () => {
             }
 
             type SuperFriendsConnection {
+              aggregate: super_friendAggregate!
               edges: [super_friendEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
             }
 
             type SuperUsersConnection {
+              aggregate: super_userAggregate!
               edges: [super_userEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -142,6 +144,15 @@ describe("Pluralize consistency", () => {
 
             type super_friend {
               name: String!
+            }
+
+            type super_friendAggregate {
+              node: super_friendAggregateNode!
+            }
+
+            type super_friendAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
             }
 
             type super_friendAggregateSelection {
@@ -200,6 +211,15 @@ describe("Pluralize consistency", () => {
               my_friendAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: super_friendWhere): super_usersuper_friendMy_friendAggregationSelection
               my_friendConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [super_userMy_friendConnectionSort!], where: super_userMy_friendConnectionWhere): super_userMy_friendConnection!
               name: String!
+            }
+
+            type super_userAggregate {
+              node: super_userAggregateNode!
+            }
+
+            type super_userAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
             }
 
             type super_userAggregateSelection {

--- a/packages/graphql/tests/schema/pluralize-consistency.test.ts
+++ b/packages/graphql/tests/schema/pluralize-consistency.test.ts
@@ -88,10 +88,10 @@ describe("Pluralize consistency", () => {
 
             type Query {
               superFriends(limit: Int, offset: Int, options: super_friendOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [super_friendSort!], where: super_friendWhere): [super_friend!]!
-              superFriendsAggregate(where: super_friendWhere): super_friendAggregateSelection!
+              superFriendsAggregate(where: super_friendWhere): super_friendAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"superFriendsConnection\\\\\\"\\")
               superFriendsConnection(after: String, first: Int, sort: [super_friendSort!], where: super_friendWhere): SuperFriendsConnection!
               superUsers(limit: Int, offset: Int, options: super_userOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [super_userSort!], where: super_userWhere): [super_user!]!
-              superUsersAggregate(where: super_userWhere): super_userAggregateSelection!
+              superUsersAggregate(where: super_userWhere): super_userAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"superUsersConnection\\\\\\"\\")
               superUsersConnection(after: String, first: Int, sort: [super_userSort!], where: super_userWhere): SuperUsersConnection!
             }
 

--- a/packages/graphql/tests/schema/query-direction.test.ts
+++ b/packages/graphql/tests/schema/query-direction.test.ts
@@ -76,7 +76,7 @@ describe("Query Direction", () => {
 
             type Query {
               users(limit: Int, offset: Int, options: UserOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [UserSort!], where: UserWhere): [User!]!
-              usersAggregate(where: UserWhere): UserAggregateSelection!
+              usersAggregate(where: UserWhere): UserAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"usersConnection\\\\\\"\\")
               usersConnection(after: String, first: Int, sort: [UserSort!], where: UserWhere): UsersConnection!
             }
 
@@ -382,7 +382,7 @@ describe("Query Direction", () => {
 
             type Query {
               users(limit: Int, offset: Int, options: UserOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [UserSort!], where: UserWhere): [User!]!
-              usersAggregate(where: UserWhere): UserAggregateSelection!
+              usersAggregate(where: UserWhere): UserAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"usersConnection\\\\\\"\\")
               usersConnection(after: String, first: Int, sort: [UserSort!], where: UserWhere): UsersConnection!
             }
 

--- a/packages/graphql/tests/schema/query-direction.test.ts
+++ b/packages/graphql/tests/schema/query-direction.test.ts
@@ -115,6 +115,15 @@ describe("Query Direction", () => {
               name: String!
             }
 
+            type UserAggregate {
+              node: UserAggregateNode!
+            }
+
+            type UserAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
             type UserAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -312,6 +321,7 @@ describe("Query Direction", () => {
             }
 
             type UsersConnection {
+              aggregate: UserAggregate!
               edges: [UserEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -411,6 +421,15 @@ describe("Query Direction", () => {
               name: String!
             }
 
+            type UserAggregate {
+              node: UserAggregateNode!
+            }
+
+            type UserAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
             type UserAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -608,6 +627,7 @@ describe("Query Direction", () => {
             }
 
             type UsersConnection {
+              aggregate: UserAggregate!
               edges: [UserEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/remove-deprecated/aggregate-operations.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/aggregate-operations.test.ts
@@ -21,16 +21,15 @@ import { printSchemaWithDirectives } from "@graphql-tools/utils";
 import { lexicographicSortSchema } from "graphql/utilities";
 import { Neo4jGraphQL } from "../../../src";
 
-describe("Aggregations", () => {
-    test("should remove ID Aggregations", async () => {
+describe("Aggregate operations", () => {
+    test("should remove deprecated aggregate operations", async () => {
         const typeDefs = /* GraphQL */ `
             type User @node {
-                someID: ID
+                someID: Int
                 someString: String
             }
 
             type Post @node {
-                someID: ID
                 title: String
                 likes: [User!]! @relationship(type: "LIKES", direction: IN, properties: "Likes")
             }
@@ -42,7 +41,7 @@ describe("Aggregations", () => {
         `;
         const neoSchema = new Neo4jGraphQL({
             typeDefs,
-            features: { excludeDeprecatedFields: { idAggregations: true } },
+            features: { excludeDeprecatedFields: { deprecatedAggregateOperations: true } },
         });
         const printedSchema = printSchemaWithDirectives(lexicographicSortSchema(await neoSchema.getSchema()));
 
@@ -78,6 +77,18 @@ describe("Aggregations", () => {
               relationshipsDeleted: Int!
             }
 
+            type IDAggregateSelection {
+              longest: ID
+              shortest: ID
+            }
+
+            type IntAggregateSelection {
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
+            }
+
             \\"\\"\\"
             The edge properties for the following fields:
             * Post.likes
@@ -91,6 +102,16 @@ describe("Aggregations", () => {
               AND: [LikesAggregationWhereInput!]
               NOT: LikesAggregationWhereInput
               OR: [LikesAggregationWhereInput!]
+              someID_MAX_EQUAL: ID @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              someID_MAX_GT: ID @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              someID_MAX_GTE: ID @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              someID_MAX_LT: ID @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              someID_MAX_LTE: ID @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              someID_MIN_EQUAL: ID @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              someID_MIN_GT: ID @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              someID_MIN_GTE: ID @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              someID_MIN_LT: ID @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              someID_MIN_LTE: ID @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
               someString_AVERAGE_LENGTH_EQUAL: Float
               someString_AVERAGE_LENGTH_GT: Float
               someString_AVERAGE_LENGTH_GTE: Float
@@ -164,7 +185,6 @@ describe("Aggregations", () => {
               likes(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), limit: Int, offset: Int, options: UserOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [UserSort!], where: UserWhere): [User!]!
               likesAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: UserWhere): PostUserLikesAggregationSelection
               likesConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [PostLikesConnectionSort!], where: PostLikesConnectionWhere): PostLikesConnection!
-              someID: ID
               title: String
             }
 
@@ -177,14 +197,8 @@ describe("Aggregations", () => {
               title: StringAggregateSelection!
             }
 
-            type PostAggregateSelection {
-              count: Int!
-              title: StringAggregateSelection!
-            }
-
             input PostCreateInput {
               likes: PostLikesFieldInput
-              someID: ID
               title: String
             }
 
@@ -261,6 +275,26 @@ describe("Aggregations", () => {
               AND: [PostLikesNodeAggregationWhereInput!]
               NOT: PostLikesNodeAggregationWhereInput
               OR: [PostLikesNodeAggregationWhereInput!]
+              someID_AVERAGE_EQUAL: Float
+              someID_AVERAGE_GT: Float
+              someID_AVERAGE_GTE: Float
+              someID_AVERAGE_LT: Float
+              someID_AVERAGE_LTE: Float
+              someID_MAX_EQUAL: Int
+              someID_MAX_GT: Int
+              someID_MAX_GTE: Int
+              someID_MAX_LT: Int
+              someID_MAX_LTE: Int
+              someID_MIN_EQUAL: Int
+              someID_MIN_GT: Int
+              someID_MIN_GTE: Int
+              someID_MIN_LT: Int
+              someID_MIN_LTE: Int
+              someID_SUM_EQUAL: Int
+              someID_SUM_GT: Int
+              someID_SUM_GTE: Int
+              someID_SUM_LT: Int
+              someID_SUM_LTE: Int
               someString_AVERAGE_LENGTH_EQUAL: Float
               someString_AVERAGE_LENGTH_GT: Float
               someString_AVERAGE_LENGTH_GTE: Float
@@ -311,14 +345,11 @@ describe("Aggregations", () => {
             Fields to sort Posts by. The order in which sorts are applied is not guaranteed when specifying many fields in one PostSort object.
             \\"\\"\\"
             input PostSort {
-              someID: SortDirection
               title: SortDirection
             }
 
             input PostUpdateInput {
               likes: [PostLikesUpdateFieldInput!]
-              someID: ID @deprecated(reason: \\"Please use the explicit _SET field\\")
-              someID_SET: ID
               title: String @deprecated(reason: \\"Please use the explicit _SET field\\")
               title_SET: String
             }
@@ -330,10 +361,12 @@ describe("Aggregations", () => {
             }
 
             type PostUserLikesEdgeAggregateSelection {
+              someID: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
               someString: StringAggregateSelection!
             }
 
             type PostUserLikesNodeAggregateSelection {
+              someID: IntAggregateSelection!
               someString: StringAggregateSelection!
             }
 
@@ -366,12 +399,6 @@ describe("Aggregations", () => {
               likes_SINGLE: UserWhere
               \\"\\"\\"Return Posts where some of the related Users match this filter\\"\\"\\"
               likes_SOME: UserWhere
-              someID: ID @deprecated(reason: \\"Please use the explicit _EQ version\\")
-              someID_CONTAINS: ID
-              someID_ENDS_WITH: ID
-              someID_EQ: ID
-              someID_IN: [ID]
-              someID_STARTS_WITH: ID
               title: String @deprecated(reason: \\"Please use the explicit _EQ version\\")
               title_CONTAINS: String
               title_ENDS_WITH: String
@@ -389,10 +416,8 @@ describe("Aggregations", () => {
 
             type Query {
               posts(limit: Int, offset: Int, options: PostOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PostSort!], where: PostWhere): [Post!]!
-              postsAggregate(where: PostWhere): PostAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"postsConnection\\\\\\"\\")
               postsConnection(after: String, first: Int, sort: [PostSort!], where: PostWhere): PostsConnection!
               users(limit: Int, offset: Int, options: UserOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [UserSort!], where: UserWhere): [User!]!
-              usersAggregate(where: UserWhere): UserAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"usersConnection\\\\\\"\\")
               usersConnection(after: String, first: Int, sort: [UserSort!], where: UserWhere): UsersConnection!
             }
 
@@ -430,7 +455,7 @@ describe("Aggregations", () => {
             }
 
             type User {
-              someID: ID
+              someID: Int
               someString: String
             }
 
@@ -440,11 +465,7 @@ describe("Aggregations", () => {
 
             type UserAggregateNode {
               count: Int!
-              someString: StringAggregateSelection!
-            }
-
-            type UserAggregateSelection {
-              count: Int!
+              someID: IntAggregateSelection!
               someString: StringAggregateSelection!
             }
 
@@ -453,7 +474,7 @@ describe("Aggregations", () => {
             }
 
             input UserCreateInput {
-              someID: ID
+              someID: Int
               someString: String
             }
 
@@ -480,8 +501,10 @@ describe("Aggregations", () => {
             }
 
             input UserUpdateInput {
-              someID: ID @deprecated(reason: \\"Please use the explicit _SET field\\")
-              someID_SET: ID
+              someID: Int @deprecated(reason: \\"Please use the explicit _SET field\\")
+              someID_DECREMENT: Int
+              someID_INCREMENT: Int
+              someID_SET: Int
               someString: String @deprecated(reason: \\"Please use the explicit _SET field\\")
               someString_SET: String
             }
@@ -490,12 +513,13 @@ describe("Aggregations", () => {
               AND: [UserWhere!]
               NOT: UserWhere
               OR: [UserWhere!]
-              someID: ID @deprecated(reason: \\"Please use the explicit _EQ version\\")
-              someID_CONTAINS: ID
-              someID_ENDS_WITH: ID
-              someID_EQ: ID
-              someID_IN: [ID]
-              someID_STARTS_WITH: ID
+              someID: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              someID_EQ: Int
+              someID_GT: Int
+              someID_GTE: Int
+              someID_IN: [Int]
+              someID_LT: Int
+              someID_LTE: Int
               someString: String @deprecated(reason: \\"Please use the explicit _EQ version\\")
               someString_CONTAINS: String
               someString_ENDS_WITH: String

--- a/packages/graphql/tests/schema/remove-deprecated/aggregations.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/aggregations.test.ts
@@ -389,10 +389,10 @@ describe("Aggregations", () => {
 
             type Query {
               posts(limit: Int, offset: Int, options: PostOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PostSort!], where: PostWhere): [Post!]!
-              postsAggregate(where: PostWhere): PostAggregateSelection!
+              postsAggregate(where: PostWhere): PostAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"postsConnection\\\\\\"\\")
               postsConnection(after: String, first: Int, sort: [PostSort!], where: PostWhere): PostsConnection!
               users(limit: Int, offset: Int, options: UserOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [UserSort!], where: UserWhere): [User!]!
-              usersAggregate(where: UserWhere): UserAggregateSelection!
+              usersAggregate(where: UserWhere): UserAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"usersConnection\\\\\\"\\")
               usersConnection(after: String, first: Int, sort: [UserSort!], where: UserWhere): UsersConnection!
             }
 

--- a/packages/graphql/tests/schema/remove-deprecated/aggregations.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/aggregations.test.ts
@@ -168,6 +168,15 @@ describe("Aggregations", () => {
               title: String
             }
 
+            type PostAggregate {
+              node: PostAggregateNode!
+            }
+
+            type PostAggregateNode {
+              count: Int!
+              title: StringAggregateSelection!
+            }
+
             type PostAggregateSelection {
               count: Int!
               title: StringAggregateSelection!
@@ -372,6 +381,7 @@ describe("Aggregations", () => {
             }
 
             type PostsConnection {
+              aggregate: PostAggregate!
               edges: [PostEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -422,6 +432,15 @@ describe("Aggregations", () => {
             type User {
               someID: ID
               someString: String
+            }
+
+            type UserAggregate {
+              node: UserAggregateNode!
+            }
+
+            type UserAggregateNode {
+              count: Int!
+              someString: StringAggregateSelection!
             }
 
             type UserAggregateSelection {
@@ -486,6 +505,7 @@ describe("Aggregations", () => {
             }
 
             type UsersConnection {
+              aggregate: UserAggregate!
               edges: [UserEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/remove-deprecated/array-methods.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/array-methods.test.ts
@@ -635,10 +635,10 @@ describe("Arrays Methods", () => {
 
             type Query {
               actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
               actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 

--- a/packages/graphql/tests/schema/remove-deprecated/array-methods.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/array-methods.test.ts
@@ -210,6 +210,15 @@ describe("Arrays Methods", () => {
               where: ActorActedInConnectionWhere
             }
 
+            type ActorAggregate {
+              node: ActorAggregateNode!
+            }
+
+            type ActorAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
             type ActorAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -311,6 +320,7 @@ describe("Arrays Methods", () => {
             }
 
             type ActorsConnection {
+              aggregate: ActorAggregate!
               edges: [ActorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -475,6 +485,16 @@ describe("Arrays Methods", () => {
               where: MovieActorsConnectionWhere
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              averageRating: FloatAggregateSelection!
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+            }
+
             type MovieAggregateSelection {
               averageRating: FloatAggregateSelection!
               count: Int!
@@ -590,6 +610,7 @@ describe("Arrays Methods", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/remove-deprecated/comments.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/comments.test.ts
@@ -134,6 +134,17 @@ describe("Comments", () => {
               isActive: Boolean
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              actorCount: IntAggregateSelection!
+              averageRating: FloatAggregateSelection!
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+            }
+
             type MovieAggregateSelection {
               actorCount: IntAggregateSelection!
               averageRating: FloatAggregateSelection!
@@ -232,6 +243,7 @@ describe("Comments", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -310,6 +322,15 @@ describe("Comments", () => {
                   name: String
                 }
 
+                type ActorAggregate {
+                  node: ActorAggregateNode!
+                }
+
+                type ActorAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
+                }
+
                 type ActorAggregateSelection {
                   count: Int!
                   name: StringAggregateSelection!
@@ -362,6 +383,7 @@ describe("Comments", () => {
                 }
 
                 type ActorsConnection {
+                  aggregate: ActorAggregate!
                   edges: [ActorEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -509,6 +531,15 @@ describe("Comments", () => {
                   where: MovieActorsConnectionWhere
                 }
 
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+                }
+
                 type MovieAggregateSelection {
                   count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -588,6 +619,7 @@ describe("Comments", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -858,6 +890,15 @@ describe("Comments", () => {
                   where: ActorActedInConnectionWhere
                 }
 
+                type ActorAggregate {
+                  node: ActorAggregateNode!
+                }
+
+                type ActorAggregateNode {
+                  count: Int!
+                  name: StringAggregateSelection!
+                }
+
                 type ActorAggregateSelection {
                   count: Int!
                   name: StringAggregateSelection!
@@ -951,6 +992,7 @@ describe("Comments", () => {
                 }
 
                 type ActorsConnection {
+                  aggregate: ActorAggregate!
                   edges: [ActorEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -997,6 +1039,16 @@ describe("Comments", () => {
                 type Movie implements Production {
                   runtime: Int!
                   title: String!
+                }
+
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  runtime: IntAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 type MovieAggregateSelection {
@@ -1061,6 +1113,7 @@ describe("Comments", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -1088,6 +1141,15 @@ describe("Comments", () => {
 
                 interface Production {
                   title: String!
+                }
+
+                type ProductionAggregate {
+                  node: ProductionAggregateNode!
+                }
+
+                type ProductionAggregateNode {
+                  count: Int!
+                  title: StringAggregateSelection!
                 }
 
                 type ProductionAggregateSelection {
@@ -1150,6 +1212,7 @@ describe("Comments", () => {
                 }
 
                 type ProductionsConnection {
+                  aggregate: ProductionAggregate!
                   edges: [ProductionEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -1175,6 +1238,16 @@ describe("Comments", () => {
                   title: String!
                 }
 
+                type SeriesAggregate {
+                  node: SeriesAggregateNode!
+                }
+
+                type SeriesAggregateNode {
+                  count: Int!
+                  episodes: IntAggregateSelection!
+                  title: StringAggregateSelection!
+                }
+
                 type SeriesAggregateSelection {
                   count: Int!
                   episodes: IntAggregateSelection!
@@ -1182,6 +1255,7 @@ describe("Comments", () => {
                 }
 
                 type SeriesConnection {
+                  aggregate: SeriesAggregate!
                   edges: [SeriesEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -1337,6 +1411,15 @@ describe("Comments", () => {
                   id: ID
                 }
 
+                type GenreAggregate {
+                  node: GenreAggregateNode!
+                }
+
+                type GenreAggregateNode {
+                  count: Int!
+                  id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+                }
+
                 type GenreAggregateSelection {
                   count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -1389,6 +1472,7 @@ describe("Comments", () => {
                 }
 
                 type GenresConnection {
+                  aggregate: GenreAggregate!
                   edges: [GenreEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -1404,6 +1488,15 @@ describe("Comments", () => {
                   search(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), limit: Int, offset: Int, options: QueryOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: SearchWhere): [Search!]!
                   searchConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, where: MovieSearchConnectionWhere): MovieSearchConnection!
                   searchNoDirective: Search
+                }
+
+                type MovieAggregate {
+                  node: MovieAggregateNode!
+                }
+
+                type MovieAggregateNode {
+                  count: Int!
+                  id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
                 }
 
                 type MovieAggregateSelection {
@@ -1622,6 +1715,7 @@ describe("Comments", () => {
                 }
 
                 type MoviesConnection {
+                  aggregate: MovieAggregate!
                   edges: [MovieEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!

--- a/packages/graphql/tests/schema/remove-deprecated/comments.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/comments.test.ts
@@ -265,7 +265,7 @@ describe("Comments", () => {
 
             type Query {
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 
@@ -644,10 +644,10 @@ describe("Comments", () => {
 
                 type Query {
                   actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-                  actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+                  actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
                   actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                 }
 
@@ -1220,16 +1220,16 @@ describe("Comments", () => {
 
                 type Query {
                   actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-                  actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+                  actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
                   actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                   productions(limit: Int, offset: Int, options: ProductionOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ProductionSort!], where: ProductionWhere): [Production!]!
-                  productionsAggregate(where: ProductionWhere): ProductionAggregateSelection!
+                  productionsAggregate(where: ProductionWhere): ProductionAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"productionsConnection\\\\\\"\\")
                   productionsConnection(after: String, first: Int, sort: [ProductionSort!], where: ProductionWhere): ProductionsConnection!
                   series(limit: Int, offset: Int, options: SeriesOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [SeriesSort!], where: SeriesWhere): [Series!]!
-                  seriesAggregate(where: SeriesWhere): SeriesAggregateSelection!
+                  seriesAggregate(where: SeriesWhere): SeriesAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"seriesConnection\\\\\\"\\")
                   seriesConnection(after: String, first: Int, sort: [SeriesSort!], where: SeriesWhere): SeriesConnection!
                 }
 
@@ -1740,10 +1740,10 @@ describe("Comments", () => {
 
                 type Query {
                   genres(limit: Int, offset: Int, options: GenreOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [GenreSort!], where: GenreWhere): [Genre!]!
-                  genresAggregate(where: GenreWhere): GenreAggregateSelection!
+                  genresAggregate(where: GenreWhere): GenreAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"genresConnection\\\\\\"\\")
                   genresConnection(after: String, first: Int, sort: [GenreSort!], where: GenreWhere): GenresConnection!
                   movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
                   moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
                   searches(limit: Int, offset: Int, options: QueryOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: SearchWhere): [Search!]!
                 }

--- a/packages/graphql/tests/schema/remove-deprecated/connect-or-create.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/connect-or-create.test.ts
@@ -54,6 +54,15 @@ describe("Connect Or Create", () => {
               name: String!
             }
 
+            type ActorAggregate {
+              node: ActorAggregateNode!
+            }
+
+            type ActorAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
             type ActorAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -252,6 +261,7 @@ describe("Connect Or Create", () => {
             }
 
             type ActorsConnection {
+              aggregate: ActorAggregate!
               edges: [ActorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -286,6 +296,16 @@ describe("Connect Or Create", () => {
             type Movie {
               isan: String!
               title: String!
+            }
+
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              isan: StringAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             type MovieAggregateSelection {
@@ -351,6 +371,7 @@ describe("Connect Or Create", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/remove-deprecated/connect-or-create.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/connect-or-create.test.ts
@@ -396,10 +396,10 @@ describe("Connect Or Create", () => {
 
             type Query {
               actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
               actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 

--- a/packages/graphql/tests/schema/remove-deprecated/directed-argument.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/directed-argument.test.ts
@@ -167,6 +167,15 @@ describe("Deprecated directed argument", () => {
               name: String!
             }
 
+            type ActorAggregate {
+              node: ActorAggregateNode!
+            }
+
+            type ActorAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
             type ActorAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -376,6 +385,7 @@ describe("Deprecated directed argument", () => {
             }
 
             type ActorsConnection {
+              aggregate: ActorAggregate!
               edges: [ActorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -417,6 +427,15 @@ describe("Deprecated directed argument", () => {
 
             type Genre {
               id: ID
+            }
+
+            type GenreAggregate {
+              node: GenreAggregateNode!
+            }
+
+            type GenreAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
             type GenreAggregateSelection {
@@ -467,6 +486,7 @@ describe("Deprecated directed argument", () => {
             }
 
             type GenresConnection {
+              aggregate: GenreAggregate!
               edges: [GenreEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -609,6 +629,15 @@ describe("Deprecated directed argument", () => {
               where: MovieActorsConnectionWhere
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              title: StringAggregateSelection!
+            }
+
             type MovieAggregateSelection {
               count: Int!
               title: StringAggregateSelection!
@@ -700,6 +729,7 @@ describe("Deprecated directed argument", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -727,6 +757,15 @@ describe("Deprecated directed argument", () => {
 
             interface Production {
               title: String!
+            }
+
+            type ProductionAggregate {
+              node: ProductionAggregateNode!
+            }
+
+            type ProductionAggregateNode {
+              count: Int!
+              title: StringAggregateSelection!
             }
 
             type ProductionAggregateSelection {
@@ -774,6 +813,7 @@ describe("Deprecated directed argument", () => {
             }
 
             type ProductionsConnection {
+              aggregate: ProductionAggregate!
               edges: [ProductionEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/remove-deprecated/directed-argument.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/directed-argument.test.ts
@@ -821,16 +821,16 @@ describe("Deprecated directed argument", () => {
 
             type Query {
               actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
               actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
               genres(limit: Int, offset: Int, options: GenreOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [GenreSort!], where: GenreWhere): [Genre!]!
-              genresAggregate(where: GenreWhere): GenreAggregateSelection!
+              genresAggregate(where: GenreWhere): GenreAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"genresConnection\\\\\\"\\")
               genresConnection(after: String, first: Int, sort: [GenreSort!], where: GenreWhere): GenresConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
               productions(limit: Int, offset: Int, options: ProductionOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ProductionSort!], where: ProductionWhere): [Production!]!
-              productionsAggregate(where: ProductionWhere): ProductionAggregateSelection!
+              productionsAggregate(where: ProductionWhere): ProductionAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"productionsConnection\\\\\\"\\")
               productionsConnection(after: String, first: Int, sort: [ProductionSort!], where: ProductionWhere): ProductionsConnection!
               searches(limit: Int, offset: Int, options: QueryOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: SearchWhere): [Search!]!
             }

--- a/packages/graphql/tests/schema/remove-deprecated/id-aggregations.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/id-aggregations.test.ts
@@ -1,0 +1,515 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { printSchemaWithDirectives } from "@graphql-tools/utils";
+import { lexicographicSortSchema } from "graphql/utilities";
+import { Neo4jGraphQL } from "../../../src";
+
+describe("Aggregations id", () => {
+    test("should remove ID Aggregations", async () => {
+        const typeDefs = /* GraphQL */ `
+            type User @node {
+                someID: ID
+                someString: String
+            }
+
+            type Post @node {
+                someID: ID
+                title: String
+                likes: [User!]! @relationship(type: "LIKES", direction: IN, properties: "Likes")
+            }
+
+            type Likes @relationshipProperties {
+                someID: ID
+                someString: String
+            }
+        `;
+        const neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            features: { excludeDeprecatedFields: { idAggregations: true } },
+        });
+        const printedSchema = printSchemaWithDirectives(lexicographicSortSchema(await neoSchema.getSchema()));
+
+        expect(printedSchema).toMatchInlineSnapshot(`
+            "schema {
+              query: Query
+              mutation: Mutation
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships created during a create mutation
+            \\"\\"\\"
+            type CreateInfo {
+              nodesCreated: Int!
+              relationshipsCreated: Int!
+            }
+
+            type CreatePostsMutationResponse {
+              info: CreateInfo!
+              posts: [Post!]!
+            }
+
+            type CreateUsersMutationResponse {
+              info: CreateInfo!
+              users: [User!]!
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships deleted during a delete mutation
+            \\"\\"\\"
+            type DeleteInfo {
+              nodesDeleted: Int!
+              relationshipsDeleted: Int!
+            }
+
+            \\"\\"\\"
+            The edge properties for the following fields:
+            * Post.likes
+            \\"\\"\\"
+            type Likes {
+              someID: ID
+              someString: String
+            }
+
+            input LikesAggregationWhereInput {
+              AND: [LikesAggregationWhereInput!]
+              NOT: LikesAggregationWhereInput
+              OR: [LikesAggregationWhereInput!]
+              someString_AVERAGE_LENGTH_EQUAL: Float
+              someString_AVERAGE_LENGTH_GT: Float
+              someString_AVERAGE_LENGTH_GTE: Float
+              someString_AVERAGE_LENGTH_LT: Float
+              someString_AVERAGE_LENGTH_LTE: Float
+              someString_LONGEST_LENGTH_EQUAL: Int
+              someString_LONGEST_LENGTH_GT: Int
+              someString_LONGEST_LENGTH_GTE: Int
+              someString_LONGEST_LENGTH_LT: Int
+              someString_LONGEST_LENGTH_LTE: Int
+              someString_SHORTEST_LENGTH_EQUAL: Int
+              someString_SHORTEST_LENGTH_GT: Int
+              someString_SHORTEST_LENGTH_GTE: Int
+              someString_SHORTEST_LENGTH_LT: Int
+              someString_SHORTEST_LENGTH_LTE: Int
+            }
+
+            input LikesCreateInput {
+              someID: ID
+              someString: String
+            }
+
+            input LikesSort {
+              someID: SortDirection
+              someString: SortDirection
+            }
+
+            input LikesUpdateInput {
+              someID: ID @deprecated(reason: \\"Please use the explicit _SET field\\")
+              someID_SET: ID
+              someString: String @deprecated(reason: \\"Please use the explicit _SET field\\")
+              someString_SET: String
+            }
+
+            input LikesWhere {
+              AND: [LikesWhere!]
+              NOT: LikesWhere
+              OR: [LikesWhere!]
+              someID: ID @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              someID_CONTAINS: ID
+              someID_ENDS_WITH: ID
+              someID_EQ: ID
+              someID_IN: [ID]
+              someID_STARTS_WITH: ID
+              someString: String @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              someString_CONTAINS: String
+              someString_ENDS_WITH: String
+              someString_EQ: String
+              someString_IN: [String]
+              someString_STARTS_WITH: String
+            }
+
+            type Mutation {
+              createPosts(input: [PostCreateInput!]!): CreatePostsMutationResponse!
+              createUsers(input: [UserCreateInput!]!): CreateUsersMutationResponse!
+              deletePosts(delete: PostDeleteInput, where: PostWhere): DeleteInfo!
+              deleteUsers(where: UserWhere): DeleteInfo!
+              updatePosts(update: PostUpdateInput, where: PostWhere): UpdatePostsMutationResponse!
+              updateUsers(update: UserUpdateInput, where: UserWhere): UpdateUsersMutationResponse!
+            }
+
+            \\"\\"\\"Pagination information (Relay)\\"\\"\\"
+            type PageInfo {
+              endCursor: String
+              hasNextPage: Boolean!
+              hasPreviousPage: Boolean!
+              startCursor: String
+            }
+
+            type Post {
+              likes(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), limit: Int, offset: Int, options: UserOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [UserSort!], where: UserWhere): [User!]!
+              likesAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: UserWhere): PostUserLikesAggregationSelection
+              likesConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [PostLikesConnectionSort!], where: PostLikesConnectionWhere): PostLikesConnection!
+              someID: ID
+              title: String
+            }
+
+            type PostAggregate {
+              node: PostAggregateNode!
+            }
+
+            type PostAggregateNode {
+              count: Int!
+              title: StringAggregateSelection!
+            }
+
+            type PostAggregateSelection {
+              count: Int!
+              title: StringAggregateSelection!
+            }
+
+            input PostCreateInput {
+              likes: PostLikesFieldInput
+              someID: ID
+              title: String
+            }
+
+            input PostDeleteInput {
+              likes: [PostLikesDeleteFieldInput!]
+            }
+
+            type PostEdge {
+              cursor: String!
+              node: Post!
+            }
+
+            input PostLikesAggregateInput {
+              AND: [PostLikesAggregateInput!]
+              NOT: PostLikesAggregateInput
+              OR: [PostLikesAggregateInput!]
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
+              count_GT: Int
+              count_GTE: Int
+              count_LT: Int
+              count_LTE: Int
+              edge: LikesAggregationWhereInput
+              node: PostLikesNodeAggregationWhereInput
+            }
+
+            input PostLikesConnectFieldInput {
+              edge: LikesCreateInput
+              \\"\\"\\"
+              Whether or not to overwrite any matching relationship with the new properties.
+              \\"\\"\\"
+              overwrite: Boolean! = true @deprecated(reason: \\"The overwrite argument is deprecated and will be removed\\")
+              where: UserConnectWhere
+            }
+
+            type PostLikesConnection {
+              edges: [PostLikesRelationship!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            input PostLikesConnectionSort {
+              edge: LikesSort
+              node: UserSort
+            }
+
+            input PostLikesConnectionWhere {
+              AND: [PostLikesConnectionWhere!]
+              NOT: PostLikesConnectionWhere
+              OR: [PostLikesConnectionWhere!]
+              edge: LikesWhere
+              node: UserWhere
+            }
+
+            input PostLikesCreateFieldInput {
+              edge: LikesCreateInput
+              node: UserCreateInput!
+            }
+
+            input PostLikesDeleteFieldInput {
+              where: PostLikesConnectionWhere
+            }
+
+            input PostLikesDisconnectFieldInput {
+              where: PostLikesConnectionWhere
+            }
+
+            input PostLikesFieldInput {
+              connect: [PostLikesConnectFieldInput!]
+              create: [PostLikesCreateFieldInput!]
+            }
+
+            input PostLikesNodeAggregationWhereInput {
+              AND: [PostLikesNodeAggregationWhereInput!]
+              NOT: PostLikesNodeAggregationWhereInput
+              OR: [PostLikesNodeAggregationWhereInput!]
+              someString_AVERAGE_LENGTH_EQUAL: Float
+              someString_AVERAGE_LENGTH_GT: Float
+              someString_AVERAGE_LENGTH_GTE: Float
+              someString_AVERAGE_LENGTH_LT: Float
+              someString_AVERAGE_LENGTH_LTE: Float
+              someString_LONGEST_LENGTH_EQUAL: Int
+              someString_LONGEST_LENGTH_GT: Int
+              someString_LONGEST_LENGTH_GTE: Int
+              someString_LONGEST_LENGTH_LT: Int
+              someString_LONGEST_LENGTH_LTE: Int
+              someString_SHORTEST_LENGTH_EQUAL: Int
+              someString_SHORTEST_LENGTH_GT: Int
+              someString_SHORTEST_LENGTH_GTE: Int
+              someString_SHORTEST_LENGTH_LT: Int
+              someString_SHORTEST_LENGTH_LTE: Int
+            }
+
+            type PostLikesRelationship {
+              cursor: String!
+              node: User!
+              properties: Likes!
+            }
+
+            input PostLikesUpdateConnectionInput {
+              edge: LikesUpdateInput
+              node: UserUpdateInput
+            }
+
+            input PostLikesUpdateFieldInput {
+              connect: [PostLikesConnectFieldInput!]
+              create: [PostLikesCreateFieldInput!]
+              delete: [PostLikesDeleteFieldInput!]
+              disconnect: [PostLikesDisconnectFieldInput!]
+              update: PostLikesUpdateConnectionInput
+              where: PostLikesConnectionWhere
+            }
+
+            input PostOptions {
+              limit: Int
+              offset: Int
+              \\"\\"\\"
+              Specify one or more PostSort objects to sort Posts by. The sorts will be applied in the order in which they are arranged in the array.
+              \\"\\"\\"
+              sort: [PostSort!]
+            }
+
+            \\"\\"\\"
+            Fields to sort Posts by. The order in which sorts are applied is not guaranteed when specifying many fields in one PostSort object.
+            \\"\\"\\"
+            input PostSort {
+              someID: SortDirection
+              title: SortDirection
+            }
+
+            input PostUpdateInput {
+              likes: [PostLikesUpdateFieldInput!]
+              someID: ID @deprecated(reason: \\"Please use the explicit _SET field\\")
+              someID_SET: ID
+              title: String @deprecated(reason: \\"Please use the explicit _SET field\\")
+              title_SET: String
+            }
+
+            type PostUserLikesAggregationSelection {
+              count: Int!
+              edge: PostUserLikesEdgeAggregateSelection
+              node: PostUserLikesNodeAggregateSelection
+            }
+
+            type PostUserLikesEdgeAggregateSelection {
+              someString: StringAggregateSelection!
+            }
+
+            type PostUserLikesNodeAggregateSelection {
+              someString: StringAggregateSelection!
+            }
+
+            input PostWhere {
+              AND: [PostWhere!]
+              NOT: PostWhere
+              OR: [PostWhere!]
+              likesAggregate: PostLikesAggregateInput
+              \\"\\"\\"
+              Return Posts where all of the related PostLikesConnections match this filter
+              \\"\\"\\"
+              likesConnection_ALL: PostLikesConnectionWhere
+              \\"\\"\\"
+              Return Posts where none of the related PostLikesConnections match this filter
+              \\"\\"\\"
+              likesConnection_NONE: PostLikesConnectionWhere
+              \\"\\"\\"
+              Return Posts where one of the related PostLikesConnections match this filter
+              \\"\\"\\"
+              likesConnection_SINGLE: PostLikesConnectionWhere
+              \\"\\"\\"
+              Return Posts where some of the related PostLikesConnections match this filter
+              \\"\\"\\"
+              likesConnection_SOME: PostLikesConnectionWhere
+              \\"\\"\\"Return Posts where all of the related Users match this filter\\"\\"\\"
+              likes_ALL: UserWhere
+              \\"\\"\\"Return Posts where none of the related Users match this filter\\"\\"\\"
+              likes_NONE: UserWhere
+              \\"\\"\\"Return Posts where one of the related Users match this filter\\"\\"\\"
+              likes_SINGLE: UserWhere
+              \\"\\"\\"Return Posts where some of the related Users match this filter\\"\\"\\"
+              likes_SOME: UserWhere
+              someID: ID @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              someID_CONTAINS: ID
+              someID_ENDS_WITH: ID
+              someID_EQ: ID
+              someID_IN: [ID]
+              someID_STARTS_WITH: ID
+              title: String @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              title_CONTAINS: String
+              title_ENDS_WITH: String
+              title_EQ: String
+              title_IN: [String]
+              title_STARTS_WITH: String
+            }
+
+            type PostsConnection {
+              aggregate: PostAggregate!
+              edges: [PostEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type Query {
+              posts(limit: Int, offset: Int, options: PostOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PostSort!], where: PostWhere): [Post!]!
+              postsAggregate(where: PostWhere): PostAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"postsConnection\\\\\\"\\")
+              postsConnection(after: String, first: Int, sort: [PostSort!], where: PostWhere): PostsConnection!
+              users(limit: Int, offset: Int, options: UserOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [UserSort!], where: UserWhere): [User!]!
+              usersAggregate(where: UserWhere): UserAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"usersConnection\\\\\\"\\")
+              usersConnection(after: String, first: Int, sort: [UserSort!], where: UserWhere): UsersConnection!
+            }
+
+            \\"\\"\\"An enum for sorting in either ascending or descending order.\\"\\"\\"
+            enum SortDirection {
+              \\"\\"\\"Sort by field values in ascending order.\\"\\"\\"
+              ASC
+              \\"\\"\\"Sort by field values in descending order.\\"\\"\\"
+              DESC
+            }
+
+            type StringAggregateSelection {
+              longest: String
+              shortest: String
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships created and deleted during an update mutation
+            \\"\\"\\"
+            type UpdateInfo {
+              nodesCreated: Int!
+              nodesDeleted: Int!
+              relationshipsCreated: Int!
+              relationshipsDeleted: Int!
+            }
+
+            type UpdatePostsMutationResponse {
+              info: UpdateInfo!
+              posts: [Post!]!
+            }
+
+            type UpdateUsersMutationResponse {
+              info: UpdateInfo!
+              users: [User!]!
+            }
+
+            type User {
+              someID: ID
+              someString: String
+            }
+
+            type UserAggregate {
+              node: UserAggregateNode!
+            }
+
+            type UserAggregateNode {
+              count: Int!
+              someString: StringAggregateSelection!
+            }
+
+            type UserAggregateSelection {
+              count: Int!
+              someString: StringAggregateSelection!
+            }
+
+            input UserConnectWhere {
+              node: UserWhere!
+            }
+
+            input UserCreateInput {
+              someID: ID
+              someString: String
+            }
+
+            type UserEdge {
+              cursor: String!
+              node: User!
+            }
+
+            input UserOptions {
+              limit: Int
+              offset: Int
+              \\"\\"\\"
+              Specify one or more UserSort objects to sort Users by. The sorts will be applied in the order in which they are arranged in the array.
+              \\"\\"\\"
+              sort: [UserSort!]
+            }
+
+            \\"\\"\\"
+            Fields to sort Users by. The order in which sorts are applied is not guaranteed when specifying many fields in one UserSort object.
+            \\"\\"\\"
+            input UserSort {
+              someID: SortDirection
+              someString: SortDirection
+            }
+
+            input UserUpdateInput {
+              someID: ID @deprecated(reason: \\"Please use the explicit _SET field\\")
+              someID_SET: ID
+              someString: String @deprecated(reason: \\"Please use the explicit _SET field\\")
+              someString_SET: String
+            }
+
+            input UserWhere {
+              AND: [UserWhere!]
+              NOT: UserWhere
+              OR: [UserWhere!]
+              someID: ID @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              someID_CONTAINS: ID
+              someID_ENDS_WITH: ID
+              someID_EQ: ID
+              someID_IN: [ID]
+              someID_STARTS_WITH: ID
+              someString: String @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              someString_CONTAINS: String
+              someString_ENDS_WITH: String
+              someString_EQ: String
+              someString_IN: [String]
+              someString_STARTS_WITH: String
+            }
+
+            type UsersConnection {
+              aggregate: UserAggregate!
+              edges: [UserEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }"
+        `);
+    });
+});

--- a/packages/graphql/tests/schema/remove-deprecated/implicit-equality.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/implicit-equality.test.ts
@@ -598,10 +598,10 @@ describe("Implicit Equality filters", () => {
 
             type Query {
               actors(limit: Int, offset: Int, sort: [ActorSort!], where: ActorWhere): [Actor!]!
-              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
               actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
               movies(limit: Int, offset: Int, sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 

--- a/packages/graphql/tests/schema/remove-deprecated/implicit-equality.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/implicit-equality.test.ts
@@ -116,6 +116,15 @@ describe("Implicit Equality filters", () => {
               name: String
             }
 
+            type ActorAggregate {
+              node: ActorAggregateNode!
+            }
+
+            type ActorAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
             type ActorAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -311,6 +320,7 @@ describe("Implicit Equality filters", () => {
             }
 
             type ActorsConnection {
+              aggregate: ActorAggregate!
               edges: [ActorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -472,6 +482,15 @@ describe("Implicit Equality filters", () => {
               where: MovieActorsConnectionWhere
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+            }
+
             type MovieAggregateSelection {
               count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -554,6 +573,7 @@ describe("Implicit Equality filters", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/remove-deprecated/implicit-set.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/implicit-set.test.ts
@@ -613,10 +613,10 @@ describe("Implicit SET field", () => {
 
             type Query {
               actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
               actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 

--- a/packages/graphql/tests/schema/remove-deprecated/implicit-set.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/implicit-set.test.ts
@@ -115,6 +115,15 @@ describe("Implicit SET field", () => {
               name: String
             }
 
+            type ActorAggregate {
+              node: ActorAggregateNode!
+            }
+
+            type ActorAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
             type ActorAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -318,6 +327,7 @@ describe("Implicit SET field", () => {
             }
 
             type ActorsConnection {
+              aggregate: ActorAggregate!
               edges: [ActorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -479,6 +489,15 @@ describe("Implicit SET field", () => {
               where: MovieActorsConnectionWhere
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+            }
+
             type MovieAggregateSelection {
               count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -569,6 +588,7 @@ describe("Implicit SET field", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/remove-deprecated/options-argument.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/options-argument.test.ts
@@ -773,16 +773,16 @@ describe("Deprecated options argument", () => {
 
             type Query {
               actors(limit: Int, offset: Int, sort: [ActorSort!], where: ActorWhere): [Actor!]!
-              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
               actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
               genres(limit: Int, offset: Int, sort: [GenreSort!], where: GenreWhere): [Genre!]!
-              genresAggregate(where: GenreWhere): GenreAggregateSelection!
+              genresAggregate(where: GenreWhere): GenreAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"genresConnection\\\\\\"\\")
               genresConnection(after: String, first: Int, sort: [GenreSort!], where: GenreWhere): GenresConnection!
               movies(limit: Int, offset: Int, sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
               productions(limit: Int, offset: Int, sort: [ProductionSort!], where: ProductionWhere): [Production!]!
-              productionsAggregate(where: ProductionWhere): ProductionAggregateSelection!
+              productionsAggregate(where: ProductionWhere): ProductionAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"productionsConnection\\\\\\"\\")
               productionsConnection(after: String, first: Int, sort: [ProductionSort!], where: ProductionWhere): ProductionsConnection!
               searches(limit: Int, offset: Int, where: SearchWhere): [Search!]!
             }

--- a/packages/graphql/tests/schema/remove-deprecated/options-argument.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/options-argument.test.ts
@@ -155,6 +155,15 @@ describe("Deprecated options argument", () => {
               name: String!
             }
 
+            type ActorAggregate {
+              node: ActorAggregateNode!
+            }
+
+            type ActorAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
             type ActorAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -355,6 +364,7 @@ describe("Deprecated options argument", () => {
             }
 
             type ActorsConnection {
+              aggregate: ActorAggregate!
               edges: [ActorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -398,6 +408,15 @@ describe("Deprecated options argument", () => {
               id: ID
             }
 
+            type GenreAggregate {
+              node: GenreAggregateNode!
+            }
+
+            type GenreAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+            }
+
             type GenreAggregateSelection {
               count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -437,6 +456,7 @@ describe("Deprecated options argument", () => {
             }
 
             type GenresConnection {
+              aggregate: GenreAggregate!
               edges: [GenreEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -579,6 +599,15 @@ describe("Deprecated options argument", () => {
               where: MovieActorsConnectionWhere
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              title: StringAggregateSelection!
+            }
+
             type MovieAggregateSelection {
               count: Int!
               title: StringAggregateSelection!
@@ -661,6 +690,7 @@ describe("Deprecated options argument", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -688,6 +718,15 @@ describe("Deprecated options argument", () => {
 
             interface Production {
               title: String!
+            }
+
+            type ProductionAggregate {
+              node: ProductionAggregateNode!
+            }
+
+            type ProductionAggregateNode {
+              count: Int!
+              title: StringAggregateSelection!
             }
 
             type ProductionAggregateSelection {
@@ -726,6 +765,7 @@ describe("Deprecated options argument", () => {
             }
 
             type ProductionsConnection {
+              aggregate: ProductionAggregate!
               edges: [ProductionEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/remove-deprecated/query-direction.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/query-direction.test.ts
@@ -116,6 +116,15 @@ describe("Query Direction", () => {
               name: String!
             }
 
+            type UserAggregate {
+              node: UserAggregateNode!
+            }
+
+            type UserAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
             type UserAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -313,6 +322,7 @@ describe("Query Direction", () => {
             }
 
             type UsersConnection {
+              aggregate: UserAggregate!
               edges: [UserEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -412,6 +422,15 @@ describe("Query Direction", () => {
               name: String!
             }
 
+            type UserAggregate {
+              node: UserAggregateNode!
+            }
+
+            type UserAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
             type UserAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -609,6 +628,7 @@ describe("Query Direction", () => {
             }
 
             type UsersConnection {
+              aggregate: UserAggregate!
               edges: [UserEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -708,6 +728,15 @@ describe("Query Direction", () => {
               name: String!
             }
 
+            type UserAggregate {
+              node: UserAggregateNode!
+            }
+
+            type UserAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
             type UserAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -905,6 +934,7 @@ describe("Query Direction", () => {
             }
 
             type UsersConnection {
+              aggregate: UserAggregate!
               edges: [UserEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/remove-deprecated/query-direction.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/query-direction.test.ts
@@ -77,7 +77,7 @@ describe("Query Direction", () => {
 
             type Query {
               users(limit: Int, offset: Int, options: UserOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [UserSort!], where: UserWhere): [User!]!
-              usersAggregate(where: UserWhere): UserAggregateSelection!
+              usersAggregate(where: UserWhere): UserAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"usersConnection\\\\\\"\\")
               usersConnection(after: String, first: Int, sort: [UserSort!], where: UserWhere): UsersConnection!
             }
 
@@ -383,7 +383,7 @@ describe("Query Direction", () => {
 
             type Query {
               users(limit: Int, offset: Int, options: UserOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [UserSort!], where: UserWhere): [User!]!
-              usersAggregate(where: UserWhere): UserAggregateSelection!
+              usersAggregate(where: UserWhere): UserAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"usersConnection\\\\\\"\\")
               usersConnection(after: String, first: Int, sort: [UserSort!], where: UserWhere): UsersConnection!
             }
 
@@ -689,7 +689,7 @@ describe("Query Direction", () => {
 
             type Query {
               users(limit: Int, offset: Int, options: UserOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [UserSort!], where: UserWhere): [User!]!
-              usersAggregate(where: UserWhere): UserAggregateSelection!
+              usersAggregate(where: UserWhere): UserAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"usersConnection\\\\\\"\\")
               usersConnection(after: String, first: Int, sort: [UserSort!], where: UserWhere): UsersConnection!
             }
 

--- a/packages/graphql/tests/schema/remove-deprecated/typename_IN.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/typename_IN.test.ts
@@ -100,6 +100,16 @@ describe("typename_IN", () => {
               title: String!
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              title: StringAggregateSelection!
+            }
+
             type MovieAggregateSelection {
               count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -159,6 +169,7 @@ describe("typename_IN", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -184,6 +195,16 @@ describe("typename_IN", () => {
             interface Production {
               id: ID!
               title: String!
+            }
+
+            type ProductionAggregate {
+              node: ProductionAggregateNode!
+            }
+
+            type ProductionAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              title: StringAggregateSelection!
             }
 
             type ProductionAggregateSelection {
@@ -239,6 +260,7 @@ describe("typename_IN", () => {
             }
 
             type ProductionsConnection {
+              aggregate: ProductionAggregate!
               edges: [ProductionEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -262,6 +284,17 @@ describe("typename_IN", () => {
               title: String!
             }
 
+            type SeriesAggregate {
+              node: SeriesAggregateNode!
+            }
+
+            type SeriesAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              numberOfEpisodes: IntAggregateSelection!
+              title: StringAggregateSelection!
+            }
+
             type SeriesAggregateSelection {
               count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -270,6 +303,7 @@ describe("typename_IN", () => {
             }
 
             type SeriesConnection {
+              aggregate: SeriesAggregate!
               edges: [SeriesEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/remove-deprecated/typename_IN.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/typename_IN.test.ts
@@ -268,13 +268,13 @@ describe("typename_IN", () => {
 
             type Query {
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
               productions(limit: Int, offset: Int, options: ProductionOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ProductionSort!], where: ProductionWhere): [Production!]!
-              productionsAggregate(where: ProductionWhere): ProductionAggregateSelection!
+              productionsAggregate(where: ProductionWhere): ProductionAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"productionsConnection\\\\\\"\\")
               productionsConnection(after: String, first: Int, sort: [ProductionSort!], where: ProductionWhere): ProductionsConnection!
               series(limit: Int, offset: Int, options: SeriesOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [SeriesSort!], where: SeriesWhere): [Series!]!
-              seriesAggregate(where: SeriesWhere): SeriesAggregateSelection!
+              seriesAggregate(where: SeriesWhere): SeriesAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"seriesConnection\\\\\\"\\")
               seriesConnection(after: String, first: Int, sort: [SeriesSort!], where: SeriesWhere): SeriesConnection!
             }
 

--- a/packages/graphql/tests/schema/scalar.test.ts
+++ b/packages/graphql/tests/schema/scalar.test.ts
@@ -176,7 +176,7 @@ describe("Scalar", () => {
 
             type Query {
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 

--- a/packages/graphql/tests/schema/scalar.test.ts
+++ b/packages/graphql/tests/schema/scalar.test.ts
@@ -78,6 +78,15 @@ describe("Scalar", () => {
               myRequiredCustomArrayScalar: [CustomScalar!]!
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+            }
+
             type MovieAggregateSelection {
               count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -145,6 +154,7 @@ describe("Scalar", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/simple.test.ts
+++ b/packages/graphql/tests/schema/simple.test.ts
@@ -205,7 +205,7 @@ describe("Simple", () => {
 
             type Query {
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 

--- a/packages/graphql/tests/schema/simple.test.ts
+++ b/packages/graphql/tests/schema/simple.test.ts
@@ -88,6 +88,17 @@ describe("Simple", () => {
               isActive: Boolean
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              actorCount: IntAggregateSelection!
+              averageRating: FloatAggregateSelection!
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+            }
+
             type MovieAggregateSelection {
               actorCount: IntAggregateSelection!
               averageRating: FloatAggregateSelection!
@@ -172,6 +183,7 @@ describe("Simple", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/string-comparators.test.ts
+++ b/packages/graphql/tests/schema/string-comparators.test.ts
@@ -158,7 +158,7 @@ describe("String Comparators", () => {
 
             type Query {
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 
@@ -313,7 +313,7 @@ describe("String Comparators", () => {
 
             type Query {
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 
@@ -479,7 +479,7 @@ describe("String Comparators", () => {
 
             type Query {
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 
@@ -1125,10 +1125,10 @@ describe("String Comparators", () => {
 
             type Query {
               actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
               actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 

--- a/packages/graphql/tests/schema/string-comparators.test.ts
+++ b/packages/graphql/tests/schema/string-comparators.test.ts
@@ -75,6 +75,15 @@ describe("String Comparators", () => {
               title: String
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              title: StringAggregateSelection!
+            }
+
             type MovieAggregateSelection {
               count: Int!
               title: StringAggregateSelection!
@@ -127,6 +136,7 @@ describe("String Comparators", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -224,6 +234,15 @@ describe("String Comparators", () => {
               title: String
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              title: StringAggregateSelection!
+            }
+
             type MovieAggregateSelection {
               count: Int!
               title: StringAggregateSelection!
@@ -272,6 +291,7 @@ describe("String Comparators", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -378,6 +398,15 @@ describe("String Comparators", () => {
               title: String
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              title: StringAggregateSelection!
+            }
+
             type MovieAggregateSelection {
               count: Int!
               title: StringAggregateSelection!
@@ -428,6 +457,7 @@ describe("String Comparators", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -691,6 +721,15 @@ describe("String Comparators", () => {
               where: ActorActedInConnectionWhere
             }
 
+            type ActorAggregate {
+              node: ActorAggregateNode!
+            }
+
+            type ActorAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
             type ActorAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -800,6 +839,7 @@ describe("String Comparators", () => {
             }
 
             type ActorsConnection {
+              aggregate: ActorAggregate!
               edges: [ActorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -956,6 +996,15 @@ describe("String Comparators", () => {
               where: MovieActorsConnectionWhere
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              title: StringAggregateSelection!
+            }
+
             type MovieAggregateSelection {
               count: Int!
               title: StringAggregateSelection!
@@ -1051,6 +1100,7 @@ describe("String Comparators", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/subscriptions.test.ts
+++ b/packages/graphql/tests/schema/subscriptions.test.ts
@@ -57,6 +57,15 @@ describe("Subscriptions", () => {
               name: String!
             }
 
+            type ActorAggregate {
+              node: ActorAggregateNode!
+            }
+
+            type ActorAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
             type ActorAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -144,6 +153,7 @@ describe("Subscriptions", () => {
             }
 
             type ActorsConnection {
+              aggregate: ActorAggregate!
               edges: [ActorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -315,6 +325,17 @@ describe("Subscriptions", () => {
               where: MovieActorsConnectionWhere
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              actorCount: IntAggregateSelection!
+              averageRating: FloatAggregateSelection!
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+            }
+
             type MovieAggregateSelection {
               actorCount: IntAggregateSelection!
               averageRating: FloatAggregateSelection!
@@ -484,6 +505,7 @@ describe("Subscriptions", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -594,6 +616,14 @@ describe("Subscriptions", () => {
               movies(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
               moviesAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: MovieWhere): ActorMovieMoviesAggregationSelection
               moviesConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [ActorMoviesConnectionSort!], where: ActorMoviesConnectionWhere): ActorMoviesConnection!
+            }
+
+            type ActorAggregate {
+              node: ActorAggregateNode!
+            }
+
+            type ActorAggregateNode {
+              count: Int!
             }
 
             type ActorAggregateSelection {
@@ -824,6 +854,7 @@ describe("Subscriptions", () => {
             }
 
             type ActorsConnection {
+              aggregate: ActorAggregate!
               edges: [ActorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -965,6 +996,17 @@ describe("Subscriptions", () => {
               disconnect: [MovieActorsDisconnectFieldInput!]
               update: MovieActorsUpdateConnectionInput
               where: MovieActorsConnectionWhere
+            }
+
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              actorCount: IntAggregateSelection!
+              averageRating: FloatAggregateSelection!
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
             type MovieAggregateSelection {
@@ -1148,6 +1190,7 @@ describe("Subscriptions", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1457,6 +1500,17 @@ describe("Subscriptions", () => {
               Star: [MovieActorsStarUpdateFieldInput!]
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              actorCount: IntAggregateSelection!
+              averageRating: FloatAggregateSelection!
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+            }
+
             type MovieAggregateSelection {
               actorCount: IntAggregateSelection!
               averageRating: FloatAggregateSelection!
@@ -1637,6 +1691,7 @@ describe("Subscriptions", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1663,6 +1718,7 @@ describe("Subscriptions", () => {
             }
 
             type PeopleConnection {
+              aggregate: PersonAggregate!
               edges: [PersonEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1672,6 +1728,14 @@ describe("Subscriptions", () => {
               movies(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
               moviesAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: MovieWhere): PersonMovieMoviesAggregationSelection
               moviesConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [PersonMoviesConnectionSort!], where: PersonMoviesConnectionWhere): PersonMoviesConnection!
+            }
+
+            type PersonAggregate {
+              node: PersonAggregateNode!
+            }
+
+            type PersonAggregateNode {
+              count: Int!
             }
 
             type PersonAggregateSelection {
@@ -1934,6 +1998,14 @@ describe("Subscriptions", () => {
               moviesConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [StarMoviesConnectionSort!], where: StarMoviesConnectionWhere): StarMoviesConnection!
             }
 
+            type StarAggregate {
+              node: StarAggregateNode!
+            }
+
+            type StarAggregateNode {
+              count: Int!
+            }
+
             type StarAggregateSelection {
               count: Int!
             }
@@ -2162,6 +2234,7 @@ describe("Subscriptions", () => {
             }
 
             type StarsConnection {
+              aggregate: StarAggregate!
               edges: [StarEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -2307,6 +2380,14 @@ describe("Subscriptions", () => {
               movies(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
               moviesAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: MovieWhere): ActorMovieMoviesAggregationSelection
               moviesConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [ActorMoviesConnectionSort!], where: ActorMoviesConnectionWhere): ActorMoviesConnection!
+            }
+
+            type ActorAggregate {
+              node: ActorAggregateNode!
+            }
+
+            type ActorAggregateNode {
+              count: Int!
             }
 
             type ActorAggregateSelection {
@@ -2537,6 +2618,7 @@ describe("Subscriptions", () => {
             }
 
             type ActorsConnection {
+              aggregate: ActorAggregate!
               edges: [ActorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -2693,6 +2775,17 @@ describe("Subscriptions", () => {
               disconnect: [MovieActorsDisconnectFieldInput!]
               update: MovieActorsUpdateConnectionInput
               where: MovieActorsConnectionWhere
+            }
+
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              actorCount: IntAggregateSelection!
+              averageRating: FloatAggregateSelection!
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
             type MovieAggregateSelection {
@@ -2876,6 +2969,7 @@ describe("Subscriptions", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -2979,6 +3073,15 @@ describe("Subscriptions", () => {
               name: String!
             }
 
+            type ActorAggregate {
+              node: ActorAggregateNode!
+            }
+
+            type ActorAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
             type ActorAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -3066,6 +3169,7 @@ describe("Subscriptions", () => {
             }
 
             type ActorsConnection {
+              aggregate: ActorAggregate!
               edges: [ActorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -3237,6 +3341,17 @@ describe("Subscriptions", () => {
               where: MovieActorsConnectionWhere
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              actorCount: IntAggregateSelection!
+              averageRating: FloatAggregateSelection!
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+            }
+
             type MovieAggregateSelection {
               actorCount: IntAggregateSelection!
               averageRating: FloatAggregateSelection!
@@ -3352,6 +3467,7 @@ describe("Subscriptions", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -3457,6 +3573,16 @@ describe("Subscriptions", () => {
               owner(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), limit: Int, offset: Int, options: UserOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [UserSort!], where: UserWhere): User
               ownerAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: UserWhere): AgreementUserOwnerAggregationSelection
               ownerConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [AgreementOwnerConnectionSort!], where: AgreementOwnerConnectionWhere): AgreementOwnerConnection!
+            }
+
+            type AgreementAggregate {
+              node: AgreementAggregateNode!
+            }
+
+            type AgreementAggregateNode {
+              count: Int!
+              id: IntAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             type AgreementAggregateSelection {
@@ -3692,6 +3818,7 @@ describe("Subscriptions", () => {
             }
 
             type AgreementsConnection {
+              aggregate: AgreementAggregate!
               edges: [AgreementEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -3795,6 +3922,16 @@ describe("Subscriptions", () => {
               username: String!
             }
 
+            type UserAggregate {
+              node: UserAggregateNode!
+            }
+
+            type UserAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+              username: StringAggregateSelection!
+            }
+
             type UserAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -3858,6 +3995,7 @@ describe("Subscriptions", () => {
             }
 
             type UsersConnection {
+              aggregate: UserAggregate!
               edges: [UserEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -4104,6 +4242,17 @@ describe("Subscriptions", () => {
               Star: [MovieActorsStarUpdateFieldInput!]
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              actorCount: IntAggregateSelection!
+              averageRating: FloatAggregateSelection!
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+            }
+
             type MovieAggregateSelection {
               actorCount: IntAggregateSelection!
               averageRating: FloatAggregateSelection!
@@ -4284,6 +4433,7 @@ describe("Subscriptions", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -4310,6 +4460,7 @@ describe("Subscriptions", () => {
             }
 
             type PeopleConnection {
+              aggregate: PersonAggregate!
               edges: [PersonEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -4319,6 +4470,14 @@ describe("Subscriptions", () => {
               movies(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
               moviesAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: MovieWhere): PersonMovieMoviesAggregationSelection
               moviesConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [PersonMoviesConnectionSort!], where: PersonMoviesConnectionWhere): PersonMoviesConnection!
+            }
+
+            type PersonAggregate {
+              node: PersonAggregateNode!
+            }
+
+            type PersonAggregateNode {
+              count: Int!
             }
 
             type PersonAggregateSelection {
@@ -4581,6 +4740,14 @@ describe("Subscriptions", () => {
               moviesConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [StarMoviesConnectionSort!], where: StarMoviesConnectionWhere): StarMoviesConnection!
             }
 
+            type StarAggregate {
+              node: StarAggregateNode!
+            }
+
+            type StarAggregateNode {
+              count: Int!
+            }
+
             type StarAggregateSelection {
               count: Int!
             }
@@ -4794,6 +4961,7 @@ describe("Subscriptions", () => {
             }
 
             type StarsConnection {
+              aggregate: StarAggregate!
               edges: [StarEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -4906,6 +5074,14 @@ describe("Subscriptions", () => {
             interface Creature {
               movies(limit: Int, offset: Int, options: ProductionOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ProductionSort!], where: ProductionWhere): Production!
               moviesConnection(after: String, first: Int, sort: [CreatureMoviesConnectionSort!], where: CreatureMoviesConnectionWhere): CreatureMoviesConnection!
+            }
+
+            type CreatureAggregate {
+              node: CreatureAggregateNode!
+            }
+
+            type CreatureAggregateNode {
+              count: Int!
             }
 
             type CreatureAggregateSelection {
@@ -5045,6 +5221,7 @@ describe("Subscriptions", () => {
             }
 
             type CreaturesConnection {
+              aggregate: CreatureAggregate!
               edges: [CreatureEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -5084,6 +5261,16 @@ describe("Subscriptions", () => {
               directorConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, where: ProductionDirectorConnectionWhere): ProductionDirectorConnection!
               id: ID
               title: String!
+            }
+
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              title: StringAggregateSelection!
             }
 
             type MovieAggregateSelection {
@@ -5207,6 +5394,7 @@ describe("Subscriptions", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -5233,6 +5421,7 @@ describe("Subscriptions", () => {
             }
 
             type PeopleConnection {
+              aggregate: PersonAggregate!
               edges: [PersonEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -5242,6 +5431,14 @@ describe("Subscriptions", () => {
               movies(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), limit: Int, offset: Int, options: ProductionOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ProductionSort!], where: ProductionWhere): Production!
               moviesAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: ProductionWhere): PersonProductionMoviesAggregationSelection
               moviesConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [CreatureMoviesConnectionSort!], where: CreatureMoviesConnectionWhere): CreatureMoviesConnection!
+            }
+
+            type PersonAggregate {
+              node: PersonAggregateNode!
+            }
+
+            type PersonAggregateNode {
+              count: Int!
             }
 
             type PersonAggregateSelection {
@@ -5373,6 +5570,15 @@ describe("Subscriptions", () => {
               director(limit: Int, offset: Int, options: CreatureOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: CreatureWhere): Creature!
               directorConnection(after: String, first: Int, where: ProductionDirectorConnectionWhere): ProductionDirectorConnection!
               id: ID
+            }
+
+            type ProductionAggregate {
+              node: ProductionAggregateNode!
+            }
+
+            type ProductionAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
             type ProductionAggregateSelection {
@@ -5513,6 +5719,7 @@ describe("Subscriptions", () => {
             }
 
             type ProductionsConnection {
+              aggregate: ProductionAggregate!
               edges: [ProductionEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -5545,6 +5752,17 @@ describe("Subscriptions", () => {
               title: String!
             }
 
+            type SeriesAggregate {
+              node: SeriesAggregateNode!
+            }
+
+            type SeriesAggregateNode {
+              count: Int!
+              episode: IntAggregateSelection!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              title: StringAggregateSelection!
+            }
+
             type SeriesAggregateSelection {
               count: Int!
               episode: IntAggregateSelection!
@@ -5553,6 +5771,7 @@ describe("Subscriptions", () => {
             }
 
             type SeriesConnection {
+              aggregate: SeriesAggregate!
               edges: [SeriesEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/subscriptions.test.ts
+++ b/packages/graphql/tests/schema/subscriptions.test.ts
@@ -530,10 +530,10 @@ describe("Subscriptions", () => {
 
             type Query {
               actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
               actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 
@@ -1215,10 +1215,10 @@ describe("Subscriptions", () => {
 
             type Query {
               actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: ActorWhere): [Actor!]!
-              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
               actorsConnection(after: String, first: Int, where: ActorWhere): ActorsConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 
@@ -1968,13 +1968,13 @@ describe("Subscriptions", () => {
             type Query {
               actors(limit: Int, offset: Int, options: QueryOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: ActorWhere): [Actor!]!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
               people(limit: Int, offset: Int, options: PersonOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: PersonWhere): [Person!]!
-              peopleAggregate(where: PersonWhere): PersonAggregateSelection!
+              peopleAggregate(where: PersonWhere): PersonAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"peopleConnection\\\\\\"\\")
               peopleConnection(after: String, first: Int, where: PersonWhere): PeopleConnection!
               stars(limit: Int, offset: Int, options: StarOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: StarWhere): [Star!]!
-              starsAggregate(where: StarWhere): StarAggregateSelection!
+              starsAggregate(where: StarWhere): StarAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"starsConnection\\\\\\"\\")
               starsConnection(after: String, first: Int, where: StarWhere): StarsConnection!
             }
 
@@ -2994,10 +2994,10 @@ describe("Subscriptions", () => {
 
             type Query {
               actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: ActorWhere): [Actor!]!
-              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
               actorsConnection(after: String, first: Int, where: ActorWhere): ActorsConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 
@@ -3492,10 +3492,10 @@ describe("Subscriptions", () => {
 
             type Query {
               actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
               actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 
@@ -3876,10 +3876,10 @@ describe("Subscriptions", () => {
 
             type Query {
               agreements(limit: Int, offset: Int, options: AgreementOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [AgreementSort!], where: AgreementWhere): [Agreement!]!
-              agreementsAggregate(where: AgreementWhere): AgreementAggregateSelection!
+              agreementsAggregate(where: AgreementWhere): AgreementAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"agreementsConnection\\\\\\"\\")
               agreementsConnection(after: String, first: Int, sort: [AgreementSort!], where: AgreementWhere): AgreementsConnection!
               users(limit: Int, offset: Int, options: UserOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [UserSort!], where: UserWhere): [User!]!
-              usersAggregate(where: UserWhere): UserAggregateSelection!
+              usersAggregate(where: UserWhere): UserAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"usersConnection\\\\\\"\\")
               usersConnection(after: String, first: Int, sort: [UserSort!], where: UserWhere): UsersConnection!
             }
 
@@ -4710,13 +4710,13 @@ describe("Subscriptions", () => {
             type Query {
               actors(limit: Int, offset: Int, options: QueryOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: ActorWhere): [Actor!]!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
               people(limit: Int, offset: Int, options: PersonOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: PersonWhere): [Person!]!
-              peopleAggregate(where: PersonWhere): PersonAggregateSelection!
+              peopleAggregate(where: PersonWhere): PersonAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"peopleConnection\\\\\\"\\")
               peopleConnection(after: String, first: Int, where: PersonWhere): PeopleConnection!
               stars(limit: Int, offset: Int, options: StarOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: StarWhere): [Star!]!
-              starsAggregate(where: StarWhere): StarAggregateSelection!
+              starsAggregate(where: StarWhere): StarAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"starsConnection\\\\\\"\\")
               starsConnection(after: String, first: Int, where: StarWhere): StarsConnection!
             }
 
@@ -5727,19 +5727,19 @@ describe("Subscriptions", () => {
 
             type Query {
               creatures(limit: Int, offset: Int, options: CreatureOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: CreatureWhere): [Creature!]!
-              creaturesAggregate(where: CreatureWhere): CreatureAggregateSelection!
+              creaturesAggregate(where: CreatureWhere): CreatureAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"creaturesConnection\\\\\\"\\")
               creaturesConnection(after: String, first: Int, where: CreatureWhere): CreaturesConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
               people(limit: Int, offset: Int, options: PersonOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: PersonWhere): [Person!]!
-              peopleAggregate(where: PersonWhere): PersonAggregateSelection!
+              peopleAggregate(where: PersonWhere): PersonAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"peopleConnection\\\\\\"\\")
               peopleConnection(after: String, first: Int, where: PersonWhere): PeopleConnection!
               productions(limit: Int, offset: Int, options: ProductionOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ProductionSort!], where: ProductionWhere): [Production!]!
-              productionsAggregate(where: ProductionWhere): ProductionAggregateSelection!
+              productionsAggregate(where: ProductionWhere): ProductionAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"productionsConnection\\\\\\"\\")
               productionsConnection(after: String, first: Int, sort: [ProductionSort!], where: ProductionWhere): ProductionsConnection!
               series(limit: Int, offset: Int, options: SeriesOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [SeriesSort!], where: SeriesWhere): [Series!]!
-              seriesAggregate(where: SeriesWhere): SeriesAggregateSelection!
+              seriesAggregate(where: SeriesWhere): SeriesAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"seriesConnection\\\\\\"\\")
               seriesConnection(after: String, first: Int, sort: [SeriesSort!], where: SeriesWhere): SeriesConnection!
             }
 

--- a/packages/graphql/tests/schema/types/bigint.test.ts
+++ b/packages/graphql/tests/schema/types/bigint.test.ts
@@ -171,7 +171,7 @@ describe("Bigint", () => {
 
             type Query {
               files(limit: Int, offset: Int, options: FileOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [FileSort!], where: FileWhere): [File!]!
-              filesAggregate(where: FileWhere): FileAggregateSelection!
+              filesAggregate(where: FileWhere): FileAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"filesConnection\\\\\\"\\")
               filesConnection(after: String, first: Int, sort: [FileSort!], where: FileWhere): FilesConnection!
             }
 

--- a/packages/graphql/tests/schema/types/bigint.test.ts
+++ b/packages/graphql/tests/schema/types/bigint.test.ts
@@ -77,6 +77,16 @@ describe("Bigint", () => {
               size: BigInt!
             }
 
+            type FileAggregate {
+              node: FileAggregateNode!
+            }
+
+            type FileAggregateNode {
+              count: Int!
+              name: StringAggregateSelection!
+              size: BigIntAggregateSelection!
+            }
+
             type FileAggregateSelection {
               count: Int!
               name: StringAggregateSelection!
@@ -139,6 +149,7 @@ describe("Bigint", () => {
             }
 
             type FilesConnection {
+              aggregate: FileAggregate!
               edges: [FileEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/types/date.test.ts
+++ b/packages/graphql/tests/schema/types/date.test.ts
@@ -73,6 +73,15 @@ describe("Date", () => {
               id: ID
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+            }
+
             type MovieAggregateSelection {
               count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -132,6 +141,7 @@ describe("Date", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/types/date.test.ts
+++ b/packages/graphql/tests/schema/types/date.test.ts
@@ -163,7 +163,7 @@ describe("Date", () => {
 
             type Query {
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 

--- a/packages/graphql/tests/schema/types/datetime.test.ts
+++ b/packages/graphql/tests/schema/types/datetime.test.ts
@@ -78,6 +78,16 @@ describe("Datetime", () => {
               id: ID
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              datetime: DateTimeAggregateSelection!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+            }
+
             type MovieAggregateSelection {
               count: Int!
               datetime: DateTimeAggregateSelection!
@@ -138,6 +148,7 @@ describe("Datetime", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/types/datetime.test.ts
+++ b/packages/graphql/tests/schema/types/datetime.test.ts
@@ -170,7 +170,7 @@ describe("Datetime", () => {
 
             type Query {
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 

--- a/packages/graphql/tests/schema/types/duration.test.ts
+++ b/packages/graphql/tests/schema/types/duration.test.ts
@@ -170,7 +170,7 @@ describe("Duration", () => {
 
             type Query {
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 

--- a/packages/graphql/tests/schema/types/duration.test.ts
+++ b/packages/graphql/tests/schema/types/duration.test.ts
@@ -78,6 +78,16 @@ describe("Duration", () => {
               id: ID
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              duration: DurationAggregateSelection!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+            }
+
             type MovieAggregateSelection {
               count: Int!
               duration: DurationAggregateSelection!
@@ -138,6 +148,7 @@ describe("Duration", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/types/localdatetime.test.ts
+++ b/packages/graphql/tests/schema/types/localdatetime.test.ts
@@ -170,7 +170,7 @@ describe("Localdatetime", () => {
 
             type Query {
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 

--- a/packages/graphql/tests/schema/types/localdatetime.test.ts
+++ b/packages/graphql/tests/schema/types/localdatetime.test.ts
@@ -78,6 +78,16 @@ describe("Localdatetime", () => {
               localDT: LocalDateTime
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              localDT: LocalDateTimeAggregateSelection!
+            }
+
             type MovieAggregateSelection {
               count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -138,6 +148,7 @@ describe("Localdatetime", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/types/localtime.test.ts
+++ b/packages/graphql/tests/schema/types/localtime.test.ts
@@ -172,7 +172,7 @@ describe("Localtime", () => {
 
             type Query {
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 

--- a/packages/graphql/tests/schema/types/localtime.test.ts
+++ b/packages/graphql/tests/schema/types/localtime.test.ts
@@ -80,6 +80,16 @@ describe("Localtime", () => {
               time: LocalTime
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              time: LocalTimeAggregateSelection!
+            }
+
             type MovieAggregateSelection {
               count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -140,6 +150,7 @@ describe("Localtime", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/types/point.test.ts
+++ b/packages/graphql/tests/schema/types/point.test.ts
@@ -63,6 +63,14 @@ describe("Point", () => {
               filmedAt: Point!
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+            }
+
             type MovieAggregateSelection {
               count: Int!
             }
@@ -112,6 +120,7 @@ describe("Point", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -251,6 +260,14 @@ describe("Point", () => {
               partLocation: CartesianPoint!
             }
 
+            type MachineAggregate {
+              node: MachineAggregateNode!
+            }
+
+            type MachineAggregateNode {
+              count: Int!
+            }
+
             type MachineAggregateSelection {
               count: Int!
             }
@@ -300,6 +317,7 @@ describe("Point", () => {
             }
 
             type MachinesConnection {
+              aggregate: MachineAggregate!
               edges: [MachineEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -390,6 +408,14 @@ describe("Point", () => {
               filmedAt: [Point!]!
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+            }
+
             type MovieAggregateSelection {
               count: Int!
             }
@@ -425,6 +451,7 @@ describe("Point", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -543,6 +570,14 @@ describe("Point", () => {
               partLocations: [CartesianPoint!]!
             }
 
+            type MachineAggregate {
+              node: MachineAggregateNode!
+            }
+
+            type MachineAggregateNode {
+              count: Int!
+            }
+
             type MachineAggregateSelection {
               count: Int!
             }
@@ -578,6 +613,7 @@ describe("Point", () => {
             }
 
             type MachinesConnection {
+              aggregate: MachineAggregate!
               edges: [MachineEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/types/point.test.ts
+++ b/packages/graphql/tests/schema/types/point.test.ts
@@ -167,7 +167,7 @@ describe("Point", () => {
 
             type Query {
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 
@@ -339,7 +339,7 @@ describe("Point", () => {
 
             type Query {
               machines(limit: Int, offset: Int, options: MachineOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MachineSort!], where: MachineWhere): [Machine!]!
-              machinesAggregate(where: MachineWhere): MachineAggregateSelection!
+              machinesAggregate(where: MachineWhere): MachineAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"machinesConnection\\\\\\"\\")
               machinesConnection(after: String, first: Int, sort: [MachineSort!], where: MachineWhere): MachinesConnection!
             }
 
@@ -491,7 +491,7 @@ describe("Point", () => {
 
             type Query {
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, where: MovieWhere): MoviesConnection!
             }
 
@@ -635,7 +635,7 @@ describe("Point", () => {
 
             type Query {
               machines(limit: Int, offset: Int, options: MachineOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: MachineWhere): [Machine!]!
-              machinesAggregate(where: MachineWhere): MachineAggregateSelection!
+              machinesAggregate(where: MachineWhere): MachineAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"machinesConnection\\\\\\"\\")
               machinesConnection(after: String, first: Int, where: MachineWhere): MachinesConnection!
             }
 

--- a/packages/graphql/tests/schema/types/time.test.ts
+++ b/packages/graphql/tests/schema/types/time.test.ts
@@ -70,6 +70,16 @@ describe("Time", () => {
               time: Time
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              time: TimeAggregateSelection!
+            }
+
             type MovieAggregateSelection {
               count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -130,6 +140,7 @@ describe("Time", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/types/time.test.ts
+++ b/packages/graphql/tests/schema/types/time.test.ts
@@ -162,7 +162,7 @@ describe("Time", () => {
 
             type Query {
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
             }
 

--- a/packages/graphql/tests/schema/union-interface-relationship.test.ts
+++ b/packages/graphql/tests/schema/union-interface-relationship.test.ts
@@ -151,6 +151,16 @@ describe("Union Interface Relationships", () => {
               name: String!
             }
 
+            type ActorAggregate {
+              node: ActorAggregateNode!
+            }
+
+            type ActorAggregateNode {
+              count: Int!
+              id: IntAggregateSelection!
+              name: StringAggregateSelection!
+            }
+
             type ActorAggregateSelection {
               count: Int!
               id: IntAggregateSelection!
@@ -421,6 +431,7 @@ describe("Union Interface Relationships", () => {
             }
 
             type ActorsConnection {
+              aggregate: ActorAggregate!
               edges: [ActorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -511,6 +522,17 @@ describe("Union Interface Relationships", () => {
               url: String!
             }
 
+            type InfluencerAggregate {
+              node: InfluencerAggregateNode!
+            }
+
+            type InfluencerAggregateNode {
+              count: Int!
+              reputation: IntAggregateSelection!
+              reviewerId: IntAggregateSelection!
+              url: StringAggregateSelection!
+            }
+
             type InfluencerAggregateSelection {
               count: Int!
               reputation: IntAggregateSelection!
@@ -587,6 +609,7 @@ describe("Union Interface Relationships", () => {
             }
 
             type InfluencersConnection {
+              aggregate: InfluencerAggregate!
               edges: [InfluencerEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -761,6 +784,16 @@ describe("Union Interface Relationships", () => {
               disconnect: [MovieActorsDisconnectFieldInput!]
               update: MovieActorsUpdateConnectionInput
               where: MovieActorsConnectionWhere
+            }
+
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              imdbId: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             type MovieAggregateSelection {
@@ -1244,6 +1277,7 @@ describe("Union Interface Relationships", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1273,6 +1307,7 @@ describe("Union Interface Relationships", () => {
             }
 
             type PeopleConnection {
+              aggregate: PersonAggregate!
               edges: [PersonEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1286,6 +1321,18 @@ describe("Union Interface Relationships", () => {
               name: String!
               reputation: Int!
               reviewerId: Int
+            }
+
+            type PersonAggregate {
+              node: PersonAggregateNode!
+            }
+
+            type PersonAggregateNode {
+              count: Int!
+              id: IntAggregateSelection!
+              name: StringAggregateSelection!
+              reputation: IntAggregateSelection!
+              reviewerId: IntAggregateSelection!
             }
 
             type PersonAggregateSelection {
@@ -1682,6 +1729,16 @@ describe("Union Interface Relationships", () => {
               reviewerId: Int
             }
 
+            type ReviewerAggregate {
+              node: ReviewerAggregateNode!
+            }
+
+            type ReviewerAggregateNode {
+              count: Int!
+              reputation: IntAggregateSelection!
+              reviewerId: IntAggregateSelection!
+            }
+
             type ReviewerAggregateSelection {
               count: Int!
               reputation: IntAggregateSelection!
@@ -1758,6 +1815,7 @@ describe("Union Interface Relationships", () => {
             }
 
             type ReviewersConnection {
+              aggregate: ReviewerAggregate!
               edges: [ReviewerEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/union-interface-relationship.test.ts
+++ b/packages/graphql/tests/schema/union-interface-relationship.test.ts
@@ -1638,20 +1638,20 @@ describe("Union Interface Relationships", () => {
 
             type Query {
               actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\"\\")
               actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
               directors(limit: Int, offset: Int, options: QueryOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: DirectorWhere): [Director!]!
               influencers(limit: Int, offset: Int, options: InfluencerOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [InfluencerSort!], where: InfluencerWhere): [Influencer!]!
-              influencersAggregate(where: InfluencerWhere): InfluencerAggregateSelection!
+              influencersAggregate(where: InfluencerWhere): InfluencerAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"influencersConnection\\\\\\"\\")
               influencersConnection(after: String, first: Int, sort: [InfluencerSort!], where: InfluencerWhere): InfluencersConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
               people(limit: Int, offset: Int, options: PersonOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [PersonSort!], where: PersonWhere): [Person!]!
-              peopleAggregate(where: PersonWhere): PersonAggregateSelection!
+              peopleAggregate(where: PersonWhere): PersonAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"peopleConnection\\\\\\"\\")
               peopleConnection(after: String, first: Int, sort: [PersonSort!], where: PersonWhere): PeopleConnection!
               reviewers(limit: Int, offset: Int, options: ReviewerOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ReviewerSort!], where: ReviewerWhere): [Reviewer!]!
-              reviewersAggregate(where: ReviewerWhere): ReviewerAggregateSelection!
+              reviewersAggregate(where: ReviewerWhere): ReviewerAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"reviewersConnection\\\\\\"\\")
               reviewersConnection(after: String, first: Int, sort: [ReviewerSort!], where: ReviewerWhere): ReviewersConnection!
             }
 

--- a/packages/graphql/tests/schema/unions.test.ts
+++ b/packages/graphql/tests/schema/unions.test.ts
@@ -405,10 +405,10 @@ describe("Unions", () => {
 
             type Query {
               genres(limit: Int, offset: Int, options: GenreOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [GenreSort!], where: GenreWhere): [Genre!]!
-              genresAggregate(where: GenreWhere): GenreAggregateSelection!
+              genresAggregate(where: GenreWhere): GenreAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"genresConnection\\\\\\"\\")
               genresConnection(after: String, first: Int, sort: [GenreSort!], where: GenreWhere): GenresConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
               searches(limit: Int, offset: Int, options: QueryOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: SearchWhere): [Search!]!
             }

--- a/packages/graphql/tests/schema/unions.test.ts
+++ b/packages/graphql/tests/schema/unions.test.ts
@@ -76,6 +76,15 @@ describe("Unions", () => {
               id: ID
             }
 
+            type GenreAggregate {
+              node: GenreAggregateNode!
+            }
+
+            type GenreAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+            }
+
             type GenreAggregateSelection {
               count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
@@ -128,6 +137,7 @@ describe("Unions", () => {
             }
 
             type GenresConnection {
+              aggregate: GenreAggregate!
               edges: [GenreEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -143,6 +153,15 @@ describe("Unions", () => {
               search(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), limit: Int, offset: Int, options: QueryOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: SearchWhere): [Search!]!
               searchConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, where: MovieSearchConnectionWhere): MovieSearchConnection!
               searchNoDirective: Search
+            }
+
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
             type MovieAggregateSelection {
@@ -361,6 +380,7 @@ describe("Unions", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/vector.test.ts
+++ b/packages/graphql/tests/schema/vector.test.ts
@@ -199,7 +199,7 @@ describe("@vector schema", () => {
             type Query {
               descriptionQuery(after: String, first: Int, sort: [MovieVectorSort!], vector: [Float!], where: MovieVectorWhere): MoviesVectorConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit the field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\"\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
               titleQuery(after: String, first: Int, sort: [MovieVectorSort!], vector: [Float!], where: MovieVectorWhere): MoviesVectorConnection!
             }

--- a/packages/graphql/tests/schema/vector.test.ts
+++ b/packages/graphql/tests/schema/vector.test.ts
@@ -83,6 +83,16 @@ describe("@vector schema", () => {
               title: String
             }
 
+            type MovieAggregate {
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              count: Int!
+              description: StringAggregateSelection!
+              title: StringAggregateSelection!
+            }
+
             type MovieAggregateSelection {
               count: Int!
               description: StringAggregateSelection!
@@ -160,6 +170,7 @@ describe("@vector schema", () => {
             }
 
             type MoviesConnection {
+              aggregate: MovieAggregate!
               edges: [MovieEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!


### PR DESCRIPTION
# Description
Add top level aggregations inside connection operations:

```graphql
query {
    moviesConnection {
        aggregate {
            node {
                count
                id {
                    longest 
                }
            }
        }
    }
}
```
