### PR TITLE
Add cypher version to generated queries

### DIFF
--- a/.changeset/lucky-panthers-appear.md
+++ b/.changeset/lucky-panthers-appear.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+Add `CYPHER 5` to generated queries to ensure the correct cypher version is used in Aura

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -79,7 +79,7 @@
         "@graphql-tools/resolvers-composition": "^7.0.0",
         "@graphql-tools/schema": "^10.0.0",
         "@graphql-tools/utils": "^10.0.0",
-        "@neo4j/cypher-builder": "2.0.2",
+        "@neo4j/cypher-builder": "2.3.0",
         "camelcase": "^6.3.0",
         "debug": "^4.3.4",
         "dot-prop": "^6.0.1",

--- a/packages/graphql/src/translate/translate-aggregate.ts
+++ b/packages/graphql/src/translate/translate-aggregate.ts
@@ -43,5 +43,7 @@ export function translateAggregate({
     const queryAST = queryASTFactory.createQueryAST({ resolveTree, entityAdapter, context });
     debug(queryAST.print());
     const clause = queryAST.buildNew(context);
-    return clause.build();
+    return clause.build({
+        cypherVersion: "5",
+    });
 }

--- a/packages/graphql/src/translate/translate-create.ts
+++ b/packages/graphql/src/translate/translate-create.ts
@@ -152,7 +152,7 @@ export default async function translateCreate({
         ];
     });
 
-    const createQueryCypher = createQuery.build({ prefix: "create_" });
+    const createQueryCypher = createQuery.build({ prefix: "create_", cypherVersion: "5" });
     const { cypher, params: resolvedCallbacks } = await callbackBucket.resolveCallbacksAndFilterCypher({
         cypher: createQueryCypher.cypher,
     });

--- a/packages/graphql/src/translate/translate-delete.ts
+++ b/packages/graphql/src/translate/translate-delete.ts
@@ -52,7 +52,9 @@ function translateUsingQueryAST({
     });
     debug(operationsTree.print());
     const clause = operationsTree.build(context, varName);
-    return clause.build();
+    return clause.build({
+        cypherVersion: "5",
+    });
 }
 export function translateDelete({
     context,

--- a/packages/graphql/src/translate/translate-read.ts
+++ b/packages/graphql/src/translate/translate-read.ts
@@ -45,5 +45,5 @@ export function translateRead({
     });
     debug(operationsTree.print());
     const clause = operationsTree.build(context, varName);
-    return clause.build();
+    return clause.build({ cypherVersion: "5" });
 }

--- a/packages/graphql/src/translate/translate-resolve-reference.ts
+++ b/packages/graphql/src/translate/translate-resolve-reference.ts
@@ -18,11 +18,11 @@
  */
 
 import type Cypher from "@neo4j/cypher-builder";
-import type { Neo4jGraphQLTranslationContext } from "../types/neo4j-graphql-translation-context";
 import Debug from "debug";
-import { QueryASTFactory } from "./queryAST/factory/QueryASTFactory";
-import type { EntityAdapter } from "../schema-model/entity/EntityAdapter";
 import { DEBUG_TRANSLATE } from "../constants";
+import type { EntityAdapter } from "../schema-model/entity/EntityAdapter";
+import type { Neo4jGraphQLTranslationContext } from "../types/neo4j-graphql-translation-context";
+import { QueryASTFactory } from "./queryAST/factory/QueryASTFactory";
 
 const debug = Debug(DEBUG_TRANSLATE);
 
@@ -46,5 +46,7 @@ export function translateResolveReference({
     });
     debug(operationsTree.print());
     const clause = operationsTree.build(context, "this");
-    return clause.build();
+    return clause.build({
+        cypherVersion: "5",
+    });
 }

--- a/packages/graphql/src/translate/translate-top-level-cypher.ts
+++ b/packages/graphql/src/translate/translate-top-level-cypher.ts
@@ -84,5 +84,7 @@ export function translateTopLevelCypher({
     const projectionStatements = queryASTResult.clauses.length
         ? Cypher.utils.concat(...queryASTResult.clauses)
         : new Cypher.Return(new Cypher.Literal("Query cannot conclude with CALL"));
-    return projectionStatements.build();
+    return projectionStatements.build({
+        cypherVersion: "5",
+    });
 }

--- a/packages/graphql/src/translate/translate-update.ts
+++ b/packages/graphql/src/translate/translate-update.ts
@@ -485,7 +485,7 @@ export default async function translateUpdate({
         ];
     });
 
-    const cypherResult = updateQuery.build({ prefix: "update_" });
+    const cypherResult = updateQuery.build({ prefix: "update_", cypherVersion: "5" });
     const { cypher, params: resolvedCallbacks } = await callbackBucket.resolveCallbacksAndFilterCypher({
         cypher: cypherResult.cypher,
     });

