### PR TITLE
Fix missing schema model on subscription engines init

### DIFF
--- a/.changeset/hip-actors-retire.md
+++ b/.changeset/hip-actors-retire.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+Fix error "SchemaModel not available on subscription mechanism" with some subscriptions engines when used with Federation

--- a/packages/graphql/src/classes/Neo4jGraphQL.ts
+++ b/packages/graphql/src/classes/Neo4jGraphQL.ts
@@ -128,7 +128,7 @@ class Neo4jGraphQL {
     public async getSubgraphSchema(): Promise<GraphQLSchema> {
         if (!this.subgraphSchema) {
             this.subgraphSchema = this.generateSubgraphSchema();
-
+            await this.subgraphSchema; // Avoids race condition with engine init
             await this.subscriptionMechanismSetup();
         }
 


### PR DESCRIPTION
# Description

Fix error "SchemaModel not available on subscription mechanism" with some subscriptions engines when used with Federation


This error was already fixed in version 6 and this backports it to LTS