### PR TITLE
Add addVersionPrefix to cypherQueryOptions in LTS

### DIFF
--- a/.changeset/soft-socks-count.md
+++ b/.changeset/soft-socks-count.md
@@ -1,0 +1,22 @@
+---
+"@neo4j/graphql": patch
+---
+
+Add `addVersionPrefix` to `cypherQueryOptions` in context to add a Cypher version with `CYPHER` before each query:
+
+```js
+{
+    cypherQueryOptions: {
+        addVersionPrefix: true,
+    },
+}
+```
+
+This prepends all Cypher queries with a `CYPHER [version]` statement:
+
+```cypher
+CYPHER 5
+MATCH (this:Movie)
+WHERE this.title = $param0
+RETURN this { .title } AS this
+```

--- a/packages/graphql/src/classes/Executor.ts
+++ b/packages/graphql/src/classes/Executor.ts
@@ -40,6 +40,7 @@ import {
 import { debugCypherAndParams } from "../debug/debug-cypher-and-params";
 import environment from "../environment";
 import type { CypherQueryOptions } from "../types";
+import { isInArray } from "../utils/is-in-array";
 import {
     Neo4jGraphQLAuthenticationError,
     Neo4jGraphQLConstraintValidationError,
@@ -48,6 +49,8 @@ import {
 } from "./Error";
 
 const debug = Debug(DEBUG_EXECUTE);
+
+const SUPPORTED_CYPHER_VERSION = "5";
 
 interface DriverLike {
     session(config);
@@ -179,16 +182,34 @@ export class Executor {
         return error;
     }
 
-    private generateQuery(query: string): string {
-        if (this.cypherQueryOptions && Object.keys(this.cypherQueryOptions).length) {
-            const cypherQueryOptions = `CYPHER ${Object.entries(this.cypherQueryOptions)
-                .map(([key, value]) => `${key}=${value}`)
-                .join(" ")}`;
+    private addCypherOptionsToQuery(query: string): string {
+        const cypherVersion = this.getCypherVersionStatement();
 
-            return `${cypherQueryOptions}\n${query}`;
+        const cypherQueryOptions = this.getCypherQueryOptionsStatement();
+
+        return `${cypherVersion}${cypherQueryOptions}${query}`;
+    }
+
+    private getCypherVersionStatement(): string {
+        if (this.cypherQueryOptions?.addVersionPrefix) {
+            return `CYPHER ${SUPPORTED_CYPHER_VERSION}\n`;
         }
+        return "";
+    }
 
-        return query;
+    private getCypherQueryOptionsStatement(): string {
+        const ignoredCypherQueryOptions: Array<keyof CypherQueryOptions> = ["addVersionPrefix"];
+        const cypherQueryOptions = Object.entries(this.cypherQueryOptions ?? []).filter(([key, _value]) => {
+            return !isInArray(ignoredCypherQueryOptions, key);
+        });
+        if (cypherQueryOptions.length) {
+            return `CYPHER ${cypherQueryOptions
+                .map(([key, value]) => {
+                    return `${key}=${value}`;
+                })
+                .join(" ")}\n`;
+        }
+        return "";
     }
 
     private getTransactionConfig(info?: GraphQLResolveInfo): TransactionConfig {
@@ -290,7 +311,7 @@ export class Executor {
         parameters: Record<string, any>,
         transaction: Transaction | ManagedTransaction
     ): Result {
-        const queryToRun = this.generateQuery(query);
+        const queryToRun = this.addCypherOptionsToQuery(query);
 
         debugCypherAndParams(debug, queryToRun, parameters);
 

--- a/packages/graphql/src/translate/translate-resolve-reference.ts
+++ b/packages/graphql/src/translate/translate-resolve-reference.ts
@@ -18,11 +18,11 @@
  */
 
 import type Cypher from "@neo4j/cypher-builder";
-import type { Neo4jGraphQLTranslationContext } from "../types/neo4j-graphql-translation-context";
 import Debug from "debug";
-import { QueryASTFactory } from "./queryAST/factory/QueryASTFactory";
-import type { EntityAdapter } from "../schema-model/entity/EntityAdapter";
 import { DEBUG_TRANSLATE } from "../constants";
+import type { EntityAdapter } from "../schema-model/entity/EntityAdapter";
+import type { Neo4jGraphQLTranslationContext } from "../types/neo4j-graphql-translation-context";
+import { QueryASTFactory } from "./queryAST/factory/QueryASTFactory";
 
 const debug = Debug(DEBUG_TRANSLATE);
 

--- a/packages/graphql/src/types/index.ts
+++ b/packages/graphql/src/types/index.ts
@@ -276,6 +276,7 @@ export interface CypherQueryOptions {
     operatorEngine?: "default" | "interpreted" | "compiled";
     interpretedPipesFallback?: "default" | "disabled" | "whitelisted_plans_only" | "all";
     replan?: "default" | "force" | "skip";
+    addVersionPrefix?: boolean;
 }
 
 /** Input field for graphql-compose */

--- a/packages/graphql/tests/integration/config-options/query-options.int.test.ts
+++ b/packages/graphql/tests/integration/config-options/query-options.int.test.ts
@@ -88,35 +88,4 @@ describe("query options", () => {
         expect(result?.data?.[Movie.plural]).toEqual([{ id }, { id }, { id }]);
     });
 
-    test("queries should work with version set to Cypher version", async () => {
-        const id = generate({
-            charset: "alphabetic",
-        });
-
-        const query = `
-            query($id: ID){
-                ${Movie.plural}(where: {id: $id}){
-                    id
-                }
-            }
-        `;
-
-        await neoSchema.checkNeo4jCompat();
-
-        await testHelper.executeCypher(
-            `
-              CREATE (:${Movie} {id: $id}), (:${Movie} {id: $id}), (:${Movie} {id: $id})
-            `,
-            { id }
-        );
-
-        const result = await testHelper.executeGraphQL(query, {
-            variableValues: { id },
-            contextValue: { cypherQueryOptions: { runtime: "interpreted", addVersionPrefix: true } },
-        });
-
-        expect(result.errors).toBeFalsy();
-
-        expect(result?.data?.[Movie.plural]).toEqual([{ id }, { id }, { id }]);
-    });
 });

--- a/packages/graphql/tests/integration/config-options/query-options.int.test.ts
+++ b/packages/graphql/tests/integration/config-options/query-options.int.test.ts
@@ -87,4 +87,36 @@ describe("query options", () => {
 
         expect(result?.data?.[Movie.plural]).toEqual([{ id }, { id }, { id }]);
     });
+
+    test("queries should work with version set to Cypher version", async () => {
+        const id = generate({
+            charset: "alphabetic",
+        });
+
+        const query = `
+            query($id: ID){
+                ${Movie.plural}(where: {id: $id}){
+                    id
+                }
+            }
+        `;
+
+        await neoSchema.checkNeo4jCompat();
+
+        await testHelper.executeCypher(
+            `
+              CREATE (:${Movie} {id: $id}), (:${Movie} {id: $id}), (:${Movie} {id: $id})
+            `,
+            { id }
+        );
+
+        const result = await testHelper.executeGraphQL(query, {
+            variableValues: { id },
+            contextValue: { cypherQueryOptions: { runtime: "interpreted", addVersionPrefix: true } },
+        });
+
+        expect(result.errors).toBeFalsy();
+
+        expect(result?.data?.[Movie.plural]).toEqual([{ id }, { id }, { id }]);
+    });
 });


### PR DESCRIPTION
# Description

Add `addVersionPrefix` to `cypherQueryOptions` in context to add a Cypher version with `CYPHER` before each query:

```js
{
    cypherQueryOptions: {
        addVersionPrefix: true,
    },
}
```

This prepends all Cypher queries with a `CYPHER [version]` statement:

```cypher
CYPHER 5
MATCH (this:Movie)
WHERE this.title = $param0
RETURN this { .title } AS this
```