--- a/packages/graphql/src/translate/unwind-create.ts
+++ b/packages/graphql/src/translate/unwind-create.ts
@@ -44,5 +44,5 @@ export default function unwindCreate({
 
     const clauses = queryAST.build(context);
 
-    return clauses.build({ prefix: "create_" });
+    return clauses.build({ prefix: "create_", cypherVersion: "5" });
 }

--- a/packages/graphql/tests/tck/advanced-filtering.test.ts
+++ b/packages/graphql/tests/tck/advanced-filtering.test.ts
@@ -72,7 +72,8 @@ describe("Cypher Advanced Filtering", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title = $param0
             RETURN this { .title } AS this"
         `);
@@ -96,7 +97,8 @@ describe("Cypher Advanced Filtering", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title = $param0
             RETURN this { .title } AS this"
         `);
@@ -120,7 +122,8 @@ describe("Cypher Advanced Filtering", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this._id IN $param0
             RETURN this { ._id } AS this"
         `);
@@ -146,7 +149,8 @@ describe("Cypher Advanced Filtering", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.id =~ $param0
             RETURN this { .id } AS this"
         `);
@@ -170,7 +174,8 @@ describe("Cypher Advanced Filtering", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE NOT (this.id = $param0)
             RETURN this { .id } AS this"
         `);
@@ -194,7 +199,8 @@ describe("Cypher Advanced Filtering", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.id CONTAINS $param0
             RETURN this { .id } AS this"
         `);
@@ -218,7 +224,8 @@ describe("Cypher Advanced Filtering", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.id STARTS WITH $param0
             RETURN this { .id } AS this"
         `);
@@ -242,7 +249,8 @@ describe("Cypher Advanced Filtering", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.id ENDS WITH $param0
             RETURN this { .id } AS this"
         `);
@@ -266,7 +274,8 @@ describe("Cypher Advanced Filtering", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.actorCount < $param0
             RETURN this { .actorCount } AS this"
         `);
@@ -293,7 +302,8 @@ describe("Cypher Advanced Filtering", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.budget < $param0
             RETURN this { .budget } AS this"
         `);
@@ -319,7 +329,8 @@ describe("Cypher Advanced Filtering", () => {
 
         const result = await translateQuery(neoSchema, query);
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title < $param0
             RETURN this { .title } AS this"
         `);
@@ -343,7 +354,8 @@ describe("Cypher Advanced Filtering", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.actorCount <= $param0
             RETURN this { .actorCount } AS this"
         `);
@@ -370,7 +382,8 @@ describe("Cypher Advanced Filtering", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.budget <= $param0
             RETURN this { .budget } AS this"
         `);
@@ -396,7 +409,8 @@ describe("Cypher Advanced Filtering", () => {
 
         const result = await translateQuery(neoSchema, query);
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title <= $param0
             RETURN this { .title } AS this"
         `);
@@ -420,7 +434,8 @@ describe("Cypher Advanced Filtering", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.actorCount > $param0
             RETURN this { .actorCount } AS this"
         `);
@@ -447,7 +462,8 @@ describe("Cypher Advanced Filtering", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.budget > $param0
             RETURN this { .budget } AS this"
         `);
@@ -473,7 +489,8 @@ describe("Cypher Advanced Filtering", () => {
 
         const result = await translateQuery(neoSchema, query);
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title > $param0
             RETURN this { .title } AS this"
         `);
@@ -497,7 +514,8 @@ describe("Cypher Advanced Filtering", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.actorCount >= $param0
             RETURN this { .actorCount } AS this"
         `);
@@ -524,7 +542,8 @@ describe("Cypher Advanced Filtering", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.budget >= $param0
             RETURN this { .budget } AS this"
         `);
@@ -550,7 +569,8 @@ describe("Cypher Advanced Filtering", () => {
 
         const result = await translateQuery(neoSchema, query);
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title >= $param0
             RETURN this { .title } AS this"
         `);
@@ -575,7 +595,8 @@ describe("Cypher Advanced Filtering", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Movie)
+                "CYPHER 5
+                MATCH (this:Movie)
                 WHERE EXISTS {
                     MATCH (this)-[:IN_GENRE]->(this0:Genre)
                     WHERE this0.name = $param0
@@ -602,7 +623,8 @@ describe("Cypher Advanced Filtering", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Movie)
+                "CYPHER 5
+                MATCH (this:Movie)
                 WHERE NOT (EXISTS {
                     MATCH (this)-[:IN_GENRE]->(this0:Genre)
                     WHERE this0.name = $param0
@@ -634,7 +656,8 @@ describe("Cypher Advanced Filtering", () => {
                 const result = await translateQuery(neoSchema, query);
 
                 expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                    "MATCH (this:Movie)
+                    "CYPHER 5
+                    MATCH (this:Movie)
                     WHERE (EXISTS {
                         MATCH (this)-[:IN_GENRE]->(this0:Genre)
                         WHERE this0.name = $param0
@@ -656,7 +679,8 @@ describe("Cypher Advanced Filtering", () => {
                 const result = await translateQuery(neoSchema, query);
 
                 expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                    "MATCH (this:Movie)
+                    "CYPHER 5
+                    MATCH (this:Movie)
                     WHERE NOT (EXISTS {
                         MATCH (this)-[:IN_GENRE]->(this0:Genre)
                         WHERE this0.name = $param0
@@ -675,7 +699,8 @@ describe("Cypher Advanced Filtering", () => {
                 const result = await translateQuery(neoSchema, query);
 
                 expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                    "MATCH (this:Movie)
+                    "CYPHER 5
+                    MATCH (this:Movie)
                     WHERE single(this0 IN [(this)-[:IN_GENRE]->(this0:Genre) WHERE this0.name = $param0 | 1] WHERE true)
                     RETURN this { .actorCount } AS this"
                 `);
@@ -691,7 +716,8 @@ describe("Cypher Advanced Filtering", () => {
                 const result = await translateQuery(neoSchema, query);
 
                 expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                    "MATCH (this:Movie)
+                    "CYPHER 5
+                    MATCH (this:Movie)
                     WHERE EXISTS {
                         MATCH (this)-[:IN_GENRE]->(this0:Genre)
                         WHERE this0.name = $param0
@@ -720,7 +746,8 @@ describe("Cypher Advanced Filtering", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Movie)
+                "CYPHER 5
+                MATCH (this:Movie)
                 WHERE EXISTS {
                     MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
                     WHERE this1.name = $param0
@@ -747,7 +774,8 @@ describe("Cypher Advanced Filtering", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Movie)
+                "CYPHER 5
+                MATCH (this:Movie)
                 WHERE NOT (EXISTS {
                     MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
                     WHERE this1.name = $param0
@@ -779,7 +807,8 @@ describe("Cypher Advanced Filtering", () => {
                 const result = await translateQuery(neoSchema, query);
 
                 expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                    "MATCH (this:Movie)
+                    "CYPHER 5
+                    MATCH (this:Movie)
                     WHERE (EXISTS {
                         MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
                         WHERE this1.name = $param0
@@ -801,7 +830,8 @@ describe("Cypher Advanced Filtering", () => {
                 const result = await translateQuery(neoSchema, query);
 
                 expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                    "MATCH (this:Movie)
+                    "CYPHER 5
+                    MATCH (this:Movie)
                     WHERE NOT (EXISTS {
                         MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
                         WHERE this1.name = $param0
@@ -820,7 +850,8 @@ describe("Cypher Advanced Filtering", () => {
                 const result = await translateQuery(neoSchema, query);
 
                 expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                    "MATCH (this:Movie)
+                    "CYPHER 5
+                    MATCH (this:Movie)
                     WHERE single(this0 IN [(this)-[this1:IN_GENRE]->(this0:Genre) WHERE this0.name = $param0 | 1] WHERE true)
                     RETURN this { .actorCount } AS this"
                 `);
@@ -836,7 +867,8 @@ describe("Cypher Advanced Filtering", () => {
                 const result = await translateQuery(neoSchema, query);
 
                 expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                    "MATCH (this:Movie)
+                    "CYPHER 5
+                    MATCH (this:Movie)
                     WHERE EXISTS {
                         MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
                         WHERE this1.name = $param0

--- a/packages/graphql/tests/tck/aggregations/alias-directive.test.ts
+++ b/packages/graphql/tests/tck/aggregations/alias-directive.test.ts
@@ -67,7 +67,8 @@ describe("Cypher Aggregations Many with Alias directive", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:Movie)
                 RETURN { shortest: min(this._id), longest: max(this._id) } AS var0
             }

--- a/packages/graphql/tests/tck/aggregations/alias.test.ts
+++ b/packages/graphql/tests/tck/aggregations/alias.test.ts
@@ -68,7 +68,8 @@ describe("Cypher Aggregations Many while Alias fields", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:Movie)
                 RETURN count(this) AS var0
             }

--- a/packages/graphql/tests/tck/aggregations/auth.test.ts
+++ b/packages/graphql/tests/tck/aggregations/auth.test.ts
@@ -81,7 +81,8 @@ describe("Cypher Aggregations with Auth", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:User)
                 WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                 RETURN count(this) AS var0
@@ -113,7 +114,8 @@ describe("Cypher Aggregations with Auth", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:User)
                 WHERE (this.name = $param0 AND ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                 RETURN count(this) AS var0
@@ -149,7 +151,8 @@ describe("Cypher Aggregations with Auth", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:User)
                 WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                 RETURN { min: min(this.imdbRatingInt), max: max(this.imdbRatingInt) } AS var0
@@ -184,7 +187,8 @@ describe("Cypher Aggregations with Auth", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:User)
                 WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                 RETURN { min: min(this.imdbRatingFloat), max: max(this.imdbRatingFloat) } AS var0
@@ -219,7 +223,8 @@ describe("Cypher Aggregations with Auth", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:User)
                 WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                 RETURN { min: min(this.imdbRatingBigInt), max: max(this.imdbRatingBigInt) } AS var0
@@ -254,7 +259,8 @@ describe("Cypher Aggregations with Auth", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:User)
                 WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                 RETURN { shortest: min(this.id), longest: max(this.id) } AS var0
@@ -289,7 +295,8 @@ describe("Cypher Aggregations with Auth", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:User)
                 WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                 WITH this
@@ -327,7 +334,8 @@ describe("Cypher Aggregations with Auth", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:User)
                 WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                 RETURN { min: apoc.date.convertFormat(toString(min(this.createdAt)), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\"), max: apoc.date.convertFormat(toString(max(this.createdAt)), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\") } AS var0

--- a/packages/graphql/tests/tck/aggregations/bigint.test.ts
+++ b/packages/graphql/tests/tck/aggregations/bigint.test.ts
@@ -50,7 +50,8 @@ describe("Cypher Aggregations BigInt", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:File)
                 RETURN { min: min(this.size) } AS var0
             }
@@ -74,7 +75,8 @@ describe("Cypher Aggregations BigInt", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:File)
                 RETURN { max: max(this.size) } AS var0
             }
@@ -98,7 +100,8 @@ describe("Cypher Aggregations BigInt", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:File)
                 RETURN { average: avg(this.size) } AS var0
             }
@@ -122,7 +125,8 @@ describe("Cypher Aggregations BigInt", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:File)
                 RETURN { sum: sum(this.size) } AS var0
             }
@@ -149,7 +153,8 @@ describe("Cypher Aggregations BigInt", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:File)
                 RETURN { min: min(this.size), max: max(this.size), average: avg(this.size), sum: sum(this.size) } AS var0
             }

--- a/packages/graphql/tests/tck/aggregations/count.test.ts
+++ b/packages/graphql/tests/tck/aggregations/count.test.ts
@@ -48,7 +48,8 @@ describe("Cypher Aggregations Count", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:Movie)
                 RETURN count(this) AS var0
             }
@@ -70,7 +71,8 @@ describe("Cypher Aggregations Count", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:Movie)
                 WHERE this.title = $param0
                 RETURN count(this) AS var0

--- a/packages/graphql/tests/tck/aggregations/datetime.test.ts
+++ b/packages/graphql/tests/tck/aggregations/datetime.test.ts
@@ -50,7 +50,8 @@ describe("Cypher Aggregations DateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:Movie)
                 RETURN { min: apoc.date.convertFormat(toString(min(this.createdAt)), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\") } AS var0
             }
@@ -74,7 +75,8 @@ describe("Cypher Aggregations DateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:Movie)
                 RETURN { max: apoc.date.convertFormat(toString(max(this.createdAt)), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\") } AS var0
             }
@@ -99,7 +101,8 @@ describe("Cypher Aggregations DateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:Movie)
                 RETURN { min: apoc.date.convertFormat(toString(min(this.createdAt)), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\"), max: apoc.date.convertFormat(toString(max(this.createdAt)), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\") } AS var0
             }

--- a/packages/graphql/tests/tck/aggregations/duration.test.ts
+++ b/packages/graphql/tests/tck/aggregations/duration.test.ts
@@ -50,7 +50,8 @@ describe("Cypher Aggregations Duration", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:Movie)
                 RETURN { min: min(this.screenTime) } AS var0
             }
@@ -74,7 +75,8 @@ describe("Cypher Aggregations Duration", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:Movie)
                 RETURN { max: max(this.screenTime) } AS var0
             }
@@ -99,7 +101,8 @@ describe("Cypher Aggregations Duration", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:Movie)
                 RETURN { min: min(this.screenTime), max: max(this.screenTime) } AS var0
             }

--- a/packages/graphql/tests/tck/aggregations/field-level-aggregations/field-level-aggregations-alias.test.ts
+++ b/packages/graphql/tests/tck/aggregations/field-level-aggregations/field-level-aggregations-alias.test.ts
@@ -65,7 +65,8 @@ describe("Field Level Aggregations Alias", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
@@ -98,7 +99,8 @@ describe("Field Level Aggregations Alias", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)

--- a/packages/graphql/tests/tck/aggregations/field-level-aggregations/field-level-aggregations-edge.test.ts
+++ b/packages/graphql/tests/tck/aggregations/field-level-aggregations/field-level-aggregations-edge.test.ts
@@ -68,7 +68,8 @@ describe("Field Level Aggregations", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)

--- a/packages/graphql/tests/tck/aggregations/field-level-aggregations/field-level-aggregations-labels.test.ts
+++ b/packages/graphql/tests/tck/aggregations/field-level-aggregations/field-level-aggregations-labels.test.ts
@@ -65,7 +65,8 @@ describe("Field Level Aggregations Alias", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Film)
+            "CYPHER 5
+            MATCH (this:Film)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Person)

--- a/packages/graphql/tests/tck/aggregations/field-level-aggregations/field-level-aggregations-where.test.ts
+++ b/packages/graphql/tests/tck/aggregations/field-level-aggregations/field-level-aggregations-where.test.ts
@@ -60,7 +60,8 @@ describe("Field Level Aggregations Where", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Person)
@@ -98,7 +99,8 @@ describe("Field Level Aggregations Where", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Person)

--- a/packages/graphql/tests/tck/aggregations/field-level-aggregations/field-level-aggregations.test.ts
+++ b/packages/graphql/tests/tck/aggregations/field-level-aggregations/field-level-aggregations.test.ts
@@ -59,7 +59,8 @@ describe("Field Level Aggregations", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
@@ -91,7 +92,8 @@ describe("Field Level Aggregations", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
@@ -132,7 +134,8 @@ describe("Field Level Aggregations", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
@@ -164,7 +167,8 @@ describe("Field Level Aggregations", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
@@ -197,7 +201,8 @@ describe("Field Level Aggregations", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             CALL {
                 WITH this
                 MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
@@ -234,7 +239,8 @@ describe("Field Level Aggregations", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)

--- a/packages/graphql/tests/tck/aggregations/float.test.ts
+++ b/packages/graphql/tests/tck/aggregations/float.test.ts
@@ -50,7 +50,8 @@ describe("Cypher Aggregations Float", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:Movie)
                 RETURN { min: min(this.actorCount) } AS var0
             }
@@ -74,7 +75,8 @@ describe("Cypher Aggregations Float", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:Movie)
                 RETURN { max: max(this.actorCount) } AS var0
             }
@@ -98,7 +100,8 @@ describe("Cypher Aggregations Float", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:Movie)
                 RETURN { average: avg(this.actorCount) } AS var0
             }
@@ -122,7 +125,8 @@ describe("Cypher Aggregations Float", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:Movie)
                 RETURN { sum: sum(this.actorCount) } AS var0
             }
@@ -149,7 +153,8 @@ describe("Cypher Aggregations Float", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:Movie)
                 RETURN { min: min(this.actorCount), max: max(this.actorCount), average: avg(this.actorCount), sum: sum(this.actorCount) } AS var0
             }
@@ -177,7 +182,8 @@ describe("Cypher Aggregations Float", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:Movie)
                 RETURN count(this) AS var0
             }

--- a/packages/graphql/tests/tck/aggregations/id.test.ts
+++ b/packages/graphql/tests/tck/aggregations/id.test.ts
@@ -50,7 +50,8 @@ describe("Cypher Aggregations ID", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:Movie)
                 RETURN { shortest: min(this.id) } AS var0
             }
@@ -74,7 +75,8 @@ describe("Cypher Aggregations ID", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:Movie)
                 RETURN { longest: max(this.id) } AS var0
             }
@@ -99,7 +101,8 @@ describe("Cypher Aggregations ID", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:Movie)
                 RETURN { shortest: min(this.id), longest: max(this.id) } AS var0
             }

--- a/packages/graphql/tests/tck/aggregations/int.test.ts
+++ b/packages/graphql/tests/tck/aggregations/int.test.ts
@@ -50,7 +50,8 @@ describe("Cypher Aggregations Int", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:Movie)
                 RETURN { min: min(this.imdbRating) } AS var0
             }
@@ -74,7 +75,8 @@ describe("Cypher Aggregations Int", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:Movie)
                 RETURN { max: max(this.imdbRating) } AS var0
             }
@@ -98,7 +100,8 @@ describe("Cypher Aggregations Int", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:Movie)
                 RETURN { average: avg(this.imdbRating) } AS var0
             }
@@ -122,7 +125,8 @@ describe("Cypher Aggregations Int", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:Movie)
                 RETURN { sum: sum(this.imdbRating) } AS var0
             }
@@ -149,7 +153,8 @@ describe("Cypher Aggregations Int", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:Movie)
                 RETURN { min: min(this.imdbRating), max: max(this.imdbRating), average: avg(this.imdbRating), sum: sum(this.imdbRating) } AS var0
             }

--- a/packages/graphql/tests/tck/aggregations/label.test.ts
+++ b/packages/graphql/tests/tck/aggregations/label.test.ts
@@ -74,7 +74,8 @@ describe("Cypher Aggregations Many while Alias fields", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:Film)
                 RETURN { _shortest: min(this.id), _longest: max(this.id) } AS var0
             }
@@ -127,7 +128,8 @@ describe("Cypher Aggregations Many while Alias fields", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:Actor:Person:Alien)
                 RETURN { _shortest: min(this.id), _longest: max(this.id) } AS var0
             }

--- a/packages/graphql/tests/tck/aggregations/localdatetime.test.ts
+++ b/packages/graphql/tests/tck/aggregations/localdatetime.test.ts
@@ -50,7 +50,8 @@ describe("Cypher Aggregations LocalDateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:Movie)
                 RETURN { min: min(this.createdAt) } AS var0
             }
@@ -74,7 +75,8 @@ describe("Cypher Aggregations LocalDateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:Movie)
                 RETURN { max: max(this.createdAt) } AS var0
             }
@@ -99,7 +101,8 @@ describe("Cypher Aggregations LocalDateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:Movie)
                 RETURN { min: min(this.createdAt), max: max(this.createdAt) } AS var0
             }

--- a/packages/graphql/tests/tck/aggregations/localtime.test.ts
+++ b/packages/graphql/tests/tck/aggregations/localtime.test.ts
@@ -50,7 +50,8 @@ describe("Cypher Aggregations LocalTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:Movie)
                 RETURN { min: min(this.createdAt) } AS var0
             }
@@ -74,7 +75,8 @@ describe("Cypher Aggregations LocalTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:Movie)
                 RETURN { max: max(this.createdAt) } AS var0
             }
@@ -99,7 +101,8 @@ describe("Cypher Aggregations LocalTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:Movie)
                 RETURN { min: min(this.createdAt), max: max(this.createdAt) } AS var0
             }

--- a/packages/graphql/tests/tck/aggregations/many.test.ts
+++ b/packages/graphql/tests/tck/aggregations/many.test.ts
@@ -67,7 +67,8 @@ describe("Cypher Aggregations Many", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:Movie)
                 RETURN { shortest: min(this.id), longest: max(this.id) } AS var0
             }

--- a/packages/graphql/tests/tck/aggregations/string.test.ts
+++ b/packages/graphql/tests/tck/aggregations/string.test.ts
@@ -51,7 +51,8 @@ describe("Cypher Aggregations String", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:Movie)
                 WITH this
                 ORDER BY size(this.title) DESC
@@ -78,7 +79,8 @@ describe("Cypher Aggregations String", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:Movie)
                 WITH this
                 ORDER BY size(this.title) DESC
@@ -106,7 +108,8 @@ describe("Cypher Aggregations String", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:Movie)
                 WITH this
                 ORDER BY size(this.title) DESC
@@ -133,7 +136,8 @@ describe("Cypher Aggregations String", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:Movie)
                 WHERE this.testId = $param0
                 WITH this

--- a/packages/graphql/tests/tck/aggregations/time.test.ts
+++ b/packages/graphql/tests/tck/aggregations/time.test.ts
@@ -50,7 +50,8 @@ describe("Cypher Aggregations Time", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:Movie)
                 RETURN { min: min(this.createdAt) } AS var0
             }
@@ -74,7 +75,8 @@ describe("Cypher Aggregations Time", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:Movie)
                 RETURN { max: max(this.createdAt) } AS var0
             }
@@ -99,7 +101,8 @@ describe("Cypher Aggregations Time", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:Movie)
                 RETURN { min: min(this.createdAt), max: max(this.createdAt) } AS var0
             }

--- a/packages/graphql/tests/tck/aggregations/where/count.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/count.test.ts
@@ -53,7 +53,8 @@ describe("Cypher Aggregations where with count", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -86,7 +87,8 @@ describe("Cypher Aggregations where with count", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -119,7 +121,8 @@ describe("Cypher Aggregations where with count", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -152,7 +155,8 @@ describe("Cypher Aggregations where with count", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -185,7 +189,8 @@ describe("Cypher Aggregations where with count", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)

--- a/packages/graphql/tests/tck/aggregations/where/edge/bigint.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/edge/bigint.test.ts
@@ -58,7 +58,8 @@ describe("Cypher Aggregations where edge with BigInt", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -91,7 +92,8 @@ describe("Cypher Aggregations where edge with BigInt", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -124,7 +126,8 @@ describe("Cypher Aggregations where edge with BigInt", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -157,7 +160,8 @@ describe("Cypher Aggregations where edge with BigInt", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -190,7 +194,8 @@ describe("Cypher Aggregations where edge with BigInt", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -223,7 +228,8 @@ describe("Cypher Aggregations where edge with BigInt", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -256,7 +262,8 @@ describe("Cypher Aggregations where edge with BigInt", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -289,7 +296,8 @@ describe("Cypher Aggregations where edge with BigInt", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -322,7 +330,8 @@ describe("Cypher Aggregations where edge with BigInt", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -355,7 +364,8 @@ describe("Cypher Aggregations where edge with BigInt", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -388,7 +398,8 @@ describe("Cypher Aggregations where edge with BigInt", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -421,7 +432,8 @@ describe("Cypher Aggregations where edge with BigInt", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -454,7 +466,8 @@ describe("Cypher Aggregations where edge with BigInt", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -487,7 +500,8 @@ describe("Cypher Aggregations where edge with BigInt", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -520,7 +534,8 @@ describe("Cypher Aggregations where edge with BigInt", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -553,7 +568,8 @@ describe("Cypher Aggregations where edge with BigInt", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -586,7 +602,8 @@ describe("Cypher Aggregations where edge with BigInt", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -619,7 +636,8 @@ describe("Cypher Aggregations where edge with BigInt", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -652,7 +670,8 @@ describe("Cypher Aggregations where edge with BigInt", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -685,7 +704,8 @@ describe("Cypher Aggregations where edge with BigInt", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)

--- a/packages/graphql/tests/tck/aggregations/where/edge/datetime.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/edge/datetime.test.ts
@@ -58,7 +58,8 @@ describe("Cypher Aggregations where edge with DateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -97,7 +98,8 @@ describe("Cypher Aggregations where edge with DateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -136,7 +138,8 @@ describe("Cypher Aggregations where edge with DateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -175,7 +178,8 @@ describe("Cypher Aggregations where edge with DateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -214,7 +218,8 @@ describe("Cypher Aggregations where edge with DateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -253,7 +258,8 @@ describe("Cypher Aggregations where edge with DateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -292,7 +298,8 @@ describe("Cypher Aggregations where edge with DateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -331,7 +338,8 @@ describe("Cypher Aggregations where edge with DateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -370,7 +378,8 @@ describe("Cypher Aggregations where edge with DateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -409,7 +418,8 @@ describe("Cypher Aggregations where edge with DateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)

--- a/packages/graphql/tests/tck/aggregations/where/edge/duration.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/edge/duration.test.ts
@@ -58,7 +58,8 @@ describe("Cypher Aggregations where edge with Duration", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -99,7 +100,8 @@ describe("Cypher Aggregations where edge with Duration", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -140,7 +142,8 @@ describe("Cypher Aggregations where edge with Duration", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -181,7 +184,8 @@ describe("Cypher Aggregations where edge with Duration", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -222,7 +226,8 @@ describe("Cypher Aggregations where edge with Duration", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -263,7 +268,8 @@ describe("Cypher Aggregations where edge with Duration", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -304,7 +310,8 @@ describe("Cypher Aggregations where edge with Duration", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -345,7 +352,8 @@ describe("Cypher Aggregations where edge with Duration", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -386,7 +394,8 @@ describe("Cypher Aggregations where edge with Duration", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -427,7 +436,8 @@ describe("Cypher Aggregations where edge with Duration", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -468,7 +478,8 @@ describe("Cypher Aggregations where edge with Duration", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -509,7 +520,8 @@ describe("Cypher Aggregations where edge with Duration", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -550,7 +562,8 @@ describe("Cypher Aggregations where edge with Duration", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -591,7 +604,8 @@ describe("Cypher Aggregations where edge with Duration", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -632,7 +646,8 @@ describe("Cypher Aggregations where edge with Duration", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)

--- a/packages/graphql/tests/tck/aggregations/where/edge/float.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/edge/float.test.ts
@@ -58,7 +58,8 @@ describe("Cypher Aggregations where edge with Float", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -88,7 +89,8 @@ describe("Cypher Aggregations where edge with Float", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -118,7 +120,8 @@ describe("Cypher Aggregations where edge with Float", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -148,7 +151,8 @@ describe("Cypher Aggregations where edge with Float", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -178,7 +182,8 @@ describe("Cypher Aggregations where edge with Float", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -208,7 +213,8 @@ describe("Cypher Aggregations where edge with Float", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -238,7 +244,8 @@ describe("Cypher Aggregations where edge with Float", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -268,7 +275,8 @@ describe("Cypher Aggregations where edge with Float", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -298,7 +306,8 @@ describe("Cypher Aggregations where edge with Float", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -328,7 +337,8 @@ describe("Cypher Aggregations where edge with Float", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -358,7 +368,8 @@ describe("Cypher Aggregations where edge with Float", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -388,7 +399,8 @@ describe("Cypher Aggregations where edge with Float", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -418,7 +430,8 @@ describe("Cypher Aggregations where edge with Float", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -448,7 +461,8 @@ describe("Cypher Aggregations where edge with Float", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -478,7 +492,8 @@ describe("Cypher Aggregations where edge with Float", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -508,7 +523,8 @@ describe("Cypher Aggregations where edge with Float", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -538,7 +554,8 @@ describe("Cypher Aggregations where edge with Float", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -568,7 +585,8 @@ describe("Cypher Aggregations where edge with Float", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -598,7 +616,8 @@ describe("Cypher Aggregations where edge with Float", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -628,7 +647,8 @@ describe("Cypher Aggregations where edge with Float", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)

--- a/packages/graphql/tests/tck/aggregations/where/edge/int.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/edge/int.test.ts
@@ -58,7 +58,8 @@ describe("Cypher Aggregations where edge with Int", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -88,7 +89,8 @@ describe("Cypher Aggregations where edge with Int", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -118,7 +120,8 @@ describe("Cypher Aggregations where edge with Int", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -148,7 +151,8 @@ describe("Cypher Aggregations where edge with Int", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -178,7 +182,8 @@ describe("Cypher Aggregations where edge with Int", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -208,7 +213,8 @@ describe("Cypher Aggregations where edge with Int", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -241,7 +247,8 @@ describe("Cypher Aggregations where edge with Int", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -274,7 +281,8 @@ describe("Cypher Aggregations where edge with Int", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -307,7 +315,8 @@ describe("Cypher Aggregations where edge with Int", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -340,7 +349,8 @@ describe("Cypher Aggregations where edge with Int", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -373,7 +383,8 @@ describe("Cypher Aggregations where edge with Int", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -406,7 +417,8 @@ describe("Cypher Aggregations where edge with Int", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -439,7 +451,8 @@ describe("Cypher Aggregations where edge with Int", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -472,7 +485,8 @@ describe("Cypher Aggregations where edge with Int", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -505,7 +519,8 @@ describe("Cypher Aggregations where edge with Int", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -538,7 +553,8 @@ describe("Cypher Aggregations where edge with Int", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -571,7 +587,8 @@ describe("Cypher Aggregations where edge with Int", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -604,7 +621,8 @@ describe("Cypher Aggregations where edge with Int", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -637,7 +655,8 @@ describe("Cypher Aggregations where edge with Int", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -670,7 +689,8 @@ describe("Cypher Aggregations where edge with Int", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)

--- a/packages/graphql/tests/tck/aggregations/where/edge/interface-relationship.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/edge/interface-relationship.test.ts
@@ -79,7 +79,8 @@ describe("Cypher Aggregations where edge with String", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             CALL {
                 WITH this
                 MATCH (this)-[this0:ACTED_IN]->(this1)
@@ -119,7 +120,8 @@ describe("Cypher Aggregations where edge with String", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this0:Actor)
                 CALL {
                     WITH this0
@@ -173,7 +175,8 @@ describe("Cypher Aggregations where edge with String", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this0:Actor)
                 CALL {
                     WITH this0

--- a/packages/graphql/tests/tck/aggregations/where/edge/localdatetime.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/edge/localdatetime.test.ts
@@ -58,7 +58,8 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -96,7 +97,8 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -134,7 +136,8 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -172,7 +175,8 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -210,7 +214,8 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -248,7 +253,8 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -286,7 +292,8 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -324,7 +331,8 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -362,7 +370,8 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -400,7 +409,8 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)

--- a/packages/graphql/tests/tck/aggregations/where/edge/localtime.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/edge/localtime.test.ts
@@ -58,7 +58,8 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -93,7 +94,8 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -128,7 +130,8 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -163,7 +166,8 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -198,7 +202,8 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -233,7 +238,8 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -268,7 +274,8 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -303,7 +310,8 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -338,7 +346,8 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -373,7 +382,8 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)

--- a/packages/graphql/tests/tck/aggregations/where/edge/string.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/edge/string.test.ts
@@ -58,7 +58,8 @@ describe("Cypher Aggregations where edge with String", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -91,7 +92,8 @@ describe("Cypher Aggregations where edge with String", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -124,7 +126,8 @@ describe("Cypher Aggregations where edge with String", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -157,7 +160,8 @@ describe("Cypher Aggregations where edge with String", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -190,7 +194,8 @@ describe("Cypher Aggregations where edge with String", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -223,7 +228,8 @@ describe("Cypher Aggregations where edge with String", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -256,7 +262,8 @@ describe("Cypher Aggregations where edge with String", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -289,7 +296,8 @@ describe("Cypher Aggregations where edge with String", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -322,7 +330,8 @@ describe("Cypher Aggregations where edge with String", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -355,7 +364,8 @@ describe("Cypher Aggregations where edge with String", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -388,7 +398,8 @@ describe("Cypher Aggregations where edge with String", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -418,7 +429,8 @@ describe("Cypher Aggregations where edge with String", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -448,7 +460,8 @@ describe("Cypher Aggregations where edge with String", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -478,7 +491,8 @@ describe("Cypher Aggregations where edge with String", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -508,7 +522,8 @@ describe("Cypher Aggregations where edge with String", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)

--- a/packages/graphql/tests/tck/aggregations/where/edge/time.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/edge/time.test.ts
@@ -58,7 +58,8 @@ describe("Cypher Aggregations where edge with Time", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -94,7 +95,8 @@ describe("Cypher Aggregations where edge with Time", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -130,7 +132,8 @@ describe("Cypher Aggregations where edge with Time", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -166,7 +169,8 @@ describe("Cypher Aggregations where edge with Time", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -202,7 +206,8 @@ describe("Cypher Aggregations where edge with Time", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -238,7 +243,8 @@ describe("Cypher Aggregations where edge with Time", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -274,7 +280,8 @@ describe("Cypher Aggregations where edge with Time", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -310,7 +317,8 @@ describe("Cypher Aggregations where edge with Time", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -346,7 +354,8 @@ describe("Cypher Aggregations where edge with Time", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -382,7 +391,8 @@ describe("Cypher Aggregations where edge with Time", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)

--- a/packages/graphql/tests/tck/aggregations/where/logical.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/logical.test.ts
@@ -53,7 +53,8 @@ describe("Cypher Aggregations where with logical AND plus OR", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -90,7 +91,8 @@ describe("Cypher Aggregations where with logical AND plus OR", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -127,7 +129,8 @@ describe("Cypher Aggregations where with logical AND plus OR", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -167,7 +170,8 @@ describe("Cypher Aggregations where with logical AND plus OR", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -220,7 +224,8 @@ describe("Cypher Aggregations where with logical AND plus OR", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)

--- a/packages/graphql/tests/tck/aggregations/where/node/bigint.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/node/bigint.test.ts
@@ -54,7 +54,8 @@ describe("Cypher Aggregations where node with BigInt", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -87,7 +88,8 @@ describe("Cypher Aggregations where node with BigInt", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -120,7 +122,8 @@ describe("Cypher Aggregations where node with BigInt", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -153,7 +156,8 @@ describe("Cypher Aggregations where node with BigInt", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -186,7 +190,8 @@ describe("Cypher Aggregations where node with BigInt", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -219,7 +224,8 @@ describe("Cypher Aggregations where node with BigInt", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -252,7 +258,8 @@ describe("Cypher Aggregations where node with BigInt", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -285,7 +292,8 @@ describe("Cypher Aggregations where node with BigInt", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -318,7 +326,8 @@ describe("Cypher Aggregations where node with BigInt", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -351,7 +360,8 @@ describe("Cypher Aggregations where node with BigInt", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -384,7 +394,8 @@ describe("Cypher Aggregations where node with BigInt", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -417,7 +428,8 @@ describe("Cypher Aggregations where node with BigInt", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -450,7 +462,8 @@ describe("Cypher Aggregations where node with BigInt", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -483,7 +496,8 @@ describe("Cypher Aggregations where node with BigInt", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -516,7 +530,8 @@ describe("Cypher Aggregations where node with BigInt", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -549,7 +564,8 @@ describe("Cypher Aggregations where node with BigInt", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -582,7 +598,8 @@ describe("Cypher Aggregations where node with BigInt", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -615,7 +632,8 @@ describe("Cypher Aggregations where node with BigInt", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -648,7 +666,8 @@ describe("Cypher Aggregations where node with BigInt", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -681,7 +700,8 @@ describe("Cypher Aggregations where node with BigInt", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)

--- a/packages/graphql/tests/tck/aggregations/where/node/datetime.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/node/datetime.test.ts
@@ -54,7 +54,8 @@ describe("Cypher Aggregations where node with DateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -93,7 +94,8 @@ describe("Cypher Aggregations where node with DateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -132,7 +134,8 @@ describe("Cypher Aggregations where node with DateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -171,7 +174,8 @@ describe("Cypher Aggregations where node with DateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -210,7 +214,8 @@ describe("Cypher Aggregations where node with DateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -249,7 +254,8 @@ describe("Cypher Aggregations where node with DateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -288,7 +294,8 @@ describe("Cypher Aggregations where node with DateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -327,7 +334,8 @@ describe("Cypher Aggregations where node with DateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -366,7 +374,8 @@ describe("Cypher Aggregations where node with DateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -405,7 +414,8 @@ describe("Cypher Aggregations where node with DateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)

--- a/packages/graphql/tests/tck/aggregations/where/node/duration.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/node/duration.test.ts
@@ -54,7 +54,8 @@ describe("Cypher Aggregations where node with Duration", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -95,7 +96,8 @@ describe("Cypher Aggregations where node with Duration", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -136,7 +138,8 @@ describe("Cypher Aggregations where node with Duration", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -177,7 +180,8 @@ describe("Cypher Aggregations where node with Duration", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -218,7 +222,8 @@ describe("Cypher Aggregations where node with Duration", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -259,7 +264,8 @@ describe("Cypher Aggregations where node with Duration", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -300,7 +306,8 @@ describe("Cypher Aggregations where node with Duration", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -341,7 +348,8 @@ describe("Cypher Aggregations where node with Duration", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -382,7 +390,8 @@ describe("Cypher Aggregations where node with Duration", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -423,7 +432,8 @@ describe("Cypher Aggregations where node with Duration", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -464,7 +474,8 @@ describe("Cypher Aggregations where node with Duration", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -505,7 +516,8 @@ describe("Cypher Aggregations where node with Duration", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -546,7 +558,8 @@ describe("Cypher Aggregations where node with Duration", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -587,7 +600,8 @@ describe("Cypher Aggregations where node with Duration", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -628,7 +642,8 @@ describe("Cypher Aggregations where node with Duration", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)

--- a/packages/graphql/tests/tck/aggregations/where/node/float.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/node/float.test.ts
@@ -54,7 +54,8 @@ describe("Cypher Aggregations where node with Float", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -84,7 +85,8 @@ describe("Cypher Aggregations where node with Float", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -114,7 +116,8 @@ describe("Cypher Aggregations where node with Float", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -144,7 +147,8 @@ describe("Cypher Aggregations where node with Float", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -174,7 +178,8 @@ describe("Cypher Aggregations where node with Float", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -204,7 +209,8 @@ describe("Cypher Aggregations where node with Float", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -234,7 +240,8 @@ describe("Cypher Aggregations where node with Float", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -264,7 +271,8 @@ describe("Cypher Aggregations where node with Float", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -294,7 +302,8 @@ describe("Cypher Aggregations where node with Float", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -324,7 +333,8 @@ describe("Cypher Aggregations where node with Float", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -354,7 +364,8 @@ describe("Cypher Aggregations where node with Float", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -384,7 +395,8 @@ describe("Cypher Aggregations where node with Float", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -414,7 +426,8 @@ describe("Cypher Aggregations where node with Float", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -444,7 +457,8 @@ describe("Cypher Aggregations where node with Float", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -474,7 +488,8 @@ describe("Cypher Aggregations where node with Float", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -504,7 +519,8 @@ describe("Cypher Aggregations where node with Float", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -534,7 +550,8 @@ describe("Cypher Aggregations where node with Float", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -564,7 +581,8 @@ describe("Cypher Aggregations where node with Float", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -594,7 +612,8 @@ describe("Cypher Aggregations where node with Float", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -624,7 +643,8 @@ describe("Cypher Aggregations where node with Float", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)

--- a/packages/graphql/tests/tck/aggregations/where/node/int.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/node/int.test.ts
@@ -54,7 +54,8 @@ describe("Cypher Aggregations where node with Int", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -84,7 +85,8 @@ describe("Cypher Aggregations where node with Int", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -114,7 +116,8 @@ describe("Cypher Aggregations where node with Int", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -144,7 +147,8 @@ describe("Cypher Aggregations where node with Int", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -174,7 +178,8 @@ describe("Cypher Aggregations where node with Int", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -204,7 +209,8 @@ describe("Cypher Aggregations where node with Int", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -237,7 +243,8 @@ describe("Cypher Aggregations where node with Int", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -270,7 +277,8 @@ describe("Cypher Aggregations where node with Int", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -303,7 +311,8 @@ describe("Cypher Aggregations where node with Int", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -336,7 +345,8 @@ describe("Cypher Aggregations where node with Int", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -369,7 +379,8 @@ describe("Cypher Aggregations where node with Int", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -402,7 +413,8 @@ describe("Cypher Aggregations where node with Int", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -435,7 +447,8 @@ describe("Cypher Aggregations where node with Int", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -468,7 +481,8 @@ describe("Cypher Aggregations where node with Int", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -501,7 +515,8 @@ describe("Cypher Aggregations where node with Int", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -534,7 +549,8 @@ describe("Cypher Aggregations where node with Int", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -567,7 +583,8 @@ describe("Cypher Aggregations where node with Int", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -600,7 +617,8 @@ describe("Cypher Aggregations where node with Int", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -633,7 +651,8 @@ describe("Cypher Aggregations where node with Int", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -666,7 +685,8 @@ describe("Cypher Aggregations where node with Int", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)

--- a/packages/graphql/tests/tck/aggregations/where/node/localdatetime.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/node/localdatetime.test.ts
@@ -54,7 +54,8 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -92,7 +93,8 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -130,7 +132,8 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -168,7 +171,8 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -206,7 +210,8 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -244,7 +249,8 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -282,7 +288,8 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -320,7 +327,8 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -358,7 +366,8 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -396,7 +405,8 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)

--- a/packages/graphql/tests/tck/aggregations/where/node/localtime.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/node/localtime.test.ts
@@ -54,7 +54,8 @@ describe("Cypher Aggregations where node with LocalTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -89,7 +90,8 @@ describe("Cypher Aggregations where node with LocalTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -124,7 +126,8 @@ describe("Cypher Aggregations where node with LocalTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -159,7 +162,8 @@ describe("Cypher Aggregations where node with LocalTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -194,7 +198,8 @@ describe("Cypher Aggregations where node with LocalTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -229,7 +234,8 @@ describe("Cypher Aggregations where node with LocalTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -264,7 +270,8 @@ describe("Cypher Aggregations where node with LocalTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -299,7 +306,8 @@ describe("Cypher Aggregations where node with LocalTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -334,7 +342,8 @@ describe("Cypher Aggregations where node with LocalTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -369,7 +378,8 @@ describe("Cypher Aggregations where node with LocalTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)

--- a/packages/graphql/tests/tck/aggregations/where/node/string.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/node/string.test.ts
@@ -54,7 +54,8 @@ describe("Cypher Aggregations where node with String", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -87,7 +88,8 @@ describe("Cypher Aggregations where node with String", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -120,7 +122,8 @@ describe("Cypher Aggregations where node with String", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -153,7 +156,8 @@ describe("Cypher Aggregations where node with String", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -186,7 +190,8 @@ describe("Cypher Aggregations where node with String", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -219,7 +224,8 @@ describe("Cypher Aggregations where node with String", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -252,7 +258,8 @@ describe("Cypher Aggregations where node with String", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -285,7 +292,8 @@ describe("Cypher Aggregations where node with String", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -318,7 +326,8 @@ describe("Cypher Aggregations where node with String", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -351,7 +360,8 @@ describe("Cypher Aggregations where node with String", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -384,7 +394,8 @@ describe("Cypher Aggregations where node with String", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -414,7 +425,8 @@ describe("Cypher Aggregations where node with String", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -444,7 +456,8 @@ describe("Cypher Aggregations where node with String", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -474,7 +487,8 @@ describe("Cypher Aggregations where node with String", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -504,7 +518,8 @@ describe("Cypher Aggregations where node with String", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -567,7 +582,8 @@ describe("Cypher Aggregations where node with String interface relationships of 
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1)
@@ -601,7 +617,8 @@ describe("Cypher Aggregations where node with String interface relationships of 
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1)
@@ -635,7 +652,8 @@ describe("Cypher Aggregations where node with String interface relationships of 
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1)
@@ -669,7 +687,8 @@ describe("Cypher Aggregations where node with String interface relationships of 
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1)
@@ -703,7 +722,8 @@ describe("Cypher Aggregations where node with String interface relationships of 
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1)
@@ -737,7 +757,8 @@ describe("Cypher Aggregations where node with String interface relationships of 
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1)
@@ -771,7 +792,8 @@ describe("Cypher Aggregations where node with String interface relationships of 
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1)
@@ -805,7 +827,8 @@ describe("Cypher Aggregations where node with String interface relationships of 
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1)
@@ -839,7 +862,8 @@ describe("Cypher Aggregations where node with String interface relationships of 
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1)
@@ -873,7 +897,8 @@ describe("Cypher Aggregations where node with String interface relationships of 
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1)
@@ -907,7 +932,8 @@ describe("Cypher Aggregations where node with String interface relationships of 
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1)
@@ -938,7 +964,8 @@ describe("Cypher Aggregations where node with String interface relationships of 
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1)
@@ -969,7 +996,8 @@ describe("Cypher Aggregations where node with String interface relationships of 
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1)
@@ -1000,7 +1028,8 @@ describe("Cypher Aggregations where node with String interface relationships of 
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1)
@@ -1031,7 +1060,8 @@ describe("Cypher Aggregations where node with String interface relationships of 
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1)

--- a/packages/graphql/tests/tck/aggregations/where/node/time.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/node/time.test.ts
@@ -54,7 +54,8 @@ describe("Cypher Aggregations where node with Time", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -90,7 +91,8 @@ describe("Cypher Aggregations where node with Time", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -126,7 +128,8 @@ describe("Cypher Aggregations where node with Time", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -162,7 +165,8 @@ describe("Cypher Aggregations where node with Time", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -198,7 +202,8 @@ describe("Cypher Aggregations where node with Time", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -234,7 +239,8 @@ describe("Cypher Aggregations where node with Time", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -270,7 +276,8 @@ describe("Cypher Aggregations where node with Time", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -306,7 +313,8 @@ describe("Cypher Aggregations where node with Time", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -342,7 +350,8 @@ describe("Cypher Aggregations where node with Time", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -378,7 +387,8 @@ describe("Cypher Aggregations where node with Time", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:LIKES]-(this1:User)

--- a/packages/graphql/tests/tck/alias.test.ts
+++ b/packages/graphql/tests/tck/alias.test.ts
@@ -70,7 +70,8 @@ describe("Cypher Alias", () => {
 
         // NOTE: Order of these subqueries have been reversed after refactor
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 CALL {

--- a/packages/graphql/tests/tck/array-methods.test.ts
+++ b/packages/graphql/tests/tck/array-methods.test.ts
@@ -48,7 +48,8 @@ describe("Arrays Methods", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WITH this
             WHERE apoc.util.validatePredicate(this.ratings IS NULL, \\"Property %s cannot be NULL\\", ['ratings'])
             SET this.ratings = this.ratings + $this_update_ratings_PUSH
@@ -93,7 +94,8 @@ describe("Arrays Methods", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WITH this
             WHERE apoc.util.validatePredicate(this.ratings IS NULL OR this.scores IS NULL, \\"Properties %s, %s cannot be NULL\\", ['ratings', 'scores'])
             SET this.ratings = this.ratings + $this_update_ratings_PUSH
@@ -152,7 +154,8 @@ describe("Arrays Methods", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WITH this
             WHERE apoc.util.validatePredicate(this.filmingLocations IS NULL, \\"Property %s cannot be NULL\\", ['filmingLocations'])
             SET this.filmingLocations = this.filmingLocations + [p in $this_update_filmingLocations_PUSH | point(p)]
@@ -207,7 +210,8 @@ describe("Arrays Methods", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WITH this
             WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__before_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(this.ratings IS NULL, \\"Property %s cannot be NULL\\", ['ratings'])
             SET this.ratings = this.ratings + $this_update_ratings_PUSH
@@ -258,7 +262,8 @@ describe("Arrays Methods", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WITH this
             WHERE apoc.util.validatePredicate(this.ratings IS NULL, \\"Property %s cannot be NULL\\", ['ratings'])
             SET this.ratings = this.ratings[0..-$this_update_ratings_POP]
@@ -304,7 +309,8 @@ describe("Arrays Methods", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WITH this
             WHERE apoc.util.validatePredicate(this.ratings IS NULL OR this.scores IS NULL, \\"Properties %s, %s cannot be NULL\\", ['ratings', 'scores'])
             SET this.ratings = this.ratings[0..-$this_update_ratings_POP]
@@ -361,7 +367,8 @@ describe("Arrays Methods", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WITH this
             WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__before_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(this.ratings IS NULL, \\"Property %s cannot be NULL\\", ['ratings'])
             SET this.ratings = this.ratings[0..-$this_update_ratings_POP]
@@ -415,7 +422,8 @@ describe("Arrays Methods", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WITH this
             WHERE apoc.util.validatePredicate(this.ratings IS NULL OR this.scores IS NULL, \\"Properties %s, %s cannot be NULL\\", ['ratings', 'scores'])
             SET this.ratings = this.ratings + $this_update_ratings_PUSH
@@ -482,7 +490,8 @@ describe("Arrays Methods", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             WHERE this.id = $param0
             WITH this
             CALL {
@@ -584,7 +593,8 @@ describe("Arrays Methods", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             WHERE this.id = $param0
             WITH this
             CALL {

--- a/packages/graphql/tests/tck/arrays.test.ts
+++ b/packages/graphql/tests/tck/arrays.test.ts
@@ -50,7 +50,8 @@ describe("Cypher Arrays", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE $param0 IN this.ratings
             RETURN this { .title, .ratings } AS this"
         `);
@@ -61,6 +62,4 @@ describe("Cypher Arrays", () => {
             }"
         `);
     });
-
-   
 });

--- a/packages/graphql/tests/tck/connections/alias.test.ts
+++ b/packages/graphql/tests/tck/connections/alias.test.ts
@@ -60,7 +60,8 @@ describe("Connections Alias", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
@@ -112,7 +113,8 @@ describe("Connections Alias", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title = $param0
             CALL {
                 WITH this

--- a/packages/graphql/tests/tck/connections/connect-or-create/connect-or-create-alias.test.ts
+++ b/packages/graphql/tests/tck/connections/connect-or-create/connect-or-create-alias.test.ts
@@ -81,7 +81,8 @@ describe("Connect or create with @alias", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:BibliographicReference:Resource)
+            "CYPHER 5
+            MATCH (this:BibliographicReference:Resource)
             WHERE this._uri = $param0
             SET this.prefLabel = $this_update_prefLabel_SET
             WITH this

--- a/packages/graphql/tests/tck/connections/connect-or-create/connect-or-create-auth.test.ts
+++ b/packages/graphql/tests/tck/connections/connect-or-create/connect-or-create-auth.test.ts
@@ -74,7 +74,8 @@ describe("connectOrCreate", () => {
             const result = await translateQuery(neoSchema, query, { token });
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "CALL {
+                "CYPHER 5
+                CALL {
                 CREATE (this0:Movie)
                 SET this0.title = $this0_title
                 WITH this0
@@ -122,7 +123,8 @@ describe("connectOrCreate", () => {
             const result = await translateQuery(neoSchema, query, { token });
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "CALL {
+                "CYPHER 5
+                CALL {
                 CREATE (this0:Movie)
                 SET this0.title = $this0_title
                 WITH this0
@@ -170,7 +172,8 @@ describe("connectOrCreate", () => {
             const result = await translateQuery(neoSchema, query, { token });
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "CALL {
+                "CYPHER 5
+                CALL {
                 CREATE (this0:Movie)
                 SET this0.title = $this0_title
                 WITH this0
@@ -218,7 +221,8 @@ describe("connectOrCreate", () => {
             const result = await translateQuery(neoSchema, query, { token });
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "CALL {
+                "CYPHER 5
+                CALL {
                 CREATE (this0:Movie)
                 SET this0.title = $this0_title
                 WITH this0
@@ -280,7 +284,8 @@ describe("connectOrCreate", () => {
             const result = await translateQuery(neoSchema, query, { token });
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Movie)
+                "CYPHER 5
+                MATCH (this:Movie)
                 SET this.title = $this_update_title_SET
                 WITH this
                 CALL {
@@ -321,7 +326,8 @@ describe("connectOrCreate", () => {
             const result = await translateQuery(neoSchema, query, { token });
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Movie)
+                "CYPHER 5
+                MATCH (this:Movie)
                 SET this.title = $this_update_title_SET
                 WITH this
                 CALL {
@@ -362,7 +368,8 @@ describe("connectOrCreate", () => {
             const result = await translateQuery(neoSchema, query, { token });
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Movie)
+                "CYPHER 5
+                MATCH (this:Movie)
                 SET this.title = $this_update_title_SET
                 WITH this
                 CALL {
@@ -403,7 +410,8 @@ describe("connectOrCreate", () => {
             const result = await translateQuery(neoSchema, query, { token });
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Movie)
+                "CYPHER 5
+                MATCH (this:Movie)
                 SET this.title = $this_update_title_SET
                 WITH this
                 CALL {
@@ -459,7 +467,8 @@ describe("connectOrCreate", () => {
             const result = await translateQuery(neoSchema, query, { token });
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Movie)
+                "CYPHER 5
+                MATCH (this:Movie)
                 SET this.title = $this_update_title_SET
                 WITH this
                 CALL {
@@ -500,7 +509,8 @@ describe("connectOrCreate", () => {
             const result = await translateQuery(neoSchema, query, { token });
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Movie)
+                "CYPHER 5
+                MATCH (this:Movie)
                 SET this.title = $this_update_title_SET
                 WITH this
                 CALL {
@@ -541,7 +551,8 @@ describe("connectOrCreate", () => {
             const result = await translateQuery(neoSchema, query, { token });
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Movie)
+                "CYPHER 5
+                MATCH (this:Movie)
                 SET this.title = $this_update_title_SET
                 WITH this
                 CALL {
@@ -582,7 +593,8 @@ describe("connectOrCreate", () => {
             const result = await translateQuery(neoSchema, query, { token });
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Movie)
+                "CYPHER 5
+                MATCH (this:Movie)
                 SET this.title = $this_update_title_SET
                 WITH this
                 CALL {
@@ -634,7 +646,8 @@ describe("connectOrCreate", () => {
             const result = await translateQuery(neoSchema, query, { token });
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Movie)
+                "CYPHER 5
+                MATCH (this:Movie)
                 SET this.title = $this_update_title_SET
                 WITH this
                 CALL {

--- a/packages/graphql/tests/tck/connections/connect-or-create/connect-or-create-unions.test.ts
+++ b/packages/graphql/tests/tck/connections/connect-or-create/connect-or-create-unions.test.ts
@@ -96,7 +96,8 @@ describe("Create or connect with unions", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
             CREATE (this0:Actor)
             SET this0.name = $this0_name
             WITH this0
@@ -192,7 +193,8 @@ describe("Create or connect with unions", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             WHERE this.name = $param0
             SET this.name = $this_update_name_SET
             WITH this

--- a/packages/graphql/tests/tck/connections/connect-or-create/connect-or-create.test.ts
+++ b/packages/graphql/tests/tck/connections/connect-or-create/connect-or-create.test.ts
@@ -73,7 +73,8 @@ describe("Create or Connect", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "CALL {
+                "CYPHER 5
+                CALL {
                 CREATE (this0:Actor)
                 SET this0.name = $this0_name
                 WITH this0
@@ -135,7 +136,8 @@ describe("Create or Connect", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Actor)
+                "CYPHER 5
+                MATCH (this:Actor)
                 WHERE this.name = $param0
                 SET this.name = $this_update_name_SET
                 WITH this
@@ -222,7 +224,8 @@ describe("Create or Connect", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "CALL {
+                "CYPHER 5
+                CALL {
                 CREATE (this0:Actor)
                 SET this0.name = $this0_name
                 WITH this0
@@ -287,7 +290,8 @@ describe("Create or Connect", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "CALL {
+                "CYPHER 5
+                CALL {
                 CREATE (this0:Actor)
                 SET this0.name = $this0_name
                 WITH this0
@@ -350,7 +354,8 @@ describe("Create or Connect", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Actor)
+                "CYPHER 5
+                MATCH (this:Actor)
                 WHERE this.name = $param0
                 SET this.name = $this_update_name_SET
                 WITH this
@@ -409,7 +414,8 @@ describe("Create or Connect", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Actor)
+                "CYPHER 5
+                MATCH (this:Actor)
                 WHERE this.name = $param0
                 SET this.name = $this_update_name_SET
                 WITH this
@@ -498,7 +504,8 @@ describe("Create or Connect", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "CALL {
+                "CYPHER 5
+                CALL {
                 CREATE (this0:Actor)
                 SET this0.name = $this0_name
                 WITH this0
@@ -562,7 +569,8 @@ describe("Create or Connect", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Actor)
+                "CYPHER 5
+                MATCH (this:Actor)
                 WHERE this.name = $param0
                 SET this.name = $this_update_name_SET
                 WITH this

--- a/packages/graphql/tests/tck/connections/filtering/composite.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/composite.test.ts
@@ -75,7 +75,8 @@ describe("Cypher -> Connections -> Filtering -> Composite", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title = $param0
             CALL {
                 WITH this
@@ -139,7 +140,8 @@ describe("Cypher -> Connections -> Filtering -> Composite", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title = $param0
             CALL {
                 WITH this
@@ -205,7 +207,8 @@ describe("Cypher -> Connections -> Filtering -> Composite", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title = $param0
             CALL {
                 WITH this
@@ -273,7 +276,8 @@ describe("Cypher -> Connections -> Filtering -> Composite", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title = $param0
             CALL {
                 WITH this
@@ -346,7 +350,8 @@ describe("Cypher -> Connections -> Filtering -> Composite", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title = $param0
             CALL {
                 WITH this

--- a/packages/graphql/tests/tck/connections/filtering/interface-relationships.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/interface-relationships.test.ts
@@ -88,7 +88,8 @@ describe("interface relationships with aliased fields", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             WHERE EXISTS {
                 MATCH (this)-[this0:ACTED_IN]->(this1)
                 WHERE (CASE
@@ -138,7 +139,8 @@ describe("interface relationships with aliased fields", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             WHERE EXISTS {
                 MATCH (this)-[this0:ACTED_IN]->(this1)
                 WHERE (CASE
@@ -178,7 +180,8 @@ describe("interface relationships with aliased fields", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:ProtectedActor)
+            "CYPHER 5
+            MATCH (this:ProtectedActor)
             WITH *
             WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND size([(this)-[this1:ACTED_IN]->(this0) WHERE (($jwt.title IS NOT NULL AND CASE
                 WHEN this0:Movie THEN this0.movieTitle

--- a/packages/graphql/tests/tck/connections/filtering/node/and.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/node/and.test.ts
@@ -70,7 +70,8 @@ describe("Cypher -> Connections -> Filtering -> Node -> AND", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
@@ -119,7 +120,8 @@ describe("Cypher -> Connections -> Filtering -> Node -> AND", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)

--- a/packages/graphql/tests/tck/connections/filtering/node/arrays.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/node/arrays.test.ts
@@ -69,7 +69,8 @@ describe("Cypher -> Connections -> Filtering -> Node -> Arrays", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
@@ -120,7 +121,8 @@ describe("Cypher -> Connections -> Filtering -> Node -> Arrays", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)

--- a/packages/graphql/tests/tck/connections/filtering/node/equality.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/node/equality.test.ts
@@ -68,7 +68,8 @@ describe("Cypher -> Connections -> Filtering -> Node -> Equality", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
@@ -115,7 +116,8 @@ describe("Cypher -> Connections -> Filtering -> Node -> Equality", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)

--- a/packages/graphql/tests/tck/connections/filtering/node/numerical.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/node/numerical.test.ts
@@ -70,7 +70,8 @@ describe("Cypher -> Connections -> Filtering -> Node -> Numerical", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
@@ -121,7 +122,8 @@ describe("Cypher -> Connections -> Filtering -> Node -> Numerical", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
@@ -172,7 +174,8 @@ describe("Cypher -> Connections -> Filtering -> Node -> Numerical", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
@@ -223,7 +226,8 @@ describe("Cypher -> Connections -> Filtering -> Node -> Numerical", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)

--- a/packages/graphql/tests/tck/connections/filtering/node/or.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/node/or.test.ts
@@ -70,7 +70,8 @@ describe("Cypher -> Connections -> Filtering -> Node -> OR", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)

--- a/packages/graphql/tests/tck/connections/filtering/node/points.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/node/points.test.ts
@@ -86,7 +86,8 @@ describe("Cypher -> Connections -> Filtering -> Node -> Points", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)

--- a/packages/graphql/tests/tck/connections/filtering/node/relationship.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/node/relationship.test.ts
@@ -61,7 +61,8 @@ describe("Cypher -> Connections -> Filtering -> Node -> Relationship", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)

--- a/packages/graphql/tests/tck/connections/filtering/node/string.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/node/string.test.ts
@@ -75,7 +75,8 @@ describe("Cypher -> Connections -> Filtering -> Node -> String", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
@@ -122,7 +123,8 @@ describe("Cypher -> Connections -> Filtering -> Node -> String", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
@@ -169,7 +171,8 @@ describe("Cypher -> Connections -> Filtering -> Node -> String", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
@@ -216,7 +219,8 @@ describe("Cypher -> Connections -> Filtering -> Node -> String", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)

--- a/packages/graphql/tests/tck/connections/filtering/relationship/and.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/relationship/and.test.ts
@@ -70,7 +70,8 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> AND", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
@@ -122,7 +123,8 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> AND", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)

--- a/packages/graphql/tests/tck/connections/filtering/relationship/arrays.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/relationship/arrays.test.ts
@@ -69,7 +69,8 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Arrays", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
@@ -125,7 +126,8 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Arrays", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)

--- a/packages/graphql/tests/tck/connections/filtering/relationship/equality.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/relationship/equality.test.ts
@@ -68,7 +68,8 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Equality", () =>
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
@@ -118,7 +119,8 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Equality", () =>
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)

--- a/packages/graphql/tests/tck/connections/filtering/relationship/numerical.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/relationship/numerical.test.ts
@@ -68,7 +68,8 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Numerical", () =
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
@@ -118,7 +119,8 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Numerical", () =
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
@@ -168,7 +170,8 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Numerical", () =
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
@@ -218,7 +221,8 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Numerical", () =
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)

--- a/packages/graphql/tests/tck/connections/filtering/relationship/or.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/relationship/or.test.ts
@@ -70,7 +70,8 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> OR", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
@@ -115,7 +116,8 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> OR", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE EXISTS {
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WHERE (this1.name = $param0 OR this0.role = $param1)

--- a/packages/graphql/tests/tck/connections/filtering/relationship/points.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/relationship/points.test.ts
@@ -84,7 +84,8 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Points", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)

--- a/packages/graphql/tests/tck/connections/filtering/relationship/string.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/relationship/string.test.ts
@@ -76,7 +76,8 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> String", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
@@ -123,7 +124,8 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> String", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
@@ -148,8 +150,6 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> String", () => {
         `);
     });
 
-   
-
     test("ENDS_WITH", async () => {
         const query = /* GraphQL */ `
             query {
@@ -172,7 +172,8 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> String", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
@@ -219,7 +220,8 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> String", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)

--- a/packages/graphql/tests/tck/connections/filtering/relationship/temporal.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/relationship/temporal.test.ts
@@ -72,7 +72,8 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Temporal", () =>
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)

--- a/packages/graphql/tests/tck/connections/interfaces.test.ts
+++ b/packages/graphql/tests/tck/connections/interfaces.test.ts
@@ -83,7 +83,8 @@ describe("Cypher -> Connections -> Interfaces", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             CALL {
                 WITH this
                 CALL {
@@ -135,7 +136,8 @@ describe("Cypher -> Connections -> Interfaces", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             CALL {
                 WITH this
                 CALL {
@@ -194,7 +196,8 @@ describe("Cypher -> Connections -> Interfaces", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             CALL {
                 WITH this
                 CALL {
@@ -261,7 +264,8 @@ describe("Cypher -> Connections -> Interfaces", () => {
                 const result = await translateQuery(neoSchema, query);
 
                 expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                    "MATCH (this:Actor)
+                    "CYPHER 5
+                    MATCH (this:Actor)
                     CALL {
                         WITH this
                         CALL {
@@ -320,7 +324,8 @@ describe("Cypher -> Connections -> Interfaces", () => {
                 const result = await translateQuery(neoSchema, query);
 
                 expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                    "MATCH (this:Actor)
+                    "CYPHER 5
+                    MATCH (this:Actor)
                     CALL {
                         WITH this
                         CALL {
@@ -378,7 +383,8 @@ describe("Cypher -> Connections -> Interfaces", () => {
                 const result = await translateQuery(neoSchema, query);
 
                 expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                    "MATCH (this:Actor)
+                    "CYPHER 5
+                    MATCH (this:Actor)
                     CALL {
                         WITH this
                         CALL {
@@ -436,7 +442,8 @@ describe("Cypher -> Connections -> Interfaces", () => {
                 const result = await translateQuery(neoSchema, query);
 
                 expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                    "MATCH (this:Actor)
+                    "CYPHER 5
+                    MATCH (this:Actor)
                     CALL {
                         WITH this
                         CALL {

--- a/packages/graphql/tests/tck/connections/mixed-nesting.test.ts
+++ b/packages/graphql/tests/tck/connections/mixed-nesting.test.ts
@@ -71,7 +71,8 @@ describe("Mixed nesting", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title = $param0
             CALL {
                 WITH this
@@ -138,7 +139,8 @@ describe("Mixed nesting", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title = $param0
             CALL {
                 WITH this
@@ -213,7 +215,8 @@ describe("Mixed nesting", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title = $param0
             CALL {
                 WITH this

--- a/packages/graphql/tests/tck/connections/projections/create.test.ts
+++ b/packages/graphql/tests/tck/connections/projections/create.test.ts
@@ -70,7 +70,8 @@ describe("Cypher -> Connections -> Projections -> Create", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Movie)
@@ -129,7 +130,8 @@ describe("Cypher -> Connections -> Projections -> Create", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Movie)
@@ -191,7 +193,8 @@ describe("Cypher -> Connections -> Projections -> Create", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Movie)

--- a/packages/graphql/tests/tck/connections/projections/projections.test.ts
+++ b/packages/graphql/tests/tck/connections/projections/projections.test.ts
@@ -64,7 +64,8 @@ describe("Relay Cursor Connection projections", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title = $param0
             CALL {
                 WITH this
@@ -109,7 +110,8 @@ describe("Relay Cursor Connection projections", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title = $param0
             CALL {
                 WITH this
@@ -149,7 +151,8 @@ describe("Relay Cursor Connection projections", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title = $param0
             CALL {
                 WITH this
@@ -195,7 +198,8 @@ describe("Relay Cursor Connection projections", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             WHERE this.name = $param0
             CALL {
                 WITH this
@@ -244,7 +248,8 @@ describe("Relay Cursor Connection projections", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             WHERE this.name = $param0
             CALL {
                 WITH this
@@ -293,7 +298,8 @@ describe("Relay Cursor Connection projections", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title = $param0
             CALL {
                 WITH this
@@ -338,7 +344,8 @@ describe("Relay Cursor Connection projections", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title = $param0
             CALL {
                 WITH this

--- a/packages/graphql/tests/tck/connections/projections/update.test.ts
+++ b/packages/graphql/tests/tck/connections/projections/update.test.ts
@@ -70,7 +70,8 @@ describe("Cypher -> Connections -> Projections -> Update", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title = $param0
             WITH *
             CALL {

--- a/packages/graphql/tests/tck/connections/relationship-properties.test.ts
+++ b/packages/graphql/tests/tck/connections/relationship-properties.test.ts
@@ -69,7 +69,8 @@ describe("Relationship Properties Cypher", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title = $param0
             CALL {
                 WITH this
@@ -116,7 +117,8 @@ describe("Relationship Properties Cypher", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title = $param0
             CALL {
                 WITH this
@@ -165,7 +167,8 @@ describe("Relationship Properties Cypher", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title = $param0
             CALL {
                 WITH this
@@ -213,7 +216,8 @@ describe("Relationship Properties Cypher", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
@@ -255,7 +259,8 @@ describe("Relationship Properties Cypher", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
@@ -309,7 +314,8 @@ describe("Relationship Properties Cypher", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title = $param0
             CALL {
                 WITH this
@@ -389,7 +395,8 @@ describe("Relationship Properties Cypher", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title = $param0
             CALL {
                 WITH this

--- a/packages/graphql/tests/tck/connections/relationship_properties/connect.test.ts
+++ b/packages/graphql/tests/tck/connections/relationship_properties/connect.test.ts
@@ -70,7 +70,8 @@ describe("Relationship Properties Connect Cypher", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
             CREATE (this0:Movie)
             SET this0.title = $this0_title
             WITH *
@@ -158,7 +159,8 @@ describe("Relationship Properties Connect Cypher", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
             CREATE (this0:Movie)
             SET this0.title = $this0_title
             WITH *
@@ -242,7 +244,8 @@ describe("Relationship Properties Connect Cypher", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title = $param0
             WITH *
             CALL {
@@ -320,7 +323,8 @@ describe("Relationship Properties Connect Cypher", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title = $param0
             WITH *
             CALL {

--- a/packages/graphql/tests/tck/connections/relationship_properties/create.test.ts
+++ b/packages/graphql/tests/tck/connections/relationship_properties/create.test.ts
@@ -77,7 +77,8 @@ describe("Relationship Properties Create Cypher", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Movie)

--- a/packages/graphql/tests/tck/connections/relationship_properties/update.test.ts
+++ b/packages/graphql/tests/tck/connections/relationship_properties/update.test.ts
@@ -65,7 +65,8 @@ describe("Cypher -> Connections -> Relationship Properties -> Update", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title = $param0
             WITH this
             CALL {
@@ -134,7 +135,8 @@ describe("Cypher -> Connections -> Relationship Properties -> Update", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title = $param0
             WITH this
             CALL {

--- a/packages/graphql/tests/tck/connections/sort.test.ts
+++ b/packages/graphql/tests/tck/connections/sort.test.ts
@@ -75,7 +75,8 @@ describe("Relationship Properties Cypher", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this0:Movie)
+            "CYPHER 5
+            MATCH (this0:Movie)
             WITH collect({ node: this0 }) AS edges
             WITH edges, size(edges) AS totalCount
             CALL {
@@ -136,7 +137,8 @@ describe("Relationship Properties Cypher", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this0:Movie)
+            "CYPHER 5
+            MATCH (this0:Movie)
             WITH collect({ node: this0 }) AS edges
             WITH edges, size(edges) AS totalCount
             CALL {

--- a/packages/graphql/tests/tck/connections/top-level-interfaces.test.ts
+++ b/packages/graphql/tests/tck/connections/top-level-interfaces.test.ts
@@ -78,7 +78,8 @@ describe("Top level interface connections", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this0:Movie)
                 WHERE this0.title = $param0
                 WITH { node: { __resolveType: \\"Movie\\", __id: id(this0), cost: this0.cost, title: this0.title } } AS edge
@@ -120,7 +121,8 @@ describe("Top level interface connections", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this0:Movie)
                 WHERE this0.title = $param0
                 WITH { node: { __resolveType: \\"Movie\\", __id: id(this0), cost: this0.cost, title: this0.title } } AS edge

--- a/packages/graphql/tests/tck/connections/unions.test.ts
+++ b/packages/graphql/tests/tck/connections/unions.test.ts
@@ -80,7 +80,8 @@ describe("Cypher -> Connections -> Unions", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Author)
+            "CYPHER 5
+            MATCH (this:Author)
             CALL {
                 WITH this
                 CALL {
@@ -136,7 +137,8 @@ describe("Cypher -> Connections -> Unions", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Author)
+            "CYPHER 5
+            MATCH (this:Author)
             CALL {
                 WITH this
                 CALL {
@@ -196,7 +198,8 @@ describe("Cypher -> Connections -> Unions", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Author)
+            "CYPHER 5
+            MATCH (this:Author)
             CALL {
                 WITH this
                 CALL {
@@ -265,7 +268,8 @@ describe("Cypher -> Connections -> Unions", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Author)
+            "CYPHER 5
+            MATCH (this:Author)
             CALL {
                 WITH this
                 CALL {
@@ -331,7 +335,8 @@ describe("Cypher -> Connections -> Unions", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Author)
+            "CYPHER 5
+            MATCH (this:Author)
             CALL {
                 WITH this
                 CALL {

--- a/packages/graphql/tests/tck/deprecated/cypher-sort-deprecated.test.ts
+++ b/packages/graphql/tests/tck/deprecated/cypher-sort-deprecated.test.ts
@@ -107,7 +107,8 @@ describe("Cypher sort deprecated", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Movie)
+                "CYPHER 5
+                MATCH (this:Movie)
                 WITH *
                 ORDER BY this.id DESC
                 RETURN this { .id, .title } AS this"
@@ -129,7 +130,8 @@ describe("Cypher sort deprecated", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Movie)
+                "CYPHER 5
+                MATCH (this:Movie)
                 WITH *
                 ORDER BY this.id DESC
                 RETURN this { .title, .id, aliased: this.id } AS this"
@@ -150,7 +152,8 @@ describe("Cypher sort deprecated", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Movie)
+                "CYPHER 5
+                MATCH (this:Movie)
                 WITH *
                 ORDER BY this.id DESC
                 RETURN this { .title, .id } AS this"
@@ -172,7 +175,8 @@ describe("Cypher sort deprecated", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 CALL {
@@ -204,7 +208,8 @@ describe("Cypher sort deprecated", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 CALL {
@@ -221,7 +226,7 @@ describe("Cypher sort deprecated", () => {
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
     });
-    
+
     test("Simple Sort On Cypher Field", async () => {
         const query = /* GraphQL */ `
             {
@@ -234,7 +239,8 @@ describe("Cypher sort deprecated", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 CALL {
@@ -267,7 +273,8 @@ describe("Cypher sort deprecated", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WITH *
             ORDER BY this.id DESC, this.title ASC
             RETURN this { .id, .title } AS this"
@@ -294,7 +301,8 @@ describe("Cypher sort deprecated", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title = $param0
             WITH *
             ORDER BY this.id DESC, this.title ASC
@@ -332,7 +340,8 @@ describe("Cypher sort deprecated", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)-[this0:HAS_GENRE]->(this1:Genre)
@@ -360,7 +369,8 @@ describe("Cypher sort deprecated", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)-[this0:HAS_GENRE]->(this1:Genre)
@@ -389,7 +399,8 @@ describe("Cypher sort deprecated", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)-[this0:HAS_GENRE]->(this1:Genre)
@@ -443,7 +454,8 @@ describe("Cypher sort deprecated", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this0:Movie)
+            "CYPHER 5
+            MATCH (this0:Movie)
             WITH collect({ node: this0 }) AS edges
             WITH edges, size(edges) AS totalCount
             CALL {
@@ -533,7 +545,8 @@ describe("Cypher sort deprecated", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             CALL {
                 WITH this
                 MATCH (this)-[this0:ACTED_IN]->(this1:Movie)

--- a/packages/graphql/tests/tck/deprecated/query-direction-aggregations.test.ts
+++ b/packages/graphql/tests/tck/deprecated/query-direction-aggregations.test.ts
@@ -49,7 +49,8 @@ describe("QueryDirection in relationships aggregations (deprecated _DEFAULT/_ONL
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             CALL {
                 WITH this
                 MATCH (this)-[this0:FRIENDS_WITH]-(this1:User)
@@ -84,7 +85,8 @@ describe("QueryDirection in relationships aggregations (deprecated _DEFAULT/_ONL
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             CALL {
                 WITH this
                 MATCH (this)-[this0:FRIENDS_WITH]->(this1:User)
@@ -119,7 +121,8 @@ describe("QueryDirection in relationships aggregations (deprecated _DEFAULT/_ONL
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             CALL {
                 WITH this
                 MATCH (this)-[this0:FRIENDS_WITH]-(this1:User)

--- a/packages/graphql/tests/tck/deprecated/query-direction-connection.test.ts
+++ b/packages/graphql/tests/tck/deprecated/query-direction-connection.test.ts
@@ -49,7 +49,8 @@ describe("QueryDirection in relationships connection (deprecated _DEFAULT/_ONLY 
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             CALL {
                 WITH this
                 MATCH (this)-[this0:FRIENDS_WITH]-(this1:User)
@@ -93,7 +94,8 @@ describe("QueryDirection in relationships connection (deprecated _DEFAULT/_ONLY 
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             CALL {
                 WITH this
                 MATCH (this)-[this0:FRIENDS_WITH]->(this1:User)
@@ -137,7 +139,8 @@ describe("QueryDirection in relationships connection (deprecated _DEFAULT/_ONLY 
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             CALL {
                 WITH this
                 MATCH (this)-[this0:FRIENDS_WITH]-(this1:User)
@@ -156,6 +159,4 @@ describe("QueryDirection in relationships connection (deprecated _DEFAULT/_ONLY 
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
     });
-
-   
 });

--- a/packages/graphql/tests/tck/deprecated/query-direction.test.ts
+++ b/packages/graphql/tests/tck/deprecated/query-direction.test.ts
@@ -53,7 +53,8 @@ describe("QueryDirection in relationships (deprecated _DEFAULT/_ONLY options)", 
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             CALL {
                 WITH this
                 MATCH (this)-[this0:FRIENDS_WITH]-(this1:User)
@@ -100,7 +101,8 @@ describe("QueryDirection in relationships (deprecated _DEFAULT/_ONLY options)", 
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             CALL {
                 WITH this
                 MATCH (this)-[this0:FRIENDS_WITH]->(this1:User)
@@ -144,7 +146,8 @@ describe("QueryDirection in relationships (deprecated _DEFAULT/_ONLY options)", 
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             CALL {
                 WITH this
                 MATCH (this)-[this0:FRIENDS_WITH]->(this1:User)
@@ -182,7 +185,8 @@ describe("QueryDirection in relationships (deprecated _DEFAULT/_ONLY options)", 
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             CALL {
                 WITH this
                 MATCH (this)-[this0:FRIENDS_WITH]-(this1:User)

--- a/packages/graphql/tests/tck/deprecated/update.test.ts
+++ b/packages/graphql/tests/tck/deprecated/update.test.ts
@@ -61,7 +61,8 @@ describe("Cypher Update", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.id = $param0
             SET this.id = $this_update_id
             RETURN collect(DISTINCT this { .id }) AS data"
@@ -95,7 +96,8 @@ describe("Cypher Update", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.id = $param0
             WITH this
             CALL {
@@ -172,7 +174,8 @@ describe("Cypher Update", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.id = $param0
             WITH this
             CALL {
@@ -256,7 +259,8 @@ describe("Cypher Update", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.id = $param0
             WITH *
             CALL {
@@ -312,7 +316,8 @@ describe("Cypher Update", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.id = $param0
             WITH *
             CALL {
@@ -380,7 +385,8 @@ describe("Cypher Update", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.id = $param0
             WITH this
             CALL {
@@ -450,7 +456,8 @@ describe("Cypher Update", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.id = $param0
             WITH this
             CALL {
@@ -538,7 +545,8 @@ describe("Cypher Update", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             WHERE this.name = $param0
             WITH this
             CREATE (this_movies0_create0_node:Movie)
@@ -586,7 +594,8 @@ describe("Cypher Update", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             WHERE this.name = $param0
             WITH this
             CREATE (this_movies0_create0_node:Movie)
@@ -641,7 +650,8 @@ describe("Cypher Update", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             WHERE this.name = $param0
             WITH this
             CREATE (this_movies0_create0_node:Movie)
@@ -695,7 +705,8 @@ describe("Cypher Update", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.id = $param0
             WITH *
             CALL {
@@ -773,7 +784,8 @@ describe("Cypher Update", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.id = $param0
             WITH *
             CALL {
@@ -855,7 +867,8 @@ describe("Cypher Update", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.id = $param0
             WITH *
             CALL {
@@ -924,7 +937,8 @@ describe("Cypher Update", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.id = $param0
             WITH *
             CALL {

--- a/packages/graphql/tests/tck/directives/alias.test.ts
+++ b/packages/graphql/tests/tck/directives/alias.test.ts
@@ -65,7 +65,8 @@ describe("Cypher alias directive", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             CALL {
                 WITH this
                 MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
@@ -103,7 +104,8 @@ describe("Cypher alias directive", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             CALL {
                 WITH this
                 MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
@@ -167,7 +169,8 @@ describe("Cypher alias directive", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Actor)

--- a/packages/graphql/tests/tck/directives/authorization/arguments/allow/allow.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/allow/allow.test.ts
@@ -116,7 +116,8 @@ describe("Cypher Auth Allow", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this { .id } AS this"
@@ -150,7 +151,8 @@ describe("Cypher Auth Allow", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             RETURN this { .password } AS this"
@@ -187,7 +189,8 @@ describe("Cypher Auth Allow", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
@@ -233,7 +236,8 @@ describe("Cypher Auth Allow", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             OPTIONAL MATCH (this)<-[:HAS_POST]-(this0:User)
             WITH *, count(this0) AS var1
             WITH *
@@ -282,7 +286,8 @@ describe("Cypher Auth Allow", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE (this.id = $param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             CALL {
@@ -341,7 +346,8 @@ describe("Cypher Auth Allow", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE (this.id = $param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             SET this.id = $this_update_id_SET
@@ -383,7 +389,8 @@ describe("Cypher Auth Allow", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE (this.id = $param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             WITH this
@@ -430,7 +437,8 @@ describe("Cypher Auth Allow", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             OPTIONAL MATCH (this)<-[:HAS_POST]-(this0:User)
             WITH *, count(this0) AS var1
             WITH *
@@ -494,7 +502,8 @@ describe("Cypher Auth Allow", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             OPTIONAL MATCH (this)<-[:HAS_POST]-(this0:User)
             WITH *, count(this0) AS var1
             WITH *
@@ -555,7 +564,8 @@ describe("Cypher Auth Allow", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WHERE (this.id = $param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             DETACH DELETE this"
         `);
@@ -589,7 +599,8 @@ describe("Cypher Auth Allow", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WHERE (this.id = $param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             WITH *
             CALL {
@@ -644,7 +655,8 @@ describe("Cypher Auth Allow", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE (this.id = $param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             WITH this
@@ -725,7 +737,8 @@ describe("Cypher Auth Allow", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Comment)
+            "CYPHER 5
+            MATCH (this:Comment)
             OPTIONAL MATCH (this)<-[:HAS_COMMENT]-(this0:User)
             WITH *, count(this0) AS var1
             WITH *
@@ -840,7 +853,8 @@ describe("Cypher Auth Allow", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE (this.id = $param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             WITH *

--- a/packages/graphql/tests/tck/directives/authorization/arguments/allow/interface-relationships/implementation-allow.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/allow/interface-relationships/implementation-allow.test.ts
@@ -94,7 +94,8 @@ describe("@auth allow on specific interface implementation", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             CALL {
                 WITH this
                 CALL {
@@ -153,7 +154,8 @@ describe("@auth allow on specific interface implementation", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WHERE this.id = $param0
             CALL {
                 WITH this
@@ -226,7 +228,8 @@ describe("@auth allow on specific interface implementation", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WHERE this.id = $param0
             WITH this
             CALL {
@@ -335,7 +338,8 @@ describe("@auth allow on specific interface implementation", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WHERE this.id = $param0
             WITH *
             CALL {

--- a/packages/graphql/tests/tck/directives/authorization/arguments/is-authenticated/interface-relationships/implementation-is-authenticated.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/is-authenticated/interface-relationships/implementation-is-authenticated.test.ts
@@ -78,7 +78,8 @@ describe("Cypher Auth isAuthenticated", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Post)
@@ -119,7 +120,8 @@ describe("Cypher Auth isAuthenticated", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Comment)
@@ -160,7 +162,8 @@ describe("Cypher Auth isAuthenticated", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             WHERE this.id = $param0
             SET this.id = $this_update_id_SET
             RETURN collect(DISTINCT this { .id }) AS data"
@@ -192,7 +195,8 @@ describe("Cypher Auth isAuthenticated", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Comment)
+            "CYPHER 5
+            MATCH (this:Comment)
             WHERE this.id = $param0
             SET this.id = $this_update_id_SET
             RETURN collect(DISTINCT this { .id }) AS data"
@@ -222,7 +226,8 @@ describe("Cypher Auth isAuthenticated", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             DETACH DELETE this"
         `);
 
@@ -244,7 +249,8 @@ describe("Cypher Auth isAuthenticated", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Comment)
+            "CYPHER 5
+            MATCH (this:Comment)
             DETACH DELETE this"
         `);
 
@@ -266,7 +272,8 @@ describe("Cypher Auth isAuthenticated", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             CALL {
                 WITH *

--- a/packages/graphql/tests/tck/directives/authorization/arguments/is-authenticated/is-authenticated.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/is-authenticated/is-authenticated.test.ts
@@ -81,7 +81,8 @@ describe("Cypher Auth isAuthenticated", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             RETURN this { .id, .name } AS this"
         `);
 
@@ -105,7 +106,8 @@ describe("Cypher Auth isAuthenticated", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             RETURN this { .id, .name, .password } AS this"
         `);
 
@@ -129,7 +131,8 @@ describe("Cypher Auth isAuthenticated", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             CALL {
                 WITH this
                 CALL {
@@ -164,7 +167,8 @@ describe("Cypher Auth isAuthenticated", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:User)
@@ -203,7 +207,8 @@ describe("Cypher Auth isAuthenticated", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:User)
@@ -244,7 +249,8 @@ describe("Cypher Auth isAuthenticated", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WHERE this.id = $param0
             SET this.id = $this_update_id_SET
             RETURN collect(DISTINCT this { .id }) AS data"
@@ -276,7 +282,8 @@ describe("Cypher Auth isAuthenticated", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WHERE this.id = $param0
             SET this.password = $this_update_password_SET
             RETURN collect(DISTINCT this { .id }) AS data"
@@ -306,7 +313,8 @@ describe("Cypher Auth isAuthenticated", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             DETACH DELETE this"
         `);
 
@@ -328,7 +336,8 @@ describe("Cypher Auth isAuthenticated", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             CALL {
                 WITH *

--- a/packages/graphql/tests/tck/directives/authorization/arguments/roles-where.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/roles-where.test.ts
@@ -97,7 +97,8 @@ describe("Cypher Auth Where with Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this { .id } AS this"
@@ -133,7 +134,8 @@ describe("Cypher Auth Where with Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE (this.name = $param0 AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             RETURN this { .id } AS this"
@@ -173,7 +175,8 @@ describe("Cypher Auth Where with Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
@@ -226,7 +229,8 @@ describe("Cypher Auth Where with Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
@@ -285,7 +289,8 @@ describe("Cypher Auth Where with Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
@@ -341,7 +346,8 @@ describe("Cypher Auth Where with Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
@@ -393,7 +399,8 @@ describe("Cypher Auth Where with Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
@@ -452,7 +459,8 @@ describe("Cypher Auth Where with Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
@@ -512,7 +520,8 @@ describe("Cypher Auth Where with Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
@@ -566,7 +575,8 @@ describe("Cypher Auth Where with Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             SET this.name = $this_update_name_SET
@@ -615,7 +625,8 @@ describe("Cypher Auth Where with Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE (this.name = $param0 AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             SET this.name = $this_update_name_SET
@@ -668,7 +679,8 @@ describe("Cypher Auth Where with Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this
@@ -744,7 +756,8 @@ describe("Cypher Auth Where with Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             DETACH DELETE this"
         `);
@@ -779,7 +792,8 @@ describe("Cypher Auth Where with Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH *
             CALL {
@@ -835,7 +849,8 @@ describe("Cypher Auth Where with Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
             CREATE (this0:User)
             SET this0.id = $this0_id
             SET this0.name = $this0_name
@@ -920,7 +935,8 @@ describe("Cypher Auth Where with Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
             CREATE (this0:User)
             SET this0.id = $this0_id
             SET this0.name = $this0_name
@@ -997,7 +1013,8 @@ describe("Cypher Auth Where with Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH *
@@ -1070,7 +1087,8 @@ describe("Cypher Auth Where with Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH *
@@ -1144,7 +1162,8 @@ describe("Cypher Auth Where with Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this
@@ -1212,7 +1231,8 @@ describe("Cypher Auth Where with Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this

--- a/packages/graphql/tests/tck/directives/authorization/arguments/roles/roles.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/roles/roles.test.ts
@@ -111,7 +111,8 @@ describe("Cypher Auth Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this { .id, .name } AS this"
@@ -148,7 +149,8 @@ describe("Cypher Auth Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             RETURN this { .id, .name, .password } AS this"
@@ -186,7 +188,8 @@ describe("Cypher Auth Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             CALL {
@@ -238,7 +241,8 @@ describe("Cypher Auth Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:User)
@@ -288,7 +292,8 @@ describe("Cypher Auth Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:User)
@@ -340,7 +345,8 @@ describe("Cypher Auth Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE (this.id = $param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             SET this.id = $this_update_id_SET
@@ -387,7 +393,8 @@ describe("Cypher Auth Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE (this.id = $param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             WITH this
@@ -437,7 +444,8 @@ describe("Cypher Auth Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH *
@@ -508,7 +516,8 @@ describe("Cypher Auth Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Comment)
+            "CYPHER 5
+            MATCH (this:Comment)
             WITH this
             CALL {
             	WITH this
@@ -590,7 +599,8 @@ describe("Cypher Auth Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this
@@ -658,7 +668,8 @@ describe("Cypher Auth Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Comment)
+            "CYPHER 5
+            MATCH (this:Comment)
             WITH this
             CALL {
             	WITH this
@@ -754,7 +765,8 @@ describe("Cypher Auth Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             DETACH DELETE this"
         `);
@@ -788,7 +800,8 @@ describe("Cypher Auth Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH *
             CALL {

--- a/packages/graphql/tests/tck/directives/authorization/arguments/validate/interface-relationships/implementation-bind.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/validate/interface-relationships/implementation-bind.test.ts
@@ -117,7 +117,8 @@ describe("Cypher Auth Allow", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
             CREATE (this0:User)
             SET this0.id = $this0_id
             SET this0.name = $this0_name
@@ -205,7 +206,8 @@ describe("Cypher Auth Allow", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
             CREATE (this0:User)
             SET this0.id = $this0_id
             SET this0.name = $this0_name
@@ -279,7 +281,8 @@ describe("Cypher Auth Allow", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WHERE this.id = $param0
             WITH this
             CALL {

--- a/packages/graphql/tests/tck/directives/authorization/arguments/validate/validate.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/validate/validate.test.ts
@@ -87,7 +87,8 @@ describe("Cypher Auth Allow", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:User)
@@ -149,7 +150,8 @@ describe("Cypher Auth Allow", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:User)
@@ -249,7 +251,8 @@ describe("Cypher Auth Allow", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WHERE this.id = $param0
             SET this.id = $this_update_id_SET
             WITH this
@@ -298,7 +301,8 @@ describe("Cypher Auth Allow", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WHERE this.id = $param0
             WITH this
             CALL {
@@ -392,7 +396,8 @@ describe("Cypher Auth Allow", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             WHERE this.id = $param0
             WITH *
             CALL {
@@ -464,7 +469,8 @@ describe("Cypher Auth Allow", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             WHERE this.id = $param0
             WITH this
             CALL {

--- a/packages/graphql/tests/tck/directives/authorization/arguments/where/connection-auth-filter.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/where/connection-auth-filter.test.ts
@@ -92,7 +92,8 @@ describe("Connection auth filter", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this0:User)
+            "CYPHER 5
+            MATCH (this0:User)
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub))
             WITH collect({ node: this0 }) AS edges
             WITH edges, size(edges) AS totalCount
@@ -137,7 +138,8 @@ describe("Connection auth filter", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this0:User)
+            "CYPHER 5
+            MATCH (this0:User)
             WHERE (this0.name = $param0 AND ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)))
             WITH collect({ node: this0 }) AS edges
             WITH edges, size(edges) AS totalCount
@@ -186,7 +188,8 @@ describe("Connection auth filter", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this0:User)
+            "CYPHER 5
+            MATCH (this0:User)
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub))
             WITH collect({ node: this0 }) AS edges
             WITH edges, size(edges) AS totalCount
@@ -248,7 +251,8 @@ describe("Connection auth filter", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this0:User)
+            "CYPHER 5
+            MATCH (this0:User)
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub))
             WITH collect({ node: this0 }) AS edges
             WITH edges, size(edges) AS totalCount
@@ -317,7 +321,8 @@ describe("Connection auth filter", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this0:User)
+            "CYPHER 5
+            MATCH (this0:User)
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub))
             WITH collect({ node: this0 }) AS edges
             WITH edges, size(edges) AS totalCount
@@ -383,7 +388,8 @@ describe("Connection auth filter", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this0:User)
+            "CYPHER 5
+            MATCH (this0:User)
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub))
             WITH collect({ node: this0 }) AS edges
             WITH edges, size(edges) AS totalCount
@@ -444,7 +450,8 @@ describe("Connection auth filter", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this0:User)
+            "CYPHER 5
+            MATCH (this0:User)
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub))
             WITH collect({ node: this0 }) AS edges
             WITH edges, size(edges) AS totalCount
@@ -513,7 +520,8 @@ describe("Connection auth filter", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this0:User)
+            "CYPHER 5
+            MATCH (this0:User)
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub))
             WITH collect({ node: this0 }) AS edges
             WITH edges, size(edges) AS totalCount
@@ -583,7 +591,8 @@ describe("Connection auth filter", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this0:User)
+            "CYPHER 5
+            MATCH (this0:User)
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub))
             WITH collect({ node: this0 }) AS edges
             WITH edges, size(edges) AS totalCount

--- a/packages/graphql/tests/tck/directives/authorization/arguments/where/interface-relationships/implementation-where.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/where/interface-relationships/implementation-where.test.ts
@@ -107,7 +107,8 @@ describe("Cypher Auth Where", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             OPTIONAL MATCH (this)<-[:HAS_CONTENT]-(this0:User)
             WITH *, count(this0) AS var1
             WITH *
@@ -141,7 +142,8 @@ describe("Cypher Auth Where", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             OPTIONAL MATCH (this)<-[:HAS_CONTENT]-(this0:User)
             WITH *, count(this0) AS var1
             WITH *
@@ -181,7 +183,8 @@ describe("Cypher Auth Where", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             CALL {
@@ -242,7 +245,8 @@ describe("Cypher Auth Where", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             CALL {
@@ -304,7 +308,8 @@ describe("Cypher Auth Where", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             CALL {
@@ -362,7 +367,8 @@ describe("Cypher Auth Where", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             OPTIONAL MATCH (this)<-[:HAS_CONTENT]-(this0:User)
             WITH *, count(this0) AS var1
             WITH *
@@ -413,7 +419,8 @@ describe("Cypher Auth Where", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             OPTIONAL MATCH (this)<-[:HAS_CONTENT]-(this0:User)
             WITH *, count(this0) AS var1
             WITH *
@@ -465,7 +472,8 @@ describe("Cypher Auth Where", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             WITH this
@@ -543,7 +551,8 @@ describe("Cypher Auth Where", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             OPTIONAL MATCH (this)<-[:HAS_CONTENT]-(this0:User)
             WITH *, count(this0) AS var1
             WHERE ($isAuthenticated = true AND (var1 <> 0 AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)))
@@ -576,7 +585,8 @@ describe("Cypher Auth Where", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             OPTIONAL MATCH (this)<-[:HAS_CONTENT]-(this0:User)
             WITH *, count(this0) AS var1
             WHERE (this.content = $param0 AND ($isAuthenticated = true AND (var1 <> 0 AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub))))
@@ -610,7 +620,8 @@ describe("Cypher Auth Where", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             WITH *
             CALL {
@@ -672,7 +683,8 @@ describe("Cypher Auth Where", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
             CREATE (this0:User)
             SET this0.id = $this0_id
             SET this0.name = $this0_name
@@ -764,7 +776,8 @@ describe("Cypher Auth Where", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
             CREATE (this0:User)
             SET this0.id = $this0_id
             SET this0.name = $this0_name
@@ -850,7 +863,8 @@ describe("Cypher Auth Where", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             WITH this
@@ -935,7 +949,8 @@ describe("Cypher Auth Where", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             WITH this
@@ -1021,7 +1036,8 @@ describe("Cypher Auth Where", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             WITH this
@@ -1096,7 +1112,8 @@ describe("Cypher Auth Where", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             WITH this

--- a/packages/graphql/tests/tck/directives/authorization/arguments/where/where.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/where/where.test.ts
@@ -88,7 +88,8 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             RETURN this { .id } AS this"
@@ -122,7 +123,8 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE (this.name = $param0 AND ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)))
             RETURN this { .id } AS this"
@@ -160,7 +162,8 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             CALL {
@@ -211,7 +214,8 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             CALL {
@@ -269,7 +273,8 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             CALL {
@@ -324,7 +329,8 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             CALL {
@@ -374,7 +380,8 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             CALL {
@@ -432,7 +439,8 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             CALL {
@@ -491,7 +499,8 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             CALL {
@@ -544,7 +553,8 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             SET this.name = $this_update_name_SET
@@ -585,7 +595,8 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE (this.name = $param0 AND ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)))
             SET this.name = $this_update_name_SET
@@ -630,7 +641,8 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             WITH this
@@ -696,7 +708,8 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             DETACH DELETE this"
         `);
@@ -729,7 +742,8 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WHERE (this.name = $param0 AND ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)))
             DETACH DELETE this"
         `);
@@ -763,7 +777,8 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             WITH *
             CALL {
@@ -817,7 +832,8 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
             CREATE (this0:User)
             SET this0.id = $this0_id
             SET this0.name = $this0_name
@@ -895,7 +911,8 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
             CREATE (this0:User)
             SET this0.id = $this0_id
             SET this0.name = $this0_name
@@ -965,7 +982,8 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             WITH *
@@ -1025,7 +1043,8 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             WITH *
@@ -1086,7 +1105,8 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             WITH this
@@ -1141,7 +1161,8 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             WITH this

--- a/packages/graphql/tests/tck/directives/authorization/projection-connection-union.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/projection-connection-union.test.ts
@@ -86,7 +86,8 @@ describe("Cypher Auth Projection On Connections On Unions", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {

--- a/packages/graphql/tests/tck/directives/authorization/projection-connection.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/projection-connection.test.ts
@@ -76,7 +76,8 @@ describe("Cypher Auth Projection On Connections", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
@@ -139,7 +140,8 @@ describe("Cypher Auth Projection On Connections", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
@@ -247,7 +249,8 @@ describe("Cypher Auth Projection On top-level connections", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this0:User)
+            "CYPHER 5
+            MATCH (this0:User)
             WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH collect({ node: this0 }) AS edges
             WITH edges, size(edges) AS totalCount
@@ -321,7 +324,8 @@ describe("Cypher Auth Projection On top-level connections", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this0:User)
+            "CYPHER 5
+            MATCH (this0:User)
             WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH collect({ node: this0 }) AS edges
             WITH edges, size(edges) AS totalCount

--- a/packages/graphql/tests/tck/directives/authorization/projection-interface-relationships.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/projection-interface-relationships.test.ts
@@ -42,7 +42,8 @@ describe("Auth projections for interface relationship fields", () => {
                 episodes: String!
             }
 
-            extend type Series @authorization(validate: [{ when: BEFORE, where: { node: { episodes_EQ: "$jwt.sub" } } }])
+            extend type Series
+                @authorization(validate: [{ when: BEFORE, where: { node: { episodes_EQ: "$jwt.sub" } } }])
 
             type ActedIn @relationshipProperties {
                 screenTime: Int!
@@ -87,7 +88,8 @@ describe("Auth projections for interface relationship fields", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             CALL {
                 WITH this
                 CALL {

--- a/packages/graphql/tests/tck/directives/authorization/projection.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/projection.test.ts
@@ -65,7 +65,8 @@ describe("Cypher Auth Projection", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH this
             WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             SET this.id = $this_update_id_SET
@@ -106,7 +107,8 @@ describe("Cypher Auth Projection", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:User)

--- a/packages/graphql/tests/tck/directives/autogenerate.test.ts
+++ b/packages/graphql/tests/tck/directives/autogenerate.test.ts
@@ -52,7 +52,8 @@ describe("Cypher autogenerate directive", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Movie)
@@ -90,7 +91,8 @@ describe("Cypher autogenerate directive", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             SET this.name = $this_update_name_SET
             RETURN collect(DISTINCT this { .id, .name }) AS data"
         `);

--- a/packages/graphql/tests/tck/directives/coalesce.test.ts
+++ b/packages/graphql/tests/tck/directives/coalesce.test.ts
@@ -89,7 +89,8 @@ describe("Cypher coalesce()", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WHERE (coalesce(this.id, \\"00000000-00000000-00000000-00000000\\") = $param0 AND coalesce(this.name, \\"Jane Smith\\") =~ $param1 AND coalesce(this.numberOfFriends, 0) > $param2 AND coalesce(this.rating, 2.5) < $param3 AND this.fromInterface = $param4 AND coalesce(this.toBeOverridden, \\"Overridden\\") = $param5 AND NOT (coalesce(this.verified, false) = $param6))
             RETURN this { .name } AS this"
         `);
@@ -145,7 +146,8 @@ describe("Cypher coalesce()", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE coalesce(this.status, \\"ACTIVE\\") = $param0
             RETURN this { .id, .status } AS this"
         `);
@@ -202,7 +204,8 @@ describe("Cypher coalesce()", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             CALL {
                 WITH this
                 MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
@@ -265,7 +268,8 @@ describe("Cypher coalesce()", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             CALL {
                 WITH this
                 MATCH (this)-[this0:ACTED_IN]->(this1:Movie)

--- a/packages/graphql/tests/tck/directives/customResolver.test.ts
+++ b/packages/graphql/tests/tck/directives/customResolver.test.ts
@@ -58,7 +58,8 @@ describe("@customResolver directive", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:User)
+                "CYPHER 5
+                MATCH (this:User)
                 RETURN this { .firstName } AS this"
             `);
 
@@ -79,7 +80,8 @@ describe("@customResolver directive", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:User)
+                "CYPHER 5
+                MATCH (this:User)
                 RETURN this { .firstName, .lastName } AS this"
             `);
 
@@ -99,7 +101,8 @@ describe("@customResolver directive", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:User)
+                "CYPHER 5
+                MATCH (this:User)
                 RETURN this { .firstName, .lastName } AS this"
             `);
 
@@ -118,7 +121,8 @@ describe("@customResolver directive", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:User)
+                "CYPHER 5
+                MATCH (this:User)
                 RETURN this { .firstName, .lastName } AS this"
             `);
 
@@ -161,7 +165,8 @@ describe("@customResolver directive", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:User)
+                "CYPHER 5
+                MATCH (this:User)
                 RETURN this { .firstName } AS this"
             `);
 
@@ -180,7 +185,8 @@ describe("@customResolver directive", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:User)
+                "CYPHER 5
+                MATCH (this:User)
                 RETURN this {  } AS this"
             `);
 
@@ -243,7 +249,8 @@ describe("@customResolver directive", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:User)
+                "CYPHER 5
+                MATCH (this:User)
                 CALL {
                     WITH this
                     MATCH (this)-[this0:LIVES_AT]->(this1:Address)
@@ -274,7 +281,8 @@ describe("@customResolver directive", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:User)
+                "CYPHER 5
+                MATCH (this:User)
                 RETURN this { .firstName } AS this"
             `);
 
@@ -299,7 +307,8 @@ describe("@customResolver directive", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:User)
+                "CYPHER 5
+                MATCH (this:User)
                 CALL {
                     WITH this
                     MATCH (this)-[this0:LIVES_AT]->(this1:Address)
@@ -330,7 +339,8 @@ describe("@customResolver directive", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:User)
+                "CYPHER 5
+                MATCH (this:User)
                 CALL {
                     WITH this
                     MATCH (this)-[this0:LIVES_AT]->(this1:Address)
@@ -408,7 +418,8 @@ describe("@customResolver directive", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Author)
+                "CYPHER 5
+                MATCH (this:Author)
                 CALL {
                     WITH this
                     CALL {
@@ -443,7 +454,8 @@ describe("@customResolver directive", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Author)
+                "CYPHER 5
+                MATCH (this:Author)
                 RETURN this { .name } AS this"
             `);
 
@@ -467,7 +479,8 @@ describe("@customResolver directive", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Author)
+                "CYPHER 5
+                MATCH (this:Author)
                 CALL {
                     WITH this
                     CALL {
@@ -502,7 +515,8 @@ describe("@customResolver directive", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Author)
+                "CYPHER 5
+                MATCH (this:Author)
                 CALL {
                     WITH this
                     CALL {
@@ -589,7 +603,8 @@ describe("@customResolver directive", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Author)
+                "CYPHER 5
+                MATCH (this:Author)
                 CALL {
                     WITH this
                     CALL {
@@ -624,7 +639,8 @@ describe("@customResolver directive", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Author)
+                "CYPHER 5
+                MATCH (this:Author)
                 RETURN this { .name } AS this"
             `);
 
@@ -648,7 +664,8 @@ describe("@customResolver directive", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Author)
+                "CYPHER 5
+                MATCH (this:Author)
                 CALL {
                     WITH this
                     CALL {
@@ -683,7 +700,8 @@ describe("@customResolver directive", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Author)
+                "CYPHER 5
+                MATCH (this:Author)
                 CALL {
                     WITH this
                     CALL {

--- a/packages/graphql/tests/tck/directives/cypher/cypher-interface.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher/cypher-interface.test.ts
@@ -140,7 +140,8 @@ describe("Cypher directive on interface", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (n)
                 WHERE (n:TVShow OR n:Movie) AND ($param0 IS NULL OR n.title = $param0)
                 RETURN n
@@ -185,7 +186,8 @@ describe("Cypher directive on interface", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (n)
                 WHERE (n:TVShow OR n:Movie) AND ($param0 IS NULL OR n.title = $param0)
                 RETURN n
@@ -246,7 +248,8 @@ describe("Cypher directive on interface", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (n)
                 WHERE (n:TVShow OR n:Movie) AND ($param0 IS NULL OR n.title = $param0)
                 RETURN n
@@ -340,7 +343,8 @@ describe("Cypher directive on interface", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (n)
                 WHERE (n:TVShow OR n:Movie) AND ($param0 IS NULL OR n.title = $param0)
                 RETURN n
@@ -418,7 +422,8 @@ describe("Cypher directive on interface", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (n)
                 WHERE (n:TVShow OR n:Movie) AND ($param0 IS NULL OR n.title = $param0)
                 RETURN n
@@ -464,7 +469,8 @@ describe("Cypher directive on interface", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (n)
                 WHERE (n:TVShow OR n:Movie) AND ($param0 IS NULL OR n.title = $param0)
                 RETURN n
@@ -526,7 +532,8 @@ describe("Cypher directive on interface", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (n)
                 WHERE (n:TVShow OR n:Movie) AND ($param0 IS NULL OR n.title = $param0)
                 RETURN n
@@ -621,7 +628,8 @@ describe("Cypher directive on interface", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (n)
                 WHERE (n:TVShow OR n:Movie) AND ($param0 IS NULL OR n.title = $param0)
                 RETURN n
@@ -714,7 +722,8 @@ describe("Cypher directive on interface", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             CALL {
                 WITH this
                 CALL {

--- a/packages/graphql/tests/tck/directives/cypher/cypher-union.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher/cypher-union.test.ts
@@ -143,7 +143,8 @@ describe("Cypher directive on union", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (n)
                 WHERE (n:TVShow OR n:Movie) AND ($param0 IS NULL OR n.title = $param0)
                 RETURN n
@@ -188,7 +189,8 @@ describe("Cypher directive on union", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (n)
                 WHERE (n:TVShow OR n:Movie) AND ($param0 IS NULL OR n.title = $param0)
                 RETURN n
@@ -250,7 +252,8 @@ describe("Cypher directive on union", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (n)
                 WHERE (n:TVShow OR n:Movie) AND ($param0 IS NULL OR n.title = $param0)
                 RETURN n
@@ -345,7 +348,8 @@ describe("Cypher directive on union", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (n)
                 WHERE (n:TVShow OR n:Movie) AND ($param0 IS NULL OR n.title = $param0)
                 RETURN n
@@ -428,7 +432,8 @@ describe("Cypher directive on union", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (n)
                 WHERE (n:TVShow OR n:Movie) AND ($param0 IS NULL OR n.title = $param0)
                 RETURN n
@@ -474,7 +479,8 @@ describe("Cypher directive on union", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (n)
                 WHERE (n:TVShow OR n:Movie) AND ($param0 IS NULL OR n.title = $param0)
                 RETURN n
@@ -537,7 +543,8 @@ describe("Cypher directive on union", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (n)
                 WHERE (n:TVShow OR n:Movie) AND ($param0 IS NULL OR n.title = $param0)
                 RETURN n
@@ -633,7 +640,8 @@ describe("Cypher directive on union", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (n)
                 WHERE (n:TVShow OR n:Movie) AND ($param0 IS NULL OR n.title = $param0)
                 RETURN n
@@ -727,7 +735,8 @@ describe("Cypher directive on union", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             CALL {
                 WITH this
                 CALL {

--- a/packages/graphql/tests/tck/directives/cypher/cypher.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher/cypher.test.ts
@@ -113,7 +113,8 @@ describe("Cypher directive", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 CALL {
@@ -144,7 +145,8 @@ describe("Cypher directive", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             CALL {
                 WITH this
                 CALL {
@@ -173,7 +175,8 @@ describe("Cypher directive", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             WITH *
             LIMIT $param0
             CALL {
@@ -211,7 +214,8 @@ describe("Cypher directive", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             CALL {
                 WITH this
                 CALL {
@@ -256,7 +260,8 @@ describe("Cypher directive", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 CALL {
@@ -315,7 +320,8 @@ describe("Cypher directive", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 CALL {
@@ -393,7 +399,8 @@ describe("Cypher directive", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 CALL {
@@ -469,7 +476,8 @@ describe("Cypher directive", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "CALL {
+                "CYPHER 5
+                CALL {
                     MATCH (m:Movie {title: $param0})
                     RETURN m
                 }
@@ -531,7 +539,8 @@ describe("Cypher directive", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "CALL {
+                "CYPHER 5
+                CALL {
                     MATCH (m:Movie {title: $param0})
                     RETURN m
                 }
@@ -592,7 +601,8 @@ describe("Cypher directive", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Movie)
+                "CYPHER 5
+                MATCH (this:Movie)
                 CALL {
                     WITH this
                     CALL {

--- a/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-aggregation.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-aggregation.test.ts
@@ -53,7 +53,8 @@ describe("cypher directive filtering - Aggregation", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:Movie)
                 CALL {
                     WITH this
@@ -115,7 +116,8 @@ describe("cypher directive filtering - Aggregation", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:Movie)
                 CALL {
                     WITH this
@@ -177,7 +179,8 @@ describe("cypher directive filtering - Aggregation", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:Movie)
                 CALL {
                     WITH this
@@ -240,7 +243,8 @@ describe("cypher directive filtering - Aggregation", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:Movie)
                 CALL {
                     WITH this

--- a/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-auth.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-auth.test.ts
@@ -64,7 +64,8 @@ describe("cypher directive filtering - Auth", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 CALL {
@@ -134,7 +135,8 @@ describe("cypher directive filtering - Auth", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 CALL {
@@ -214,7 +216,8 @@ describe("cypher directive filtering - Auth", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             RETURN this { .title } AS this"
         `);
 
@@ -263,7 +266,8 @@ describe("cypher directive filtering - Auth", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             CALL {
                 WITH this
                 MATCH (this)-[:ACTED_IN]->(this0:Movie)
@@ -339,7 +343,8 @@ describe("cypher directive filtering - Auth", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 CALL {
@@ -409,7 +414,8 @@ describe("cypher directive filtering - Auth", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 CALL {

--- a/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-connect.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-connect.test.ts
@@ -86,7 +86,8 @@ describe("cypher directive filtering", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
             CREATE (this0:Movie)
             SET this0.title = $this0_title
             WITH *

--- a/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-list-auth.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-list-auth.test.ts
@@ -67,7 +67,8 @@ describe("cypher directive filtering - List Auth", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 CALL {
@@ -153,7 +154,8 @@ describe("cypher directive filtering - List Auth", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 CALL {
@@ -226,7 +228,8 @@ describe("cypher directive filtering - List Auth", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 CALL {
@@ -311,7 +314,8 @@ describe("cypher directive filtering - List Auth", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             RETURN this { .title } AS this"
         `);
 
@@ -362,7 +366,8 @@ describe("cypher directive filtering - List Auth", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             CALL {
                 WITH this
                 MATCH (this)-[:ACTED_IN]->(this0:Movie)
@@ -442,7 +447,8 @@ describe("cypher directive filtering - List Auth", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 CALL {
@@ -516,7 +522,8 @@ describe("cypher directive filtering - List Auth", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 CALL {

--- a/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-list.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-list.test.ts
@@ -50,7 +50,8 @@ describe("cypher directive filtering - Lists", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 CALL {

--- a/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-misc.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-misc.test.ts
@@ -67,7 +67,8 @@ describe("cypher directive filtering - Auth", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 CALL {
@@ -148,7 +149,8 @@ describe("cypher directive filtering - Auth", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             CALL {
                 WITH this
                 MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
@@ -215,7 +217,8 @@ describe("cypher directive filtering - Auth", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 CALL {
@@ -298,7 +301,8 @@ describe("cypher directive filtering - Auth", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 CALL {
@@ -386,7 +390,8 @@ describe("cypher directive filtering - Auth", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 CALL {

--- a/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-one-to-one-relationship.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-one-to-one-relationship.test.ts
@@ -65,7 +65,8 @@ describe("cypher directive filtering - One To One Relationship", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 CALL {
@@ -133,7 +134,8 @@ describe("cypher directive filtering - One To One Relationship", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 CALL {
@@ -210,7 +212,8 @@ describe("cypher directive filtering - One To One Relationship", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 CALL {
@@ -289,7 +292,8 @@ describe("cypher directive filtering - One To One Relationship", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 CALL {
@@ -359,7 +363,8 @@ describe("cypher directive filtering - One To One Relationship", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 CALL {
@@ -445,7 +450,8 @@ describe("cypher directive filtering - One To One Relationship", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Person)
+            "CYPHER 5
+            MATCH (this:Person)
             CALL {
                 WITH this
                 CALL {
@@ -568,7 +574,8 @@ describe("cypher directive filtering - One To One Relationship", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Person)
+            "CYPHER 5
+            MATCH (this:Person)
             CALL {
                 WITH this
                 CALL {
@@ -690,7 +697,8 @@ describe("cypher directive filtering - One To One Relationship", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Person)
+            "CYPHER 5
+            MATCH (this:Person)
             CALL {
                 WITH this
                 CALL {
@@ -812,7 +820,8 @@ describe("cypher directive filtering - One To One Relationship", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Person)
+            "CYPHER 5
+            MATCH (this:Person)
             CALL {
                 WITH this
                 CALL {
@@ -935,7 +944,8 @@ describe("cypher directive filtering - One To One Relationship", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Person)
+            "CYPHER 5
+            MATCH (this:Person)
             CALL {
                 WITH this
                 CALL {
@@ -1058,7 +1068,8 @@ describe("cypher directive filtering - One To One Relationship", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Person)
+            "CYPHER 5
+            MATCH (this:Person)
             CALL {
                 WITH this
                 CALL {
@@ -1180,7 +1191,8 @@ describe("cypher directive filtering - One To One Relationship", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Person)
+            "CYPHER 5
+            MATCH (this:Person)
             CALL {
                 WITH this
                 CALL {
@@ -1302,7 +1314,8 @@ describe("cypher directive filtering - One To One Relationship", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Person)
+            "CYPHER 5
+            MATCH (this:Person)
             CALL {
                 WITH this
                 CALL {
@@ -1427,7 +1440,8 @@ describe("cypher directive filtering - One To One Relationship", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Person)
+            "CYPHER 5
+            MATCH (this:Person)
             CALL {
                 WITH this
                 CALL {
@@ -1551,7 +1565,8 @@ describe("cypher directive filtering - One To One Relationship", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 CALL {

--- a/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-scalar.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-scalar.test.ts
@@ -51,7 +51,8 @@ describe("cypher directive filtering - Auth", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 CALL {
@@ -120,7 +121,8 @@ describe("cypher directive filtering - Auth", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 CALL {
@@ -189,7 +191,8 @@ describe("cypher directive filtering - Auth", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 CALL {

--- a/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-sorting.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-sorting.test.ts
@@ -60,7 +60,8 @@ describe("cypher directive filtering", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 CALL {
@@ -141,7 +142,8 @@ describe("cypher directive filtering", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 CALL {

--- a/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-spatial.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-spatial.test.ts
@@ -61,7 +61,8 @@ describe("cypher directive filtering - Auth", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 CALL {
@@ -141,7 +142,8 @@ describe("cypher directive filtering - Auth", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 CALL {

--- a/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-temporal.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-temporal.test.ts
@@ -55,7 +55,8 @@ describe("cypher directive filtering - Auth", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 CALL {
@@ -129,7 +130,8 @@ describe("cypher directive filtering - Auth", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 CALL {

--- a/packages/graphql/tests/tck/directives/cypher/filtering/relationships/cypher-filtering-relationship-auth.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher/filtering/relationships/cypher-filtering-relationship-auth.test.ts
@@ -78,7 +78,8 @@ describe("cypher directive filtering - relationship auth filter", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this0:Movie)
+            "CYPHER 5
+            MATCH (this0:Movie)
             CALL {
                 WITH this0
                 CALL {
@@ -170,7 +171,8 @@ describe("cypher directive filtering - relationship auth filter", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this0:Movie)
+            "CYPHER 5
+            MATCH (this0:Movie)
             CALL {
                 WITH this0
                 CALL {
@@ -262,7 +264,8 @@ describe("cypher directive filtering - relationship auth filter", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this0:Movie)
+            "CYPHER 5
+            MATCH (this0:Movie)
             CALL {
                 WITH this0
                 CALL {
@@ -354,7 +357,8 @@ describe("cypher directive filtering - relationship auth filter", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this0:Movie)
+            "CYPHER 5
+            MATCH (this0:Movie)
             CALL {
                 WITH this0
                 CALL {

--- a/packages/graphql/tests/tck/directives/cypher/filtering/relationships/cypher-filtering-relationship-connection.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher/filtering/relationships/cypher-filtering-relationship-connection.test.ts
@@ -67,7 +67,8 @@ describe("Connection API - cypher directive filtering - Relationship", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this0:Movie)
+            "CYPHER 5
+            MATCH (this0:Movie)
             CALL {
                 WITH this0
                 CALL {
@@ -144,7 +145,8 @@ describe("Connection API - cypher directive filtering - Relationship", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this0:Movie)
+            "CYPHER 5
+            MATCH (this0:Movie)
             CALL {
                 WITH this0
                 CALL {
@@ -221,7 +223,8 @@ describe("Connection API - cypher directive filtering - Relationship", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this0:Movie)
+            "CYPHER 5
+            MATCH (this0:Movie)
             CALL {
                 WITH this0
                 CALL {
@@ -298,7 +301,8 @@ describe("Connection API - cypher directive filtering - Relationship", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this0:Movie)
+            "CYPHER 5
+            MATCH (this0:Movie)
             CALL {
                 WITH this0
                 CALL {
@@ -375,7 +379,8 @@ describe("Connection API - cypher directive filtering - Relationship", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this0:Movie)
+            "CYPHER 5
+            MATCH (this0:Movie)
             CALL {
                 WITH this0
                 CALL {
@@ -454,7 +459,8 @@ describe("Connection API - cypher directive filtering - Relationship", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this0:Movie)
+            "CYPHER 5
+            MATCH (this0:Movie)
             CALL {
                 WITH this0
                 CALL {
@@ -558,7 +564,8 @@ describe("Connection API - cypher directive filtering - Relationship", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this0:Movie)
+            "CYPHER 5
+            MATCH (this0:Movie)
             CALL {
                 WITH this0
                 CALL {

--- a/packages/graphql/tests/tck/directives/cypher/filtering/relationships/cypher-filtering-relationship.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher/filtering/relationships/cypher-filtering-relationship.test.ts
@@ -63,7 +63,8 @@ describe("cypher directive filtering - Relationship", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 CALL {
@@ -128,7 +129,8 @@ describe("cypher directive filtering - Relationship", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 CALL {
@@ -193,7 +195,8 @@ describe("cypher directive filtering - Relationship", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 CALL {
@@ -258,7 +261,8 @@ describe("cypher directive filtering - Relationship", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 CALL {
@@ -322,7 +326,8 @@ describe("cypher directive filtering - Relationship", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 CALL {
@@ -414,7 +419,8 @@ describe("cypher directive filtering - Relationship", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 CALL {

--- a/packages/graphql/tests/tck/directives/interface-relationships/create/connect.test.ts
+++ b/packages/graphql/tests/tck/directives/interface-relationships/create/connect.test.ts
@@ -87,7 +87,8 @@ describe("Interface Relationships - Create connect", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
             CREATE (this0:Actor)
             SET this0.name = $this0_name
             WITH *

--- a/packages/graphql/tests/tck/directives/interface-relationships/create/create.test.ts
+++ b/packages/graphql/tests/tck/directives/interface-relationships/create/create.test.ts
@@ -90,7 +90,8 @@ describe("Interface Relationships - Create create", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
             CREATE (this0:Actor)
             SET this0.name = $this0_name
             WITH *

--- a/packages/graphql/tests/tck/directives/interface-relationships/delete/delete.test.ts
+++ b/packages/graphql/tests/tck/directives/interface-relationships/delete/delete.test.ts
@@ -71,7 +71,8 @@ describe("Interface Relationships - Delete delete", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             WITH *
             CALL {
                 WITH *
@@ -127,7 +128,8 @@ describe("Interface Relationships - Delete delete", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             WITH *
             CALL {
                 WITH *

--- a/packages/graphql/tests/tck/directives/interface-relationships/read.test.ts
+++ b/packages/graphql/tests/tck/directives/interface-relationships/read.test.ts
@@ -76,7 +76,8 @@ describe("Interface Relationships", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             CALL {
                 WITH this
                 CALL {
@@ -119,7 +120,8 @@ describe("Interface Relationships", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             CALL {
                 WITH this
                 CALL {
@@ -162,7 +164,8 @@ describe("Interface Relationships", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             CALL {
                 WITH this
                 CALL {
@@ -226,7 +229,8 @@ describe("Interface Relationships", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             CALL {
                 WITH this
                 CALL {
@@ -277,7 +281,8 @@ describe("Interface Relationships", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             CALL {
                 WITH this
                 CALL {

--- a/packages/graphql/tests/tck/directives/interface-relationships/update/connect.test.ts
+++ b/packages/graphql/tests/tck/directives/interface-relationships/update/connect.test.ts
@@ -78,7 +78,8 @@ describe("Interface Relationships - Update connect", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             WITH this
             CALL {
             	 WITH this
@@ -170,7 +171,8 @@ describe("Interface Relationships - Update connect", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             WITH this
             CALL {
             	 WITH this

--- a/packages/graphql/tests/tck/directives/interface-relationships/update/create.test.ts
+++ b/packages/graphql/tests/tck/directives/interface-relationships/update/create.test.ts
@@ -87,7 +87,8 @@ describe("Interface Relationships - Update create", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             WITH this
             CALL {
             	 WITH this

--- a/packages/graphql/tests/tck/directives/interface-relationships/update/delete.test.ts
+++ b/packages/graphql/tests/tck/directives/interface-relationships/update/delete.test.ts
@@ -72,7 +72,8 @@ describe("Interface Relationships - Update delete", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             WITH this
             CALL {
             	 WITH this
@@ -183,7 +184,8 @@ describe("Interface Relationships - Update delete", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             WITH this
             CALL {
             	 WITH this

--- a/packages/graphql/tests/tck/directives/interface-relationships/update/disconnect.test.ts
+++ b/packages/graphql/tests/tck/directives/interface-relationships/update/disconnect.test.ts
@@ -72,7 +72,8 @@ describe("Interface Relationships - Update disconnect", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             WITH this
             CALL {
             	 WITH this
@@ -162,7 +163,8 @@ describe("Interface Relationships - Update disconnect", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             WITH this
             CALL {
             	 WITH this

--- a/packages/graphql/tests/tck/directives/interface-relationships/update/update.test.ts
+++ b/packages/graphql/tests/tck/directives/interface-relationships/update/update.test.ts
@@ -79,7 +79,8 @@ describe("Interface Relationships - Update update", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             WITH this
             CALL {
             	 WITH this
@@ -158,7 +159,8 @@ describe("Interface Relationships - Update update", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             WITH this
             CALL {
             	 WITH this

--- a/packages/graphql/tests/tck/directives/node/node-additional-labels.test.ts
+++ b/packages/graphql/tests/tck/directives/node/node-additional-labels.test.ts
@@ -55,7 +55,8 @@ describe("Node directive with additionalLabels", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Film:Multimedia)
+            "CYPHER 5
+            MATCH (this:Film:Multimedia)
             RETURN this { .title } AS this"
         `);
 
@@ -77,7 +78,8 @@ describe("Node directive with additionalLabels", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Film:Multimedia)
+            "CYPHER 5
+            MATCH (this:Film:Multimedia)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor:Person)
@@ -109,7 +111,8 @@ describe("Node directive with additionalLabels", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Film:Multimedia)
@@ -174,7 +177,8 @@ describe("Node directive with additionalLabels", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Film:Multimedia)
+            "CYPHER 5
+            MATCH (this:Film:Multimedia)
             WHERE this.id = $param0
             DETACH DELETE this"
         `);
@@ -200,7 +204,8 @@ describe("Node directive with additionalLabels", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Film:Multimedia)
+            "CYPHER 5
+            MATCH (this:Film:Multimedia)
             WHERE this.id = $param0
             SET this.id = $this_update_id_SET
             RETURN collect(DISTINCT this { .id }) AS data"

--- a/packages/graphql/tests/tck/directives/node/node-label-interface.test.ts
+++ b/packages/graphql/tests/tck/directives/node/node-label-interface.test.ts
@@ -65,7 +65,8 @@ describe("Node directive with interface", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Film)
+            "CYPHER 5
+            MATCH (this:Film)
             WHERE this.title = $param0
             CALL {
                 WITH this

--- a/packages/graphql/tests/tck/directives/node/node-label-jwt.test.ts
+++ b/packages/graphql/tests/tck/directives/node/node-label-jwt.test.ts
@@ -60,7 +60,8 @@ describe("Label in Node directive", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Film)
+            "CYPHER 5
+            MATCH (this:Film)
             RETURN this { .title } AS this"
         `);
 
@@ -83,7 +84,8 @@ describe("Label in Node directive", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor:Person)
+            "CYPHER 5
+            MATCH (this:Actor:Person)
             WHERE this.age > $param0
             CALL {
                 WITH this
@@ -117,11 +119,12 @@ describe("Label in Node directive", () => {
             }
         `;
 
-        const token = createBearerToken("secret", { movielabel: "Film", personlabel: "Person"  });
+        const token = createBearerToken("secret", { movielabel: "Film", personlabel: "Person" });
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Film)

--- a/packages/graphql/tests/tck/directives/node/node-label-union.test.ts
+++ b/packages/graphql/tests/tck/directives/node/node-label-union.test.ts
@@ -66,7 +66,8 @@ describe("Node directive with unions", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Film)
+            "CYPHER 5
+            MATCH (this:Film)
             WHERE this.title = $param0
             CALL {
                 WITH this

--- a/packages/graphql/tests/tck/directives/node/node-label.test.ts
+++ b/packages/graphql/tests/tck/directives/node/node-label.test.ts
@@ -55,7 +55,8 @@ describe("Label in Node directive", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Film)
+            "CYPHER 5
+            MATCH (this:Film)
             RETURN this { .title } AS this"
         `);
 
@@ -77,7 +78,8 @@ describe("Label in Node directive", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Film)
+            "CYPHER 5
+            MATCH (this:Film)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Person)
@@ -109,7 +111,8 @@ describe("Label in Node directive", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Film)
+            "CYPHER 5
+            MATCH (this:Film)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Person)
@@ -143,7 +146,8 @@ describe("Label in Node directive", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Film)
@@ -184,7 +188,8 @@ describe("Label in Node directive", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Film)
@@ -251,7 +256,8 @@ describe("Label in Node directive", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Film)
+            "CYPHER 5
+            MATCH (this:Film)
             WHERE this.id = $param0
             SET this.id = $this_update_id_SET
             RETURN collect(DISTINCT this { .id }) AS data"
@@ -287,7 +293,8 @@ describe("Label in Node directive", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Film)
+            "CYPHER 5
+            MATCH (this:Film)
             WHERE this.id = $param0
             WITH this
             CALL {
@@ -347,7 +354,8 @@ describe("Label in Node directive", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Film)
+            "CYPHER 5
+            MATCH (this:Film)
             WHERE this.id = $param0
             WITH *
             CALL {
@@ -396,7 +404,8 @@ describe("Label in Node directive", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Film)
+            "CYPHER 5
+            MATCH (this:Film)
             WHERE this.id = $param0
             WITH this
             CALL {
@@ -454,7 +463,8 @@ describe("Label in Node directive", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Film)
+            "CYPHER 5
+            MATCH (this:Film)
             WHERE this.id = $param0
             DETACH DELETE this"
         `);
@@ -481,7 +491,8 @@ describe("Label in Node directive", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Film)
+            "CYPHER 5
+            MATCH (this:Film)
             WHERE this.id = $param0
             WITH *
             CALL {
@@ -519,7 +530,8 @@ describe("Label in Node directive", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Film)
+            "CYPHER 5
+            MATCH (this:Film)
             WHERE EXISTS {
                 MATCH (this)<-[:ACTED_IN]-(this0:Person)
                 WHERE this0.name = $param0

--- a/packages/graphql/tests/tck/directives/node/node-with-auth-projection.test.ts
+++ b/packages/graphql/tests/tck/directives/node/node-with-auth-projection.test.ts
@@ -72,7 +72,8 @@ describe("Cypher Auth Projection On Connections", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Person)
+            "CYPHER 5
+            MATCH (this:Person)
             WITH *
             WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {

--- a/packages/graphql/tests/tck/directives/node/node-with-auth.test.ts
+++ b/packages/graphql/tests/tck/directives/node/node-with-auth.test.ts
@@ -80,7 +80,8 @@ describe("Node Directive", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Person)
+            "CYPHER 5
+            MATCH (this:Person)
             WITH *
             WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this { .id } AS this"
@@ -112,7 +113,8 @@ describe("Node Directive", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Comment)
+            "CYPHER 5
+            MATCH (this:Comment)
             OPTIONAL MATCH (this)<-[:HAS_POST]-(this0:Person)
             WITH *, count(this0) AS var1
             WHERE ((var1 <> 0 AND this0.id = $param0) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))

--- a/packages/graphql/tests/tck/directives/plural.test.ts
+++ b/packages/graphql/tests/tck/directives/plural.test.ts
@@ -48,7 +48,8 @@ describe("Plural directive", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Tech)
+            "CYPHER 5
+            MATCH (this:Tech)
             RETURN this { .name } AS this"
         `);
 
@@ -67,7 +68,8 @@ describe("Plural directive", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this:Tech)
                 RETURN count(this) AS var0
             }
@@ -91,7 +93,8 @@ describe("Plural directive", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Tech)
@@ -127,7 +130,8 @@ describe("Plural directive", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Tech)
+            "CYPHER 5
+            MATCH (this:Tech)
             SET this.name = $this_update_name_SET
             RETURN collect(DISTINCT this { .name }) AS data"
         `);
@@ -152,7 +156,8 @@ describe("Plural directive", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Tech)
+            "CYPHER 5
+            MATCH (this:Tech)
             WHERE this.name = $param0
             DETACH DELETE this"
         `);
@@ -176,7 +181,8 @@ describe("Plural directive", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Tech)
+            "CYPHER 5
+            MATCH (this:Tech)
             RETURN this { .name } AS this"
         `);
 

--- a/packages/graphql/tests/tck/directives/relationship.test.ts
+++ b/packages/graphql/tests/tck/directives/relationship.test.ts
@@ -65,7 +65,8 @@ describe("Cypher relationship", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)-[this0:TOP_ACTOR]->(this1:Actor)
@@ -93,7 +94,8 @@ describe("Cypher relationship", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
@@ -124,7 +126,8 @@ describe("Cypher relationship", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)-[this0:TOP_ACTOR]->(this1:Actor)
@@ -161,7 +164,8 @@ describe("Cypher relationship", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title = $param0
             CALL {
                 WITH this

--- a/packages/graphql/tests/tck/directives/vector/auth.test.ts
+++ b/packages/graphql/tests/tck/directives/vector/auth.test.ts
@@ -85,7 +85,8 @@ describe("Cypher -> vector -> Auth", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL db.index.vector.queryNodes(\\"movie_index\\", 4, $param0) YIELD node AS this0, score AS var1
+            "CYPHER 5
+            CALL db.index.vector.queryNodes(\\"movie_index\\", 4, $param0) YIELD node AS this0, score AS var1
             WHERE ($param1 IN labels(this0) AND ($isAuthenticated = true AND EXISTS {
                 MATCH (this0)<-[:DIRECTED]-(this2:Person)
                 WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
@@ -284,7 +285,8 @@ describe("Cypher -> vector -> Auth", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL db.index.vector.queryNodes(\\"movie_index\\", 4, $param0) YIELD node AS this0, score AS var1
+            "CYPHER 5
+            CALL db.index.vector.queryNodes(\\"movie_index\\", 4, $param0) YIELD node AS this0, score AS var1
             WHERE ($param1 IN labels(this0) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND EXISTS {
                 MATCH (this0)<-[:DIRECTED]-(this2:Person)
                 WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
@@ -485,7 +487,8 @@ describe("Cypher -> vector -> Auth", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL db.index.vector.queryNodes(\\"movie_index\\", 4, $param0) YIELD node AS this0, score AS var1
+            "CYPHER 5
+            CALL db.index.vector.queryNodes(\\"movie_index\\", 4, $param0) YIELD node AS this0, score AS var1
             WHERE ($param1 IN labels(this0) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (EXISTS {
                 MATCH (this0)<-[:DIRECTED]-(this2:Person)
                 WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
@@ -691,7 +694,8 @@ describe("Cypher -> vector -> Auth", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL db.index.vector.queryNodes(\\"movie_index\\", 4, $param0) YIELD node AS this0, score AS var1
+            "CYPHER 5
+            CALL db.index.vector.queryNodes(\\"movie_index\\", 4, $param0) YIELD node AS this0, score AS var1
             WHERE ($param1 IN labels(this0) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND EXISTS {
                 MATCH (this0)<-[this2:DIRECTED]-(this3:Person)
                 WHERE ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
@@ -897,7 +901,8 @@ describe("Cypher -> vector -> Auth", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL db.index.vector.queryNodes(\\"movie_index\\", 4, $param0) YIELD node AS this0, score AS var1
+            "CYPHER 5
+            CALL db.index.vector.queryNodes(\\"movie_index\\", 4, $param0) YIELD node AS this0, score AS var1
             WHERE ($param1 IN labels(this0) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (EXISTS {
                 MATCH (this0)<-[this2:DIRECTED]-(this3:Person)
                 WHERE ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
@@ -1107,7 +1112,8 @@ describe("Cypher -> vector -> Auth", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL db.index.vector.queryNodes(\\"movie_index\\", 4, $param0) YIELD node AS this0, score AS var1
+            "CYPHER 5
+            CALL db.index.vector.queryNodes(\\"movie_index\\", 4, $param0) YIELD node AS this0, score AS var1
             WHERE ($param1 IN labels(this0) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND EXISTS {
                 MATCH (this0)<-[this2:DIRECTED]-(this3:Person)
                 WHERE ($param3 IS NOT NULL AND this2.year = $param3)
@@ -1311,7 +1317,8 @@ describe("Cypher -> vector -> Auth", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL db.index.vector.queryNodes(\\"movie_index\\", 4, $param0) YIELD node AS this0, score AS var1
+            "CYPHER 5
+            CALL db.index.vector.queryNodes(\\"movie_index\\", 4, $param0) YIELD node AS this0, score AS var1
             WHERE ($param1 IN labels(this0) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (EXISTS {
                 MATCH (this0)<-[this2:DIRECTED]-(this3:Person)
                 WHERE ($param3 IS NOT NULL AND this2.year = $param3)

--- a/packages/graphql/tests/tck/directives/vector/match.test.ts
+++ b/packages/graphql/tests/tck/directives/vector/match.test.ts
@@ -75,18 +75,19 @@ describe("Vector index match", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "CALL db.index.vector.queryNodes(\\"movie_index\\", 4, $param0) YIELD node AS this0, score AS var1
-                WHERE $param1 IN labels(this0)
-                WITH collect({ node: this0, score: var1 }) AS edges
-                WITH edges, size(edges) AS totalCount
-                CALL {
-                    WITH edges
-                    UNWIND edges AS edge
-                    WITH edge.node AS this0, edge.score AS var1
-                    RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" }, score: var1 }) AS var2
-                }
-                RETURN { edges: var2, totalCount: totalCount } AS this"
-            `);
+            "CYPHER 5
+            CALL db.index.vector.queryNodes(\\"movie_index\\", 4, $param0) YIELD node AS this0, score AS var1
+            WHERE $param1 IN labels(this0)
+            WITH collect({ node: this0, score: var1 }) AS edges
+            WITH edges, size(edges) AS totalCount
+            CALL {
+                WITH edges
+                UNWIND edges AS edge
+                WITH edge.node AS this0, edge.score AS var1
+                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" }, score: var1 }) AS var2
+            }
+            RETURN { edges: var2, totalCount: totalCount } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
                 "{
@@ -248,7 +249,8 @@ describe("Vector index match", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL db.index.vector.queryNodes(\\"movie_index\\", 4, $param0) YIELD node AS this0, score AS var1
+            "CYPHER 5
+            CALL db.index.vector.queryNodes(\\"movie_index\\", 4, $param0) YIELD node AS this0, score AS var1
             WHERE ($param1 IN labels(this0) AND this0.released > $param2)
             WITH collect({ node: this0, score: var1 }) AS edges
             WITH edges, size(edges) AS totalCount
@@ -423,7 +425,8 @@ describe("Vector index match", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL db.index.vector.queryNodes(\\"movie_index\\", 4, $param0) YIELD node AS this0, score AS var1
+            "CYPHER 5
+            CALL db.index.vector.queryNodes(\\"movie_index\\", 4, $param0) YIELD node AS this0, score AS var1
             WHERE $param1 IN labels(this0)
             WITH collect({ node: this0, score: var1 }) AS edges
             WITH edges, size(edges) AS totalCount

--- a/packages/graphql/tests/tck/directives/vector/phrase.test.ts
+++ b/packages/graphql/tests/tck/directives/vector/phrase.test.ts
@@ -85,7 +85,8 @@ describe("phrase input - genAI plugin", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "WITH genai.vector.encode($param0, \\"OpenAI\\", { token: \\"my-token\\", model: \\"my-model\\", dimensions: 256 }) AS var0
+            "CYPHER 5
+            WITH genai.vector.encode($param0, \\"OpenAI\\", { token: \\"my-token\\", model: \\"my-model\\", dimensions: 256 }) AS var0
             CALL db.index.vector.queryNodes(\\"movie_index\\", 4, var0) YIELD node AS this1, score AS var2
             WHERE $param1 IN labels(this1)
             WITH collect({ node: this1, score: var2 }) AS edges

--- a/packages/graphql/tests/tck/directives/vector/score.test.ts
+++ b/packages/graphql/tests/tck/directives/vector/score.test.ts
@@ -73,7 +73,8 @@ describe("Cypher -> vector -> Score", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL db.index.vector.queryNodes(\\"movie_index\\", 4, $param0) YIELD node AS this0, score AS var1
+            "CYPHER 5
+            CALL db.index.vector.queryNodes(\\"movie_index\\", 4, $param0) YIELD node AS this0, score AS var1
             WHERE ($param1 IN labels(this0) AND var1 >= $param2)
             WITH collect({ node: this0, score: var1 }) AS edges
             WITH edges, size(edges) AS totalCount
@@ -245,7 +246,8 @@ describe("Cypher -> vector -> Score", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL db.index.vector.queryNodes(\\"movie_index\\", 4, $param0) YIELD node AS this0, score AS var1
+            "CYPHER 5
+            CALL db.index.vector.queryNodes(\\"movie_index\\", 4, $param0) YIELD node AS this0, score AS var1
             WHERE $param1 IN labels(this0)
             WITH collect({ node: this0, score: var1 }) AS edges
             WITH edges, size(edges) AS totalCount
@@ -418,7 +420,8 @@ describe("Cypher -> vector -> Score", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL db.index.vector.queryNodes(\\"movie_index\\", 4, $param0) YIELD node AS this0, score AS var1
+            "CYPHER 5
+            CALL db.index.vector.queryNodes(\\"movie_index\\", 4, $param0) YIELD node AS this0, score AS var1
             WHERE $param1 IN labels(this0)
             WITH collect({ node: this0, score: var1 }) AS edges
             WITH edges, size(edges) AS totalCount

--- a/packages/graphql/tests/tck/federation/authorization.test.ts
+++ b/packages/graphql/tests/tck/federation/authorization.test.ts
@@ -65,7 +65,8 @@ describe("Federation and authorization", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE (this.id = $param0 AND ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)))
             RETURN this { .id, .name } AS this"
@@ -127,7 +128,8 @@ describe("Federation and authorization", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE (this.id = $param0 AND ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)))
             RETURN this { .id, .name, .password } AS this"
@@ -196,7 +198,8 @@ describe("Federation and authorization", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Post)
+            "CYPHER 5
+            MATCH (this:Post)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:AUTHORED]-(this1:User)

--- a/packages/graphql/tests/tck/fragments.test.ts
+++ b/packages/graphql/tests/tck/fragments.test.ts
@@ -76,7 +76,8 @@ describe("Cypher Fragment", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             RETURN this { .id, .username } AS this"
         `);
 
@@ -101,7 +102,8 @@ describe("Cypher Fragment", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             CALL {
                 WITH this
                 CALL {
@@ -141,7 +143,8 @@ describe("Cypher Fragment", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             RETURN this { .username, .id } AS this"
         `);
 
@@ -209,7 +212,8 @@ describe("Cypher Fragment", () => {
         const result = await translateQuery(testNeoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             WHERE this.name = $param0
             CALL {
                 WITH this

--- a/packages/graphql/tests/tck/fulltext/aggregate.test.ts
+++ b/packages/graphql/tests/tck/fulltext/aggregate.test.ts
@@ -48,7 +48,8 @@ describe("Cypher -> fulltext -> Aggregate", () => {
         const result = await translateQuery(neoSchema, query, {});
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
                 WHERE $param1 IN labels(this0)
                 RETURN count(this0) AS var2

--- a/packages/graphql/tests/tck/fulltext/auth.test.ts
+++ b/packages/graphql/tests/tck/fulltext/auth.test.ts
@@ -75,7 +75,8 @@ describe("Cypher -> fulltext -> Auth", () => {
             const result = await translateQuery(neoSchema, query, { token, neo4jVersion: "4.4" });
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
+                "CYPHER 5
+                CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
                 WHERE $param1 IN labels(this0)
                 WITH *
                 WHERE ($isAuthenticated = true AND size([(this0)<-[:DIRECTED]-(this2:Person) WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub) | 1]) > 0)
@@ -134,7 +135,8 @@ describe("Cypher -> fulltext -> Auth", () => {
             const result = await translateQuery(neoSchema, query, { token, neo4jVersion: "4.4" });
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
+                "CYPHER 5
+                CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
                 WHERE $param1 IN labels(this0)
                 WITH *
                 WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND size([(this0)<-[:DIRECTED]-(this2:Person) WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub) | 1]) > 0), \\"@neo4j/graphql/FORBIDDEN\\", [0])
@@ -193,7 +195,8 @@ describe("Cypher -> fulltext -> Auth", () => {
             const result = await translateQuery(neoSchema, query, { token, neo4jVersion: "4.4" });
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
+                "CYPHER 5
+                CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
                 WHERE $param1 IN labels(this0)
                 WITH *
                 WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND size([(this0)<-[:DIRECTED]-(this2:Person) WHERE NOT ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub) | 1]) = 0), \\"@neo4j/graphql/FORBIDDEN\\", [0])
@@ -257,7 +260,8 @@ describe("Cypher -> fulltext -> Auth", () => {
             const result = await translateQuery(neoSchema, query, { token, neo4jVersion: "4.4" });
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
+                "CYPHER 5
+                CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
                 WHERE $param1 IN labels(this0)
                 WITH *
                 WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND size([(this0)<-[this3:DIRECTED]-(this2:Person) WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub) | 1]) > 0), \\"@neo4j/graphql/FORBIDDEN\\", [0])
@@ -321,7 +325,8 @@ describe("Cypher -> fulltext -> Auth", () => {
             const result = await translateQuery(neoSchema, query, { token, neo4jVersion: "4.4" });
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
+                "CYPHER 5
+                CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
                 WHERE $param1 IN labels(this0)
                 WITH *
                 WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND size([(this0)<-[this3:DIRECTED]-(this2:Person) WHERE NOT ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub) | 1]) = 0), \\"@neo4j/graphql/FORBIDDEN\\", [0])
@@ -389,7 +394,8 @@ describe("Cypher -> fulltext -> Auth", () => {
             const result = await translateQuery(neoSchema, query, { token, neo4jVersion: "4.4" });
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
+                "CYPHER 5
+                CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
                 WHERE $param1 IN labels(this0)
                 WITH *
                 WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND size([(this0)<-[this2:DIRECTED]-(this3:Person) WHERE ($param3 IS NOT NULL AND this2.year = $param3) | 1]) > 0), \\"@neo4j/graphql/FORBIDDEN\\", [0])
@@ -451,7 +457,8 @@ describe("Cypher -> fulltext -> Auth", () => {
             const result = await translateQuery(neoSchema, query, { token, neo4jVersion: "4.4" });
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
+                "CYPHER 5
+                CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
                 WHERE $param1 IN labels(this0)
                 WITH *
                 WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND size([(this0)<-[this2:DIRECTED]-(this3:Person) WHERE NOT ($param3 IS NOT NULL AND this2.year = $param3) | 1]) = 0), \\"@neo4j/graphql/FORBIDDEN\\", [0])
@@ -507,7 +514,8 @@ describe("Cypher -> fulltext -> Auth", () => {
             const result = await translateQuery(neoSchema, query, { token, neo4jVersion: "5" });
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
+                "CYPHER 5
+                CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
                 WHERE $param1 IN labels(this0)
                 WITH *
                 WHERE ($isAuthenticated = true AND EXISTS {
@@ -569,7 +577,8 @@ describe("Cypher -> fulltext -> Auth", () => {
             const result = await translateQuery(neoSchema, query, { token, neo4jVersion: "5" });
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
+                "CYPHER 5
+                CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
                 WHERE $param1 IN labels(this0)
                 WITH *
                 WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND EXISTS {
@@ -631,7 +640,8 @@ describe("Cypher -> fulltext -> Auth", () => {
             const result = await translateQuery(neoSchema, query, { token, neo4jVersion: "5" });
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
+                "CYPHER 5
+                CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
                 WHERE $param1 IN labels(this0)
                 WITH *
                 WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (EXISTS {
@@ -701,7 +711,8 @@ describe("Cypher -> fulltext -> Auth", () => {
             const result = await translateQuery(neoSchema, query, { token, neo4jVersion: "5" });
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
+                "CYPHER 5
+                CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
                 WHERE $param1 IN labels(this0)
                 WITH *
                 WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND EXISTS {
@@ -768,7 +779,8 @@ describe("Cypher -> fulltext -> Auth", () => {
             const result = await translateQuery(neoSchema, query, { token, neo4jVersion: "5" });
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
+                "CYPHER 5
+                CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
                 WHERE $param1 IN labels(this0)
                 WITH *
                 WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (EXISTS {
@@ -842,7 +854,8 @@ describe("Cypher -> fulltext -> Auth", () => {
             const result = await translateQuery(neoSchema, query, { token, neo4jVersion: "5" });
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
+                "CYPHER 5
+                CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
                 WHERE $param1 IN labels(this0)
                 WITH *
                 WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND EXISTS {
@@ -907,7 +920,8 @@ describe("Cypher -> fulltext -> Auth", () => {
             const result = await translateQuery(neoSchema, query, { token, neo4jVersion: "5" });
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
+                "CYPHER 5
+                CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
                 WHERE $param1 IN labels(this0)
                 WITH *
                 WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (EXISTS {

--- a/packages/graphql/tests/tck/fulltext/match.test.ts
+++ b/packages/graphql/tests/tck/fulltext/match.test.ts
@@ -48,7 +48,8 @@ describe("Cypher -> fulltext -> Match", () => {
         const result = await translateQuery(neoSchema, query, {});
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
+            "CYPHER 5
+            CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
             WHERE $param1 IN labels(this0)
             RETURN this0 { .title } AS this"
         `);
@@ -76,7 +77,8 @@ describe("Cypher -> fulltext -> Match", () => {
         const result = await translateQuery(neoSchema, query, {});
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
+            "CYPHER 5
+            CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
             WHERE ($param1 IN labels(this0) AND this0.title = $param2)
             RETURN this0 { .title } AS this"
         `);

--- a/packages/graphql/tests/tck/fulltext/node-labels.test.ts
+++ b/packages/graphql/tests/tck/fulltext/node-labels.test.ts
@@ -46,7 +46,8 @@ describe("Cypher -> fulltext -> Additional Labels", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
+            "CYPHER 5
+            CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
             WHERE ($param1 IN labels(this0) AND $param2 IN labels(this0))
             RETURN this0 { .title } AS this"
         `);
@@ -92,7 +93,8 @@ describe("Cypher -> fulltext -> Additional Labels", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
+            "CYPHER 5
+            CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
             WHERE ($param1 IN labels(this0) AND $param2 IN labels(this0))
             RETURN this0 { .title } AS this"
         `);

--- a/packages/graphql/tests/tck/fulltext/score.test.ts
+++ b/packages/graphql/tests/tck/fulltext/score.test.ts
@@ -53,7 +53,8 @@ describe("Cypher -> fulltext -> Score", () => {
         const result = await translateQuery(neoSchema, query, {});
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
+            "CYPHER 5
+            CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
             WHERE $param1 IN labels(this0)
             RETURN this0 { .title, .released } AS movie, var1 AS score"
         `);
@@ -82,7 +83,8 @@ describe("Cypher -> fulltext -> Score", () => {
         const result = await translateQuery(neoSchema, query, {});
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
+            "CYPHER 5
+            CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
             WHERE ($param1 IN labels(this0) AND this0.released > $param2)
             RETURN this0 { .title, .released } AS movie, var1 AS score"
         `);
@@ -114,7 +116,8 @@ describe("Cypher -> fulltext -> Score", () => {
         const result = await translateQuery(neoSchema, query, {});
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
+            "CYPHER 5
+            CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
             WHERE ($param1 IN labels(this0) AND var1 >= $param2)
             RETURN this0 { .title } AS movie, var1 AS score"
         `);
@@ -143,7 +146,8 @@ describe("Cypher -> fulltext -> Score", () => {
         const result = await translateQuery(neoSchema, query, {});
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
+            "CYPHER 5
+            CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
             WHERE $param1 IN labels(this0)
             WITH *
             ORDER BY this0.title DESC
@@ -173,7 +177,8 @@ describe("Cypher -> fulltext -> Score", () => {
         const result = await translateQuery(neoSchema, query, {});
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
+            "CYPHER 5
+            CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
             WHERE $param1 IN labels(this0)
             WITH *
             ORDER BY var1 ASC
@@ -206,7 +211,8 @@ describe("Cypher -> fulltext -> Score", () => {
         const result = await translateQuery(neoSchema, query, {});
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
+            "CYPHER 5
+            CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
             WHERE $param1 IN labels(this0)
             WITH *
             ORDER BY var1 ASC, this0.title DESC

--- a/packages/graphql/tests/tck/global-node.test.ts
+++ b/packages/graphql/tests/tck/global-node.test.ts
@@ -57,7 +57,8 @@ describe("Global nodes", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title = $param0
             RETURN this { .title } AS this"
         `);
@@ -94,7 +95,8 @@ describe("Global nodes", () => {
             variableValues: { id: toGlobalId({ typeName: "Actor", field: "dbId", id: "123455" }) },
         });
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             WHERE this.id = $param0
             RETURN this { .name, dbId: this.id } AS this"
         `);
@@ -138,7 +140,8 @@ describe("Global nodes", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             WHERE this.id = $param0
             RETURN this { .name } AS this"
         `);
@@ -180,7 +183,8 @@ describe("Global nodes", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             WHERE this.dbId = $param0
             RETURN this { .dbId, .name } AS this"
         `);

--- a/packages/graphql/tests/tck/info.test.ts
+++ b/packages/graphql/tests/tck/info.test.ts
@@ -57,7 +57,8 @@ describe("info", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Movie)

--- a/packages/graphql/tests/tck/issues/1115.test.ts
+++ b/packages/graphql/tests/tck/issues/1115.test.ts
@@ -82,7 +82,8 @@ describe("https://github.com/neo4j/graphql/issues/1115", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Parent)
+            "CYPHER 5
+            MATCH (this:Parent)
             WITH this
             CALL {
                 WITH this

--- a/packages/graphql/tests/tck/issues/1131.test.ts
+++ b/packages/graphql/tests/tck/issues/1131.test.ts
@@ -81,7 +81,8 @@ describe("https://github.com/neo4j/graphql/issues/1131", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:BibliographicReference:Resource)
+            "CYPHER 5
+            MATCH (this:BibliographicReference:Resource)
             WHERE this.uri = $param0
             SET this.prefLabel = $this_update_prefLabel_SET
             WITH this

--- a/packages/graphql/tests/tck/issues/1132.test.ts
+++ b/packages/graphql/tests/tck/issues/1132.test.ts
@@ -61,7 +61,8 @@ describe("https://github.com/neo4j/graphql/issues/1132", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Source)
+            "CYPHER 5
+            MATCH (this:Source)
             WITH *
             CALL {
             	WITH this
@@ -135,7 +136,8 @@ describe("https://github.com/neo4j/graphql/issues/1132", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Source)
+            "CYPHER 5
+            MATCH (this:Source)
             WITH this
             CALL {
             WITH this

--- a/packages/graphql/tests/tck/issues/1150.test.ts
+++ b/packages/graphql/tests/tck/issues/1150.test.ts
@@ -108,7 +108,8 @@ describe("https://github.com/neo4j/graphql/issues/1150", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Drive)
+            "CYPHER 5
+            MATCH (this:Drive)
             WHERE this.current = $param0
             CALL {
                 WITH this

--- a/packages/graphql/tests/tck/issues/1182.test.ts
+++ b/packages/graphql/tests/tck/issues/1182.test.ts
@@ -77,7 +77,8 @@ describe("https://github.com/neo4j/graphql/issues/1182", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
             CREATE (this0:Movie)
             SET this0.id = randomUUID()
             SET this0.title = $this0_title

--- a/packages/graphql/tests/tck/issues/1221.test.ts
+++ b/packages/graphql/tests/tck/issues/1221.test.ts
@@ -83,7 +83,8 @@ describe("https://github.com/neo4j/graphql/issues/1221", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Series)
+            "CYPHER 5
+            MATCH (this:Series)
             WHERE (this.current = $param0 AND single(this1 IN [(this)-[this3:ARCHITECTURE]->(this1:MasterData) WHERE single(this0 IN [(this1)-[this2:HAS_NAME]->(this0:NameDetails) WHERE this0.fullName = $param1 | 1] WHERE true) | 1] WHERE true))
             CALL {
                 WITH this
@@ -201,7 +202,8 @@ describe("https://github.com/neo4j/graphql/issues/1221", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Main)
+            "CYPHER 5
+            MATCH (this:Main)
             WHERE (this.current = $param0 AND single(this0 IN [(this)-[this5:MAIN]->(this0:Series) WHERE EXISTS {
                 MATCH (this0)-[this1:ARCHITECTURE]->(this2:MasterData)
                 WHERE single(this3 IN [(this2)-[this4:HAS_NAME]->(this3:NameDetails) WHERE this3.fullName = $param1 | 1] WHERE true)

--- a/packages/graphql/tests/tck/issues/1249.test.ts
+++ b/packages/graphql/tests/tck/issues/1249.test.ts
@@ -81,7 +81,8 @@ describe("https://github.com/neo4j/graphql/issues/1249", () => {
         const result = await translateQuery(neoSchema, query, { contextValues: { cypherParams: { tenant: "BULK" } } });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Bulk:BULK)
+            "CYPHER 5
+            MATCH (this:Bulk:BULK)
             CALL {
                 WITH this
                 MATCH (this)-[this0:MATERIAL_BULK]->(this1:Material)

--- a/packages/graphql/tests/tck/issues/1320.test.ts
+++ b/packages/graphql/tests/tck/issues/1320.test.ts
@@ -66,7 +66,8 @@ describe("https://github.com/neo4j/graphql/issues/1320", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Team)
+            "CYPHER 5
+            MATCH (this:Team)
             CALL {
                 WITH this
                 MATCH (this)-[this0:OWNS_RISK]->(this1:Risk)

--- a/packages/graphql/tests/tck/issues/1348.test.ts
+++ b/packages/graphql/tests/tck/issues/1348.test.ts
@@ -79,7 +79,8 @@ describe("https://github.com/neo4j/graphql/issues/1348", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:ProgrammeItem)
+            "CYPHER 5
+            MATCH (this:ProgrammeItem)
             CALL {
                 WITH this
                 CALL {
@@ -135,7 +136,8 @@ describe("https://github.com/neo4j/graphql/issues/1348", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:ProgrammeItem)
+            "CYPHER 5
+            MATCH (this:ProgrammeItem)
             CALL {
                 WITH this
                 CALL {

--- a/packages/graphql/tests/tck/issues/1364.test.ts
+++ b/packages/graphql/tests/tck/issues/1364.test.ts
@@ -91,7 +91,8 @@ describe("https://github.com/neo4j/graphql/issues/1364", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this0:Movie)
+            "CYPHER 5
+            MATCH (this0:Movie)
             WITH collect({ node: this0 }) AS edges
             WITH edges, size(edges) AS totalCount
             CALL {
@@ -134,7 +135,8 @@ describe("https://github.com/neo4j/graphql/issues/1364", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this0:Movie)
+            "CYPHER 5
+            MATCH (this0:Movie)
             WITH collect({ node: this0 }) AS edges
             WITH edges, size(edges) AS totalCount
             CALL {
@@ -178,7 +180,8 @@ describe("https://github.com/neo4j/graphql/issues/1364", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this0:Movie)
+            "CYPHER 5
+            MATCH (this0:Movie)
             WITH collect({ node: this0 }) AS edges
             WITH edges, size(edges) AS totalCount
             CALL {

--- a/packages/graphql/tests/tck/issues/1430.test.ts
+++ b/packages/graphql/tests/tck/issues/1430.test.ts
@@ -77,7 +77,8 @@ describe("https://github.com/neo4j/graphql/issues/1430", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:ABCE)
+            "CYPHER 5
+            MATCH (this:ABCE)
             WHERE this.id = $param0
             WITH this
             CALL {
@@ -147,7 +148,8 @@ describe("https://github.com/neo4j/graphql/issues/1430", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:ABCE)
+            "CYPHER 5
+            MATCH (this:ABCE)
             WHERE this.id = $param0
             WITH this
             CALL {

--- a/packages/graphql/tests/tck/issues/1528.test.ts
+++ b/packages/graphql/tests/tck/issues/1528.test.ts
@@ -69,7 +69,8 @@ describe("https://github.com/neo4j/graphql/issues/1528", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Genre)
+            "CYPHER 5
+            MATCH (this:Genre)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:IS_GENRE]-(this1:Movie)

--- a/packages/graphql/tests/tck/issues/1535.test.ts
+++ b/packages/graphql/tests/tck/issues/1535.test.ts
@@ -78,7 +78,8 @@ describe("https://github.com/neo4j/graphql/issues/1535", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Tenant)
+            "CYPHER 5
+            MATCH (this:Tenant)
             CALL {
                 WITH this
                 CALL {

--- a/packages/graphql/tests/tck/issues/1536.test.ts
+++ b/packages/graphql/tests/tck/issues/1536.test.ts
@@ -66,7 +66,8 @@ describe("https://github.com/neo4j/graphql/issues/1536", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:SomeNode)
+            "CYPHER 5
+            MATCH (this:SomeNode)
             CALL {
                 WITH this
                 MATCH (this)-[this0:HAS_OTHER_NODES]->(this1:OtherNode)

--- a/packages/graphql/tests/tck/issues/1566.test.ts
+++ b/packages/graphql/tests/tck/issues/1566.test.ts
@@ -79,7 +79,8 @@ describe("https://github.com/neo4j/graphql/issues/1566", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Community)
+            "CYPHER 5
+            MATCH (this:Community)
             WHERE this.id = $param0
             CALL {
                 WITH this

--- a/packages/graphql/tests/tck/issues/1628.test.ts
+++ b/packages/graphql/tests/tck/issues/1628.test.ts
@@ -59,7 +59,8 @@ describe("https://github.com/neo4j/graphql/issues/1628", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:frbr__Work:Resource)
+            "CYPHER 5
+            MATCH (this:frbr__Work:Resource)
             WHERE EXISTS {
                 MATCH (this)-[:dcterms__title]->(this0:dcterms_title:property)
                 WHERE this0.value CONTAINS $param0

--- a/packages/graphql/tests/tck/issues/1687.test.ts
+++ b/packages/graphql/tests/tck/issues/1687.test.ts
@@ -61,7 +61,8 @@ describe("https://github.com/neo4j/graphql/issues/1687", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Genre)
+            "CYPHER 5
+            MATCH (this:Genre)
             WHERE (EXISTS {
                 MATCH (this)<-[this0:HAS_GENRE]-(this1)
                 WHERE (this1.title = $param0 AND this1:Movie)

--- a/packages/graphql/tests/tck/issues/1751.test.ts
+++ b/packages/graphql/tests/tck/issues/1751.test.ts
@@ -78,7 +78,8 @@ describe("https://github.com/neo4j/graphql/issues/1751", () => {
         const result = await translateQuery(neoSchema, query, { variableValues });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Organization)
+            "CYPHER 5
+            MATCH (this:Organization)
             WHERE this.title = $param0
             WITH *
             CALL {

--- a/packages/graphql/tests/tck/issues/1756.test.ts
+++ b/packages/graphql/tests/tck/issues/1756.test.ts
@@ -80,7 +80,8 @@ describe("https://github.com/neo4j/graphql/issues/1756", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
             CREATE (this0:Product)
             SET this0.id = $resolvedCallbacks.this0_id_nanoid
             SET this0.name = $this0_name

--- a/packages/graphql/tests/tck/issues/1760.test.ts
+++ b/packages/graphql/tests/tck/issues/1760.test.ts
@@ -138,7 +138,8 @@ describe("https://github.com/neo4j/graphql/issues/1760", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:ApplicationVariant)
+            "CYPHER 5
+            MATCH (this:ApplicationVariant)
             WITH *
             WHERE (this.current = $param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             CALL {

--- a/packages/graphql/tests/tck/issues/1779.test.ts
+++ b/packages/graphql/tests/tck/issues/1779.test.ts
@@ -58,7 +58,8 @@ describe("https://github.com/neo4j/graphql/issues/1779", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Person)
+            "CYPHER 5
+            MATCH (this:Person)
             CALL {
                 WITH this
                 MATCH (this)-[this0:attends]->(this1:School)

--- a/packages/graphql/tests/tck/issues/1783.test.ts
+++ b/packages/graphql/tests/tck/issues/1783.test.ts
@@ -118,7 +118,8 @@ describe("https://github.com/neo4j/graphql/issues/1783", () => {
         const result = await translateQuery(neoSchema, query, { variableValues });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Series)
+            "CYPHER 5
+            MATCH (this:Series)
             WHERE (this.current = $param0 AND single(this2 IN [(this)-[this3:ARCHITECTURE]->(this2:MasterData) WHERE (single(this0 IN [(this2)-[this1:HAS_NAME]->(this0:NameDetails) WHERE (this0.fullName = $param1 AND this1.current = $param2) | 1] WHERE true) AND this3.current = $param3) | 1] WHERE true) AND single(this4 IN [(this)-[this5:HAS_NAME]->(this4:NameDetails) WHERE (this4.fullName CONTAINS $param4 AND this5.current = $param5) | 1] WHERE true))
             CALL {
                 WITH this

--- a/packages/graphql/tests/tck/issues/1848.test.ts
+++ b/packages/graphql/tests/tck/issues/1848.test.ts
@@ -86,7 +86,8 @@ describe("https://github.com/neo4j/graphql/issues/1848", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Community:UNIVERSAL)
+            "CYPHER 5
+            MATCH (this:Community:UNIVERSAL)
             CALL {
                 WITH this
                 CALL {

--- a/packages/graphql/tests/tck/issues/190.test.ts
+++ b/packages/graphql/tests/tck/issues/190.test.ts
@@ -61,7 +61,8 @@ describe("#190", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WHERE EXISTS {
                 MATCH (this)-[:HAS_DEMOGRAPHIC]->(this0:UserDemographics)
                 WHERE (this0.type = $param0 AND this0.value = $param1)
@@ -105,7 +106,8 @@ describe("#190", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WHERE EXISTS {
                 MATCH (this)-[:HAS_DEMOGRAPHIC]->(this0:UserDemographics)
                 WHERE ((this0.type = $param0 AND this0.value = $param1) OR this0.type = $param2 OR this0.type = $param3)

--- a/packages/graphql/tests/tck/issues/1933.test.ts
+++ b/packages/graphql/tests/tck/issues/1933.test.ts
@@ -77,7 +77,8 @@ describe("https://github.com/neo4j/graphql/issues/1933", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Employee)
+            "CYPHER 5
+            MATCH (this:Employee)
             CALL {
                 WITH this
                 MATCH (this)-[this0:PARTICIPATES]->(this1:Project)

--- a/packages/graphql/tests/tck/issues/2022.test.ts
+++ b/packages/graphql/tests/tck/issues/2022.test.ts
@@ -88,7 +88,8 @@ describe("https://github.com/neo4j/graphql/issues/2022", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this0:ArtPiece)
+            "CYPHER 5
+            MATCH (this0:ArtPiece)
             WITH collect({ node: this0 }) AS edges
             WITH edges, size(edges) AS totalCount
             CALL {

--- a/packages/graphql/tests/tck/issues/2100.test.ts
+++ b/packages/graphql/tests/tck/issues/2100.test.ts
@@ -105,7 +105,8 @@ describe("https://github.com/neo4j/graphql/issues/2100", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Bacenta)
+            "CYPHER 5
+            MATCH (this:Bacenta)
             WHERE this.id = $param0
             CALL {
                 WITH this

--- a/packages/graphql/tests/tck/issues/2189.test.ts
+++ b/packages/graphql/tests/tck/issues/2189.test.ts
@@ -76,7 +76,8 @@ describe("https://github.com/neo4j/graphql/issues/2189", () => {
 
         const result = await translateQuery(neoSchema, query);
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Test_Item)
@@ -166,7 +167,8 @@ describe("https://github.com/neo4j/graphql/issues/2189", () => {
 
         const result = await translateQuery(neoSchema, query);
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Test_Item)
@@ -274,7 +276,8 @@ describe("https://github.com/neo4j/graphql/issues/2189", () => {
 
         const result = await translateQuery(neoSchema, query);
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Test_Item)
@@ -395,7 +398,8 @@ describe("https://github.com/neo4j/graphql/issues/2189", () => {
 
         const result = await translateQuery(neoSchema, query);
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Test_Item)

--- a/packages/graphql/tests/tck/issues/2249.test.ts
+++ b/packages/graphql/tests/tck/issues/2249.test.ts
@@ -85,7 +85,8 @@ describe("https://github.com/neo4j/graphql/issues/2249", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title = $param0
             WITH this
             CALL {

--- a/packages/graphql/tests/tck/issues/2262.test.ts
+++ b/packages/graphql/tests/tck/issues/2262.test.ts
@@ -69,7 +69,8 @@ describe("https://github.com/neo4j/graphql/issues/2262", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Component)
+            "CYPHER 5
+            MATCH (this:Component)
             WHERE this.uuid = $param0
             CALL {
                 WITH this

--- a/packages/graphql/tests/tck/issues/2267.test.ts
+++ b/packages/graphql/tests/tck/issues/2267.test.ts
@@ -67,7 +67,8 @@ describe("https://github.com/neo4j/graphql/issues/2267", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Place)
+            "CYPHER 5
+            MATCH (this:Place)
             WITH *
             ORDER BY this.displayName ASC
             CALL {

--- a/packages/graphql/tests/tck/issues/2396.test.ts
+++ b/packages/graphql/tests/tck/issues/2396.test.ts
@@ -152,7 +152,8 @@ describe("https://github.com/neo4j/graphql/issues/2396", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Mandate)
+            "CYPHER 5
+            MATCH (this:Mandate)
             OPTIONAL MATCH (this)-[:HAS_VALUATION]->(this0:Valuation)
             WITH *, count(this0) AS var1
             WITH *
@@ -220,7 +221,8 @@ describe("https://github.com/neo4j/graphql/issues/2396", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Mandate)
+            "CYPHER 5
+            MATCH (this:Mandate)
             OPTIONAL MATCH (this)-[:HAS_VALUATION]->(this0:Valuation)
             WITH *, count(this0) AS var1
             WITH *
@@ -296,7 +298,8 @@ describe("https://github.com/neo4j/graphql/issues/2396", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Mandate)
+            "CYPHER 5
+            MATCH (this:Mandate)
             CALL {
                 WITH this
                 MATCH (this)-[:HAS_VALUATION]->(this0:Valuation)
@@ -400,7 +403,8 @@ describe("https://github.com/neo4j/graphql/issues/2396", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Mandate)
+            "CYPHER 5
+            MATCH (this:Mandate)
             CALL {
                 WITH this
                 MATCH (this)-[:HAS_VALUATION]->(this0:Valuation)
@@ -515,7 +519,8 @@ describe("https://github.com/neo4j/graphql/issues/2396", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Mandate)
+            "CYPHER 5
+            MATCH (this:Mandate)
             CALL {
                 WITH this
                 MATCH (this)-[:HAS_VALUATION]->(this0:Valuation)

--- a/packages/graphql/tests/tck/issues/2437.test.ts
+++ b/packages/graphql/tests/tck/issues/2437.test.ts
@@ -81,7 +81,8 @@ describe("https://github.com/neo4j/graphql/issues/2437", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Agent)
+            "CYPHER 5
+            MATCH (this:Agent)
             WITH *
             WHERE (this.uuid = $param0 AND ($isAuthenticated = true AND this.archivedAt IS NULL))
             CALL {

--- a/packages/graphql/tests/tck/issues/2581.test.ts
+++ b/packages/graphql/tests/tck/issues/2581.test.ts
@@ -90,7 +90,8 @@ describe("https://github.com/neo4j/graphql/issues/2581", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Author)
+            "CYPHER 5
+            MATCH (this:Author)
             CALL {
                 WITH this
                 CALL {
@@ -134,7 +135,8 @@ describe("https://github.com/neo4j/graphql/issues/2581", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Author)
+            "CYPHER 5
+            MATCH (this:Author)
             CALL {
                 WITH this
                 CALL {

--- a/packages/graphql/tests/tck/issues/2614.test.ts
+++ b/packages/graphql/tests/tck/issues/2614.test.ts
@@ -71,7 +71,8 @@ describe("https://github.com/neo4j/graphql/issues/2614", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             CALL {
                 WITH this
                 CALL {

--- a/packages/graphql/tests/tck/issues/2670.test.ts
+++ b/packages/graphql/tests/tck/issues/2670.test.ts
@@ -63,7 +63,8 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
@@ -103,7 +104,8 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
@@ -143,7 +145,8 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
@@ -189,7 +192,8 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
@@ -235,7 +239,8 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
@@ -274,7 +279,8 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
@@ -316,7 +322,8 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
@@ -356,7 +363,8 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
@@ -396,7 +404,8 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
@@ -436,7 +445,8 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
@@ -492,7 +502,8 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
@@ -541,7 +552,8 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
@@ -599,7 +611,8 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
@@ -657,7 +670,8 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
@@ -711,7 +725,8 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)-[this0:IN_GENRE]->(this1:Genre)

--- a/packages/graphql/tests/tck/issues/2708.test.ts
+++ b/packages/graphql/tests/tck/issues/2708.test.ts
@@ -63,7 +63,8 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)-[:IN_GENRE]->(this0:Genre)
@@ -103,7 +104,8 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)-[:IN_GENRE]->(this0:Genre)
@@ -143,7 +145,8 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)-[:IN_GENRE]->(this0:Genre)
@@ -183,7 +186,8 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)-[:IN_GENRE]->(this0:Genre)
@@ -223,7 +227,8 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)-[:IN_GENRE]->(this0:Genre)
@@ -260,7 +265,8 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)-[:IN_GENRE]->(this0:Genre)
@@ -300,7 +306,8 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)-[:IN_GENRE]->(this0:Genre)
@@ -340,7 +347,8 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)-[:IN_GENRE]->(this0:Genre)
@@ -380,7 +388,8 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)-[:IN_GENRE]->(this0:Genre)
@@ -420,7 +429,8 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)-[:IN_GENRE]->(this0:Genre)
@@ -476,7 +486,8 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)-[:IN_GENRE]->(this0:Genre)
@@ -516,7 +527,8 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)-[:IN_GENRE]->(this0:Genre)
@@ -581,7 +593,8 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)-[:IN_GENRE]->(this0:Genre)
@@ -639,7 +652,8 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)-[:IN_GENRE]->(this0:Genre)
@@ -695,7 +709,8 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)-[:IN_GENRE]->(this0:Genre)
@@ -744,7 +759,8 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)-[:IN_GENRE]->(this0:Genre)
@@ -797,7 +813,8 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)-[:IN_GENRE]->(this0:Genre)
@@ -878,7 +895,8 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)-[:IN_GENRE]->(this0:Genre)

--- a/packages/graphql/tests/tck/issues/2709.test.ts
+++ b/packages/graphql/tests/tck/issues/2709.test.ts
@@ -102,7 +102,8 @@ describe("https://github.com/neo4j/graphql/issues/2709", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Film)
+            "CYPHER 5
+            MATCH (this:Film)
             WHERE EXISTS {
                 MATCH (this)<-[this0:DISTRIBUTED_BY]-(this1)
                 WHERE (this1.name = $param0 AND (this1:Dishney OR this1:Prime OR this1:Netflix))
@@ -121,7 +122,9 @@ describe("https://github.com/neo4j/graphql/issues/2709", () => {
         const query = /* GraphQL */ `
             query {
                 movies(
-                    where: { distributionConnection_SOME: { node: { OR: [{ name_EQ: "test4" }, { name_EQ: "test1" }] } } }
+                    where: {
+                        distributionConnection_SOME: { node: { OR: [{ name_EQ: "test4" }, { name_EQ: "test1" }] } }
+                    }
                 ) {
                     title
                 }
@@ -130,7 +133,8 @@ describe("https://github.com/neo4j/graphql/issues/2709", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Film)
+            "CYPHER 5
+            MATCH (this:Film)
             WHERE EXISTS {
                 MATCH (this)<-[this0:DISTRIBUTED_BY]-(this1)
                 WHERE ((this1.name = $param0 OR this1.name = $param1) AND (this1:Dishney OR this1:Prime OR this1:Netflix))
@@ -224,7 +228,8 @@ describe("https://github.com/neo4j/graphql/issues/2709 union parity", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Film)
+            "CYPHER 5
+            MATCH (this:Film)
             WHERE EXISTS {
                 MATCH (this)<-[this0:DISTRIBUTED_BY]-(this1:Netflix)
                 WHERE this1.name = $param0
@@ -250,7 +255,8 @@ describe("https://github.com/neo4j/graphql/issues/2709 union parity", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Film)
+            "CYPHER 5
+            MATCH (this:Film)
             WHERE EXISTS {
                 MATCH (this)<-[this0:DISTRIBUTED_BY]-(this1:Dishney)
                 WHERE this1.name = $param0
@@ -276,7 +282,8 @@ describe("https://github.com/neo4j/graphql/issues/2709 union parity", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Film)
+            "CYPHER 5
+            MATCH (this:Film)
             WHERE EXISTS {
                 MATCH (this)<-[this0:DISTRIBUTED_BY]-(this1:Dishney)
                 WHERE this1.name = $param0

--- a/packages/graphql/tests/tck/issues/2713.test.ts
+++ b/packages/graphql/tests/tck/issues/2713.test.ts
@@ -63,7 +63,8 @@ describe("https://github.com/neo4j/graphql/issues/2713", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
@@ -121,7 +122,8 @@ describe("https://github.com/neo4j/graphql/issues/2713", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
@@ -179,7 +181,8 @@ describe("https://github.com/neo4j/graphql/issues/2713", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE (EXISTS {
                 MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
                 WHERE this1.name = $param0

--- a/packages/graphql/tests/tck/issues/2766.test.ts
+++ b/packages/graphql/tests/tck/issues/2766.test.ts
@@ -69,7 +69,8 @@ describe("https://github.com/neo4j/graphql/issues/2766", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             CALL {
                 WITH this
                 CALL {

--- a/packages/graphql/tests/tck/issues/2782.test.ts
+++ b/packages/graphql/tests/tck/issues/2782.test.ts
@@ -95,7 +95,8 @@ describe("https://github.com/neo4j/graphql/issues/2782", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Product)
+            "CYPHER 5
+            MATCH (this:Product)
             SET this.id = $this_update_id_SET
             SET this.name = $this_update_name_SET
             WITH this

--- a/packages/graphql/tests/tck/issues/2789.test.ts
+++ b/packages/graphql/tests/tck/issues/2789.test.ts
@@ -50,7 +50,8 @@ describe("https://github.com/neo4j/graphql/issues/2789", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WITH *
             WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($param1 IS NOT NULL AND this.id = $param1)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this

--- a/packages/graphql/tests/tck/issues/2803.test.ts
+++ b/packages/graphql/tests/tck/issues/2803.test.ts
@@ -58,7 +58,8 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             CALL {
                 WITH this
                 MATCH (this)-[:ACTED_IN]->(this0:Movie)
@@ -128,7 +129,8 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             CALL {
                 WITH this
                 MATCH (this)-[:ACTED_IN]->(this0:Movie)
@@ -200,7 +202,8 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[:ACTED_IN]-(this0:Actor)
@@ -281,7 +284,8 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[:ACTED_IN]-(this0:Actor)
@@ -375,7 +379,8 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             CALL {
                 WITH this
                 MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
@@ -445,7 +450,8 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             CALL {
                 WITH this
                 MATCH (this)-[:ACTED_IN]->(this0:Movie)
@@ -527,7 +533,8 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
@@ -612,7 +619,8 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
@@ -702,7 +710,8 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             CALL {
                 WITH this
                 MATCH (this)-[:ACTED_IN]->(this0:Movie)
@@ -767,7 +776,8 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             CALL {
                 WITH this
                 MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
@@ -838,7 +848,8 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
@@ -899,7 +910,8 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             CALL {
                 WITH this
                 MATCH (this)-[:ACTED_IN]->(this0:Movie)
@@ -961,7 +973,8 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             CALL {
                 WITH this
                 MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
@@ -1021,7 +1034,8 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             CALL {
                 WITH this
                 MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
@@ -1072,7 +1086,8 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             CALL {
                 WITH this
                 MATCH (this)-[:ACTED_IN]->(this0:Movie)
@@ -1150,7 +1165,8 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             CALL {
                 WITH this
                 MATCH (this)-[:ACTED_IN]->(this0:Movie)
@@ -1228,7 +1244,8 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             CALL {
                 WITH this
                 MATCH (this)-[:ACTED_IN]->(this0:Movie)
@@ -1315,7 +1332,8 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             CALL {
                 WITH this
                 MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
@@ -1378,7 +1396,8 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             CALL {
                 WITH this
                 MATCH (this)-[this0:ACTED_IN]->(this1:Movie)

--- a/packages/graphql/tests/tck/issues/2812.test.ts
+++ b/packages/graphql/tests/tck/issues/2812.test.ts
@@ -82,7 +82,8 @@ describe("https://github.com/neo4j/graphql/issues/2812", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Movie)
@@ -192,7 +193,8 @@ describe("https://github.com/neo4j/graphql/issues/2812", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Movie)
@@ -300,7 +302,8 @@ describe("https://github.com/neo4j/graphql/issues/2812", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Movie)

--- a/packages/graphql/tests/tck/issues/2871.test.ts
+++ b/packages/graphql/tests/tck/issues/2871.test.ts
@@ -61,7 +61,8 @@ describe("https://github.com/neo4j/graphql/issues/2871", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:FirstLevel)
+            "CYPHER 5
+            MATCH (this:FirstLevel)
             OPTIONAL MATCH (this)-[:HAS_SECOND_LEVEL]->(this0:SecondLevel)
             WITH *, count(this0) AS var1
             WITH *
@@ -92,7 +93,8 @@ describe("https://github.com/neo4j/graphql/issues/2871", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:FirstLevel)
+            "CYPHER 5
+            MATCH (this:FirstLevel)
             OPTIONAL MATCH (this)-[:HAS_SECOND_LEVEL]->(this0:SecondLevel)
             WITH *, count(this0) AS var1
             WITH *
@@ -126,7 +128,8 @@ describe("https://github.com/neo4j/graphql/issues/2871", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:FirstLevel)
+            "CYPHER 5
+            MATCH (this:FirstLevel)
             OPTIONAL MATCH (this)-[:HAS_SECOND_LEVEL]->(this0:SecondLevel)
             WITH *, count(this0) AS var1
             WITH *

--- a/packages/graphql/tests/tck/issues/288.test.ts
+++ b/packages/graphql/tests/tck/issues/288.test.ts
@@ -57,7 +57,8 @@ describe("#288", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:USER)
@@ -96,7 +97,8 @@ describe("#288", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:USER)
+            "CYPHER 5
+            MATCH (this:USER)
             WHERE this.USERID = $param0
             SET this.COMPANYID = $this_update_COMPANYID_SET
             RETURN collect(DISTINCT this { .USERID, .COMPANYID }) AS data"

--- a/packages/graphql/tests/tck/issues/2925.test.ts
+++ b/packages/graphql/tests/tck/issues/2925.test.ts
@@ -55,7 +55,8 @@ describe("https://github.com/neo4j/graphql/issues/2925", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WHERE single(this0 IN [(this)-[:HAS_GROUP]->(this0:Group) WHERE this0.name IN $param0 | 1] WHERE true)
             RETURN this { .name } AS this"
         `);
@@ -81,7 +82,8 @@ describe("https://github.com/neo4j/graphql/issues/2925", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             OPTIONAL MATCH (this)-[:HAS_REQUIRED_GROUP]->(this0:Group)
             WITH *, count(this0) AS var1
             WITH *
@@ -110,7 +112,8 @@ describe("https://github.com/neo4j/graphql/issues/2925", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Group)
+            "CYPHER 5
+            MATCH (this:Group)
             WHERE EXISTS {
                 MATCH (this)<-[:HAS_GROUP]-(this0:User)
                 WHERE single(this1 IN [(this0)-[:HAS_GROUP]->(this1:Group) WHERE this1.name IN $param0 | 1] WHERE true)
@@ -139,7 +142,8 @@ describe("https://github.com/neo4j/graphql/issues/2925", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Group)
+            "CYPHER 5
+            MATCH (this:Group)
             CALL {
                 WITH this
                 MATCH (this)<-[:HAS_GROUP]-(this0:User)

--- a/packages/graphql/tests/tck/issues/3027.test.ts
+++ b/packages/graphql/tests/tck/issues/3027.test.ts
@@ -84,7 +84,8 @@ describe("https://github.com/neo4j/graphql/issues/3027", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Book)
+                "CYPHER 5
+                MATCH (this:Book)
                 WHERE this.isbn = $param0
                 WITH this
                 WITH *
@@ -186,7 +187,8 @@ describe("https://github.com/neo4j/graphql/issues/3027", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Book)
+                "CYPHER 5
+                MATCH (this:Book)
                 WHERE this.isbn = $param0
                 WITH this
                 CALL {

--- a/packages/graphql/tests/tck/issues/3215.test.ts
+++ b/packages/graphql/tests/tck/issues/3215.test.ts
@@ -50,7 +50,8 @@ describe("https://github.com/neo4j/graphql/issues/3215", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Actor)
+                "CYPHER 5
+                MATCH (this:Actor)
                 WHERE this.age > $param0
                 RETURN this { .name, .age } AS this"
             `);
@@ -78,7 +79,8 @@ describe("https://github.com/neo4j/graphql/issues/3215", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Actor)
+                "CYPHER 5
+                MATCH (this:Actor)
                 WHERE this.age > $param0
                 RETURN this { .name, .age } AS this"
             `);

--- a/packages/graphql/tests/tck/issues/324.test.ts
+++ b/packages/graphql/tests/tck/issues/324.test.ts
@@ -87,7 +87,8 @@ describe("#324", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Person)
+            "CYPHER 5
+            MATCH (this:Person)
             WHERE this.identifier = $param0
             WITH this
             CALL {

--- a/packages/graphql/tests/tck/issues/3251.test.ts
+++ b/packages/graphql/tests/tck/issues/3251.test.ts
@@ -65,7 +65,8 @@ describe("https://github.com/neo4j/graphql/issues/3251", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Movie)
+                "CYPHER 5
+                MATCH (this:Movie)
                 WHERE this.name = $param0
                 SET this.name = $this_update_name_SET
                 WITH *

--- a/packages/graphql/tests/tck/issues/3394.test.ts
+++ b/packages/graphql/tests/tck/issues/3394.test.ts
@@ -55,7 +55,8 @@ describe("https://github.com/neo4j/graphql/issues/3394", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Product)
+            "CYPHER 5
+            MATCH (this:Product)
             WITH *
             ORDER BY this.fg_item DESC
             RETURN this { .description, id: this.fg_item_id, partNumber: this.fg_item } AS this"
@@ -80,7 +81,8 @@ describe("https://github.com/neo4j/graphql/issues/3394", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Employee)
+            "CYPHER 5
+            MATCH (this:Employee)
             CALL {
                 WITH this
                 MATCH (this)-[this0:CAN_ACCESS]->(this1:Product)
@@ -112,7 +114,8 @@ describe("https://github.com/neo4j/graphql/issues/3394", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this0:Product)
+                "CYPHER 5
+                MATCH (this0:Product)
                 WITH collect({ node: this0 }) AS edges
                 WITH edges, size(edges) AS totalCount
                 CALL {
@@ -149,7 +152,8 @@ describe("https://github.com/neo4j/graphql/issues/3394", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Employee)
+                "CYPHER 5
+                MATCH (this:Employee)
                 CALL {
                     WITH this
                     MATCH (this)-[this0:CAN_ACCESS]->(this1:Product)

--- a/packages/graphql/tests/tck/issues/360.test.ts
+++ b/packages/graphql/tests/tck/issues/360.test.ts
@@ -57,7 +57,8 @@ describe("#360", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Event)
+            "CYPHER 5
+            MATCH (this:Event)
             WHERE (this.start >= $param0 AND this.start <= $param1)
             RETURN this { .activity, start: apoc.date.convertFormat(toString(this.start), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\") } AS this"
         `);
@@ -91,7 +92,9 @@ describe("#360", () => {
     test("Should exclude undefined members in OR", async () => {
         const query = /* GraphQL */ `
             query ($rangeStart: DateTime, $rangeEnd: DateTime, $activity: String) {
-                events(where: { OR: [{ start_GTE: $rangeStart }, { start_LTE: $rangeEnd }, { activity_EQ: $activity }] }) {
+                events(
+                    where: { OR: [{ start_GTE: $rangeStart }, { start_LTE: $rangeEnd }, { activity_EQ: $activity }] }
+                ) {
                     start
                     activity
                 }
@@ -103,7 +106,8 @@ describe("#360", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Event)
+            "CYPHER 5
+            MATCH (this:Event)
             WHERE (this.start >= $param0 OR this.start <= $param1)
             RETURN this { .activity, start: apoc.date.convertFormat(toString(this.start), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\") } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/3765.test.ts
+++ b/packages/graphql/tests/tck/issues/3765.test.ts
@@ -59,16 +59,17 @@ describe("https://github.com/neo4j/graphql/issues/3765", () => {
                 const result = await translateQuery(neoSchema, query);
 
                 expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                                    "MATCH (this:Post)
-                                    CALL {
-                                        WITH this
-                                        MATCH (this)<-[this0:LIKES]-(this1:User)
-                                        RETURN (count(this1) > $param0 AND (count(this1) > $param1 AND count(this1) < $param2)) AS var2
-                                    }
-                                    WITH *
-                                    WHERE var2 = true
-                                    RETURN this { .content } AS this"
-                            `);
+                    "CYPHER 5
+                    MATCH (this:Post)
+                    CALL {
+                        WITH this
+                        MATCH (this)<-[this0:LIKES]-(this1:User)
+                        RETURN (count(this1) > $param0 AND (count(this1) > $param1 AND count(this1) < $param2)) AS var2
+                    }
+                    WITH *
+                    WHERE var2 = true
+                    RETURN this { .content } AS this"
+                `);
 
                 expect(formatParams(result.params)).toMatchInlineSnapshot(`
                                     "{
@@ -100,16 +101,17 @@ describe("https://github.com/neo4j/graphql/issues/3765", () => {
                 const result = await translateQuery(neoSchema, query);
 
                 expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                                    "MATCH (this:Post)
-                                    CALL {
-                                        WITH this
-                                        MATCH (this)<-[this0:LIKES]-(this1:User)
-                                        RETURN (count(this1) > $param0 AND (count(this1) < $param1 AND count(this1) > $param2)) AS var2
-                                    }
-                                    WITH *
-                                    WHERE var2 = true
-                                    RETURN this { .content } AS this"
-                            `);
+                    "CYPHER 5
+                    MATCH (this:Post)
+                    CALL {
+                        WITH this
+                        MATCH (this)<-[this0:LIKES]-(this1:User)
+                        RETURN (count(this1) > $param0 AND (count(this1) < $param1 AND count(this1) > $param2)) AS var2
+                    }
+                    WITH *
+                    WHERE var2 = true
+                    RETURN this { .content } AS this"
+                `);
 
                 expect(formatParams(result.params)).toMatchInlineSnapshot(`
                                     "{
@@ -141,16 +143,17 @@ describe("https://github.com/neo4j/graphql/issues/3765", () => {
                 const result = await translateQuery(neoSchema, query);
 
                 expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                                    "MATCH (this:Post)
-                                    CALL {
-                                        WITH this
-                                        MATCH (this)<-[this0:LIKES]-(this1:User)
-                                        RETURN (count(this1) > $param0 AND (count(this1) > $param1 OR count(this1) < $param2)) AS var2
-                                    }
-                                    WITH *
-                                    WHERE var2 = true
-                                    RETURN this { .content } AS this"
-                            `);
+                    "CYPHER 5
+                    MATCH (this:Post)
+                    CALL {
+                        WITH this
+                        MATCH (this)<-[this0:LIKES]-(this1:User)
+                        RETURN (count(this1) > $param0 AND (count(this1) > $param1 OR count(this1) < $param2)) AS var2
+                    }
+                    WITH *
+                    WHERE var2 = true
+                    RETURN this { .content } AS this"
+                `);
 
                 expect(formatParams(result.params)).toMatchInlineSnapshot(`
                                     "{
@@ -189,16 +192,17 @@ describe("https://github.com/neo4j/graphql/issues/3765", () => {
                 const result = await translateQuery(neoSchema, query);
 
                 expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                                    "MATCH (this:Post)
-                                    CALL {
-                                        WITH this
-                                        MATCH (this)<-[this0:LIKES]-(this1:User)
-                                        RETURN (count(this1) > $param0 AND ((count(this1) <= $param1 AND count(this1) > $param2) OR count(this1) < $param3)) AS var2
-                                    }
-                                    WITH *
-                                    WHERE var2 = true
-                                    RETURN this { .content } AS this"
-                            `);
+                    "CYPHER 5
+                    MATCH (this:Post)
+                    CALL {
+                        WITH this
+                        MATCH (this)<-[this0:LIKES]-(this1:User)
+                        RETURN (count(this1) > $param0 AND ((count(this1) <= $param1 AND count(this1) > $param2) OR count(this1) < $param3)) AS var2
+                    }
+                    WITH *
+                    WHERE var2 = true
+                    RETURN this { .content } AS this"
+                `);
 
                 expect(formatParams(result.params)).toMatchInlineSnapshot(`
                                     "{
@@ -241,16 +245,17 @@ describe("https://github.com/neo4j/graphql/issues/3765", () => {
                 const result = await translateQuery(neoSchema, query);
 
                 expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                                    "MATCH (this:Post)
-                                    CALL {
-                                        WITH this
-                                        MATCH (this)<-[this0:LIKES]-(this1:User)
-                                        RETURN (count(this1) > $param0 AND ((count(this1) > $param1 AND count(this1) <= $param2) OR count(this1) < $param3)) AS var2
-                                    }
-                                    WITH *
-                                    WHERE var2 = true
-                                    RETURN this { .content } AS this"
-                            `);
+                    "CYPHER 5
+                    MATCH (this:Post)
+                    CALL {
+                        WITH this
+                        MATCH (this)<-[this0:LIKES]-(this1:User)
+                        RETURN (count(this1) > $param0 AND ((count(this1) > $param1 AND count(this1) <= $param2) OR count(this1) < $param3)) AS var2
+                    }
+                    WITH *
+                    WHERE var2 = true
+                    RETURN this { .content } AS this"
+                `);
 
                 expect(formatParams(result.params)).toMatchInlineSnapshot(`
                                     "{
@@ -295,7 +300,8 @@ describe("https://github.com/neo4j/graphql/issues/3765", () => {
                 const result = await translateQuery(neoSchema, query);
 
                 expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                    "MATCH (this:Post)
+                    "CYPHER 5
+                    MATCH (this:Post)
                     CALL {
                         WITH this
                         MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -343,7 +349,8 @@ describe("https://github.com/neo4j/graphql/issues/3765", () => {
                 const result = await translateQuery(neoSchema, query);
 
                 expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                    "MATCH (this:Post)
+                    "CYPHER 5
+                    MATCH (this:Post)
                     CALL {
                         WITH this
                         MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -391,7 +398,8 @@ describe("https://github.com/neo4j/graphql/issues/3765", () => {
                 const result = await translateQuery(neoSchema, query);
 
                 expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                    "MATCH (this:Post)
+                    "CYPHER 5
+                    MATCH (this:Post)
                     CALL {
                         WITH this
                         MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -444,7 +452,8 @@ describe("https://github.com/neo4j/graphql/issues/3765", () => {
                 const result = await translateQuery(neoSchema, query);
 
                 expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                    "MATCH (this:Post)
+                    "CYPHER 5
+                    MATCH (this:Post)
                     CALL {
                         WITH this
                         MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -503,7 +512,8 @@ describe("https://github.com/neo4j/graphql/issues/3765", () => {
                 const result = await translateQuery(neoSchema, query);
 
                 expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                    "MATCH (this:Post)
+                    "CYPHER 5
+                    MATCH (this:Post)
                     CALL {
                         WITH this
                         MATCH (this)<-[this0:LIKES]-(this1:User)
@@ -560,7 +570,8 @@ describe("https://github.com/neo4j/graphql/issues/3765", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Post)
+                "CYPHER 5
+                MATCH (this:Post)
                 WHERE (this.content = $param0 AND this.alternateContent = $param1)
                 RETURN this { .content } AS this"
             `);
@@ -589,7 +600,8 @@ describe("https://github.com/neo4j/graphql/issues/3765", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Post)
+                "CYPHER 5
+                MATCH (this:Post)
                 WHERE ((this.content = $param0 AND this.alternateContent = $param1) OR this.content = $param2)
                 RETURN this { .content } AS this"
             `);
@@ -615,7 +627,8 @@ describe("https://github.com/neo4j/graphql/issues/3765", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Post)
+                "CYPHER 5
+                MATCH (this:Post)
                 WHERE NOT (this.content = $param0 AND this.alternateContent = $param1)
                 RETURN this { .content } AS this"
             `);
@@ -642,7 +655,8 @@ describe("https://github.com/neo4j/graphql/issues/3765", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Post)
+                "CYPHER 5
+                MATCH (this:Post)
                 WHERE EXISTS {
                     MATCH (this)<-[:LIKES]-(this0:User)
                     WHERE (this0.name = $param0 AND this0.otherName = $param1)
@@ -670,7 +684,8 @@ describe("https://github.com/neo4j/graphql/issues/3765", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Post)
+                "CYPHER 5
+                MATCH (this:Post)
                 WHERE ((EXISTS {
                     MATCH (this)<-[:LIKES]-(this0:User)
                     WHERE this0.otherName = $param0
@@ -712,7 +727,8 @@ describe("https://github.com/neo4j/graphql/issues/3765", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Post)
+                "CYPHER 5
+                MATCH (this:Post)
                 WHERE (EXISTS {
                     MATCH (this)<-[:LIKES]-(this0:User)
                     WHERE this0.name = $param0

--- a/packages/graphql/tests/tck/issues/387.test.ts
+++ b/packages/graphql/tests/tck/issues/387.test.ts
@@ -81,7 +81,8 @@ describe("https://github.com/neo4j/graphql/issues/387", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Place)
+            "CYPHER 5
+            MATCH (this:Place)
             CALL {
                 WITH this
                 CALL {

--- a/packages/graphql/tests/tck/issues/3888.test.ts
+++ b/packages/graphql/tests/tck/issues/3888.test.ts
@@ -54,7 +54,11 @@ describe("https://github.com/neo4j/graphql/issues/3888", () => {
             mutation {
                 createPosts(
                     input: [
-                        { title: "Test1", content: "Test1", author: { connect: { where: { node: { id_EQ: "michel" } } } } }
+                        {
+                            title: "Test1"
+                            content: "Test1"
+                            author: { connect: { where: { node: { id_EQ: "michel" } } } }
+                        }
                     ]
                 ) {
                     posts {
@@ -70,7 +74,8 @@ describe("https://github.com/neo4j/graphql/issues/3888", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
             CREATE (this0:Post)
             SET this0.title = $this0_title
             SET this0.content = $this0_content

--- a/packages/graphql/tests/tck/issues/3901.test.ts
+++ b/packages/graphql/tests/tck/issues/3901.test.ts
@@ -121,7 +121,8 @@ describe("https://github.com/neo4j/graphql/issues/3901", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
             CREATE (this0:Serie)
             SET this0.id = randomUUID()
             SET this0.title = $this0_title

--- a/packages/graphql/tests/tck/issues/3905.test.ts
+++ b/packages/graphql/tests/tck/issues/3905.test.ts
@@ -75,7 +75,8 @@ describe("https://github.com/neo4j/graphql/issues/3905", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 WITH [[{entity_id:1, other_entity_id: 2}],[{entity_id: 2, other_entity_id:3},{entity_id:3, other_entity_id: 4}]] as paths
                 RETURN {paths: paths} as result
             }

--- a/packages/graphql/tests/tck/issues/4001.test.ts
+++ b/packages/graphql/tests/tck/issues/4001.test.ts
@@ -68,7 +68,8 @@ describe("https://github.com/neo4j/graphql/issues/4001", () => {
         const result = await translateQuery(neoSchema, query, {});
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Serie)
+            "CYPHER 5
+            MATCH (this:Serie)
             CALL {
                 WITH this
                 CALL {
@@ -121,7 +122,8 @@ describe("https://github.com/neo4j/graphql/issues/4001", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Serie)
+            "CYPHER 5
+            MATCH (this:Serie)
             CALL {
                 WITH this
                 CALL {
@@ -167,7 +169,8 @@ describe("https://github.com/neo4j/graphql/issues/4001", () => {
         const result = await translateQuery(neoSchema, query, {});
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Serie)
+            "CYPHER 5
+            MATCH (this:Serie)
             CALL {
                 WITH this
                 CALL {

--- a/packages/graphql/tests/tck/issues/4004.test.ts
+++ b/packages/graphql/tests/tck/issues/4004.test.ts
@@ -62,7 +62,8 @@ describe("https://github.com/neo4j/graphql/issues/4004", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Series)
+            "CYPHER 5
+            MATCH (this:Series)
             CALL {
                 WITH this
                 CALL {

--- a/packages/graphql/tests/tck/issues/4007.test.ts
+++ b/packages/graphql/tests/tck/issues/4007.test.ts
@@ -60,7 +60,8 @@ describe("https://github.com/neo4j/graphql/issues/4007", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)

--- a/packages/graphql/tests/tck/issues/4015.test.ts
+++ b/packages/graphql/tests/tck/issues/4015.test.ts
@@ -64,7 +64,8 @@ describe("https://github.com/neo4j/graphql/issues/4015", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)

--- a/packages/graphql/tests/tck/issues/402.test.ts
+++ b/packages/graphql/tests/tck/issues/402.test.ts
@@ -56,7 +56,8 @@ describe("#402", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Event)
+            "CYPHER 5
+            MATCH (this:Event)
             CALL {
                 WITH this
                 MATCH (this)-[this0:HAPPENS_IN]->(this1:Area)

--- a/packages/graphql/tests/tck/issues/4077.test.ts
+++ b/packages/graphql/tests/tck/issues/4077.test.ts
@@ -112,7 +112,8 @@ describe("https://github.com/neo4j/graphql/issues/4077", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:PreviewClip)
+            "CYPHER 5
+            MATCH (this:PreviewClip)
             OPTIONAL MATCH (this)<-[:VIDEO_HAS_PREVIEW_CLIP]-(this0:Video)
             WITH *, count(this0) AS var1
             CALL {
@@ -159,7 +160,8 @@ describe("https://github.com/neo4j/graphql/issues/4077", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Video)
+            "CYPHER 5
+            MATCH (this:Video)
             OPTIONAL MATCH (this)<-[:PUBLISHER]-(this0:User)
             WITH *, count(this0) AS var1
             WITH *

--- a/packages/graphql/tests/tck/issues/4095.test.ts
+++ b/packages/graphql/tests/tck/issues/4095.test.ts
@@ -71,7 +71,8 @@ describe("https://github.com/neo4j/graphql/issues/4095", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Family)
+            "CYPHER 5
+            MATCH (this:Family)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:MEMBER_OF]-(this1:Person)

--- a/packages/graphql/tests/tck/issues/4110.test.ts
+++ b/packages/graphql/tests/tck/issues/4110.test.ts
@@ -68,7 +68,8 @@ describe("https://github.com/neo4j/graphql/issues/4110", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Company)
+            "CYPHER 5
+            MATCH (this:Company)
             CALL {
                 WITH this
                 MATCH (this)-[:CONNECT_TO]->(this0:InBetween)

--- a/packages/graphql/tests/tck/issues/4115.test.ts
+++ b/packages/graphql/tests/tck/issues/4115.test.ts
@@ -90,7 +90,8 @@ describe("https://github.com/neo4j/graphql/issues/4115", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Family)
+            "CYPHER 5
+            MATCH (this:Family)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:MEMBER_OF]-(this1:Person)

--- a/packages/graphql/tests/tck/issues/4116.test.ts
+++ b/packages/graphql/tests/tck/issues/4116.test.ts
@@ -81,7 +81,8 @@ describe("https://github.com/neo4j/graphql/issues/4115", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Family)
+            "CYPHER 5
+            MATCH (this:Family)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:MEMBER_OF]-(this1:Person)

--- a/packages/graphql/tests/tck/issues/4118.test.ts
+++ b/packages/graphql/tests/tck/issues/4118.test.ts
@@ -130,7 +130,8 @@ describe("https://github.com/neo4j/graphql/issues/2871", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
             CREATE (this0:LOL)
             WITH *
             CALL {

--- a/packages/graphql/tests/tck/issues/4170.test.ts
+++ b/packages/graphql/tests/tck/issues/4170.test.ts
@@ -134,7 +134,8 @@ describe("https://github.com/neo4j/graphql/issues/4170", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
             CREATE (this0:Tenant)
             SET this0.id = randomUUID()
             WITH *

--- a/packages/graphql/tests/tck/issues/4214.test.ts
+++ b/packages/graphql/tests/tck/issues/4214.test.ts
@@ -158,7 +158,8 @@ describe("https://github.com/neo4j/graphql/issues/4214", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
             CREATE (this0:TransactionItem)
             SET this0.name = $this0_name
             SET this0.price = $this0_price

--- a/packages/graphql/tests/tck/issues/4223.test.ts
+++ b/packages/graphql/tests/tck/issues/4223.test.ts
@@ -152,7 +152,8 @@ describe("https://github.com/neo4j/graphql/issues/4223", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
             CREATE (this0:Tenant)
             SET this0.id = randomUUID()
             WITH *

--- a/packages/graphql/tests/tck/issues/4239.test.ts
+++ b/packages/graphql/tests/tck/issues/4239.test.ts
@@ -80,7 +80,8 @@ describe("https://github.com/neo4j/graphql/issues/4239", () => {
         const result = await translateQuery(neoSchema, query, { token, neo4jVersion: "4.4" });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WITH *
             WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND size([(this)<-[this1:DIRECTED]-(this0:Person) WHERE ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub) | 1]) > 0), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this { .title } AS this"
@@ -135,7 +136,8 @@ describe("https://github.com/neo4j/graphql/issues/4239", () => {
         const result = await translateQuery(neoSchema, query, { token, neo4jVersion: "4.4" });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WITH *
             WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND size([(this)<-[:DIRECTED]-(this0:Person) WHERE ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub) | 1]) > 0), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this { .title } AS this"
@@ -195,7 +197,8 @@ describe("https://github.com/neo4j/graphql/issues/4239", () => {
         const result = await translateQuery(neoSchema, query, { token, neo4jVersion: "5.0" });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WITH *
             WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND EXISTS {
                 MATCH (this)<-[this0:DIRECTED]-(this1:Person)

--- a/packages/graphql/tests/tck/issues/4268.test.ts
+++ b/packages/graphql/tests/tck/issues/4268.test.ts
@@ -55,7 +55,8 @@ describe("https://github.com/neo4j/graphql/issues/4268", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WITH *
             WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (($jwt.roles IS NOT NULL AND $jwt.roles = $param2) OR ($jwt.roles IS NOT NULL AND $jwt.roles = $param3))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this { .title } AS this"
@@ -125,7 +126,8 @@ describe("https://github.com/neo4j/graphql/issues/4268", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WITH *
             WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ((($jwt.roles IS NOT NULL AND $jwt.roles = $param2) OR ($jwt.roles IS NOT NULL AND $jwt.roles = $param3)) OR (($jwt.roles IS NOT NULL AND $jwt.roles = $param4) OR ($jwt.roles IS NOT NULL AND $jwt.roles = $param5)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this { .title } AS this"
@@ -161,7 +163,10 @@ describe("https://github.com/neo4j/graphql/issues/4268", () => {
                 @node
                 @authorization(
                     validate: [
-                        { when: [BEFORE], where: { jwt: { AND: [{ roles_EQ: "admin" }, { roles_EQ: "super-admin" }] } } }
+                        {
+                            when: [BEFORE]
+                            where: { jwt: { AND: [{ roles_EQ: "admin" }, { roles_EQ: "super-admin" }] } }
+                        }
                     ]
                 ) {
                 title: String
@@ -187,7 +192,8 @@ describe("https://github.com/neo4j/graphql/issues/4268", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WITH *
             WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (($jwt.roles IS NOT NULL AND $jwt.roles = $param2) AND ($jwt.roles IS NOT NULL AND $jwt.roles = $param3))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this { .title } AS this"
@@ -257,7 +263,8 @@ describe("https://github.com/neo4j/graphql/issues/4268", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WITH *
             WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ((($jwt.roles IS NOT NULL AND $jwt.roles = $param2) AND ($jwt.roles IS NOT NULL AND $jwt.roles = $param3)) AND (($jwt.roles IS NOT NULL AND $jwt.roles = $param4) AND ($jwt.roles IS NOT NULL AND $jwt.roles = $param5)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this { .title } AS this"
@@ -315,7 +322,8 @@ describe("https://github.com/neo4j/graphql/issues/4268", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WITH *
             WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND NOT ($jwt.roles IS NOT NULL AND $jwt.roles = $param2)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this { .title } AS this"
@@ -346,7 +354,9 @@ describe("https://github.com/neo4j/graphql/issues/4268", () => {
 
             type Movie
                 @node
-                @authorization(validate: [{ when: [BEFORE], where: { jwt: { NOT: { NOT: { roles_EQ: "admin" } } } } }]) {
+                @authorization(
+                    validate: [{ when: [BEFORE], where: { jwt: { NOT: { NOT: { roles_EQ: "admin" } } } } }]
+                ) {
                 title: String
                 director: [Person!]! @relationship(type: "DIRECTED", direction: IN)
             }
@@ -370,7 +380,8 @@ describe("https://github.com/neo4j/graphql/issues/4268", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WITH *
             WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND NOT (NOT ($jwt.roles IS NOT NULL AND $jwt.roles = $param2))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this { .title } AS this"

--- a/packages/graphql/tests/tck/issues/4287.test.ts
+++ b/packages/graphql/tests/tck/issues/4287.test.ts
@@ -65,7 +65,8 @@ describe("https://github.com/neo4j/graphql/issues/4287", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             CALL {
                 WITH this
                 CALL {

--- a/packages/graphql/tests/tck/issues/4292.test.ts
+++ b/packages/graphql/tests/tck/issues/4292.test.ts
@@ -182,7 +182,8 @@ describe("https://github.com/neo4j/graphql/issues/4292", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Group)
+            "CYPHER 5
+            MATCH (this:Group)
             WHERE this.id = $param0
             CALL {
                 WITH this

--- a/packages/graphql/tests/tck/issues/433.test.ts
+++ b/packages/graphql/tests/tck/issues/433.test.ts
@@ -61,7 +61,8 @@ describe("#413", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)-[this0:ACTED_IN]->(this1:Person)

--- a/packages/graphql/tests/tck/issues/4405.test.ts
+++ b/packages/graphql/tests/tck/issues/4405.test.ts
@@ -58,7 +58,8 @@ describe("https://github.com/neo4j/graphql/issues/4405", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             WITH *
             WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND size([(this)-[this1:ACTED_IN]->(this0:Movie) WHERE ($param1 IS NOT NULL AND this0.title IN $param1) | 1]) > 0), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this { .name } AS this"
@@ -118,7 +119,8 @@ describe("https://github.com/neo4j/graphql/issues/4405", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             WITH *
             WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND size([(this)-[this1:ACTED_IN]->(this0:Movie) WHERE (($param1 IS NOT NULL AND this0.title IN $param1) OR ($param2 IS NOT NULL AND this0.title IN $param2)) | 1]) > 0), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this { .name } AS this"

--- a/packages/graphql/tests/tck/issues/4429.test.ts
+++ b/packages/graphql/tests/tck/issues/4429.test.ts
@@ -158,7 +158,8 @@ describe("https://github.com/neo4j/graphql/issues/4429", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
             CREATE (this0:Tenant)
             SET this0.id = randomUUID()
             WITH *

--- a/packages/graphql/tests/tck/issues/4432.test.ts
+++ b/packages/graphql/tests/tck/issues/4432.test.ts
@@ -69,7 +69,8 @@ describe("https://github.com/neo4j/graphql/issues/4532", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Inventory)
+            "CYPHER 5
+            MATCH (this:Inventory)
             CALL {
                 WITH this
                 CALL {

--- a/packages/graphql/tests/tck/issues/4450.test.ts
+++ b/packages/graphql/tests/tck/issues/4450.test.ts
@@ -59,7 +59,8 @@ describe("https://github.com/neo4j/graphql/issues/4450", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             CALL {
                 WITH this
                 MATCH (this)-[this0:IN_SCENE]->(this1:Scene)

--- a/packages/graphql/tests/tck/issues/4477.test.ts
+++ b/packages/graphql/tests/tck/issues/4477.test.ts
@@ -55,7 +55,8 @@ describe("https://github.com/neo4j/graphql/issues/4477", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Brand)
+            "CYPHER 5
+            MATCH (this:Brand)
             CALL {
                 WITH this
                 MATCH (this)-[this0:HAS_SERVICE]->(this1:Service)

--- a/packages/graphql/tests/tck/issues/4583.test.ts
+++ b/packages/graphql/tests/tck/issues/4583.test.ts
@@ -88,7 +88,8 @@ describe("https://github.com/neo4j/graphql/issues/4583", () => {
         const result = await translateQuery(neoSchema, mutation);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
             CREATE (this0:Actor)
             SET this0.name = $this0_name
             WITH *
@@ -181,7 +182,8 @@ describe("https://github.com/neo4j/graphql/issues/4583", () => {
         const result = await translateQuery(neoSchema, mutation);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
             CREATE (this0:Actor)
             SET this0.name = $this0_name
             WITH *
@@ -280,7 +282,8 @@ describe("https://github.com/neo4j/graphql/issues/4583", () => {
         const result = await translateQuery(neoSchema, mutation);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
             CREATE (this0:Actor)
             SET this0.name = $this0_name
             WITH *

--- a/packages/graphql/tests/tck/issues/4667.test.ts
+++ b/packages/graphql/tests/tck/issues/4667.test.ts
@@ -47,7 +47,8 @@ describe("https://github.com/neo4j/graphql/issues/4667", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:MyThing)
+            "CYPHER 5
+            MATCH (this:MyThing)
             WHERE NOT (EXISTS {
                 MATCH (this)-[:THE_STUFF]->(this0:MyStuff)
             })

--- a/packages/graphql/tests/tck/issues/4704.test.ts
+++ b/packages/graphql/tests/tck/issues/4704.test.ts
@@ -82,7 +82,8 @@ describe("https://github.com/neo4j/graphql/issues/4704", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             WHERE ((EXISTS {
                 MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
                 WHERE (EXISTS {
@@ -167,7 +168,8 @@ describe("https://github.com/neo4j/graphql/issues/4704", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             WHERE (single(this1 IN [(this)-[this3:ACTED_IN]->(this1:Movie) WHERE single(this0 IN [(this1)<-[this2:ACTED_IN]-(this0:Actor) WHERE this0.name = $param0 | 1] WHERE true) | 1] WHERE true) XOR single(this5 IN [(this)-[this7:ACTED_IN]->(this5:Series) WHERE single(this4 IN [(this5)<-[this6:STARRED_IN]-(this4:Actor) WHERE this4.name = $param1 | 1] WHERE true) | 1] WHERE true))
             CALL {
                 WITH this
@@ -201,7 +203,9 @@ describe("https://github.com/neo4j/graphql/issues/4704", () => {
             {
                 actors(
                     where: {
-                        actedInConnection_NONE: { node: { actorsConnection_NONE: { node: { name_EQ: "Keanu Reeves" } } } }
+                        actedInConnection_NONE: {
+                            node: { actorsConnection_NONE: { node: { name_EQ: "Keanu Reeves" } } }
+                        }
                     }
                 ) {
                     actedIn {
@@ -214,7 +218,8 @@ describe("https://github.com/neo4j/graphql/issues/4704", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             WHERE (NOT (EXISTS {
                 MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
                 WHERE NOT (EXISTS {

--- a/packages/graphql/tests/tck/issues/4741.test.ts
+++ b/packages/graphql/tests/tck/issues/4741.test.ts
@@ -61,7 +61,8 @@ describe("https://github.com/neo4j/graphql/issues/4741", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this0:Opportunity)
+            "CYPHER 5
+            MATCH (this0:Opportunity)
             CALL {
                 WITH this0
                 MATCH (this0)-[this1:HAS_LIST]->(this2:ListOli)

--- a/packages/graphql/tests/tck/issues/4814.test.ts
+++ b/packages/graphql/tests/tck/issues/4814.test.ts
@@ -71,7 +71,8 @@ describe("https://github.com/neo4j/graphql/issues/4814", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this0:AStep)
                 WHERE this0.id = $param0
                 CALL {
@@ -148,7 +149,8 @@ describe("https://github.com/neo4j/graphql/issues/4814", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this0:AStep)
                 WHERE this0.id = $param0
                 CALL {
@@ -221,7 +223,8 @@ describe("https://github.com/neo4j/graphql/issues/4814", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this0:AStep)
                 WHERE this0.id = $param0
                 CALL {
@@ -292,7 +295,8 @@ describe("https://github.com/neo4j/graphql/issues/4814", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (this0:AStep)
                 WHERE this0.id = $param0
                 CALL {

--- a/packages/graphql/tests/tck/issues/4831.test.ts
+++ b/packages/graphql/tests/tck/issues/4831.test.ts
@@ -51,7 +51,8 @@ describe("https://github.com/neo4j/graphql/issues/4831", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Test)
+                "CYPHER 5
+                MATCH (this:Test)
                 CALL {
                     WITH this
                     CALL {
@@ -84,7 +85,8 @@ describe("https://github.com/neo4j/graphql/issues/4831", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Test)
+                "CYPHER 5
+                MATCH (this:Test)
                 CALL {
                     WITH this
                     CALL {
@@ -117,7 +119,8 @@ describe("https://github.com/neo4j/graphql/issues/4831", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Test)
+                "CYPHER 5
+                MATCH (this:Test)
                 CALL {
                     WITH this
                     CALL {
@@ -146,7 +149,8 @@ describe("https://github.com/neo4j/graphql/issues/4831", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Test)
+                "CYPHER 5
+                MATCH (this:Test)
                 CALL {
                     WITH this
                     CALL {
@@ -177,7 +181,8 @@ describe("https://github.com/neo4j/graphql/issues/4831", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Test)
+                "CYPHER 5
+                MATCH (this:Test)
                 CALL {
                     WITH this
                     CALL {
@@ -210,7 +215,8 @@ describe("https://github.com/neo4j/graphql/issues/4831", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Test)
+                "CYPHER 5
+                MATCH (this:Test)
                 CALL {
                     WITH this
                     CALL {
@@ -243,7 +249,8 @@ describe("https://github.com/neo4j/graphql/issues/4831", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Test)
+                "CYPHER 5
+                MATCH (this:Test)
                 CALL {
                     WITH this
                     CALL {
@@ -272,7 +279,8 @@ describe("https://github.com/neo4j/graphql/issues/4831", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Test)
+                "CYPHER 5
+                MATCH (this:Test)
                 CALL {
                     WITH this
                     CALL {

--- a/packages/graphql/tests/tck/issues/4838.test.ts
+++ b/packages/graphql/tests/tck/issues/4838.test.ts
@@ -55,7 +55,8 @@ describe("https://github.com/neo4j/graphql/issues/4838", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Test)
@@ -99,7 +100,8 @@ describe("https://github.com/neo4j/graphql/issues/4838", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:ParentTest)

--- a/packages/graphql/tests/tck/issues/487.test.ts
+++ b/packages/graphql/tests/tck/issues/487.test.ts
@@ -86,7 +86,8 @@ describe("https://github.com/neo4j/graphql/issues/487", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (node)
                 WHERE
                     \\"Book\\" IN labels(node) OR
@@ -195,7 +196,8 @@ describe("https://github.com/neo4j/graphql/issues/487", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (node)
                 WHERE
                     \\"Book\\" IN labels(node) OR

--- a/packages/graphql/tests/tck/issues/488.test.ts
+++ b/packages/graphql/tests/tck/issues/488.test.ts
@@ -72,7 +72,8 @@ describe("https://github.com/neo4j/graphql/issues/488", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Journalist)
+            "CYPHER 5
+            MATCH (this:Journalist)
             WHERE EXISTS {
                 MATCH (this)-[this0:HAS_KEYWORD]->(this1:Emoji)
                 WHERE this1.type = $param0
@@ -126,7 +127,8 @@ describe("https://github.com/neo4j/graphql/issues/488", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Journalist)
+            "CYPHER 5
+            MATCH (this:Journalist)
             WHERE NOT (EXISTS {
                 MATCH (this)-[this0:HAS_KEYWORD]->(this1:Emoji)
                 WHERE this1.type = $param0

--- a/packages/graphql/tests/tck/issues/5023.test.ts
+++ b/packages/graphql/tests/tck/issues/5023.test.ts
@@ -115,7 +115,8 @@ describe("https://github.com/neo4j/graphql/issues/5023", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Tenant)
+            "CYPHER 5
+            MATCH (this:Tenant)
             WITH *
             WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND size([(this)<-[:ADMIN_IN]-(this0:User) WHERE ($jwt.id IS NOT NULL AND this0.userId = $jwt.id) | 1]) > 0), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this

--- a/packages/graphql/tests/tck/issues/5030.test.ts
+++ b/packages/graphql/tests/tck/issues/5030.test.ts
@@ -60,7 +60,8 @@ describe("https://github.com/neo4j/graphql/issues/5030", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (m:Movie) RETURN m as this
             }
             WITH this AS this0

--- a/packages/graphql/tests/tck/issues/505.test.ts
+++ b/packages/graphql/tests/tck/issues/505.test.ts
@@ -118,7 +118,8 @@ describe("https://github.com/neo4j/graphql/issues/505", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WHERE this.id = $param0
             CALL {
                 WITH this
@@ -160,7 +161,8 @@ describe("https://github.com/neo4j/graphql/issues/505", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Workspace)
+            "CYPHER 5
+            MATCH (this:Workspace)
             WITH *
             WHERE (this.id = $param0 AND ($isAuthenticated = true AND (size([(this)<-[:MEMBER_OF]-(this0:User) WHERE ($jwt.sub IS NOT NULL AND this0.authId = $jwt.sub) | 1]) > 0 OR size([(this)-[:HAS_ADMIN]->(this1:User) WHERE ($jwt.sub IS NOT NULL AND this1.authId = $jwt.sub) | 1]) > 0)))
             CALL {
@@ -200,7 +202,8 @@ describe("https://github.com/neo4j/graphql/issues/505", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Page)
+            "CYPHER 5
+            MATCH (this:Page)
             OPTIONAL MATCH (this)<-[:HAS_PAGE]-(this0:Workspace)
             WITH *, count(this0) AS var1
             OPTIONAL MATCH (this)<-[:CREATED_PAGE]-(this2:User)
@@ -234,7 +237,8 @@ describe("https://github.com/neo4j/graphql/issues/505", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Page)
+            "CYPHER 5
+            MATCH (this:Page)
             OPTIONAL MATCH (this)<-[:CREATED_PAGE]-(this0:User)
             WITH *, count(this0) AS var1
             OPTIONAL MATCH (this)<-[:HAS_PAGE]-(this2:Workspace)

--- a/packages/graphql/tests/tck/issues/5066.test.ts
+++ b/packages/graphql/tests/tck/issues/5066.test.ts
@@ -124,7 +124,8 @@ describe("https://github.com/neo4j/graphql/issues/5066", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Party)
+            "CYPHER 5
+            MATCH (this:Party)
             CALL {
                 WITH this
                 MATCH (this)<-[this0:CREATED_PARTY]-(this1:AdminGroup)

--- a/packages/graphql/tests/tck/issues/5080.test.ts
+++ b/packages/graphql/tests/tck/issues/5080.test.ts
@@ -117,7 +117,8 @@ describe("https://github.com/neo4j/graphql/issues/5080", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH(s:Car)
                 WHERE (s.id = $param0.carId)
                 REMOVE s:Car

--- a/packages/graphql/tests/tck/issues/5143.test.ts
+++ b/packages/graphql/tests/tck/issues/5143.test.ts
@@ -78,7 +78,8 @@ describe("https://github.com/neo4j/graphql/issues/5143", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MATCH (video:Video)
                 RETURN video
                 LIMIT 1

--- a/packages/graphql/tests/tck/issues/5270.test.ts
+++ b/packages/graphql/tests/tck/issues/5270.test.ts
@@ -85,7 +85,8 @@ describe("https://github.com/neo4j/graphql/issues/5270", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 OPTIONAL MATCH (u:User {id: $jwt.sub}) RETURN u
             }
             WITH u AS this0

--- a/packages/graphql/tests/tck/issues/5467.test.ts
+++ b/packages/graphql/tests/tck/issues/5467.test.ts
@@ -66,7 +66,8 @@ describe("https://github.com/neo4j/graphql/issues/5467", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
                 MERGE (t:Test {name: $param0}) SET t.groups = $param1
                 return t
             }

--- a/packages/graphql/tests/tck/issues/5497.test.ts
+++ b/packages/graphql/tests/tck/issues/5497.test.ts
@@ -96,7 +96,8 @@ describe("https://github.com/neo4j/graphql/issues/5497", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:File)
+            "CYPHER 5
+            MATCH (this:File)
             WHERE this.id = $param0
             WITH this
             CALL {

--- a/packages/graphql/tests/tck/issues/5515.test.ts
+++ b/packages/graphql/tests/tck/issues/5515.test.ts
@@ -82,7 +82,8 @@ describe("https://github.com/neo4j/graphql/issues/5515", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Category)
+            "CYPHER 5
+            MATCH (this:Category)
             CALL {
                 WITH this
                 MATCH (this)<-[:HAS_CATEGORY]-(this0:Cabinet)

--- a/packages/graphql/tests/tck/issues/5599.test.ts
+++ b/packages/graphql/tests/tck/issues/5599.test.ts
@@ -65,7 +65,8 @@ describe("https://github.com/neo4j/graphql/issues/5599", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WITH *
             CALL {
             WITH *
@@ -131,7 +132,8 @@ describe("https://github.com/neo4j/graphql/issues/5599", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WITH *
             CALL {
             WITH *

--- a/packages/graphql/tests/tck/issues/5635.test.ts
+++ b/packages/graphql/tests/tck/issues/5635.test.ts
@@ -76,7 +76,8 @@ describe("https://github.com/neo4j/graphql/issues/5635", () => {
         const result = await translateQuery(neoSchema, mutation);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
             CREATE (this0:MyNode)
             SET this0.id = randomUUID()
             SET this0.name = $this0_name

--- a/packages/graphql/tests/tck/issues/582.test.ts
+++ b/packages/graphql/tests/tck/issues/582.test.ts
@@ -70,7 +70,8 @@ describe("#582", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Entity)
+            "CYPHER 5
+            MATCH (this:Entity)
             WHERE (this.type = $param0 AND EXISTS {
                 MATCH (this)-[this0:EDGE]->(this1:Entity)
                 WHERE (this1.type = $param1 AND EXISTS {
@@ -123,7 +124,8 @@ describe("#582", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Entity)
+            "CYPHER 5
+            MATCH (this:Entity)
             WHERE (this.type = $param0 AND EXISTS {
                 MATCH (this)-[this0:EDGE]->(this1:Entity)
                 WHERE (this1.type = $param1 AND EXISTS {

--- a/packages/graphql/tests/tck/issues/583.test.ts
+++ b/packages/graphql/tests/tck/issues/583.test.ts
@@ -79,7 +79,8 @@ describe("https://github.com/neo4j/graphql/issues/583", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             CALL {
                 WITH this
                 CALL {

--- a/packages/graphql/tests/tck/issues/5887.test.ts
+++ b/packages/graphql/tests/tck/issues/5887.test.ts
@@ -65,7 +65,8 @@ describe("https://github.com/neo4j/graphql/issues/5887", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Test)
+            "CYPHER 5
+            MATCH (this:Test)
             OPTIONAL MATCH (this)-[:HAS]->(this0:A)
             WITH *, count(this0) AS var1
             OPTIONAL MATCH (this)-[:HAS]->(this2:B)
@@ -113,7 +114,8 @@ describe("https://github.com/neo4j/graphql/issues/5887", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Test)
+            "CYPHER 5
+            MATCH (this:Test)
             OPTIONAL MATCH (this)-[:HAS]->(this0:A)
             WITH *, count(this0) AS var1
             OPTIONAL MATCH (this)-[:HAS]->(this2:B)
@@ -161,7 +163,8 @@ describe("https://github.com/neo4j/graphql/issues/5887", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Test)
+            "CYPHER 5
+            MATCH (this:Test)
             OPTIONAL MATCH (this)-[:HAS]->(this0:A)
             WITH *, count(this0) AS var1
             OPTIONAL MATCH (this)-[:HAS]->(this2:B)

--- a/packages/graphql/tests/tck/issues/601.test.ts
+++ b/packages/graphql/tests/tck/issues/601.test.ts
@@ -93,7 +93,8 @@ describe("#601", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Stakeholder)
+            "CYPHER 5
+            MATCH (this:Stakeholder)
             WITH *
             WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {

--- a/packages/graphql/tests/tck/issues/630.test.ts
+++ b/packages/graphql/tests/tck/issues/630.test.ts
@@ -66,7 +66,8 @@ describe("Cypher directive", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             CALL {
                 WITH this
                 CALL {

--- a/packages/graphql/tests/tck/issues/832.test.ts
+++ b/packages/graphql/tests/tck/issues/832.test.ts
@@ -83,7 +83,8 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
             CREATE (this0:Interaction)
             SET this0.id = randomUUID()
             SET this0.kind = $this0_kind
@@ -308,7 +309,8 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
             CREATE (this0:Interaction)
             SET this0.id = randomUUID()
             SET this0.kind = $this0_kind
@@ -438,7 +440,8 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
             CREATE (this0:Interaction)
             SET this0.id = randomUUID()
             SET this0.kind = $this0_kind
@@ -579,7 +582,8 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
             CREATE (this0:Interaction)
             SET this0.id = randomUUID()
             SET this0.kind = $this0_kind
@@ -865,7 +869,8 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
             CREATE (this0:Interaction)
             SET this0.id = randomUUID()
             SET this0.kind = $this0_kind

--- a/packages/graphql/tests/tck/issues/847.test.ts
+++ b/packages/graphql/tests/tck/issues/847.test.ts
@@ -66,7 +66,8 @@ describe("https://github.com/neo4j/graphql/issues/847", () => {
         const result = await translateQuery(neoSchema, query, {});
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Interaction)
+            "CYPHER 5
+            MATCH (this:Interaction)
             CALL {
                 WITH this
                 CALL {

--- a/packages/graphql/tests/tck/issues/894.test.ts
+++ b/packages/graphql/tests/tck/issues/894.test.ts
@@ -65,7 +65,8 @@ describe("https://github.com/neo4j/graphql/issues/894", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             WHERE this.name = $param0
             WITH this
             CALL {

--- a/packages/graphql/tests/tck/issues/901.test.ts
+++ b/packages/graphql/tests/tck/issues/901.test.ts
@@ -88,7 +88,8 @@ describe("https://github.com/neo4j/graphql/issues/901", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Series)
+            "CYPHER 5
+            MATCH (this:Series)
             WHERE (single(this0 IN [(this)-[this1:HAS_MANUFACTURER]->(this0:Series) WHERE (this0.name = $param0 AND this1.current = $param1) | 1] WHERE true) OR single(this2 IN [(this)-[this3:HAS_BRAND]->(this2:Series) WHERE (this2.name = $param2 AND this3.current = $param3) | 1] WHERE true))
             CALL {
                 WITH this

--- a/packages/graphql/tests/tck/issues/988.test.ts
+++ b/packages/graphql/tests/tck/issues/988.test.ts
@@ -133,7 +133,8 @@ describe("https://github.com/neo4j/graphql/issues/988", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Series)
+            "CYPHER 5
+            MATCH (this:Series)
             WHERE (this.current = $param0 AND ((EXISTS {
                 MATCH (this)-[this0:MANUFACTURER]->(this1:Manufacturer)
                 WHERE (this1.name = $param1 AND this0.current = $param2)

--- a/packages/graphql/tests/tck/issues/context-variable-not-always-resolved-on-cypher-queries.test.ts
+++ b/packages/graphql/tests/tck/issues/context-variable-not-always-resolved-on-cypher-queries.test.ts
@@ -90,7 +90,8 @@ describe("context-variable-not-always-resolved-on-cypher-queries", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Exprlabel:test:Resource)
+            "CYPHER 5
+            MATCH (this:Exprlabel:test:Resource)
             WHERE single(this0 IN [(this)-[:realizationOf]->(this0:WorkLabel:test:Resource) WHERE EXISTS {
                 MATCH (this0)-[:hasResourceType]->(this1:ResourceType)
                 WHERE this1.uri = $param0
@@ -140,7 +141,8 @@ describe("context-variable-not-always-resolved-on-cypher-queries", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Exprlabel:test:Resource)
+            "CYPHER 5
+            MATCH (this:Exprlabel:test:Resource)
             WHERE single(this0 IN [(this)-[:realizationOf]->(this0:WorkLabel:test:Resource) WHERE EXISTS {
                 MATCH (this0)-[:hasResourceType]->(this1:ResourceType)
                 WHERE this1.uri = $param0
@@ -206,7 +208,8 @@ describe("context-variable-not-always-resolved-on-cypher-queries", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Exprlabel:test:Resource)
+            "CYPHER 5
+            MATCH (this:Exprlabel:test:Resource)
             WHERE single(this0 IN [(this)-[:realizationOf]->(this0:WorkLabel:test:Resource) WHERE EXISTS {
                 MATCH (this0)-[:hasResourceType]->(this1:ResourceType)
                 WHERE this1.uri = $param0

--- a/packages/graphql/tests/tck/issues/missing-custom-cypher-on-unions.test.ts
+++ b/packages/graphql/tests/tck/issues/missing-custom-cypher-on-unions.test.ts
@@ -149,7 +149,8 @@ describe("Missing custom Cypher on unions", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:HierarchicalComponent:Resource)
+            "CYPHER 5
+            MATCH (this:HierarchicalComponent:Resource)
             OPTIONAL MATCH (this)-[:isContained]->(this0:HierarchicalRoot:Resource)
             WITH *, count(this0) AS var1
             WITH *

--- a/packages/graphql/tests/tck/math.test.ts
+++ b/packages/graphql/tests/tck/math.test.ts
@@ -74,7 +74,8 @@ describe("Math operators", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WITH this
             CALL {
             WITH this
@@ -111,7 +112,8 @@ describe("Math operators", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WITH this
             CALL {
             WITH this
@@ -147,7 +149,8 @@ describe("Math operators", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             WITH this
             CALL {
             	WITH this
@@ -206,7 +209,8 @@ describe("Math operators", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             WITH this
             CALL {
             	WITH this
@@ -282,7 +286,8 @@ describe("Math operators", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             WITH this
             CALL {
             	 WITH this

--- a/packages/graphql/tests/tck/nested-unions.test.ts
+++ b/packages/graphql/tests/tck/nested-unions.test.ts
@@ -92,7 +92,8 @@ describe("Nested Unions", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title = $param0
             WITH *
             CALL {
@@ -211,7 +212,8 @@ describe("Nested Unions", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title = $param0
             WITH this
             CALL {

--- a/packages/graphql/tests/tck/null.test.ts
+++ b/packages/graphql/tests/tck/null.test.ts
@@ -56,7 +56,8 @@ describe("Cypher NULL", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title IS NULL
             RETURN this { .title } AS this"
         `);
@@ -76,7 +77,8 @@ describe("Cypher NULL", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE NOT (this.title IS NULL)
             RETURN this { .title } AS this"
         `);
@@ -96,7 +98,8 @@ describe("Cypher NULL", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE NOT (EXISTS {
                 MATCH (this)<-[:ACTED_IN]-(this0:Actor)
             })
@@ -118,7 +121,8 @@ describe("Cypher NULL", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE NOT (NOT (EXISTS {
                 MATCH (this)<-[:ACTED_IN]-(this0:Actor)
             }))

--- a/packages/graphql/tests/tck/operations/batch/batch-create-auth.test.ts
+++ b/packages/graphql/tests/tck/operations/batch/batch-create-auth.test.ts
@@ -80,7 +80,8 @@ describe("Batch Create, Auth", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Movie)
@@ -144,7 +145,8 @@ describe("Batch Create, Auth", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Movie)
@@ -280,7 +282,8 @@ describe("Batch Create, Auth", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
             CREATE (this0:Movie)
             SET this0.id = $this0_id
             WITH *

--- a/packages/graphql/tests/tck/operations/batch/batch-create-fields.test.ts
+++ b/packages/graphql/tests/tck/operations/batch/batch-create-fields.test.ts
@@ -77,7 +77,8 @@ describe("Batch Create, Scalar types", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Movie)
@@ -161,7 +162,8 @@ describe("Batch Create, Scalar types", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Movie)
@@ -288,7 +290,8 @@ describe("Batch Create, Scalar types", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Movie)
@@ -416,7 +419,8 @@ describe("Batch Create, Scalar types", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
             CREATE (this0:Movie)
             SET this0.createdAt = datetime()
             SET this0.id = $this0_id

--- a/packages/graphql/tests/tck/operations/batch/batch-create-interface.test.ts
+++ b/packages/graphql/tests/tck/operations/batch/batch-create-interface.test.ts
@@ -79,7 +79,8 @@ describe("Batch Create, Interface", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Movie)
@@ -144,7 +145,8 @@ describe("Batch Create, Interface", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
             CREATE (this0:Movie)
             SET this0.id = $this0_id
             WITH *
@@ -299,7 +301,8 @@ describe("Batch Create, Interface", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
             CREATE (this0:Movie)
             SET this0.id = $this0_id
             WITH *

--- a/packages/graphql/tests/tck/operations/batch/batch-create.test.ts
+++ b/packages/graphql/tests/tck/operations/batch/batch-create.test.ts
@@ -67,7 +67,8 @@ describe("Batch Create", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Movie)
@@ -132,7 +133,8 @@ describe("Batch Create", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Movie)
@@ -257,7 +259,8 @@ describe("Batch Create", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Movie)
@@ -369,7 +372,8 @@ describe("Batch Create", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
             CREATE (this0:Movie)
             SET this0.id = $this0_id
             WITH *
@@ -501,7 +505,8 @@ describe("Batch Create", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
             CREATE (this0:Movie)
             SET this0.id = $this0_id
             WITH *

--- a/packages/graphql/tests/tck/operations/connect.test.ts
+++ b/packages/graphql/tests/tck/operations/connect.test.ts
@@ -106,7 +106,8 @@ describe("Cypher Connect", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
             CREATE (this0:Product)
             SET this0.id = $this0_id
             SET this0.name = $this0_name

--- a/packages/graphql/tests/tck/operations/create.test.ts
+++ b/packages/graphql/tests/tck/operations/create.test.ts
@@ -56,7 +56,8 @@ describe("Cypher Create", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Movie)
@@ -92,7 +93,8 @@ describe("Cypher Create", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Movie)
@@ -136,7 +138,8 @@ describe("Cypher Create", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Movie)
@@ -218,7 +221,8 @@ describe("Cypher Create", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Movie)
@@ -313,7 +317,8 @@ describe("Cypher Create", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
             CREATE (this0:Movie)
             SET this0.id = $this0_id
             WITH *
@@ -376,7 +381,8 @@ describe("Cypher Create", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
             CREATE (this0:Actor)
             SET this0.name = $this0_name
             WITH *

--- a/packages/graphql/tests/tck/operations/delete-interface.test.ts
+++ b/packages/graphql/tests/tck/operations/delete-interface.test.ts
@@ -89,7 +89,8 @@ describe("Cypher Delete - interface", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             WHERE this.name = $param0
             DETACH DELETE this"
         `);
@@ -104,7 +105,10 @@ describe("Cypher Delete - interface", () => {
     test("Single Nested Delete", async () => {
         const query = /* GraphQL */ `
             mutation {
-                deleteActors(where: { name_EQ: "Keanu" }, delete: { actedIn: { where: { node: { title_EQ: "Matrix" } } } }) {
+                deleteActors(
+                    where: { name_EQ: "Keanu" }
+                    delete: { actedIn: { where: { node: { title_EQ: "Matrix" } } } }
+                ) {
                     nodesDeleted
                 }
             }
@@ -113,7 +117,8 @@ describe("Cypher Delete - interface", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             WHERE this.name = $param0
             WITH *
             CALL {
@@ -166,7 +171,8 @@ describe("Cypher Delete - interface", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             WHERE this.name = $param0
             WITH *
             CALL {
@@ -221,7 +227,8 @@ describe("Cypher Delete - interface", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             WHERE this.name = $param0
             WITH *
             CALL {
@@ -281,7 +288,8 @@ describe("Cypher Delete - interface", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             WHERE this.name = $param0
             WITH *
             CALL {

--- a/packages/graphql/tests/tck/operations/delete-union.test.ts
+++ b/packages/graphql/tests/tck/operations/delete-union.test.ts
@@ -84,7 +84,8 @@ describe("Cypher Delete - union", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             WHERE this.name = $param0
             DETACH DELETE this"
         `);
@@ -111,7 +112,8 @@ describe("Cypher Delete - union", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             WHERE this.name = $param0
             WITH *
             CALL {
@@ -159,7 +161,8 @@ describe("Cypher Delete - union", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             WHERE this.name = $param0
             WITH *
             CALL {
@@ -219,7 +222,8 @@ describe("Cypher Delete - union", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             WHERE this.name = $param0
             WITH *
             CALL {
@@ -280,7 +284,8 @@ describe("Cypher Delete - union", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             WHERE this.name = $param0
             WITH *
             CALL {

--- a/packages/graphql/tests/tck/operations/delete.test.ts
+++ b/packages/graphql/tests/tck/operations/delete.test.ts
@@ -55,7 +55,8 @@ describe("Cypher Delete", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.id = $param0
             DETACH DELETE this"
         `);
@@ -70,7 +71,10 @@ describe("Cypher Delete", () => {
     test("Single Nested Delete", async () => {
         const query = /* GraphQL */ `
             mutation {
-                deleteMovies(where: { id_EQ: 123 }, delete: { actors: { where: { node: { name_EQ: "Actor to delete" } } } }) {
+                deleteMovies(
+                    where: { id_EQ: 123 }
+                    delete: { actors: { where: { node: { name_EQ: "Actor to delete" } } } }
+                ) {
                     nodesDeleted
                 }
             }
@@ -79,7 +83,8 @@ describe("Cypher Delete", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.id = $param0
             WITH *
             CALL {
@@ -125,7 +130,8 @@ describe("Cypher Delete", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.id = $param0
             WITH *
             CALL {
@@ -183,7 +189,8 @@ describe("Cypher Delete", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.id = $param0
             WITH *
             CALL {
@@ -247,7 +254,8 @@ describe("Cypher Delete", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.id = $param0
             WITH *
             CALL {

--- a/packages/graphql/tests/tck/operations/disconnect.test.ts
+++ b/packages/graphql/tests/tck/operations/disconnect.test.ts
@@ -104,7 +104,8 @@ describe("Cypher Disconnect", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Product)
+            "CYPHER 5
+            MATCH (this:Product)
             SET this.id = $this_update_id_SET
             SET this.name = $this_update_name_SET
             WITH this

--- a/packages/graphql/tests/tck/operations/update.test.ts
+++ b/packages/graphql/tests/tck/operations/update.test.ts
@@ -61,7 +61,8 @@ describe("Cypher Update", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.id = $param0
             SET this.id = $this_update_id_SET
             RETURN collect(DISTINCT this { .id }) AS data"
@@ -97,7 +98,8 @@ describe("Cypher Update", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.id = $param0
             WITH this
             CALL {
@@ -174,7 +176,8 @@ describe("Cypher Update", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.id = $param0
             WITH this
             CALL {
@@ -258,7 +261,8 @@ describe("Cypher Update", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.id = $param0
             WITH *
             CALL {
@@ -314,7 +318,8 @@ describe("Cypher Update", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.id = $param0
             WITH *
             CALL {
@@ -382,7 +387,8 @@ describe("Cypher Update", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.id = $param0
             WITH this
             CALL {
@@ -452,7 +458,8 @@ describe("Cypher Update", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.id = $param0
             WITH this
             CALL {
@@ -540,7 +547,8 @@ describe("Cypher Update", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             WHERE this.name = $param0
             WITH this
             CREATE (this_movies0_create0_node:Movie)
@@ -588,7 +596,8 @@ describe("Cypher Update", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             WHERE this.name = $param0
             WITH this
             CREATE (this_movies0_create0_node:Movie)
@@ -643,7 +652,8 @@ describe("Cypher Update", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             WHERE this.name = $param0
             WITH this
             CREATE (this_movies0_create0_node:Movie)
@@ -697,7 +707,8 @@ describe("Cypher Update", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.id = $param0
             WITH *
             CALL {
@@ -775,7 +786,8 @@ describe("Cypher Update", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.id = $param0
             WITH *
             CALL {
@@ -857,7 +869,8 @@ describe("Cypher Update", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.id = $param0
             WITH *
             CALL {
@@ -926,7 +939,8 @@ describe("Cypher Update", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.id = $param0
             WITH *
             CALL {

--- a/packages/graphql/tests/tck/pagination.test.ts
+++ b/packages/graphql/tests/tck/pagination.test.ts
@@ -49,7 +49,8 @@ describe("Cypher pagination tests", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WITH *
             SKIP $param0
             RETURN this { .title } AS this"
@@ -77,7 +78,8 @@ describe("Cypher pagination tests", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WITH *
             LIMIT $param0
             RETURN this { .title } AS this"
@@ -105,7 +107,8 @@ describe("Cypher pagination tests", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WITH *
             SKIP $param0
             LIMIT $param1
@@ -140,7 +143,8 @@ describe("Cypher pagination tests", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WITH *
             SKIP $param0
             LIMIT $param1
@@ -175,7 +179,8 @@ describe("Cypher pagination tests", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title = $param0
             WITH *
             SKIP $param1

--- a/packages/graphql/tests/tck/pagination/cypher-connection-pagination.test.ts
+++ b/packages/graphql/tests/tck/pagination/cypher-connection-pagination.test.ts
@@ -110,7 +110,8 @@ describe("Cypher Connection pagination", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this0:Movie)
+            "CYPHER 5
+            MATCH (this0:Movie)
             WITH collect({ node: this0 }) AS edges
             WITH edges, size(edges) AS totalCount
             CALL {
@@ -154,7 +155,8 @@ describe("Cypher Connection pagination", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this0:Movie)
+            "CYPHER 5
+            MATCH (this0:Movie)
             WITH collect({ node: this0 }) AS edges
             WITH edges, size(edges) AS totalCount
             CALL {
@@ -199,7 +201,8 @@ describe("Cypher Connection pagination", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this0:Movie)
+            "CYPHER 5
+            MATCH (this0:Movie)
             WITH collect({ node: this0 }) AS edges
             WITH edges, size(edges) AS totalCount
             CALL {
@@ -260,7 +263,8 @@ describe("Cypher Connection pagination", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this0:Movie)
+            "CYPHER 5
+            MATCH (this0:Movie)
             WHERE this0.title = $param0
             WITH collect({ node: this0 }) AS edges
             WITH edges, size(edges) AS totalCount
@@ -324,7 +328,8 @@ describe("Cypher Connection pagination", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this0:Movie)
+            "CYPHER 5
+            MATCH (this0:Movie)
             WITH collect({ node: this0 }) AS edges
             WITH edges, size(edges) AS totalCount
             CALL {
@@ -392,7 +397,8 @@ describe("Cypher Connection pagination", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this0:Movie)
+            "CYPHER 5
+            MATCH (this0:Movie)
             WITH collect({ node: this0 }) AS edges
             WITH edges, size(edges) AS totalCount
             CALL {

--- a/packages/graphql/tests/tck/pagination/cypher-pagination.test.ts
+++ b/packages/graphql/tests/tck/pagination/cypher-pagination.test.ts
@@ -102,7 +102,8 @@ describe("Cypher Sort tests", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 CALL {
@@ -134,7 +135,8 @@ describe("Cypher Sort tests", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 CALL {
@@ -167,7 +169,8 @@ describe("Cypher Sort tests", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 CALL {
@@ -215,7 +218,8 @@ describe("Cypher Sort tests", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title = $param0
             CALL {
                 WITH this
@@ -263,7 +267,8 @@ describe("Cypher Sort tests", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)-[this0:HAS_GENRE]->(this1:Genre)

--- a/packages/graphql/tests/tck/pagination/sort.test.ts
+++ b/packages/graphql/tests/tck/pagination/sort.test.ts
@@ -75,7 +75,8 @@ describe("Sort", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WITH *
             ORDER BY this.id ASC
             RETURN this { .id, .title } AS this"
@@ -97,7 +98,8 @@ describe("Sort", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WITH *
             ORDER BY this.id DESC
             RETURN this { .id, .title } AS this"
@@ -119,7 +121,8 @@ describe("Sort", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WITH *
             ORDER BY this.id DESC
             RETURN this { .title, .id, aliased: this.id } AS this"
@@ -141,7 +144,8 @@ describe("Sort", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WITH *
             ORDER BY this.id DESC, this.title ASC
             RETURN this { .id, .title } AS this"
@@ -164,7 +168,8 @@ describe("Sort", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)-[this0:HAS_GENRE]->(this1:Genre)
@@ -192,7 +197,8 @@ describe("Sort", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 MATCH (this)-[this0:HAS_GENRE]->(this1:Genre)

--- a/packages/graphql/tests/tck/pringles.test.ts
+++ b/packages/graphql/tests/tck/pringles.test.ts
@@ -106,7 +106,8 @@ describe("Cypher Create Pringles", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
             CREATE (this0:Product)
             SET this0.id = $this0_id
             SET this0.name = $this0_name
@@ -277,7 +278,8 @@ describe("Cypher Create Pringles", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Product)
+            "CYPHER 5
+            MATCH (this:Product)
             WHERE this.name = $param0
             WITH this
             CALL {

--- a/packages/graphql/tests/tck/projection.test.ts
+++ b/packages/graphql/tests/tck/projection.test.ts
@@ -87,7 +87,8 @@ describe("Cypher Projection", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Product)

--- a/packages/graphql/tests/tck/rfcs/query-limits.test.ts
+++ b/packages/graphql/tests/tck/rfcs/query-limits.test.ts
@@ -63,7 +63,8 @@ describe("tck/rfcs/query-limits", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Movie)
+                "CYPHER 5
+                MATCH (this:Movie)
                 WITH *
                 LIMIT $param0
                 RETURN this { .id } AS this"
@@ -91,7 +92,8 @@ describe("tck/rfcs/query-limits", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Show)
+                "CYPHER 5
+                MATCH (this:Show)
                 WITH *
                 LIMIT $param0
                 RETURN this { .id } AS this"
@@ -119,7 +121,8 @@ describe("tck/rfcs/query-limits", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Show)
+                "CYPHER 5
+                MATCH (this:Show)
                 WITH *
                 LIMIT $param0
                 RETURN this { .id } AS this"
@@ -152,7 +155,8 @@ describe("tck/rfcs/query-limits", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Movie)
+                "CYPHER 5
+                MATCH (this:Movie)
                 WITH *
                 LIMIT $param0
                 CALL {
@@ -198,7 +202,8 @@ describe("tck/rfcs/query-limits", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Movie)
+                "CYPHER 5
+                MATCH (this:Movie)
                 WITH *
                 LIMIT $param0
                 CALL {
@@ -252,7 +257,8 @@ describe("tck/rfcs/query-limits", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Movie)
+                "CYPHER 5
+                MATCH (this:Movie)
                 WITH *
                 LIMIT $param0
                 CALL {
@@ -306,7 +312,8 @@ describe("tck/rfcs/query-limits", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Festival)
+                "CYPHER 5
+                MATCH (this:Festival)
                 CALL {
                     WITH this
                     MATCH (this)<-[this0:PART_OF]-(this1:Show)
@@ -350,7 +357,8 @@ describe("tck/rfcs/query-limits", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Movie)
+                "CYPHER 5
+                MATCH (this:Movie)
                 WITH *
                 LIMIT $param0
                 CALL {

--- a/packages/graphql/tests/tck/rfcs/rfc-003.test.ts
+++ b/packages/graphql/tests/tck/rfcs/rfc-003.test.ts
@@ -52,7 +52,8 @@ describe("tck/rfs/003", () => {
                 const result = await translateQuery(neoSchema, mutation);
 
                 expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                    "UNWIND $create_param0 AS create_var0
+                    "CYPHER 5
+                    UNWIND $create_param0 AS create_var0
                     CALL {
                         WITH create_var0
                         CREATE (create_this1:Movie)
@@ -111,7 +112,8 @@ describe("tck/rfs/003", () => {
                 const result = await translateQuery(neoSchema, mutation);
 
                 expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                    "UNWIND $create_param0 AS create_var0
+                    "CYPHER 5
+                    UNWIND $create_param0 AS create_var0
                     CALL {
                         WITH create_var0
                         CREATE (create_this1:Movie)
@@ -177,7 +179,8 @@ describe("tck/rfs/003", () => {
                     const result = await translateQuery(neoSchema, mutation);
 
                     expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                        "UNWIND $create_param0 AS create_var0
+                        "CYPHER 5
+                        UNWIND $create_param0 AS create_var0
                         CALL {
                             WITH create_var0
                             CREATE (create_this1:Movie)
@@ -267,7 +270,8 @@ describe("tck/rfs/003", () => {
                     const result = await translateQuery(neoSchema, mutation);
 
                     expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                        "UNWIND $create_param0 AS create_var0
+                        "CYPHER 5
+                        UNWIND $create_param0 AS create_var0
                         CALL {
                             WITH create_var0
                             CREATE (create_this1:Movie)
@@ -353,7 +357,8 @@ describe("tck/rfs/003", () => {
                     const result = await translateQuery(neoSchema, mutation);
 
                     expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                        "MATCH (this:Movie)
+                        "CYPHER 5
+                        MATCH (this:Movie)
                         WHERE this.id = $param0
                         SET this.id = $this_update_id_SET
                         WITH *
@@ -405,7 +410,8 @@ describe("tck/rfs/003", () => {
                     const result = await translateQuery(neoSchema, mutation);
 
                     expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                        "MATCH (this:Movie)
+                        "CYPHER 5
+                        MATCH (this:Movie)
                         WHERE this.id = $param0
                         SET this.id = $this_update_id_SET
                         WITH *
@@ -467,7 +473,8 @@ describe("tck/rfs/003", () => {
                         const result = await translateQuery(neoSchema, mutation);
 
                         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                            "MATCH (this:Movie)
+                            "CYPHER 5
+                            MATCH (this:Movie)
                             WHERE this.id = $param0
                             WITH this
                             CALL {
@@ -542,7 +549,8 @@ describe("tck/rfs/003", () => {
                         const result = await translateQuery(neoSchema, mutation);
 
                         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                            "MATCH (this:Movie)
+                            "CYPHER 5
+                            MATCH (this:Movie)
                             WHERE this.id = $param0
                             WITH this
                             CALL {
@@ -617,7 +625,8 @@ describe("tck/rfs/003", () => {
                         const result = await translateQuery(neoSchema, mutation);
 
                         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                            "MATCH (this:Movie)
+                            "CYPHER 5
+                            MATCH (this:Movie)
                             WHERE this.id = $param0
                             WITH this
                             WITH *
@@ -707,7 +716,8 @@ describe("tck/rfs/003", () => {
                         const result = await translateQuery(neoSchema, mutation);
 
                         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                            "MATCH (this:Movie)
+                            "CYPHER 5
+                            MATCH (this:Movie)
                             WHERE this.id = $param0
                             WITH *
                             CALL {
@@ -835,7 +845,8 @@ describe("tck/rfs/003", () => {
                         const result = await translateQuery(neoSchema, mutation);
 
                         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                            "MATCH (this:Movie)
+                            "CYPHER 5
+                            MATCH (this:Movie)
                             WHERE this.id = $param0
                             WITH *
                             CALL {
@@ -946,7 +957,8 @@ describe("tck/rfs/003", () => {
                     const result = await translateQuery(neoSchema, mutation);
 
                     expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                        "CALL {
+                        "CYPHER 5
+                        CALL {
                         CREATE (this0:Movie)
                         SET this0.id = $this0_id
                         WITH *
@@ -1019,7 +1031,8 @@ describe("tck/rfs/003", () => {
                     const result = await translateQuery(neoSchema, mutation);
 
                     expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                        "CALL {
+                        "CYPHER 5
+                        CALL {
                         CREATE (this0:Movie)
                         SET this0.id = $this0_id
                         WITH *
@@ -1110,7 +1123,8 @@ describe("tck/rfs/003", () => {
                         const result = await translateQuery(neoSchema, mutation);
 
                         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                            "CALL {
+                            "CYPHER 5
+                            CALL {
                             CREATE (this0:Movie)
                             SET this0.id = $this0_id
                             WITH *
@@ -1212,7 +1226,8 @@ describe("tck/rfs/003", () => {
                     const result = await translateQuery(neoSchema, mutation);
 
                     expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                        "MATCH (this:Movie)
+                        "CYPHER 5
+                        MATCH (this:Movie)
                         WHERE this.id = $param0
                         WITH this
                         CALL {
@@ -1310,7 +1325,8 @@ describe("tck/rfs/003", () => {
                     const result = await translateQuery(neoSchema, mutation);
 
                     expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                        "MATCH (this:Movie)
+                        "CYPHER 5
+                        MATCH (this:Movie)
                         WHERE this.id = $param0
                         WITH this
                         CALL {
@@ -1440,7 +1456,8 @@ describe("tck/rfs/003", () => {
                     const result = await translateQuery(neoSchema, mutation);
 
                     expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                        "MATCH (this:Movie)
+                        "CYPHER 5
+                        MATCH (this:Movie)
                         WHERE this.id = $param0
                         WITH this
                         CALL {

--- a/packages/graphql/tests/tck/rfcs/rfc-022.test.ts
+++ b/packages/graphql/tests/tck/rfcs/rfc-022.test.ts
@@ -66,7 +66,8 @@ describe("tck/rfs/022 subquery projection", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Movie)
+                "CYPHER 5
+                MATCH (this:Movie)
                 WHERE this.released = $param0
                 CALL {
                     WITH this
@@ -108,7 +109,8 @@ describe("tck/rfs/022 subquery projection", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Movie)
+                "CYPHER 5
+                MATCH (this:Movie)
                 WHERE this.released = $param0
                 CALL {
                     WITH this
@@ -156,7 +158,10 @@ describe("tck/rfs/022 subquery projection", () => {
                     @authorization(
                         filter: [{ where: { node: { name_EQ: "The Matrix" } } }]
                         validate: [
-                            { when: [BEFORE], where: { node: { name_EQ: "$jwt.test" }, jwt: { roles_INCLUDES: "admin" } } }
+                            {
+                                when: [BEFORE]
+                                where: { node: { name_EQ: "$jwt.test" }, jwt: { roles_INCLUDES: "admin" } }
+                            }
                         ]
                     ) {
                     name: String!
@@ -194,7 +199,8 @@ describe("tck/rfs/022 subquery projection", () => {
             });
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Movie)
+                "CYPHER 5
+                MATCH (this:Movie)
                 WHERE this.released = $param0
                 CALL {
                     WITH this

--- a/packages/graphql/tests/tck/root-connection.test.ts
+++ b/packages/graphql/tests/tck/root-connection.test.ts
@@ -60,7 +60,8 @@ describe("Root Connection Query tests", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this0:Movie)
+            "CYPHER 5
+            MATCH (this0:Movie)
             WHERE this0.title = $param0
             WITH collect({ node: this0 }) AS edges
             WITH edges, size(edges) AS totalCount
@@ -96,7 +97,8 @@ describe("Root Connection Query tests", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this0:Movie)
+            "CYPHER 5
+            MATCH (this0:Movie)
             WITH collect({ node: this0 }) AS edges
             WITH edges, size(edges) AS totalCount
             CALL {
@@ -134,7 +136,8 @@ describe("Root Connection Query tests", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this0:Movie)
+            "CYPHER 5
+            MATCH (this0:Movie)
             WHERE this0.title CONTAINS $param0
             WITH collect({ node: this0 }) AS edges
             WITH edges, size(edges) AS totalCount
@@ -181,7 +184,8 @@ describe("Root Connection Query tests", () => {
         `;
         const result = await translateQuery(neoSchema, query);
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this0:Movie)
+            "CYPHER 5
+            MATCH (this0:Movie)
             WITH collect({ node: this0 }) AS edges
             WITH edges, size(edges) AS totalCount
             CALL {

--- a/packages/graphql/tests/tck/simple.test.ts
+++ b/packages/graphql/tests/tck/simple.test.ts
@@ -49,7 +49,8 @@ describe("Simple Cypher tests", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title = $param0
             RETURN this { .title } AS this"
         `);
@@ -74,7 +75,8 @@ describe("Simple Cypher tests", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title = $param0
             RETURN this { .id, .title } AS this"
         `);
@@ -101,7 +103,8 @@ describe("Simple Cypher tests", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title = $param0
             RETURN this { .id, .title } AS this"
         `);

--- a/packages/graphql/tests/tck/subscriptions/create-auth.test.ts
+++ b/packages/graphql/tests/tck/subscriptions/create-auth.test.ts
@@ -68,7 +68,8 @@ describe("Subscriptions metadata on create", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Actor)

--- a/packages/graphql/tests/tck/subscriptions/create.test.ts
+++ b/packages/graphql/tests/tck/subscriptions/create.test.ts
@@ -101,7 +101,8 @@ describe("Subscriptions metadata on create", () => {
         );
         // TODO: make a test with rel type as union/ interface
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Movie)
@@ -205,7 +206,8 @@ describe("Subscriptions metadata on create", () => {
         );
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Movie)
@@ -325,7 +327,8 @@ describe("Subscriptions metadata on create", () => {
         );
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Movie)
@@ -480,7 +483,8 @@ describe("Subscriptions metadata on create", () => {
         );
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
             CREATE (this0:Movie)
             SET this0.title = $this0_title
             WITH *
@@ -619,7 +623,8 @@ describe("Subscriptions metadata on create", () => {
         );
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
             CREATE (this0:Movie)
             SET this0.title = $this0_title
             WITH *
@@ -704,7 +709,8 @@ describe("Subscriptions metadata on create", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Movie)
@@ -740,7 +746,8 @@ describe("Subscriptions metadata on create", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Movie)
@@ -782,7 +789,8 @@ describe("Subscriptions metadata on create", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Movie)
@@ -853,7 +861,8 @@ describe("Subscriptions metadata on create", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Movie)
@@ -960,7 +969,8 @@ describe("Subscriptions metadata on create", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Movie)
@@ -1082,7 +1092,8 @@ describe("Subscriptions metadata on create", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Movie)
@@ -1177,7 +1188,8 @@ describe("Subscriptions metadata on create", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Movie)

--- a/packages/graphql/tests/tck/subscriptions/delete.test.ts
+++ b/packages/graphql/tests/tck/subscriptions/delete.test.ts
@@ -58,7 +58,8 @@ describe("Subscriptions metadata on delete", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.id = $param0
             DETACH DELETE this"
         `);
@@ -82,7 +83,8 @@ describe("Subscriptions metadata on delete", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.id = $param0
             WITH *
             CALL {
@@ -132,7 +134,8 @@ describe("Subscriptions metadata on delete", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.id = $param0
             WITH *
             CALL {

--- a/packages/graphql/tests/tck/subscriptions/update.test.ts
+++ b/packages/graphql/tests/tck/subscriptions/update.test.ts
@@ -60,7 +60,8 @@ describe("Subscriptions metadata on update", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.id = $param0
             SET this.id = $this_update_id_SET
             RETURN collect(DISTINCT this { .id }) AS data"
@@ -95,7 +96,8 @@ describe("Subscriptions metadata on update", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.id = $param0
             SET this.id = $this_update_id_SET
             WITH this

--- a/packages/graphql/tests/tck/types/bigint.test.ts
+++ b/packages/graphql/tests/tck/types/bigint.test.ts
@@ -49,7 +49,8 @@ describe("Cypher BigInt", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:File)
+            "CYPHER 5
+            MATCH (this:File)
             WHERE this.size = $param0
             RETURN this { .name } AS this"
         `);
@@ -76,7 +77,8 @@ describe("Cypher BigInt", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:File)
+            "CYPHER 5
+            MATCH (this:File)
             WHERE this.size = $param0
             RETURN this { .name } AS this"
         `);
@@ -105,7 +107,8 @@ describe("Cypher BigInt", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:File)
+            "CYPHER 5
+            MATCH (this:File)
             WHERE this.size = $param0
             RETURN this { .name } AS this"
         `);

--- a/packages/graphql/tests/tck/types/date.test.ts
+++ b/packages/graphql/tests/tck/types/date.test.ts
@@ -49,7 +49,8 @@ describe("Cypher Date", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.date = $param0
             RETURN this { .date } AS this"
         `);
@@ -77,7 +78,8 @@ describe("Cypher Date", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.date >= $param0
             RETURN this { .date } AS this"
         `);
@@ -107,7 +109,8 @@ describe("Cypher Date", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Movie)
@@ -148,7 +151,8 @@ describe("Cypher Date", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             SET this.date = $this_update_date_SET
             RETURN collect(DISTINCT this { .id, .date }) AS data"
         `);

--- a/packages/graphql/tests/tck/types/datetime.test.ts
+++ b/packages/graphql/tests/tck/types/datetime.test.ts
@@ -49,7 +49,8 @@ describe("Cypher DateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.datetime = $param0
             RETURN this { datetime: apoc.date.convertFormat(toString(this.datetime), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\") } AS this"
         `);
@@ -84,7 +85,8 @@ describe("Cypher DateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Movie)
@@ -130,7 +132,8 @@ describe("Cypher DateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             SET this.datetime = $this_update_datetime_SET
             RETURN collect(DISTINCT this { .id, datetime: apoc.date.convertFormat(toString(this.datetime), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\") }) AS data"
         `);

--- a/packages/graphql/tests/tck/types/duration.test.ts
+++ b/packages/graphql/tests/tck/types/duration.test.ts
@@ -49,7 +49,8 @@ describe("Cypher Duration", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.duration = $param0
             RETURN this { .duration } AS this"
         `);
@@ -84,7 +85,8 @@ describe("Cypher Duration", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE (datetime() + this.duration) >= (datetime() + $param0)
             RETURN this { .duration } AS this"
         `);
@@ -121,7 +123,8 @@ describe("Cypher Duration", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Movie)
@@ -169,7 +172,8 @@ describe("Cypher Duration", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             SET this.duration = $this_update_duration_SET
             RETURN collect(DISTINCT this { .id, .duration }) AS data"
         `);

--- a/packages/graphql/tests/tck/types/localdatetime.test.ts
+++ b/packages/graphql/tests/tck/types/localdatetime.test.ts
@@ -49,7 +49,8 @@ describe("Cypher LocalDateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.localDT = $param0
             RETURN this { .localDT } AS this"
         `);
@@ -81,7 +82,8 @@ describe("Cypher LocalDateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.localDT >= $param0
             RETURN this { .localDT } AS this"
         `);
@@ -115,7 +117,8 @@ describe("Cypher LocalDateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Movie)
@@ -160,7 +163,8 @@ describe("Cypher LocalDateTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             SET this.localDT = $this_update_localDT_SET
             RETURN collect(DISTINCT this { .id, .localDT }) AS data"
         `);

--- a/packages/graphql/tests/tck/types/localtime.test.ts
+++ b/packages/graphql/tests/tck/types/localtime.test.ts
@@ -49,7 +49,8 @@ describe("Cypher LocalTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.time = $param0
             RETURN this { .time } AS this"
         `);
@@ -78,7 +79,8 @@ describe("Cypher LocalTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.time >= $param0
             RETURN this { .time } AS this"
         `);
@@ -109,7 +111,8 @@ describe("Cypher LocalTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Movie)
@@ -151,7 +154,8 @@ describe("Cypher LocalTime", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             SET this.time = $this_update_time_SET
             RETURN collect(DISTINCT this { .id, .time }) AS data"
         `);

--- a/packages/graphql/tests/tck/types/point.test.ts
+++ b/packages/graphql/tests/tck/types/point.test.ts
@@ -53,7 +53,8 @@ describe("Cypher Points", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:PointContainer)
+            "CYPHER 5
+            MATCH (this:PointContainer)
             WHERE this.point = point($param0)
             RETURN this { .point } AS this"
         `);
@@ -83,7 +84,8 @@ describe("Cypher Points", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:PointContainer)
+            "CYPHER 5
+            MATCH (this:PointContainer)
             WHERE NOT (this.point = point($param0))
             RETURN this { .point } AS this"
         `);
@@ -114,7 +116,8 @@ describe("Cypher Points", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:PointContainer)
+            "CYPHER 5
+            MATCH (this:PointContainer)
             WHERE this.point IN [var0 IN $param0 | point(var0)]
             RETURN this { .point } AS this"
         `);
@@ -147,7 +150,8 @@ describe("Cypher Points", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:PointContainer)
+                "CYPHER 5
+                MATCH (this:PointContainer)
                 WHERE point.distance(this.point, point($param0.point)) < $param0.distance
                 RETURN this { .point } AS this"
             `);
@@ -180,7 +184,8 @@ describe("Cypher Points", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:PointContainer)
+                "CYPHER 5
+                MATCH (this:PointContainer)
                 WHERE point.distance(this.point, point($param0.point)) <= $param0.distance
                 RETURN this { .point } AS this"
             `);
@@ -213,7 +218,8 @@ describe("Cypher Points", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:PointContainer)
+                "CYPHER 5
+                MATCH (this:PointContainer)
                 WHERE point.distance(this.point, point($param0.point)) > $param0.distance
                 RETURN this { .point } AS this"
             `);
@@ -246,7 +252,8 @@ describe("Cypher Points", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:PointContainer)
+                "CYPHER 5
+                MATCH (this:PointContainer)
                 WHERE point.distance(this.point, point($param0.point)) >= $param0.distance
                 RETURN this { .point } AS this"
             `);
@@ -281,7 +288,8 @@ describe("Cypher Points", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:PointContainer)
+                "CYPHER 5
+                MATCH (this:PointContainer)
                 WHERE point.distance(this.point, point($param0.point)) = $param0.distance
                 RETURN this { .point } AS this"
             `);
@@ -318,7 +326,8 @@ describe("Cypher Points", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:PointContainer)
@@ -364,7 +373,8 @@ describe("Cypher Points", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:PointContainer)
+            "CYPHER 5
+            MATCH (this:PointContainer)
             WHERE this.id = $param0
             SET this.point = point($this_update_point_SET)
             RETURN collect(DISTINCT this { .point }) AS data"

--- a/packages/graphql/tests/tck/types/points.test.ts
+++ b/packages/graphql/tests/tck/types/points.test.ts
@@ -53,7 +53,8 @@ describe("Cypher Points", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:PointContainer)
+            "CYPHER 5
+            MATCH (this:PointContainer)
             WHERE this.points = [var0 IN $param0 | point(var0)]
             RETURN this { .points } AS this"
         `);
@@ -85,7 +86,8 @@ describe("Cypher Points", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:PointContainer)
+            "CYPHER 5
+            MATCH (this:PointContainer)
             WHERE NOT (this.points = [var0 IN $param0 | point(var0)])
             RETURN this { .points } AS this"
         `);
@@ -118,7 +120,8 @@ describe("Cypher Points", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:PointContainer)
+            "CYPHER 5
+            MATCH (this:PointContainer)
             WHERE point($param0) IN this.points
             RETURN this { .points } AS this"
         `);
@@ -151,7 +154,8 @@ describe("Cypher Points", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:PointContainer)
@@ -199,7 +203,8 @@ describe("Cypher Points", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:PointContainer)
+            "CYPHER 5
+            MATCH (this:PointContainer)
             WHERE this.id = $param0
             SET this.points = [p in $this_update_points_SET | point(p)]
             RETURN collect(DISTINCT this { .points }) AS data"

--- a/packages/graphql/tests/tck/types/time.test.ts
+++ b/packages/graphql/tests/tck/types/time.test.ts
@@ -49,7 +49,8 @@ describe("Cypher Time", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.time = $param0
             RETURN this { .time } AS this"
         `);
@@ -79,7 +80,8 @@ describe("Cypher Time", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.time >= $param0
             RETURN this { .time } AS this"
         `);
@@ -111,7 +113,8 @@ describe("Cypher Time", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Movie)
@@ -154,7 +157,8 @@ describe("Cypher Time", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             SET this.time = $this_update_time_SET
             RETURN collect(DISTINCT this { .id, .time }) AS data"
         `);
@@ -187,7 +191,8 @@ describe("Cypher Time", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param0 AS create_var0
+            "CYPHER 5
+            UNWIND $create_param0 AS create_var0
             CALL {
                 WITH create_var0
                 CREATE (create_this1:Movie)

--- a/packages/graphql/tests/tck/undirected-relationships/query-direction-aggregations.test.ts
+++ b/packages/graphql/tests/tck/undirected-relationships/query-direction-aggregations.test.ts
@@ -48,7 +48,8 @@ describe("QueryDirection in relationships aggregations", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             CALL {
                 WITH this
                 MATCH (this)-[this0:FRIENDS_WITH]->(this1:User)
@@ -83,7 +84,8 @@ describe("QueryDirection in relationships aggregations", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             CALL {
                 WITH this
                 MATCH (this)-[this0:FRIENDS_WITH]-(this1:User)

--- a/packages/graphql/tests/tck/undirected-relationships/query-direction-connection.test.ts
+++ b/packages/graphql/tests/tck/undirected-relationships/query-direction-connection.test.ts
@@ -48,7 +48,8 @@ describe("QueryDirection in relationships connection", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             CALL {
                 WITH this
                 MATCH (this)-[this0:FRIENDS_WITH]->(this1:User)
@@ -92,7 +93,8 @@ describe("QueryDirection in relationships connection", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             CALL {
                 WITH this
                 MATCH (this)-[this0:FRIENDS_WITH]-(this1:User)

--- a/packages/graphql/tests/tck/undirected-relationships/query-direction.test.ts
+++ b/packages/graphql/tests/tck/undirected-relationships/query-direction.test.ts
@@ -52,7 +52,8 @@ describe("queryDirection in relationships", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:User)
+                "CYPHER 5
+                MATCH (this:User)
                 CALL {
                     WITH this
                     MATCH (this)-[this0:FRIENDS_WITH]->(this1:User)
@@ -80,7 +81,8 @@ describe("queryDirection in relationships", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:User)
+                "CYPHER 5
+                MATCH (this:User)
                 WHERE EXISTS {
                     MATCH (this)-[:FRIENDS_WITH]->(this0:User)
                     WHERE this0.name = $param0
@@ -121,7 +123,8 @@ describe("queryDirection in relationships", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:User)
+                "CYPHER 5
+                MATCH (this:User)
                 WHERE EXISTS {
                     MATCH (this)-[:FRIENDS_WITH]->(this0:User)
                     WHERE this0.name = $param0
@@ -197,7 +200,8 @@ describe("queryDirection in relationships", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:User)
+                "CYPHER 5
+                MATCH (this:User)
                 WHERE EXISTS {
                     MATCH (this)-[:FRIENDS_WITH]->(this0:User)
                     WHERE this0.name = $param0
@@ -277,7 +281,8 @@ describe("queryDirection in relationships", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:User)
+                "CYPHER 5
+                MATCH (this:User)
                 WHERE EXISTS {
                     MATCH (this)-[:FRIENDS_WITH]->(this0:User)
                     WHERE this0.name = $param0
@@ -345,7 +350,8 @@ describe("queryDirection in relationships", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:User)
+                "CYPHER 5
+                MATCH (this:User)
                 WHERE EXISTS {
                     MATCH (this)-[:FRIENDS_WITH]->(this0:User)
                     WHERE this0.name = $param0
@@ -407,7 +413,8 @@ describe("queryDirection in relationships", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:User)
+                "CYPHER 5
+                MATCH (this:User)
                 CALL {
                     WITH this
                     MATCH (this)-[this0:FRIENDS_WITH]->(this1:User)
@@ -435,7 +442,8 @@ describe("queryDirection in relationships", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:User)
+                "CYPHER 5
+                MATCH (this:User)
                 WHERE EXISTS {
                     MATCH (this)-[:FRIENDS_WITH]->(this0:User)
                     WHERE this0.name = $param0
@@ -476,7 +484,8 @@ describe("queryDirection in relationships", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:User)
+                "CYPHER 5
+                MATCH (this:User)
                 WHERE EXISTS {
                     MATCH (this)-[:FRIENDS_WITH]->(this0:User)
                     WHERE this0.name = $param0
@@ -552,7 +561,8 @@ describe("queryDirection in relationships", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:User)
+                "CYPHER 5
+                MATCH (this:User)
                 WHERE EXISTS {
                     MATCH (this)-[:FRIENDS_WITH]->(this0:User)
                     WHERE this0.name = $param0
@@ -632,7 +642,8 @@ describe("queryDirection in relationships", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:User)
+                "CYPHER 5
+                MATCH (this:User)
                 WHERE EXISTS {
                     MATCH (this)-[:FRIENDS_WITH]->(this0:User)
                     WHERE this0.name = $param0
@@ -700,7 +711,8 @@ describe("queryDirection in relationships", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:User)
+                "CYPHER 5
+                MATCH (this:User)
                 WHERE EXISTS {
                     MATCH (this)-[:FRIENDS_WITH]->(this0:User)
                     WHERE this0.name = $param0
@@ -761,7 +773,8 @@ describe("queryDirection in relationships", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:User)
+                "CYPHER 5
+                MATCH (this:User)
                 CALL {
                     WITH this
                     MATCH (this)-[this0:FRIENDS_WITH]-(this1:User)
@@ -789,7 +802,8 @@ describe("queryDirection in relationships", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:User)
+                "CYPHER 5
+                MATCH (this:User)
                 WHERE EXISTS {
                     MATCH (this)-[:FRIENDS_WITH]-(this0:User)
                     WHERE this0.name = $param0
@@ -830,7 +844,8 @@ describe("queryDirection in relationships", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:User)
+                "CYPHER 5
+                MATCH (this:User)
                 WHERE EXISTS {
                     MATCH (this)-[:FRIENDS_WITH]-(this0:User)
                     WHERE this0.name = $param0
@@ -906,7 +921,8 @@ describe("queryDirection in relationships", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:User)
+                "CYPHER 5
+                MATCH (this:User)
                 WHERE EXISTS {
                     MATCH (this)-[:FRIENDS_WITH]-(this0:User)
                     WHERE this0.name = $param0
@@ -986,7 +1002,8 @@ describe("queryDirection in relationships", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:User)
+                "CYPHER 5
+                MATCH (this:User)
                 WHERE EXISTS {
                     MATCH (this)-[:FRIENDS_WITH]-(this0:User)
                     WHERE this0.name = $param0
@@ -1054,7 +1071,8 @@ describe("queryDirection in relationships", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:User)
+                "CYPHER 5
+                MATCH (this:User)
                 WHERE EXISTS {
                     MATCH (this)-[:FRIENDS_WITH]-(this0:User)
                     WHERE this0.name = $param0
@@ -1116,7 +1134,8 @@ describe("queryDirection in relationships", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:User)
+                "CYPHER 5
+                MATCH (this:User)
                 CALL {
                     WITH this
                     MATCH (this)-[this0:FRIENDS_WITH]-(this1:User)
@@ -1144,7 +1163,8 @@ describe("queryDirection in relationships", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:User)
+                "CYPHER 5
+                MATCH (this:User)
                 WHERE EXISTS {
                     MATCH (this)-[:FRIENDS_WITH]-(this0:User)
                     WHERE this0.name = $param0
@@ -1185,7 +1205,8 @@ describe("queryDirection in relationships", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:User)
+                "CYPHER 5
+                MATCH (this:User)
                 WHERE EXISTS {
                     MATCH (this)-[:FRIENDS_WITH]-(this0:User)
                     WHERE this0.name = $param0
@@ -1261,7 +1282,8 @@ describe("queryDirection in relationships", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:User)
+                "CYPHER 5
+                MATCH (this:User)
                 WHERE EXISTS {
                     MATCH (this)-[:FRIENDS_WITH]-(this0:User)
                     WHERE this0.name = $param0
@@ -1341,7 +1363,8 @@ describe("queryDirection in relationships", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:User)
+                "CYPHER 5
+                MATCH (this:User)
                 WHERE EXISTS {
                     MATCH (this)-[:FRIENDS_WITH]-(this0:User)
                     WHERE this0.name = $param0
@@ -1409,7 +1432,8 @@ describe("queryDirection in relationships", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:User)
+                "CYPHER 5
+                MATCH (this:User)
                 WHERE EXISTS {
                     MATCH (this)-[:FRIENDS_WITH]-(this0:User)
                     WHERE this0.name = $param0

--- a/packages/graphql/tests/tck/undirected-relationships/undirected-aggregations.test.ts
+++ b/packages/graphql/tests/tck/undirected-relationships/undirected-aggregations.test.ts
@@ -48,7 +48,8 @@ describe("Undirected Aggregations", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             CALL {
                 WITH this
                 MATCH (this)-[this0:FRIENDS_WITH]-(this1:User)

--- a/packages/graphql/tests/tck/undirected-relationships/undirected-connection.test.ts
+++ b/packages/graphql/tests/tck/undirected-relationships/undirected-connection.test.ts
@@ -48,7 +48,8 @@ describe("Undirected connections", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             CALL {
                 WITH this
                 MATCH (this)-[this0:FRIENDS_WITH]-(this1:User)

--- a/packages/graphql/tests/tck/undirected-relationships/undirected-relationships.test.ts
+++ b/packages/graphql/tests/tck/undirected-relationships/undirected-relationships.test.ts
@@ -52,7 +52,8 @@ describe("Undirected relationships", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             CALL {
                 WITH this
                 MATCH (this)-[this0:FRIENDS_WITH]-(this1:User)
@@ -111,7 +112,8 @@ describe("Undirected relationships", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
+            "CYPHER 5
+            MATCH (this:User)
             CALL {
                 WITH this
                 CALL {
@@ -179,7 +181,8 @@ describe("Undirected relationships", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor)
+            "CYPHER 5
+            MATCH (this:Actor)
             CALL {
                 WITH this
                 CALL {
@@ -237,7 +240,8 @@ describe("Undirected relationships", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Foo)
+            "CYPHER 5
+            MATCH (this:Foo)
             CALL {
                 WITH this
                 MATCH (this)-[this0:DRINKS_AT]->(this1:Bar)

--- a/packages/graphql/tests/tck/union.test.ts
+++ b/packages/graphql/tests/tck/union.test.ts
@@ -76,7 +76,8 @@ describe("Cypher Union", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 CALL {
@@ -125,7 +126,8 @@ describe("Cypher Union", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             CALL {
                 WITH this
                 CALL {
@@ -181,7 +183,8 @@ describe("Cypher Union", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title = $param0
             CALL {
                 WITH this
@@ -245,7 +248,8 @@ describe("Cypher Union", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
             CREATE (this0:Movie)
             SET this0.title = $this0_title
             WITH *
@@ -285,7 +289,8 @@ describe("Cypher Union", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WITH this
             CREATE (this_search_Genre0_create0_node:Genre)
             SET this_search_Genre0_create0_node.name = $this_search_Genre0_create0_node_name
@@ -323,7 +328,8 @@ describe("Cypher Union", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
+            "CYPHER 5
+            CALL {
             CREATE (this0:Movie)
             SET this0.title = $this0_title
             WITH *
@@ -387,7 +393,8 @@ describe("Cypher Union", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title = $param0
             WITH this
             CALL {
@@ -450,7 +457,8 @@ describe("Cypher Union", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title = $param0
             WITH this
             CALL {
@@ -516,7 +524,8 @@ describe("Cypher Union", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title = $param0
             WITH *
             CALL {
@@ -566,7 +575,8 @@ describe("Cypher Union", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title = $param0
             WITH *
             CALL {

--- a/packages/graphql/tests/tck/where.test.ts
+++ b/packages/graphql/tests/tck/where.test.ts
@@ -58,7 +58,8 @@ describe("Cypher WHERE", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE (this.title = $param0 AND this.isFavorite = $param1)
             RETURN this { .title } AS this"
         `);
@@ -83,7 +84,8 @@ describe("Cypher WHERE", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title = $param0
             RETURN this { .title } AS this"
         `);
@@ -107,7 +109,8 @@ describe("Cypher WHERE", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE (this.title = $param0 AND this.isFavorite = $param1)
             RETURN this { .title } AS this"
         `);
@@ -132,7 +135,8 @@ describe("Cypher WHERE", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title = $param0
             RETURN this { .title } AS this"
         `);
@@ -156,7 +160,8 @@ describe("Cypher WHERE", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE (this.title = $param0 AND this.title = $param1)
             RETURN this { .title } AS this"
         `);
@@ -181,7 +186,8 @@ describe("Cypher WHERE", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE (this.id = $param0 AND (this.title = $param1 OR this.isFavorite = $param2))
             RETURN this { .title } AS this"
         `);
@@ -207,7 +213,8 @@ describe("Cypher WHERE", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title = $param0
             RETURN this { .title } AS this"
         `);
@@ -231,7 +238,8 @@ describe("Cypher WHERE", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title = $param0
             RETURN this { .title } AS this"
         `);
@@ -255,7 +263,8 @@ describe("Cypher WHERE", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title = $param0
             RETURN this { .title } AS this"
         `);
@@ -279,7 +288,8 @@ describe("Cypher WHERE", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE this.title = $param0
             RETURN this { .title } AS this"
         `);
@@ -304,7 +314,8 @@ describe("Cypher WHERE", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Movie)
+                "CYPHER 5
+                MATCH (this:Movie)
                 WHERE this.title IS NULL
                 RETURN this { .title } AS this"
             `);
@@ -324,7 +335,8 @@ describe("Cypher WHERE", () => {
             const result = await translateQuery(neoSchema, query);
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                "MATCH (this:Movie)
+                "CYPHER 5
+                MATCH (this:Movie)
                 WHERE NOT (this.title IS NULL)
                 RETURN this { .title } AS this"
             `);
@@ -345,7 +357,8 @@ describe("Cypher WHERE", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE NOT (this.title = $param0)
             RETURN this { .title } AS this"
         `);
@@ -369,7 +382,8 @@ describe("Cypher WHERE", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Movie)
+            "CYPHER 5
+            MATCH (this:Movie)
             WHERE NOT (this.title = $param0 AND this.isFavorite = $param1)
             RETURN this { .title } AS this"
         `);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2059,10 +2059,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@neo4j/cypher-builder@npm:2.0.2":
-  version: 2.0.2
-  resolution: "@neo4j/cypher-builder@npm:2.0.2"
-  checksum: 10c0/776f7204df4c226bf26c1e9e8db472b6498d85b7aacf4ca67ec210ca4c6e884a1c08e5bd7779dccadef4b79a22775c9f7d99b73cba9c8d38e518551792a38f03
+"@neo4j/cypher-builder@npm:2.3.0":
+  version: 2.3.0
+  resolution: "@neo4j/cypher-builder@npm:2.3.0"
+  checksum: 10c0/bd7d98b8c3a84e9562ff88b9f2ad10a9258aabc2204dba247d4aa83944bce6f5100a3e14199a688dea62de2313910b90e03da7a9b1a423d0a279b022e5909fc3
   languageName: node
   linkType: hard
 
@@ -2083,7 +2083,7 @@ __metadata:
     "@graphql-tools/resolvers-composition": "npm:^7.0.0"
     "@graphql-tools/schema": "npm:^10.0.0"
     "@graphql-tools/utils": "npm:^10.0.0"
-    "@neo4j/cypher-builder": "npm:2.0.2"
+    "@neo4j/cypher-builder": "npm:2.3.0"
     "@types/deep-equal": "npm:1.0.4"
     "@types/is-uuid": "npm:1.0.2"
     "@types/jest": "npm:29.5.14"


### PR DESCRIPTION
# Description

Add `Cypher 5` to generated queries to ensure the correct Cypher version is used in Aura