### PR TITLE
Count aggregation

### DIFF
--- a/.changeset/hot-bikes-complain.md
+++ b/.changeset/hot-bikes-complain.md
@@ -1,0 +1,32 @@
+---
+"@neo4j/graphql": patch
+---
+
+Add count fields in aggregations with support for nodes and edges count:
+
+```graphql
+query {
+    moviesConnection {
+        aggregate {
+            count {
+                nodes
+            }
+        }
+    }
+}
+```
+
+```graphql
+query {
+    movies {
+        actorsConnection {
+            aggregate {
+                count {
+                    nodes
+                    edges
+                }
+            }
+        }
+    }
+}
+```

--- a/packages/graphql/src/graphql/objects/CartesianPoint.ts
+++ b/packages/graphql/src/graphql/objects/CartesianPoint.ts
@@ -41,7 +41,7 @@ export const CartesianPoint = new GraphQLObjectType({
         },
         srid: {
             type: new GraphQLNonNull(GraphQLInt),
-            resolve: (source, args, context, info) => numericalResolver(source, args, context, info),
+            resolve: numericalResolver,
         },
     },
 });

--- a/packages/graphql/src/graphql/objects/Point.ts
+++ b/packages/graphql/src/graphql/objects/Point.ts
@@ -44,7 +44,7 @@ export const Point = new GraphQLObjectType({
         },
         srid: {
             type: new GraphQLNonNull(GraphQLInt),
-            resolve: (source, args, context, info) => numericalResolver(source, args, context, info),
+            resolve: numericalResolver,
         },
     },
 });

--- a/packages/graphql/src/schema-model/entity/model-adapters/ImplementingEntityOperations.ts
+++ b/packages/graphql/src/schema-model/entity/model-adapters/ImplementingEntityOperations.ts
@@ -144,7 +144,12 @@ export class ImplementingEntityOperations<T extends InterfaceEntityAdapter | Con
         return `${this.entityAdapter.name}ImplementationsSubscriptionWhere`;
     }
 
+    /** @deprecated use `getAggregateFieldTypename` instead */
     public getAggregationFieldTypename(): string {
+        return this.aggregateTypeNames.selection;
+    }
+
+    public getAggregateFieldTypename(): string {
         return this.aggregateTypeNames.selection;
     }
 

--- a/packages/graphql/src/schema-model/relationship/model-adapters/RelationshipAdapter.ts
+++ b/packages/graphql/src/schema-model/relationship/model-adapters/RelationshipAdapter.ts
@@ -206,10 +206,6 @@ export class RelationshipAdapter {
             return false;
         }
 
-        if (this.target instanceof UnionEntityAdapter || this.source instanceof InterfaceEntityAdapter) {
-            return false;
-        }
-
         return this.annotations.selectable?.onAggregate !== false;
     }
 

--- a/packages/graphql/src/schema-model/relationship/model-adapters/RelationshipBaseOperations.ts
+++ b/packages/graphql/src/schema-model/relationship/model-adapters/RelationshipBaseOperations.ts
@@ -39,13 +39,23 @@ export abstract class RelationshipBaseOperations<T extends RelationshipAdapter |
 
     protected abstract get edgePrefix(): string;
 
-    /**Note: Required for now to infer the types without ResolveTree */
+    /**Note: Required for now to infer the types without ResolveTree
+     * @deprecated use getAggregateFieldTypename
+     *
+     */
     public getAggregationFieldTypename(nestedField?: "node" | "edge"): string {
         const nestedFieldStr = upperFirst(nestedField || "");
         const aggregationStr = nestedField ? "Aggregate" : "Aggregation";
         return `${this.relationship.source.name}${this.relationship.target.name}${upperFirst(
             this.relationship.name
         )}${nestedFieldStr}${aggregationStr}Selection`;
+    }
+
+    public getAggregateFieldTypename(nestedField?: "node" | "edge"): string {
+        const nestedFieldStr = upperFirst(nestedField || "");
+        return `${this.relationship.source.name}${this.relationship.target.name}${upperFirst(
+            this.relationship.name
+        )}${nestedFieldStr}AggregateSelection`;
     }
 
     public getTargetTypePrettyName(): string {

--- a/packages/graphql/src/schema/aggregations/field-aggregation-composer.ts
+++ b/packages/graphql/src/schema/aggregations/field-aggregation-composer.ts
@@ -27,6 +27,7 @@ import { RelationshipAdapter } from "../../schema-model/relationship/model-adapt
 import type { RelationshipDeclarationAdapter } from "../../schema-model/relationship/model-adapters/RelationshipDeclarationAdapter";
 import type { Neo4jFeaturesSettings } from "../../types";
 import { DEPRECATE_ID_AGGREGATION } from "../constants";
+import { getCountConnectionType } from "../generation/aggregate-types";
 import { shouldAddDeprecatedFields } from "../generation/utils";
 import { numericalResolver } from "../resolvers/field/numerical";
 import { AggregationTypesMapper } from "./aggregation-types-mapper";
@@ -80,6 +81,15 @@ export class FieldAggregationComposer {
                 aggregateSelectionEdgeFields
             );
         }
+
+        this.composer.createObjectTC({
+            name: relationshipAdapter.operations.getAggregateFieldTypename(),
+            fields: {
+                count: getCountConnectionType(this.composer),
+                ...(aggregateSelectionNode ? { node: aggregateSelectionNode } : {}),
+                ...(aggregateSelectionEdge ? { edge: aggregateSelectionEdge } : {}),
+            },
+        });
 
         return this.composer.createObjectTC({
             name: relationshipAdapter.operations.getAggregationFieldTypename(),

--- a/packages/graphql/src/schema/aggregations/field-aggregation-composer.ts
+++ b/packages/graphql/src/schema/aggregations/field-aggregation-composer.ts
@@ -85,7 +85,7 @@ export class FieldAggregationComposer {
         this.composer.createObjectTC({
             name: relationshipAdapter.operations.getAggregateFieldTypename(),
             fields: {
-                count: getCountConnectionType(this.composer),
+                count: getCountConnectionType(this.composer).NonNull,
                 ...(aggregateSelectionNode ? { node: aggregateSelectionNode } : {}),
                 ...(aggregateSelectionEdge ? { edge: aggregateSelectionEdge } : {}),
             },

--- a/packages/graphql/src/schema/generation/aggregate-types.ts
+++ b/packages/graphql/src/schema/generation/aggregate-types.ts
@@ -74,6 +74,27 @@ export function withAggregateSelectionType({
     return aggregateSelection;
 }
 
+/** Top level count */
+export function getCountType(composer: SchemaComposer): ObjectTypeComposer {
+    const CountFieldName = "Count";
+    return composer.getOrCreateOTC(CountFieldName, (countField) => {
+        countField.addFields({
+            nodes: new GraphQLNonNull(GraphQLInt),
+        });
+    });
+}
+
+/** Nested count */
+export function getCountConnectionType(composer: SchemaComposer): ObjectTypeComposer {
+    const CountFieldName = "CountConnection";
+    return composer.getOrCreateOTC(CountFieldName, (countField) => {
+        countField.addFields({
+            nodes: new GraphQLNonNull(GraphQLInt),
+            edges: new GraphQLNonNull(GraphQLInt),
+        });
+    });
+}
+
 /** Create aggregate field inside connections */
 function createConnectionAggregate({
     entityAdapter,
@@ -88,26 +109,33 @@ function createConnectionAggregate({
     composer: SchemaComposer;
     features: Neo4jFeaturesSettings | undefined;
 }): ObjectTypeComposer {
-    const aggregateNode = composer.createObjectTC({
-        name: entityAdapter.operations.aggregateTypeNames.node,
-        fields: {
-            count: {
-                type: new GraphQLNonNull(GraphQLInt),
-                resolve: numericalResolver,
-                args: {},
-            },
-        },
-        directives: graphqlDirectivesToCompose(propagatedDirectives),
-    });
-    aggregateNode.addFields(makeAggregableFields({ entityAdapter, aggregationTypesMapper, features }));
+    const aggregableFields = makeAggregableFields({ entityAdapter, aggregationTypesMapper, features });
+    let aggregateNode: ObjectTypeComposer | undefined;
+    const hasNodeAggregateFields = Object.keys(aggregableFields).length > 0;
+    if (hasNodeAggregateFields) {
+        aggregateNode = composer.createObjectTC({
+            name: entityAdapter.operations.aggregateTypeNames.node,
+            fields: {},
+            directives: graphqlDirectivesToCompose(propagatedDirectives),
+        });
+        aggregateNode.addFields(aggregableFields);
+    }
 
-    return composer.createObjectTC({
+    const connectionAggregate = composer.createObjectTC({
         name: entityAdapter.operations.aggregateTypeNames.connection,
         fields: {
-            node: aggregateNode.NonNull,
+            count: getCountType(composer),
         },
         directives: graphqlDirectivesToCompose(propagatedDirectives),
     });
+
+    if (aggregateNode) {
+        connectionAggregate.addFields({
+            node: aggregateNode.NonNull,
+        });
+    }
+
+    return connectionAggregate;
 }
 
 function makeAggregableFields({

--- a/packages/graphql/src/schema/generation/aggregate-types.ts
+++ b/packages/graphql/src/schema/generation/aggregate-types.ts
@@ -81,7 +81,7 @@ export function getCountType(composer: SchemaComposer): ObjectTypeComposer {
         countField.addFields({
             nodes: {
                 type: new GraphQLNonNull(GraphQLInt),
-                resolve: (source, args, context, info) => numericalResolver(source, args, context, info),
+                resolve: numericalResolver,
             },
         });
     });
@@ -94,11 +94,11 @@ export function getCountConnectionType(composer: SchemaComposer): ObjectTypeComp
         countField.addFields({
             nodes: {
                 type: new GraphQLNonNull(GraphQLInt),
-                resolve: (source, args, context, info) => numericalResolver(source, args, context, info),
+                resolve: numericalResolver,
             },
             edges: {
                 type: new GraphQLNonNull(GraphQLInt),
-                resolve: (source, args, context, info) => numericalResolver(source, args, context, info),
+                resolve: numericalResolver,
             },
         });
     });

--- a/packages/graphql/src/schema/generation/aggregate-types.ts
+++ b/packages/graphql/src/schema/generation/aggregate-types.ts
@@ -76,8 +76,8 @@ export function withAggregateSelectionType({
 
 /** Top level count */
 export function getCountType(composer: SchemaComposer): ObjectTypeComposer {
-    const CountFieldName = "Count";
-    return composer.getOrCreateOTC(CountFieldName, (countField) => {
+    const countFieldName = "Count";
+    return composer.getOrCreateOTC(countFieldName, (countField) => {
         countField.addFields({
             nodes: {
                 type: new GraphQLNonNull(GraphQLInt),
@@ -89,8 +89,8 @@ export function getCountType(composer: SchemaComposer): ObjectTypeComposer {
 
 /** Nested count */
 export function getCountConnectionType(composer: SchemaComposer): ObjectTypeComposer {
-    const CountFieldName = "CountConnection";
-    return composer.getOrCreateOTC(CountFieldName, (countField) => {
+    const countFieldName = "CountConnection";
+    return composer.getOrCreateOTC(countFieldName, (countField) => {
         countField.addFields({
             nodes: {
                 type: new GraphQLNonNull(GraphQLInt),

--- a/packages/graphql/src/schema/generation/aggregate-types.ts
+++ b/packages/graphql/src/schema/generation/aggregate-types.ts
@@ -79,7 +79,10 @@ export function getCountType(composer: SchemaComposer): ObjectTypeComposer {
     const CountFieldName = "Count";
     return composer.getOrCreateOTC(CountFieldName, (countField) => {
         countField.addFields({
-            nodes: new GraphQLNonNull(GraphQLInt),
+            nodes: {
+                type: new GraphQLNonNull(GraphQLInt),
+                resolve: (source, args, context, info) => numericalResolver(source, args, context, info),
+            },
         });
     });
 }
@@ -89,8 +92,14 @@ export function getCountConnectionType(composer: SchemaComposer): ObjectTypeComp
     const CountFieldName = "CountConnection";
     return composer.getOrCreateOTC(CountFieldName, (countField) => {
         countField.addFields({
-            nodes: new GraphQLNonNull(GraphQLInt),
-            edges: new GraphQLNonNull(GraphQLInt),
+            nodes: {
+                type: new GraphQLNonNull(GraphQLInt),
+                resolve: (source, args, context, info) => numericalResolver(source, args, context, info),
+            },
+            edges: {
+                type: new GraphQLNonNull(GraphQLInt),
+                resolve: (source, args, context, info) => numericalResolver(source, args, context, info),
+            },
         });
     });
 }
@@ -124,7 +133,7 @@ function createConnectionAggregate({
     const connectionAggregate = composer.createObjectTC({
         name: entityAdapter.operations.aggregateTypeNames.connection,
         fields: {
-            count: getCountType(composer),
+            count: getCountType(composer).NonNull,
         },
         directives: graphqlDirectivesToCompose(propagatedDirectives),
     });

--- a/packages/graphql/src/schema/generation/connection-object-type.ts
+++ b/packages/graphql/src/schema/generation/connection-object-type.ts
@@ -51,7 +51,7 @@ export function withConnectionObjectType({
 
     if (relationshipAdapter.isAggregable() && !isTargetUnion && !isSourceInterface) {
         connectionObjectType.addFields({
-            aggregate: composer.getOTC(relationshipAdapter.operations.getAggregationFieldTypename()).NonNull,
+            aggregate: composer.getOTC(relationshipAdapter.operations.getAggregateFieldTypename()).NonNull,
         });
     }
 

--- a/packages/graphql/src/translate/queryAST/ast/fields/aggregation-fields/CountField.ts
+++ b/packages/graphql/src/translate/queryAST/ast/fields/aggregation-fields/CountField.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Cypher from "@neo4j/cypher-builder";
+import type { Entity } from "../../../../../schema-model/entity/Entity";
+import type { QueryASTNode } from "../../QueryASTNode";
+import { AggregationField } from "./AggregationField";
+
+export class CountField extends AggregationField {
+    private entity: Entity;
+
+    constructor({ alias, entity }: { alias: string; entity: Entity }) {
+        super(alias);
+        this.entity = entity;
+    }
+
+    public getChildren(): QueryASTNode[] {
+        return [];
+    }
+
+    public getProjectionField(variable: Cypher.Variable): Record<string, Cypher.Expr> {
+        return { [this.alias]: variable };
+    }
+
+    public getAggregationExpr(variable: Cypher.Variable): Cypher.Expr {
+        return Cypher.count(variable);
+    }
+
+    public getAggregationProjection(target: Cypher.Variable, returnVar: Cypher.Variable): Cypher.Clause {
+        return new Cypher.Return([new Cypher.Map({ nodes: this.getAggregationExpr(target) }), returnVar]);
+    }
+}

--- a/packages/graphql/src/translate/queryAST/ast/fields/aggregation-fields/CountField.ts
+++ b/packages/graphql/src/translate/queryAST/ast/fields/aggregation-fields/CountField.ts
@@ -24,10 +24,22 @@ import { AggregationField } from "./AggregationField";
 
 export class CountField extends AggregationField {
     private entity: Entity;
+    public edgeVar: Cypher.Variable | undefined;
 
-    constructor({ alias, entity }: { alias: string; entity: Entity }) {
+    private countFields: { nodes: boolean; edges: boolean };
+
+    constructor({
+        alias,
+        entity,
+        fields,
+    }: {
+        alias: string;
+        entity: Entity;
+        fields: { nodes: boolean; edges: boolean };
+    }) {
         super(alias);
         this.entity = entity;
+        this.countFields = fields;
     }
 
     public getChildren(): QueryASTNode[] {
@@ -43,6 +55,20 @@ export class CountField extends AggregationField {
     }
 
     public getAggregationProjection(target: Cypher.Variable, returnVar: Cypher.Variable): Cypher.Clause {
-        return new Cypher.Return([new Cypher.Map({ nodes: this.getAggregationExpr(target) }), returnVar]);
+        const resultMap = new Cypher.Map();
+
+        if (this.countFields.nodes) {
+            resultMap.set("nodes", this.getAggregationExpr(target));
+        }
+        if (this.countFields.edges) {
+            if (!this.edgeVar) {
+                throw new Error(
+                    "Edge variable not defined in Count field. This is likely a bug with the GraphQL library."
+                );
+            }
+            resultMap.set("edges", this.getAggregationExpr(this.edgeVar));
+        }
+
+        return new Cypher.Return([resultMap, returnVar]);
     }
 }

--- a/packages/graphql/src/translate/queryAST/ast/fields/aggregation-fields/DeprecatedCountField.ts
+++ b/packages/graphql/src/translate/queryAST/ast/fields/aggregation-fields/DeprecatedCountField.ts
@@ -22,7 +22,7 @@ import type { Entity } from "../../../../../schema-model/entity/Entity";
 import type { QueryASTNode } from "../../QueryASTNode";
 import { AggregationField } from "./AggregationField";
 
-export class CountField extends AggregationField {
+export class DeprecatedCountField extends AggregationField {
     private entity: Entity;
 
     constructor({ alias, entity }: { alias: string; entity: Entity }) {

--- a/packages/graphql/src/translate/queryAST/ast/operations/AggregationOperation.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/AggregationOperation.ts
@@ -172,12 +172,7 @@ export class AggregationOperation extends Operation {
         const nodeMap = new Cypher.Map();
         const fieldSubqueries = this.fields.map((f) => {
             const returnVariable = new Cypher.Variable();
-            if (this.isInConnectionField) {
-                // Default fields are in node in connection translation
-                nodeMap.set(f.getProjectionField(returnVariable));
-            } else {
-                this.aggregationProjectionMap.set(f.getProjectionField(returnVariable));
-            }
+            this.aggregationProjectionMap.set(f.getProjectionField(returnVariable));
             return this.createSubquery(f, pattern, returnVariable, context);
         });
 

--- a/packages/graphql/src/translate/queryAST/ast/operations/AggregationOperation.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/AggregationOperation.ts
@@ -25,6 +25,7 @@ import { wrapSubqueriesInCypherCalls } from "../../utils/wrap-subquery-in-calls"
 import { QueryASTContext } from "../QueryASTContext";
 import type { QueryASTNode } from "../QueryASTNode";
 import type { AggregationField } from "../fields/aggregation-fields/AggregationField";
+import { CountField } from "../fields/aggregation-fields/CountField";
 import type { Filter } from "../filters/Filter";
 import type { AuthorizationFilters } from "../filters/authorization-filters/AuthorizationFilters";
 import type { EntitySelection } from "../selection/EntitySelection";
@@ -231,6 +232,10 @@ export class AggregationOperation extends Operation {
             } else {
                 matchClause.where(filterPredicates);
             }
+        }
+
+        if (field instanceof CountField) {
+            field.edgeVar = nestedContext.relationship;
         }
 
         const ret = this.getFieldProjectionClause(targetVar, returnVariable, field);

--- a/packages/graphql/src/translate/queryAST/ast/operations/composite/CompositeAggregationOperation.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/composite/CompositeAggregationOperation.ts
@@ -148,13 +148,7 @@ export class CompositeAggregationOperation extends Operation {
     private transpileAggregationOperation(context: QueryASTContext, addWith = true): OperationTranspileResult {
         this.addWith = addWith;
 
-        let fieldSubqueries: Cypher.CompositeClause[];
-        if (this.isInConnectionField) {
-            fieldSubqueries = this.createSubqueries(this.fields, context, this.nodeMap);
-        } else {
-            // NOTE: this is to support deprecated aggregations
-            fieldSubqueries = this.createSubqueries(this.fields, context, this.aggregationProjectionMap);
-        }
+        const fieldSubqueries = this.createSubqueries(this.fields, context, this.aggregationProjectionMap);
 
         const nodeFieldSubqueries = this.createSubqueries(this.nodeFields, context, this.nodeMap);
         const edgeFieldSubqueries = this.createSubqueries(

--- a/packages/graphql/src/translate/queryAST/factory/FieldFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/FieldFactory.ts
@@ -138,7 +138,7 @@ export class FieldFactory {
         return filterTruthy(
             Object.values(rawFields).map((field) => {
                 if (field.name === "count") {
-                    if (field.fieldsByTypeName["Count"]) {
+                    if (field.fieldsByTypeName["Count"] || field.fieldsByTypeName["CountConnection"]) {
                         // New Count
                         return new CountField({
                             alias: field.alias,

--- a/packages/graphql/src/translate/queryAST/factory/FieldFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/FieldFactory.ts
@@ -34,6 +34,7 @@ import type { Field } from "../ast/fields/Field";
 import { OperationField } from "../ast/fields/OperationField";
 import { AggregationAttributeField } from "../ast/fields/aggregation-fields/AggregationAttributeField";
 import type { AggregationField } from "../ast/fields/aggregation-fields/AggregationField";
+import { CountField } from "../ast/fields/aggregation-fields/CountField";
 import { DeprecatedCountField } from "../ast/fields/aggregation-fields/DeprecatedCountField";
 import { AttributeField } from "../ast/fields/attribute-fields/AttributeField";
 import { DateTimeField } from "../ast/fields/attribute-fields/DateTimeField";
@@ -137,6 +138,13 @@ export class FieldFactory {
         return filterTruthy(
             Object.values(rawFields).map((field) => {
                 if (field.name === "count") {
+                    if (field.fieldsByTypeName["Count"]) {
+                        // New Count
+                        return new CountField({
+                            alias: field.alias,
+                            entity: entity as any,
+                        });
+                    }
                     return new DeprecatedCountField({
                         alias: field.alias,
                         entity: entity as any,

--- a/packages/graphql/src/translate/queryAST/factory/FieldFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/FieldFactory.ts
@@ -42,6 +42,7 @@ import type { ConnectionReadOperation } from "../ast/operations/ConnectionReadOp
 import type { CompositeConnectionReadOperation } from "../ast/operations/composite/CompositeConnectionReadOperation";
 import { isConcreteEntity } from "../utils/is-concrete-entity";
 import type { QueryASTFactory } from "./QueryASTFactory";
+import { findFieldsByNameInFieldsByTypeNameField } from "./parsers/find-fields-by-name-in-fields-by-type-name-field";
 import { parseSelectionSetField } from "./parsers/parse-selection-set-fields";
 
 export class FieldFactory {
@@ -138,11 +139,17 @@ export class FieldFactory {
         return filterTruthy(
             Object.values(rawFields).map((field) => {
                 if (field.name === "count") {
-                    if (field.fieldsByTypeName["Count"] || field.fieldsByTypeName["CountConnection"]) {
-                        // New Count
+                    const countFields = field.fieldsByTypeName["Count"] ?? field.fieldsByTypeName["CountConnection"];
+                    if (countFields) {
+                        const hasNodes = findFieldsByNameInFieldsByTypeNameField(countFields, "nodes").length > 0;
+                        const hasEdges = findFieldsByNameInFieldsByTypeNameField(countFields, "edges").length > 0;
                         return new CountField({
                             alias: field.alias,
                             entity: entity as any,
+                            fields: {
+                                nodes: hasNodes,
+                                edges: hasEdges,
+                            },
                         });
                     }
                     return new DeprecatedCountField({

--- a/packages/graphql/src/translate/queryAST/factory/FieldFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/FieldFactory.ts
@@ -34,7 +34,7 @@ import type { Field } from "../ast/fields/Field";
 import { OperationField } from "../ast/fields/OperationField";
 import { AggregationAttributeField } from "../ast/fields/aggregation-fields/AggregationAttributeField";
 import type { AggregationField } from "../ast/fields/aggregation-fields/AggregationField";
-import { CountField } from "../ast/fields/aggregation-fields/CountField";
+import { DeprecatedCountField } from "../ast/fields/aggregation-fields/DeprecatedCountField";
 import { AttributeField } from "../ast/fields/attribute-fields/AttributeField";
 import { DateTimeField } from "../ast/fields/attribute-fields/DateTimeField";
 import type { ConnectionReadOperation } from "../ast/operations/ConnectionReadOperation";
@@ -137,7 +137,7 @@ export class FieldFactory {
         return filterTruthy(
             Object.values(rawFields).map((field) => {
                 if (field.name === "count") {
-                    return new CountField({
+                    return new DeprecatedCountField({
                         alias: field.alias,
                         entity: entity as any,
                     });

--- a/packages/graphql/src/translate/queryAST/factory/Operations/AggregateFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/Operations/AggregateFactory.ts
@@ -158,22 +158,6 @@ export class AggregateFactory {
                     selection,
                 });
 
-                const parsedProjectionFields = this.getAggregationParsedProjectionFields(entity, resolveTree);
-
-                // TODO: Move to hydrate?
-                const nodeRawFields = {
-                    ...parsedProjectionFields.node?.fieldsByTypeName[entityOrRel.operations.aggregateTypeNames.node],
-                    ...parsedProjectionFields.fields, // Support for deprecated aggregate
-                };
-                const authFilters = this.queryASTFactory.authorizationFactory.getAuthFilters({
-                    entity,
-                    operations: ["AGGREGATE"],
-                    attributes: this.queryASTFactory.operationsFactory.getSelectedAttributes(entity, nodeRawFields),
-                    context,
-                });
-
-                operation.addAuthFilters(...authFilters);
-
                 return this.hydrateAggregationOperation({
                     operation,
                     entity,
@@ -355,6 +339,10 @@ export class AggregateFactory {
                     entity,
                     operations: ["AGGREGATE"],
                     context,
+                    attributes: this.queryASTFactory.operationsFactory.getSelectedAttributes(entity, {
+                        ...nodeRawFields,
+                        ...rawProjectionFields,
+                    }),
                 });
 
                 operation.addAuthFilters(...authFilters);

--- a/packages/graphql/src/translate/queryAST/factory/Operations/AggregateFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/Operations/AggregateFactory.ts
@@ -33,6 +33,7 @@ import { getConcreteEntities } from "../../utils/get-concrete-entities";
 import { isConcreteEntity } from "../../utils/is-concrete-entity";
 import { isInterfaceEntity } from "../../utils/is-interface-entity";
 import type { QueryASTFactory } from "../QueryASTFactory";
+import { findFieldsByNameInFieldsByTypeNameField } from "../parsers/find-fields-by-name-in-fields-by-type-name-field";
 
 export class AggregateFactory {
     private queryASTFactory: QueryASTFactory;
@@ -62,6 +63,7 @@ export class AggregateFactory {
 
         if (entityOrRel instanceof RelationshipAdapter) {
             if (isConcreteEntity(entity)) {
+                // RELATIONSHIP WITH CONCRETE TARGET
                 checkEntityAuthentication({
                     entity: entity.entity,
                     targetOperations: ["AGGREGATE"],
@@ -87,6 +89,7 @@ export class AggregateFactory {
                     whereArgs: resolveTreeWhere,
                 });
             } else {
+                // RELATIONSHIP WITH INTERFACE TARGET
                 const concreteEntities = getConcreteEntities(entity, resolveTreeWhere);
 
                 const parsedProjectionFields = this.getAggregationParsedProjectionFields(entityOrRel, resolveTree);
@@ -137,6 +140,8 @@ export class AggregateFactory {
             }
         } else {
             if (isConcreteEntity(entity)) {
+                // TOP LEVEL CONCRETE
+                console.log("Top Level Concrete");
                 let selection: EntitySelection;
                 // NOTE: If we introduce vector index aggregation, checking the phrase will cause a problem
                 if (context.resolveTree.args.fulltext || context.resolveTree.args.phrase) {
@@ -156,31 +161,30 @@ export class AggregateFactory {
 
                 const parsedProjectionFields = this.getAggregationParsedProjectionFields(entity, resolveTree);
 
-                const fields = this.queryASTFactory.fieldFactory.createAggregationFields(
-                    entity,
-                    parsedProjectionFields.fields
-                );
-
-                operation.setFields(fields);
-
-                const whereArgs = this.queryASTFactory.operationsFactory.getWhereArgs(resolveTree);
+                // TODO: Move to hydrate?
+                const nodeRawFields = {
+                    ...parsedProjectionFields.node?.fieldsByTypeName[entityOrRel.operations.aggregateTypeNames.node],
+                    ...parsedProjectionFields.fields, // Support for deprecated aggregate
+                };
                 const authFilters = this.queryASTFactory.authorizationFactory.getAuthFilters({
                     entity,
                     operations: ["AGGREGATE"],
-                    attributes: this.queryASTFactory.operationsFactory.getSelectedAttributes(
-                        entity,
-                        parsedProjectionFields.fields
-                    ),
+                    attributes: this.queryASTFactory.operationsFactory.getSelectedAttributes(entity, nodeRawFields),
                     context,
                 });
 
-                const filters = this.queryASTFactory.filterFactory.createNodeFilters(entity, whereArgs); // Aggregation filters only apply to target node
-
-                operation.addFilters(...filters);
                 operation.addAuthFilters(...authFilters);
 
-                return operation;
+                return this.hydrateAggregationOperation({
+                    operation,
+                    entity,
+                    resolveTree,
+                    context,
+                    whereArgs: resolveTreeWhere,
+                });
+                // return operation;
             } else {
+                console.log("Top Level Interface");
                 // TOP level interface/union
                 const concreteEntities = getConcreteEntities(entity, resolveTreeWhere);
 
@@ -233,7 +237,10 @@ export class AggregateFactory {
     } {
         let nodeFields: Record<string, ResolveTree> = {};
         if (adapter instanceof ConcreteEntityAdapter) {
-            nodeFields = resolveTree.fieldsByTypeName[adapter.operations.aggregateTypeNames.node] ?? {};
+            nodeFields = {
+                ...(resolveTree.fieldsByTypeName[adapter.operations.aggregateTypeNames.node] ?? {}),
+                ...(resolveTree.fieldsByTypeName[adapter.operations.aggregateTypeNames.connection] ?? {}),
+            };
         }
         if (adapter instanceof RelationshipAdapter) {
             nodeFields = resolveTree.fieldsByTypeName[adapter.operations.getAggregationFieldTypename("node")] ?? {};
@@ -245,7 +252,6 @@ export class AggregateFactory {
             ...resolveTree.fieldsByTypeName[adapter.operations.getAggregateFieldTypename()],
             ...nodeFields,
         };
-
         return this.queryASTFactory.operationsFactory.splitConnectionFields(rawProjectionFields);
     }
 
@@ -317,6 +323,27 @@ export class AggregateFactory {
             };
 
             const fields = this.queryASTFactory.fieldFactory.createAggregationFields(entity, rawProjectionFields);
+            // TOP Level aggregate in connection
+            const connectionFields = {
+                // TOP level connection fields
+                ...resolveTree.fieldsByTypeName[entity.operations.aggregateTypeNames.connection],
+            };
+
+            const nodeResolveTree = findFieldsByNameInFieldsByTypeNameField(connectionFields, "node")[0];
+            const nodeRawFields = {
+                ...nodeResolveTree?.fieldsByTypeName[entity.operations.aggregateTypeNames.node],
+            };
+
+            const nodeFields = this.queryASTFactory.fieldFactory.createAggregationFields(entity, nodeRawFields);
+            operation.setNodeFields(nodeFields);
+            const countResolveTree = findFieldsByNameInFieldsByTypeNameField(connectionFields, "count")[0];
+
+            if (countResolveTree) {
+                const connetionTopFields = this.queryASTFactory.fieldFactory.createAggregationFields(entity, {
+                    count: countResolveTree,
+                });
+                fields.push(...connetionTopFields);
+            }
 
             if (isInterfaceEntity(entity)) {
                 const filters = this.queryASTFactory.filterFactory.createInterfaceNodeFilters({

--- a/packages/graphql/src/translate/queryAST/factory/Operations/AggregateFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/Operations/AggregateFactory.ts
@@ -141,7 +141,6 @@ export class AggregateFactory {
         } else {
             if (isConcreteEntity(entity)) {
                 // TOP LEVEL CONCRETE
-                console.log("Top Level Concrete");
                 let selection: EntitySelection;
                 // NOTE: If we introduce vector index aggregation, checking the phrase will cause a problem
                 if (context.resolveTree.args.fulltext || context.resolveTree.args.phrase) {
@@ -182,9 +181,7 @@ export class AggregateFactory {
                     context,
                     whereArgs: resolveTreeWhere,
                 });
-                // return operation;
             } else {
-                console.log("Top Level Interface");
                 // TOP level interface/union
                 const concreteEntities = getConcreteEntities(entity, resolveTreeWhere);
 

--- a/packages/graphql/src/translate/queryAST/factory/Operations/AggregateFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/Operations/AggregateFactory.ts
@@ -242,6 +242,7 @@ export class AggregateFactory {
         const rawProjectionFields = {
             // Handle deprecated aggregations
             ...resolveTree.fieldsByTypeName[adapter.operations.getAggregationFieldTypename()],
+            ...resolveTree.fieldsByTypeName[adapter.operations.getAggregateFieldTypename()],
             ...nodeFields,
         };
 

--- a/packages/graphql/src/translate/queryAST/factory/Operations/ConnectionFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/Operations/ConnectionFactory.ts
@@ -230,6 +230,7 @@ export class ConnectionFactory {
             target,
             resolveTree,
         });
+
         this.hydrateConnectionOperationWithAggregation({
             target,
             resolveTreeAggregate: resolveTreeAggregate[0],
@@ -257,7 +258,6 @@ export class ConnectionFactory {
         if (relationship) {
             const resolveTreeAggregateFields =
                 resolveTreeAggregate?.fieldsByTypeName[relationship.operations.getAggregateFieldTypename()];
-            console.log("resolveTreeAggregateFields", resolveTreeAggregateFields);
             if (resolveTreeAggregate && resolveTreeAggregateFields) {
                 const nodeField = getResolveTreeByFieldName({
                     fieldName: "node",
@@ -294,22 +294,20 @@ export class ConnectionFactory {
                     fieldName: "node",
                     selection: resolveTreeAggregateFields,
                 });
-                if (nodeField) {
-                    const aggregationOperation = this.aggregateFactory.createAggregationOperation({
-                        entityOrRel: relationship ?? target,
-                        resolveTree: nodeField,
-                        context,
-                    });
-                    // NOTE: This will always be true on 7.x and this attribute should be removed
-                    aggregationOperation.isInConnectionField = true;
-                    const aggregationField = new ConnectionAggregationField({
-                        alias: resolveTreeAggregate.name, // Alias is hanlded by graphql on top level
-                        nodeAlias: nodeField.alias,
-                        operation: aggregationOperation,
-                    });
+                const aggregationOperation = this.aggregateFactory.createAggregationOperation({
+                    entityOrRel: relationship ?? target,
+                    resolveTree: resolveTreeAggregate,
+                    context,
+                });
+                // NOTE: This will always be true on 7.x and this attribute should be removed
+                aggregationOperation.isInConnectionField = true;
+                const aggregationField = new ConnectionAggregationField({
+                    alias: resolveTreeAggregate.name, // Alias is hanlded by graphql on top level
+                    nodeAlias: nodeField?.alias ?? "node",
+                    operation: aggregationOperation,
+                });
 
-                    operation.setAggregationField(aggregationField);
-                }
+                operation.setAggregationField(aggregationField);
             }
         }
     }
@@ -391,7 +389,6 @@ export class ConnectionFactory {
         let edgeField: ResolveTree | undefined;
 
         const fields: Record<string, ResolveTree> = {};
-
         Object.entries(rawFields).forEach(([key, field]) => {
             if (field.name === "node") {
                 nodeField = field;
@@ -402,11 +399,12 @@ export class ConnectionFactory {
             }
         });
 
-        return {
+        const result = {
             node: nodeField,
             edge: edgeField,
             fields,
         };
+        return result;
     }
 
     private getConnectionOptions(

--- a/packages/graphql/src/translate/queryAST/factory/Operations/ConnectionFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/Operations/ConnectionFactory.ts
@@ -256,8 +256,8 @@ export class ConnectionFactory {
     }) {
         if (relationship) {
             const resolveTreeAggregateFields =
-                resolveTreeAggregate?.fieldsByTypeName[relationship.operations.getAggregationFieldTypename()];
-
+                resolveTreeAggregate?.fieldsByTypeName[relationship.operations.getAggregateFieldTypename()];
+            console.log("resolveTreeAggregateFields", resolveTreeAggregateFields);
             if (resolveTreeAggregate && resolveTreeAggregateFields) {
                 const nodeField = getResolveTreeByFieldName({
                     fieldName: "node",
@@ -315,7 +315,7 @@ export class ConnectionFactory {
     }
 
     private hydrateConnectionOperationsASTWithSort<
-        T extends ConnectionReadOperation | CompositeConnectionReadOperation
+        T extends ConnectionReadOperation | CompositeConnectionReadOperation,
     >({
         entityOrRel,
         resolveTree,

--- a/packages/graphql/src/translate/queryAST/factory/Operations/ConnectionFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/Operations/ConnectionFactory.ts
@@ -31,7 +31,6 @@ import type { RelationshipAdapter } from "../../../../schema-model/relationship/
 import type { ConnectionQueryArgs } from "../../../../types";
 import type { Neo4jGraphQLTranslationContext } from "../../../../types/neo4j-graphql-translation-context";
 import { checkEntityAuthentication } from "../../../authorization/check-authentication";
-import { getResolveTreeByFieldName } from "../../../utils/resolveTree";
 import { ConnectionAggregationField } from "../../ast/fields/ConnectionAggregationField";
 import type { Field } from "../../ast/fields/Field";
 import { ConnectionReadOperation } from "../../ast/operations/ConnectionReadOperation";
@@ -259,15 +258,6 @@ export class ConnectionFactory {
             const resolveTreeAggregateFields =
                 resolveTreeAggregate?.fieldsByTypeName[relationship.operations.getAggregateFieldTypename()];
             if (resolveTreeAggregate && resolveTreeAggregateFields) {
-                const nodeField = getResolveTreeByFieldName({
-                    fieldName: "node",
-                    selection: resolveTreeAggregateFields,
-                });
-                const edgeField = getResolveTreeByFieldName({
-                    fieldName: "edge",
-                    selection: resolveTreeAggregateFields,
-                });
-
                 const aggregationOperation = this.aggregateFactory.createAggregationOperation({
                     entityOrRel: relationship ?? target,
                     resolveTree: resolveTreeAggregate,
@@ -277,7 +267,7 @@ export class ConnectionFactory {
                 aggregationOperation.isInConnectionField = true;
                 const aggregationField = new ConnectionAggregationField({
                     alias: resolveTreeAggregate.name, // Alias is hanlded by graphql on top level
-                    nodeAlias: nodeField?.alias ?? "node",
+                    nodeAlias: "node",
                     operation: aggregationOperation,
                 });
 
@@ -288,10 +278,6 @@ export class ConnectionFactory {
                 resolveTreeAggregate?.fieldsByTypeName[target.operations.aggregateTypeNames.connection];
 
             if (resolveTreeAggregate && resolveTreeAggregateFields) {
-                const nodeField = getResolveTreeByFieldName({
-                    fieldName: "node",
-                    selection: resolveTreeAggregateFields,
-                });
                 const aggregationOperation = this.aggregateFactory.createAggregationOperation({
                     entityOrRel: relationship ?? target,
                     resolveTree: resolveTreeAggregate,
@@ -301,7 +287,7 @@ export class ConnectionFactory {
                 aggregationOperation.isInConnectionField = true;
                 const aggregationField = new ConnectionAggregationField({
                     alias: resolveTreeAggregate.name, // Alias is hanlded by graphql on top level
-                    nodeAlias: nodeField?.alias ?? "node",
+                    nodeAlias: "node",
                     operation: aggregationOperation,
                 });
 

--- a/packages/graphql/src/translate/queryAST/factory/Operations/ConnectionFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/Operations/ConnectionFactory.ts
@@ -268,22 +268,20 @@ export class ConnectionFactory {
                     selection: resolveTreeAggregateFields,
                 });
 
-                if (nodeField || edgeField) {
-                    const aggregationOperation = this.aggregateFactory.createAggregationOperation({
-                        entityOrRel: relationship ?? target,
-                        resolveTree: resolveTreeAggregate,
-                        context,
-                    });
-                    // NOTE: This will always be true on 7.x and this attribute should be removed
-                    aggregationOperation.isInConnectionField = true;
-                    const aggregationField = new ConnectionAggregationField({
-                        alias: resolveTreeAggregate.name, // Alias is hanlded by graphql on top level
-                        nodeAlias: nodeField?.alias ?? "node",
-                        operation: aggregationOperation,
-                    });
+                const aggregationOperation = this.aggregateFactory.createAggregationOperation({
+                    entityOrRel: relationship ?? target,
+                    resolveTree: resolveTreeAggregate,
+                    context,
+                });
+                // NOTE: This will always be true on 7.x and this attribute should be removed
+                aggregationOperation.isInConnectionField = true;
+                const aggregationField = new ConnectionAggregationField({
+                    alias: resolveTreeAggregate.name, // Alias is hanlded by graphql on top level
+                    nodeAlias: nodeField?.alias ?? "node",
+                    operation: aggregationOperation,
+                });
 
-                    operation.setAggregationField(aggregationField);
-                }
+                operation.setAggregationField(aggregationField);
             }
         } else {
             const resolveTreeAggregateFields =

--- a/packages/graphql/tests/integration/aggregations/field-level/authorization/field-aggregation-field-authorization.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/field-level/authorization/field-aggregation-field-authorization.int.test.ts
@@ -72,7 +72,7 @@ describe("Field Level Aggregations Field Authorization", () => {
             query {
                 ${Series.operations.connection} {
                     aggregate {
-                        node{
+                        node {
                             title {
                                 longest
                             }

--- a/packages/graphql/tests/integration/aggregations/field-level/field-level-aggregations.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/field-level/field-level-aggregations.int.test.ts
@@ -71,6 +71,7 @@ describe("Field Level Aggregations", () => {
                         aggregate {
                             count {
                                 nodes
+                                edges
                             }
                         }
                     }
@@ -89,6 +90,7 @@ describe("Field Level Aggregations", () => {
                         aggregate: {
                             count: {
                                 nodes: 2,
+                                edges: 2,
                             },
                         },
                     },

--- a/packages/graphql/tests/integration/aggregations/field-level/field-level-aggregations.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/field-level/field-level-aggregations.int.test.ts
@@ -63,15 +63,14 @@ describe("Field Level Aggregations", () => {
         await testHelper.close();
     });
 
-    // eslint-disable-next-line jest/no-disabled-tests
-    test.skip("count nodes", async () => {
+    test("count nodes", async () => {
         const query = `
             query {
                 ${typeMovie.plural} {
                     actorsConnection {
                         aggregate {
-                            node {
-                                count
+                            count {
+                                nodes
                             }
                         }
                     }
@@ -88,8 +87,8 @@ describe("Field Level Aggregations", () => {
                 {
                     actorsConnection: {
                         aggregate: {
-                            node: {
-                                count: 2,
+                            count: {
+                                nodes: 2,
                             },
                         },
                     },

--- a/packages/graphql/tests/integration/aggregations/top-level/alias.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/alias.int.test.ts
@@ -69,8 +69,10 @@ describe("aggregations-top_level-alias", () => {
                 {
                     ${typeMovie.operations.connection}(where: { testString_EQ: "${testString}" }) {
                         aggr: aggregate {
+                            _count: count {
+                                n: nodes
+                            }
                             n: node {
-                                _count: count
                                 _id: id {
                                     _shortest: shortest
                                     _longest: longest
@@ -101,8 +103,10 @@ describe("aggregations-top_level-alias", () => {
         expect(gqlResult.data).toEqual({
             [typeMovie.operations.connection]: {
                 aggr: {
+                    _count: {
+                        n: 4,
+                    },
                     n: {
-                        _count: 4,
                         _id: {
                             _shortest: "1",
                             _longest: "4444",
@@ -160,8 +164,10 @@ describe("aggregations-top_level-alias", () => {
                 {
                     ${typeMovie.operations.connection}(where: { testString_EQ: "${testString}" }) {
                         aggr1: aggregate {
+                            count {
+                                nodes
+                            }
                             node {
-                                count
                                 title {
                                     shortest: shortest
                                     longest: longest
@@ -192,8 +198,8 @@ describe("aggregations-top_level-alias", () => {
         expect(gqlResult.data).toEqual({
             [typeMovie.operations.connection]: {
                 aggr1: {
+                    count: { nodes: 4 },
                     node: {
-                        count: 4,
                         title: {
                             shortest: "1",
                             longest: "4444",

--- a/packages/graphql/tests/integration/aggregations/top-level/authorization.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/authorization.int.test.ts
@@ -48,8 +48,8 @@ describe("aggregations-top_level authorization", () => {
             {
                 ${randomType.operations.connection} {
                     aggregate {
-                        node {
-                            count
+                        count {
+                            nodes
                         }
                     }
                 }
@@ -105,8 +105,8 @@ describe("aggregations-top_level authorization", () => {
             {
                 ${Post.operations.connection} {
                     aggregate {
-                        node {
-                            count
+                        count {
+                            nodes
                         }
                     }
                 }
@@ -135,8 +135,8 @@ describe("aggregations-top_level authorization", () => {
         expect(gqlResult.data).toEqual({
             [Post.operations.connection]: {
                 aggregate: {
-                    node: {
-                        count: 1,
+                    count: {
+                        nodes: 1,
                     },
                 },
             },

--- a/packages/graphql/tests/integration/aggregations/top-level/basic.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/basic.int.test.ts
@@ -46,8 +46,10 @@ describe("aggregations-top_level-basic", () => {
                 {
                     ${randomType.operations.connection} {
                         aggregate {
+                            count {
+                                nodes
+                            }
                             node {
-                                count
                                 id {
                                     longest 
                                 }
@@ -64,8 +66,10 @@ describe("aggregations-top_level-basic", () => {
         expect(gqlResult.data).toEqual({
             [randomType.operations.connection]: {
                 aggregate: {
+                    count: {
+                        nodes: 2,
+                    },
                     node: {
-                        count: 2,
                         id: {
                             longest: "asd3",
                         },
@@ -90,8 +94,8 @@ describe("aggregations-top_level-basic", () => {
                 {
                     ${randomType.operations.connection} {
                         aggregate {
-                            node {
-                                count
+                            count {
+                                nodes
                             }
                         }
                     }
@@ -105,8 +109,8 @@ describe("aggregations-top_level-basic", () => {
         expect(gqlResult.data).toEqual({
             [randomType.operations.connection]: {
                 aggregate: {
-                    node: {
-                        count: 0,
+                    count: {
+                        nodes: 0,
                     },
                 },
             },

--- a/packages/graphql/tests/integration/aggregations/top-level/count.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/count.int.test.ts
@@ -51,8 +51,8 @@ describe("Aggregate -> count", () => {
                 {
                     ${randomType.operations.connection}{
                         aggregate {
-                            node {
-                                count
+                            count {
+                                nodes
                             }
                         }
                     }
@@ -65,8 +65,8 @@ describe("Aggregate -> count", () => {
         expect(gqlResult.data).toEqual({
             [randomType.operations.connection]: {
                 aggregate: {
-                    node: {
-                        count: 2,
+                    count: {
+                        nodes: 2,
                     },
                 },
             },
@@ -109,8 +109,8 @@ describe("Aggregate -> count", () => {
                 {
                   ${randomType.operations.connection}(where: { OR: [{id_EQ: "${id1}"}, {id_EQ: "${id2}"}] }){
                     aggregate {
-                        node {
-                            count
+                        count {
+                            nodes
                         }
                     }
                   }
@@ -124,8 +124,8 @@ describe("Aggregate -> count", () => {
         expect(gqlResult.data).toEqual({
             [randomType.operations.connection]: {
                 aggregate: {
-                    node: {
-                        count: 2,
+                    count: {
+                        nodes: 2,
                     },
                 },
             },

--- a/packages/graphql/tests/integration/interfaces/aggegations/aggregation-interfaces-top-level-with-auth.int.test.ts
+++ b/packages/graphql/tests/integration/interfaces/aggegations/aggregation-interfaces-top-level-with-auth.int.test.ts
@@ -79,8 +79,10 @@ describe("Top-level interface query fields with authorization", () => {
             query {
                 productionsConnection {
                     aggregate {
+                        count {
+                            nodes
+                        }
                         node {
-                            count
                             title {
                                 longest
                                 shortest
@@ -97,8 +99,10 @@ describe("Top-level interface query fields with authorization", () => {
         expect(queryResult.data).toEqual({
             productionsConnection: {
                 aggregate: {
+                    count: {
+                        nodes: 4,
+                    },
                     node: {
-                        count: 4,
                         title: {
                             longest: "The Matrix is a very interesting movie: The Documentary",
                             shortest: "The Show",
@@ -114,8 +118,10 @@ describe("Top-level interface query fields with authorization", () => {
             query {
                 productionsConnection {
                     aggregate  {
+                        count {
+                            nodes
+                        }
                         node {
-                            count
                             title {
                                 longest
                                 shortest

--- a/packages/graphql/tests/integration/interfaces/aggegations/aggregation-interfaces-top-level.int.test.ts
+++ b/packages/graphql/tests/integration/interfaces/aggegations/aggregation-interfaces-top-level.int.test.ts
@@ -66,7 +66,7 @@ describe("Top-level interface query fields", () => {
         await testHelper.close();
     });
 
-    test.only("top level count and string fields", async () => {
+    test("top level count and string fields", async () => {
         const query = `
             query {
                 productionsConnection {

--- a/packages/graphql/tests/integration/interfaces/aggegations/aggregation-interfaces-top-level.int.test.ts
+++ b/packages/graphql/tests/integration/interfaces/aggegations/aggregation-interfaces-top-level.int.test.ts
@@ -66,13 +66,15 @@ describe("Top-level interface query fields", () => {
         await testHelper.close();
     });
 
-    test("top level count and string fields", async () => {
+    test.only("top level count and string fields", async () => {
         const query = `
             query {
                 productionsConnection {
                     aggregate {
+                        count {
+                            nodes
+                        }
                         node {
-                            count
                             title {
                                 longest
                                 shortest
@@ -89,8 +91,10 @@ describe("Top-level interface query fields", () => {
         expect(queryResult.data).toEqual({
             productionsConnection: {
                 aggregate: {
+                    count: {
+                        nodes: 4,
+                    },
                     node: {
-                        count: 4,
                         title: {
                             longest: "The Matrix is a very interesting movie: The Documentary",
                             shortest: "The Show",

--- a/packages/graphql/tests/schema/aggregations.test.ts
+++ b/packages/graphql/tests/schema/aggregations.test.ts
@@ -59,6 +59,10 @@ describe("Aggregations", () => {
               sum: BigInt
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -148,11 +152,11 @@ describe("Aggregations", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               createdAt: DateTimeAggregateSelection!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
               imdbRating: FloatAggregateSelection!
@@ -457,6 +461,15 @@ describe("Aggregations", () => {
               max: BigInt
               min: BigInt
               sum: BigInt
+            }
+
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
             }
 
             \\"\\"\\"
@@ -858,11 +871,11 @@ describe("Aggregations", () => {
             }
 
             type PostAggregate {
+              count: Count!
               node: PostAggregateNode!
             }
 
             type PostAggregateNode {
-              count: Int!
               someID: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
               title: StringAggregateSelection!
             }
@@ -912,7 +925,7 @@ describe("Aggregations", () => {
             }
 
             type PostLikesConnection {
-              aggregate: PostUserLikesAggregationSelection!
+              aggregate: PostUserLikesAggregateSelection!
               edges: [PostLikesRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1140,6 +1153,12 @@ describe("Aggregations", () => {
               title_SET: String
             }
 
+            type PostUserLikesAggregateSelection {
+              count: CountConnection!
+              edge: PostUserLikesEdgeAggregateSelection
+              node: PostUserLikesNodeAggregateSelection
+            }
+
             type PostUserLikesAggregationSelection {
               count: Int!
               edge: PostUserLikesEdgeAggregateSelection
@@ -1286,11 +1305,11 @@ describe("Aggregations", () => {
             }
 
             type UserAggregate {
+              count: Count!
               node: UserAggregateNode!
             }
 
             type UserAggregateNode {
-              count: Int!
               someBigInt: BigIntAggregateSelection!
               someDateTime: DateTimeAggregateSelection!
               someDuration: DurationAggregateSelection!

--- a/packages/graphql/tests/schema/array-methods.test.ts
+++ b/packages/graphql/tests/schema/array-methods.test.ts
@@ -114,7 +114,7 @@ describe("Arrays Methods", () => {
             }
 
             type ActorActedInConnection {
-              aggregate: ActorMovieActedInAggregationSelection!
+              aggregate: ActorMovieActedInAggregateSelection!
               edges: [ActorActedInRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -210,11 +210,11 @@ describe("Arrays Methods", () => {
             }
 
             type ActorAggregate {
+              count: Count!
               node: ActorAggregateNode!
             }
 
             type ActorAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -247,6 +247,11 @@ describe("Arrays Methods", () => {
             type ActorEdge {
               cursor: String!
               node: Actor!
+            }
+
+            type ActorMovieActedInAggregateSelection {
+              count: CountConnection!
+              node: ActorMovieActedInNodeAggregateSelection
             }
 
             type ActorMovieActedInAggregationSelection {
@@ -325,6 +330,15 @@ describe("Arrays Methods", () => {
               totalCount: Int!
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             type CreateActorsMutationResponse {
               actors: [Actor!]!
               info: CreateInfo!
@@ -372,6 +386,11 @@ describe("Arrays Methods", () => {
               ratings: [Float!]!
             }
 
+            type MovieActorActorsAggregateSelection {
+              count: CountConnection!
+              node: MovieActorActorsNodeAggregateSelection
+            }
+
             type MovieActorActorsAggregationSelection {
               count: Int!
               node: MovieActorActorsNodeAggregateSelection
@@ -405,7 +424,7 @@ describe("Arrays Methods", () => {
             }
 
             type MovieActorsConnection {
-              aggregate: MovieActorActorsAggregationSelection!
+              aggregate: MovieActorActorsAggregateSelection!
               edges: [MovieActorsRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -486,12 +505,12 @@ describe("Arrays Methods", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
               averageRating: FloatAggregateSelection!
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 

--- a/packages/graphql/tests/schema/arrays.test.ts
+++ b/packages/graphql/tests/schema/arrays.test.ts
@@ -40,6 +40,10 @@ describe("Arrays", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -80,12 +84,12 @@ describe("Arrays", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
               averageRating: FloatAggregateSelection!
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 

--- a/packages/graphql/tests/schema/authorization.test.ts
+++ b/packages/graphql/tests/schema/authorization.test.ts
@@ -47,6 +47,15 @@ describe("Authorization", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -104,11 +113,11 @@ describe("Authorization", () => {
             }
 
             type PostAggregate {
+              count: Count!
               node: PostAggregateNode!
             }
 
             type PostAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
               name: StringAggregateSelection!
             }
@@ -142,7 +151,7 @@ describe("Authorization", () => {
             }
 
             type PostAuthorConnection {
-              aggregate: PostUserAuthorAggregationSelection!
+              aggregate: PostUserAuthorAggregateSelection!
               edges: [PostAuthorRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -267,6 +276,11 @@ describe("Authorization", () => {
               name_SET: String
             }
 
+            type PostUserAuthorAggregateSelection {
+              count: CountConnection!
+              node: PostUserAuthorNodeAggregateSelection
+            }
+
             type PostUserAuthorAggregationSelection {
               count: Int!
               node: PostUserAuthorNodeAggregateSelection
@@ -356,11 +370,11 @@ describe("Authorization", () => {
             }
 
             type UserAggregate {
+              count: Count!
               node: UserAggregateNode!
             }
 
             type UserAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
               name: StringAggregateSelection!
             }
@@ -430,7 +444,7 @@ describe("Authorization", () => {
             }
 
             type UserPostsConnection {
-              aggregate: UserUserPostsAggregationSelection!
+              aggregate: UserUserPostsAggregateSelection!
               edges: [UserPostsRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -529,6 +543,11 @@ describe("Authorization", () => {
               name: String @deprecated(reason: \\"Please use the explicit _SET field\\")
               name_SET: String
               posts: [UserPostsUpdateFieldInput!]
+            }
+
+            type UserUserPostsAggregateSelection {
+              count: CountConnection!
+              node: UserUserPostsNodeAggregateSelection
             }
 
             type UserUserPostsAggregationSelection {

--- a/packages/graphql/tests/schema/comments.test.ts
+++ b/packages/graphql/tests/schema/comments.test.ts
@@ -65,6 +65,10 @@ describe("Comments", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -133,13 +137,13 @@ describe("Comments", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
               actorCount: IntAggregateSelection!
               averageRating: FloatAggregateSelection!
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
@@ -319,11 +323,11 @@ describe("Comments", () => {
                 }
 
                 type ActorAggregate {
+                  count: Count!
                   node: ActorAggregateNode!
                 }
 
                 type ActorAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -385,6 +389,15 @@ describe("Comments", () => {
                   totalCount: Int!
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
+                type CountConnection {
+                  edges: Int!
+                  nodes: Int!
+                }
+
                 type CreateActorsMutationResponse {
                   actors: [Actor!]!
                   info: CreateInfo!
@@ -424,6 +437,11 @@ describe("Comments", () => {
                   id: ID
                 }
 
+                type MovieActorActorsAggregateSelection {
+                  count: CountConnection!
+                  node: MovieActorActorsNodeAggregateSelection
+                }
+
                 type MovieActorActorsAggregationSelection {
                   count: Int!
                   node: MovieActorActorsNodeAggregateSelection
@@ -455,7 +473,7 @@ describe("Comments", () => {
                 }
 
                 type MovieActorsConnection {
-                  aggregate: MovieActorActorsAggregationSelection!
+                  aggregate: MovieActorActorsAggregateSelection!
                   edges: [MovieActorsRelationship!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -529,11 +547,11 @@ describe("Comments", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
                 }
 
@@ -808,7 +826,7 @@ describe("Comments", () => {
                 }
 
                 type ActorActedInConnection {
-                  aggregate: ActorProductionActedInAggregationSelection!
+                  aggregate: ActorProductionActedInAggregateSelection!
                   edges: [ActorActedInRelationship!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -887,11 +905,11 @@ describe("Comments", () => {
                 }
 
                 type ActorAggregate {
+                  count: Count!
                   node: ActorAggregateNode!
                 }
 
                 type ActorAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -921,6 +939,12 @@ describe("Comments", () => {
                   Specify one or more ActorSort objects to sort Actors by. The sorts will be applied in the order in which they are arranged in the array.
                   \\"\\"\\"
                   sort: [ActorSort!]
+                }
+
+                type ActorProductionActedInAggregateSelection {
+                  count: CountConnection!
+                  edge: ActorProductionActedInEdgeAggregateSelection
+                  node: ActorProductionActedInNodeAggregateSelection
                 }
 
                 type ActorProductionActedInAggregationSelection {
@@ -994,6 +1018,15 @@ describe("Comments", () => {
                   totalCount: Int!
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
+                type CountConnection {
+                  edges: Int!
+                  nodes: Int!
+                }
+
                 type CreateActorsMutationResponse {
                   actors: [Actor!]!
                   info: CreateInfo!
@@ -1038,11 +1071,11 @@ describe("Comments", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   runtime: IntAggregateSelection!
                   title: StringAggregateSelection!
                 }
@@ -1140,11 +1173,11 @@ describe("Comments", () => {
                 }
 
                 type ProductionAggregate {
+                  count: Count!
                   node: ProductionAggregateNode!
                 }
 
                 type ProductionAggregateNode {
-                  count: Int!
                   title: StringAggregateSelection!
                 }
 
@@ -1235,11 +1268,11 @@ describe("Comments", () => {
                 }
 
                 type SeriesAggregate {
+                  count: Count!
                   node: SeriesAggregateNode!
                 }
 
                 type SeriesAggregateNode {
-                  count: Int!
                   episodes: IntAggregateSelection!
                   title: StringAggregateSelection!
                 }
@@ -1375,6 +1408,10 @@ describe("Comments", () => {
                   mutation: Mutation
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
                 type CreateGenresMutationResponse {
                   genres: [Genre!]!
                   info: CreateInfo!
@@ -1406,11 +1443,11 @@ describe("Comments", () => {
                 }
 
                 type GenreAggregate {
+                  count: Count!
                   node: GenreAggregateNode!
                 }
 
                 type GenreAggregateNode {
-                  count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
                 }
 
@@ -1485,11 +1522,11 @@ describe("Comments", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
                 }
 

--- a/packages/graphql/tests/schema/connect-or-create-id.test.ts
+++ b/packages/graphql/tests/schema/connect-or-create-id.test.ts
@@ -52,11 +52,11 @@ describe("connect or create with id", () => {
             }
 
             type ActorAggregate {
+              count: Count!
               node: ActorAggregateNode!
             }
 
             type ActorAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -77,6 +77,11 @@ describe("connect or create with id", () => {
             type ActorEdge {
               cursor: String!
               node: Actor!
+            }
+
+            type ActorMovieMoviesAggregateSelection {
+              count: CountConnection!
+              node: ActorMovieMoviesNodeAggregateSelection
             }
 
             type ActorMovieMoviesAggregationSelection {
@@ -120,7 +125,7 @@ describe("connect or create with id", () => {
             }
 
             type ActorMoviesConnection {
-              aggregate: ActorMovieMoviesAggregationSelection!
+              aggregate: ActorMovieMoviesAggregateSelection!
               edges: [ActorMoviesRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -271,6 +276,15 @@ describe("connect or create with id", () => {
               totalCount: Int!
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             type CreateActorsMutationResponse {
               actors: [Actor!]!
               info: CreateInfo!
@@ -308,11 +322,11 @@ describe("connect or create with id", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
               title: StringAggregateSelection!
             }
@@ -481,6 +495,15 @@ describe("connect or create with id", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -547,12 +570,12 @@ describe("connect or create with id", () => {
             }
 
             type PostAggregate {
+              count: Count!
               node: PostAggregateNode!
             }
 
             type PostAggregateNode {
               content: StringAggregateSelection!
-              count: Int!
               createdAt: DateTimeAggregateSelection!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
@@ -615,7 +638,7 @@ describe("connect or create with id", () => {
             }
 
             type PostCreatorConnection {
-              aggregate: PostUserCreatorAggregationSelection!
+              aggregate: PostUserCreatorAggregateSelection!
               edges: [PostCreatorRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -754,6 +777,11 @@ describe("connect or create with id", () => {
               id_SET: ID
             }
 
+            type PostUserCreatorAggregateSelection {
+              count: CountConnection!
+              node: PostUserCreatorNodeAggregateSelection
+            }
+
             type PostUserCreatorAggregationSelection {
               count: Int!
               node: PostUserCreatorNodeAggregateSelection
@@ -850,11 +878,11 @@ describe("connect or create with id", () => {
             }
 
             type UserAggregate {
+              count: Count!
               node: UserAggregateNode!
             }
 
             type UserAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
               name: StringAggregateSelection!
             }
@@ -908,6 +936,11 @@ describe("connect or create with id", () => {
               sort: [UserSort!]
             }
 
+            type UserPostPostsAggregateSelection {
+              count: CountConnection!
+              node: UserPostPostsNodeAggregateSelection
+            }
+
             type UserPostPostsAggregationSelection {
               count: Int!
               node: UserPostPostsNodeAggregateSelection
@@ -951,7 +984,7 @@ describe("connect or create with id", () => {
             }
 
             type UserPostsConnection {
-              aggregate: UserPostPostsAggregationSelection!
+              aggregate: UserPostPostsAggregateSelection!
               edges: [UserPostsRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/connect-or-create-unions.test.ts
+++ b/packages/graphql/tests/schema/connect-or-create-unions.test.ts
@@ -248,11 +248,11 @@ describe("Connect Or Create", () => {
             }
 
             type ActorAggregate {
+              count: Count!
               node: ActorAggregateNode!
             }
 
             type ActorAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -340,6 +340,10 @@ describe("Connect Or Create", () => {
               totalCount: Int!
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             type CreateActorsMutationResponse {
               actors: [Actor!]!
               info: CreateInfo!
@@ -377,11 +381,11 @@ describe("Connect Or Create", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               isan: StringAggregateSelection!
               title: StringAggregateSelection!
             }
@@ -521,11 +525,11 @@ describe("Connect Or Create", () => {
             }
 
             type SeriesAggregate {
+              count: Count!
               node: SeriesAggregateNode!
             }
 
             type SeriesAggregateNode {
-              count: Int!
               isan: StringAggregateSelection!
               title: StringAggregateSelection!
             }

--- a/packages/graphql/tests/schema/connect-or-create.test.ts
+++ b/packages/graphql/tests/schema/connect-or-create.test.ts
@@ -52,11 +52,11 @@ describe("Connect Or Create", () => {
             }
 
             type ActorAggregate {
+              count: Count!
               node: ActorAggregateNode!
             }
 
             type ActorAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -77,6 +77,11 @@ describe("Connect Or Create", () => {
             type ActorEdge {
               cursor: String!
               node: Actor!
+            }
+
+            type ActorMovieMoviesAggregateSelection {
+              count: CountConnection!
+              node: ActorMovieMoviesNodeAggregateSelection
             }
 
             type ActorMovieMoviesAggregationSelection {
@@ -120,7 +125,7 @@ describe("Connect Or Create", () => {
             }
 
             type ActorMoviesConnection {
-              aggregate: ActorMovieMoviesAggregationSelection!
+              aggregate: ActorMovieMoviesAggregateSelection!
               edges: [ActorMoviesRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -276,6 +281,15 @@ describe("Connect Or Create", () => {
               totalCount: Int!
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             type CreateActorsMutationResponse {
               actors: [Actor!]!
               info: CreateInfo!
@@ -308,11 +322,11 @@ describe("Connect Or Create", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               isan: StringAggregateSelection!
               title: StringAggregateSelection!
             }
@@ -583,11 +597,11 @@ describe("Connect Or Create", () => {
             }
 
             type ActorAggregate {
+              count: Count!
               node: ActorAggregateNode!
             }
 
             type ActorAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -608,6 +622,12 @@ describe("Connect Or Create", () => {
             type ActorEdge {
               cursor: String!
               node: Actor!
+            }
+
+            type ActorMovieMoviesAggregateSelection {
+              count: CountConnection!
+              edge: ActorMovieMoviesEdgeAggregateSelection
+              node: ActorMovieMoviesNodeAggregateSelection
             }
 
             type ActorMovieMoviesAggregationSelection {
@@ -660,7 +680,7 @@ describe("Connect Or Create", () => {
             }
 
             type ActorMoviesConnection {
-              aggregate: ActorMovieMoviesAggregationSelection!
+              aggregate: ActorMovieMoviesAggregateSelection!
               edges: [ActorMoviesRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -821,6 +841,15 @@ describe("Connect Or Create", () => {
               totalCount: Int!
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             type CreateActorsMutationResponse {
               actors: [Actor!]!
               info: CreateInfo!
@@ -860,11 +889,11 @@ describe("Connect Or Create", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               isan: StringAggregateSelection!
               title: StringAggregateSelection!
             }

--- a/packages/graphql/tests/schema/connections/enums.test.ts
+++ b/packages/graphql/tests/schema/connections/enums.test.ts
@@ -92,11 +92,11 @@ describe("Enums", () => {
             }
 
             type ActorAggregate {
+              count: Count!
               node: ActorAggregateNode!
             }
 
             type ActorAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -129,6 +129,11 @@ describe("Enums", () => {
             type ActorEdge {
               cursor: String!
               node: Actor!
+            }
+
+            type ActorMovieMoviesAggregateSelection {
+              count: CountConnection!
+              node: ActorMovieMoviesNodeAggregateSelection
             }
 
             type ActorMovieMoviesAggregationSelection {
@@ -164,7 +169,7 @@ describe("Enums", () => {
             }
 
             type ActorMoviesConnection {
-              aggregate: ActorMovieMoviesAggregationSelection!
+              aggregate: ActorMovieMoviesAggregateSelection!
               edges: [ActorMoviesRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -310,6 +315,15 @@ describe("Enums", () => {
               totalCount: Int!
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             type CreateActorsMutationResponse {
               actors: [Actor!]!
               info: CreateInfo!
@@ -341,6 +355,11 @@ describe("Enums", () => {
               actorsAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: ActorWhere): MovieActorActorsAggregationSelection @deprecated(reason: \\"Please use field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\" instead\\")
               actorsConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [MovieActorsConnectionSort!], where: MovieActorsConnectionWhere): MovieActorsConnection!
               title: String!
+            }
+
+            type MovieActorActorsAggregateSelection {
+              count: CountConnection!
+              node: MovieActorActorsNodeAggregateSelection
             }
 
             type MovieActorActorsAggregationSelection {
@@ -376,7 +395,7 @@ describe("Enums", () => {
             }
 
             type MovieActorsConnection {
-              aggregate: MovieActorActorsAggregationSelection!
+              aggregate: MovieActorActorsAggregateSelection!
               edges: [MovieActorsRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -457,11 +476,11 @@ describe("Enums", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               title: StringAggregateSelection!
             }
 

--- a/packages/graphql/tests/schema/connections/interfaces.test.ts
+++ b/packages/graphql/tests/schema/connections/interfaces.test.ts
@@ -62,6 +62,10 @@ describe("Connection with interfaces", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -92,11 +96,11 @@ describe("Connection with interfaces", () => {
             }
 
             type CreatureAggregate {
+              count: Count!
               node: CreatureAggregateNode!
             }
 
             type CreatureAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
@@ -292,11 +296,11 @@ describe("Connection with interfaces", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
               title: StringAggregateSelection!
             }
@@ -507,11 +511,11 @@ describe("Connection with interfaces", () => {
             }
 
             type PersonAggregate {
+              count: Count!
               node: PersonAggregateNode!
             }
 
             type PersonAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
@@ -653,11 +657,11 @@ describe("Connection with interfaces", () => {
             }
 
             type ProductionAggregate {
+              count: Count!
               node: ProductionAggregateNode!
             }
 
             type ProductionAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
@@ -884,11 +888,11 @@ describe("Connection with interfaces", () => {
             }
 
             type SeriesAggregate {
+              count: Count!
               node: SeriesAggregateNode!
             }
 
             type SeriesAggregateNode {
-              count: Int!
               episode: IntAggregateSelection!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
               title: StringAggregateSelection!

--- a/packages/graphql/tests/schema/connections/sort.test.ts
+++ b/packages/graphql/tests/schema/connections/sort.test.ts
@@ -43,6 +43,15 @@ describe("Sort", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -86,11 +95,11 @@ describe("Sort", () => {
             }
 
             type Node1Aggregate {
+              count: Count!
               node: Node1AggregateNode!
             }
 
             type Node1AggregateNode {
-              count: Int!
               property: StringAggregateSelection!
             }
 
@@ -123,6 +132,10 @@ describe("Sort", () => {
             type Node1Edge {
               cursor: String!
               node: Node1!
+            }
+
+            type Node1Node2RelatedToAggregateSelection {
+              count: CountConnection!
             }
 
             type Node1Node2RelatedToAggregationSelection {
@@ -160,7 +173,7 @@ describe("Sort", () => {
             }
 
             type Node1RelatedToConnection {
-              aggregate: Node1Node2RelatedToAggregationSelection!
+              aggregate: Node1Node2RelatedToAggregateSelection!
               edges: [Node1RelatedToRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -274,11 +287,7 @@ describe("Sort", () => {
             }
 
             type Node2Aggregate {
-              node: Node2AggregateNode!
-            }
-
-            type Node2AggregateNode {
-              count: Int!
+              count: Count!
             }
 
             type Node2AggregateSelection {
@@ -308,6 +317,11 @@ describe("Sort", () => {
             type Node2Edge {
               cursor: String!
               node: Node2!
+            }
+
+            type Node2Node1RelatedToAggregateSelection {
+              count: CountConnection!
+              node: Node2Node1RelatedToNodeAggregateSelection
             }
 
             type Node2Node1RelatedToAggregationSelection {
@@ -347,7 +361,7 @@ describe("Sort", () => {
             }
 
             type Node2RelatedToConnection {
-              aggregate: Node2Node1RelatedToAggregationSelection!
+              aggregate: Node2Node1RelatedToAggregateSelection!
               edges: [Node2RelatedToRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/connections/unions.test.ts
+++ b/packages/graphql/tests/schema/connections/unions.test.ts
@@ -62,11 +62,11 @@ describe("Unions", () => {
             }
 
             type AuthorAggregate {
+              count: Count!
               node: AuthorAggregateNode!
             }
 
             type AuthorAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -320,11 +320,11 @@ describe("Unions", () => {
             }
 
             type BookAggregate {
+              count: Count!
               node: BookAggregateNode!
             }
 
             type BookAggregateNode {
-              count: Int!
               title: StringAggregateSelection!
             }
 
@@ -345,6 +345,12 @@ describe("Unions", () => {
               count_LTE: Int
               edge: WroteAggregationWhereInput
               node: BookAuthorNodeAggregationWhereInput
+            }
+
+            type BookAuthorAuthorAggregateSelection {
+              count: CountConnection!
+              edge: BookAuthorAuthorEdgeAggregateSelection
+              node: BookAuthorAuthorNodeAggregateSelection
             }
 
             type BookAuthorAuthorAggregationSelection {
@@ -372,7 +378,7 @@ describe("Unions", () => {
             }
 
             type BookAuthorConnection {
-              aggregate: BookAuthorAuthorAggregationSelection!
+              aggregate: BookAuthorAuthorAggregateSelection!
               edges: [BookAuthorRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -544,6 +550,15 @@ describe("Unions", () => {
               totalCount: Int!
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             type CreateAuthorsMutationResponse {
               authors: [Author!]!
               info: CreateInfo!
@@ -590,11 +605,11 @@ describe("Unions", () => {
             }
 
             type JournalAggregate {
+              count: Count!
               node: JournalAggregateNode!
             }
 
             type JournalAggregateNode {
-              count: Int!
               subject: StringAggregateSelection!
             }
 
@@ -615,6 +630,12 @@ describe("Unions", () => {
               count_LTE: Int
               edge: WroteAggregationWhereInput
               node: JournalAuthorNodeAggregationWhereInput
+            }
+
+            type JournalAuthorAuthorAggregateSelection {
+              count: CountConnection!
+              edge: JournalAuthorAuthorEdgeAggregateSelection
+              node: JournalAuthorAuthorNodeAggregateSelection
             }
 
             type JournalAuthorAuthorAggregationSelection {
@@ -642,7 +663,7 @@ describe("Unions", () => {
             }
 
             type JournalAuthorConnection {
-              aggregate: JournalAuthorAuthorAggregationSelection!
+              aggregate: JournalAuthorAuthorAggregateSelection!
               edges: [JournalAuthorRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/custom-mutations.test.ts
+++ b/packages/graphql/tests/schema/custom-mutations.test.ts
@@ -58,6 +58,10 @@ describe("Custom-mutations", () => {
               subscription: Subscription
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -93,11 +97,11 @@ describe("Custom-mutations", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 

--- a/packages/graphql/tests/schema/directive-preserve.test.ts
+++ b/packages/graphql/tests/schema/directive-preserve.test.ts
@@ -46,6 +46,10 @@ describe("Directive-preserve", () => {
 
             directive @preservedTopLevel(boolean: Boolean, float: Float, int: Int, string: String) on OBJECT
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -77,11 +81,11 @@ describe("Directive-preserve", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
@@ -207,6 +211,15 @@ describe("Directive-preserve", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             type CreateGenresMutationResponse {
               genres: [Genre!]!
               info: CreateInfo!
@@ -248,11 +261,11 @@ describe("Directive-preserve", () => {
             }
 
             type GenreAggregate {
+              count: Count!
               node: GenreAggregateNode!
             }
 
             type GenreAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -285,6 +298,11 @@ describe("Directive-preserve", () => {
             type GenreEdge {
               cursor: String!
               node: Genre!
+            }
+
+            type GenreMovieMoviesAggregateSelection {
+              count: CountConnection!
+              node: GenreMovieMoviesNodeAggregateSelection
             }
 
             type GenreMovieMoviesAggregationSelection {
@@ -321,7 +339,7 @@ describe("Directive-preserve", () => {
             }
 
             type GenreMoviesConnection {
-              aggregate: GenreMovieMoviesAggregationSelection!
+              aggregate: GenreMovieMoviesAggregateSelection!
               edges: [GenreMoviesRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -519,11 +537,11 @@ describe("Directive-preserve", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               imdbRating: FloatAggregateSelection!
               title: StringAggregateSelection!
               year: IntAggregateSelection!
@@ -564,6 +582,11 @@ describe("Directive-preserve", () => {
               node: Movie!
             }
 
+            type MovieGenreGenresAggregateSelection {
+              count: CountConnection!
+              node: MovieGenreGenresNodeAggregateSelection
+            }
+
             type MovieGenreGenresAggregationSelection {
               count: Int!
               node: MovieGenreGenresNodeAggregateSelection
@@ -596,7 +619,7 @@ describe("Directive-preserve", () => {
             }
 
             type MovieGenresConnection {
-              aggregate: MovieGenreGenresAggregationSelection!
+              aggregate: MovieGenreGenresAggregateSelection!
               edges: [MovieGenresRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -956,7 +979,7 @@ describe("Directive-preserve", () => {
             }
 
             type ActorActedInConnection {
-              aggregate: ActorProductionActedInAggregationSelection!
+              aggregate: ActorProductionActedInAggregateSelection!
               edges: [ActorActedInRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1037,11 +1060,11 @@ describe("Directive-preserve", () => {
             }
 
             type ActorAggregate {
+              count: Count!
               node: ActorAggregateNode!
             }
 
             type ActorAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -1083,6 +1106,12 @@ describe("Directive-preserve", () => {
               Specify one or more ActorSort objects to sort Actors by. The sorts will be applied in the order in which they are arranged in the array.
               \\"\\"\\"
               sort: [ActorSort!]
+            }
+
+            type ActorProductionActedInAggregateSelection {
+              count: CountConnection!
+              edge: ActorProductionActedInEdgeAggregateSelection
+              node: ActorProductionActedInNodeAggregateSelection
             }
 
             type ActorProductionActedInAggregationSelection {
@@ -1154,6 +1183,15 @@ describe("Directive-preserve", () => {
               edges: [ActorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
+            }
+
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
             }
 
             type CreateActorsMutationResponse {
@@ -1286,11 +1324,11 @@ describe("Directive-preserve", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               runtime: IntAggregateSelection!
               title: StringAggregateSelection!
             }
@@ -1567,11 +1605,11 @@ describe("Directive-preserve", () => {
             }
 
             type ProductionAggregate {
+              count: Count!
               node: ProductionAggregateNode!
             }
 
             type ProductionAggregateNode {
-              count: Int!
               title: StringAggregateSelection!
             }
 
@@ -1786,11 +1824,11 @@ describe("Directive-preserve", () => {
             }
 
             type SeriesAggregate {
+              count: Count!
               node: SeriesAggregateNode!
             }
 
             type SeriesAggregateNode {
-              count: Int!
               episodes: IntAggregateSelection!
               title: StringAggregateSelection!
             }
@@ -2066,7 +2104,7 @@ describe("Directive-preserve", () => {
             }
 
             type ActorActedInConnection {
-              aggregate: ActorProductionActedInAggregationSelection!
+              aggregate: ActorProductionActedInAggregateSelection!
               edges: [ActorActedInRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -2145,11 +2183,11 @@ describe("Directive-preserve", () => {
             }
 
             type ActorAggregate {
+              count: Count!
               node: ActorAggregateNode!
             }
 
             type ActorAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -2191,6 +2229,12 @@ describe("Directive-preserve", () => {
               Specify one or more ActorSort objects to sort Actors by. The sorts will be applied in the order in which they are arranged in the array.
               \\"\\"\\"
               sort: [ActorSort!]
+            }
+
+            type ActorProductionActedInAggregateSelection {
+              count: CountConnection!
+              edge: ActorProductionActedInEdgeAggregateSelection
+              node: ActorProductionActedInNodeAggregateSelection
             }
 
             type ActorProductionActedInAggregationSelection {
@@ -2264,6 +2308,15 @@ describe("Directive-preserve", () => {
               totalCount: Int!
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             type CreateActorsMutationResponse {
               actors: [Actor!]!
               info: CreateInfo!
@@ -2310,6 +2363,12 @@ describe("Directive-preserve", () => {
               title: String!
             }
 
+            type MovieActorActorsAggregateSelection {
+              count: CountConnection!
+              edge: MovieActorActorsEdgeAggregateSelection
+              node: MovieActorActorsNodeAggregateSelection
+            }
+
             type MovieActorActorsAggregationSelection {
               count: Int!
               edge: MovieActorActorsEdgeAggregateSelection
@@ -2349,7 +2408,7 @@ describe("Directive-preserve", () => {
             }
 
             type MovieActorsConnection {
-              aggregate: MovieActorActorsAggregationSelection!
+              aggregate: MovieActorActorsAggregateSelection!
               edges: [MovieActorsRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -2430,11 +2489,11 @@ describe("Directive-preserve", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               runtime: IntAggregateSelection!
               title: StringAggregateSelection!
             }
@@ -2564,11 +2623,11 @@ describe("Directive-preserve", () => {
             }
 
             type ProductionAggregate {
+              count: Count!
               node: ProductionAggregateNode!
             }
 
             type ProductionAggregateNode {
-              count: Int!
               title: StringAggregateSelection!
             }
 
@@ -2661,6 +2720,12 @@ describe("Directive-preserve", () => {
               title: String!
             }
 
+            type SeriesActorActorsAggregateSelection {
+              count: CountConnection!
+              edge: SeriesActorActorsEdgeAggregateSelection
+              node: SeriesActorActorsNodeAggregateSelection
+            }
+
             type SeriesActorActorsAggregationSelection {
               count: Int!
               edge: SeriesActorActorsEdgeAggregateSelection
@@ -2700,7 +2765,7 @@ describe("Directive-preserve", () => {
             }
 
             type SeriesActorsConnection {
-              aggregate: SeriesActorActorsAggregationSelection!
+              aggregate: SeriesActorActorsAggregateSelection!
               edges: [SeriesActorsRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -2781,11 +2846,11 @@ describe("Directive-preserve", () => {
             }
 
             type SeriesAggregate {
+              count: Count!
               node: SeriesAggregateNode!
             }
 
             type SeriesAggregateNode {
-              count: Int!
               episodes: IntAggregateSelection!
               title: StringAggregateSelection!
             }
@@ -3049,7 +3114,7 @@ describe("Directive-preserve", () => {
             }
 
             type ActorActedInConnection {
-              aggregate: ActorProductionActedInAggregationSelection!
+              aggregate: ActorProductionActedInAggregateSelection!
               edges: [ActorActedInRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -3128,11 +3193,11 @@ describe("Directive-preserve", () => {
             }
 
             type ActorAggregate {
+              count: Count!
               node: ActorAggregateNode!
             }
 
             type ActorAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -3174,6 +3239,12 @@ describe("Directive-preserve", () => {
               Specify one or more ActorSort objects to sort Actors by. The sorts will be applied in the order in which they are arranged in the array.
               \\"\\"\\"
               sort: [ActorSort!]
+            }
+
+            type ActorProductionActedInAggregateSelection {
+              count: CountConnection!
+              edge: ActorProductionActedInEdgeAggregateSelection
+              node: ActorProductionActedInNodeAggregateSelection
             }
 
             type ActorProductionActedInAggregationSelection {
@@ -3247,6 +3318,15 @@ describe("Directive-preserve", () => {
               totalCount: Int!
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             type CreateActorsMutationResponse {
               actors: [Actor!]!
               info: CreateInfo!
@@ -3293,6 +3373,12 @@ describe("Directive-preserve", () => {
               title: String!
             }
 
+            type MovieActorActorsAggregateSelection {
+              count: CountConnection!
+              edge: MovieActorActorsEdgeAggregateSelection
+              node: MovieActorActorsNodeAggregateSelection
+            }
+
             type MovieActorActorsAggregationSelection {
               count: Int!
               edge: MovieActorActorsEdgeAggregateSelection
@@ -3332,7 +3418,7 @@ describe("Directive-preserve", () => {
             }
 
             type MovieActorsConnection {
-              aggregate: MovieActorActorsAggregationSelection!
+              aggregate: MovieActorActorsAggregateSelection!
               edges: [MovieActorsRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -3413,11 +3499,11 @@ describe("Directive-preserve", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               runtime: IntAggregateSelection!
               title: StringAggregateSelection!
             }
@@ -3547,11 +3633,11 @@ describe("Directive-preserve", () => {
             }
 
             type ProductionAggregate {
+              count: Count!
               node: ProductionAggregateNode!
             }
 
             type ProductionAggregateNode {
-              count: Int!
               title: StringAggregateSelection!
             }
 
@@ -3644,6 +3730,12 @@ describe("Directive-preserve", () => {
               title: String!
             }
 
+            type SeriesActorActorsAggregateSelection {
+              count: CountConnection!
+              edge: SeriesActorActorsEdgeAggregateSelection
+              node: SeriesActorActorsNodeAggregateSelection
+            }
+
             type SeriesActorActorsAggregationSelection {
               count: Int!
               edge: SeriesActorActorsEdgeAggregateSelection
@@ -3683,7 +3775,7 @@ describe("Directive-preserve", () => {
             }
 
             type SeriesActorsConnection {
-              aggregate: SeriesActorActorsAggregationSelection!
+              aggregate: SeriesActorActorsAggregateSelection!
               edges: [SeriesActorsRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -3764,11 +3856,11 @@ describe("Directive-preserve", () => {
             }
 
             type SeriesAggregate {
+              count: Count!
               node: SeriesAggregateNode!
             }
 
             type SeriesAggregateNode {
-              count: Int!
               episodes: IntAggregateSelection!
               title: StringAggregateSelection!
             }
@@ -3950,11 +4042,11 @@ describe("Directive-preserve", () => {
             }
 
             type BlogAggregate {
+              count: Count!
               node: BlogAggregateNode!
             }
 
             type BlogAggregateNode {
-              count: Int!
               title: StringAggregateSelection!
             }
 
@@ -3998,6 +4090,11 @@ describe("Directive-preserve", () => {
               sort: [BlogSort!]
             }
 
+            type BlogPostPostsAggregateSelection {
+              count: CountConnection!
+              node: BlogPostPostsNodeAggregateSelection
+            }
+
             type BlogPostPostsAggregationSelection {
               count: Int!
               node: BlogPostPostsNodeAggregateSelection
@@ -4029,7 +4126,7 @@ describe("Directive-preserve", () => {
             }
 
             type BlogPostsConnection {
-              aggregate: BlogPostPostsAggregationSelection!
+              aggregate: BlogPostPostsAggregateSelection!
               edges: [BlogPostsRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -4166,6 +4263,15 @@ describe("Directive-preserve", () => {
               Post: PostWhere
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             type CreateBlogsMutationResponse {
               blogs: [Blog!]!
               info: CreateInfo!
@@ -4222,12 +4328,12 @@ describe("Directive-preserve", () => {
             }
 
             type PostAggregate {
+              count: Count!
               node: PostAggregateNode!
             }
 
             type PostAggregateNode {
               content: StringAggregateSelection!
-              count: Int!
             }
 
             type PostAggregateSelection {
@@ -4352,11 +4458,11 @@ describe("Directive-preserve", () => {
             }
 
             type UserAggregate {
+              count: Count!
               node: UserAggregateNode!
             }
 
             type UserAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 

--- a/packages/graphql/tests/schema/directives/alias.test.ts
+++ b/packages/graphql/tests/schema/directives/alias.test.ts
@@ -82,7 +82,7 @@ describe("Alias", () => {
             }
 
             type ActorActedInConnection {
-              aggregate: ActorMovieActedInAggregationSelection!
+              aggregate: ActorMovieActedInAggregateSelection!
               edges: [ActorActedInRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -269,12 +269,12 @@ describe("Alias", () => {
             }
 
             type ActorAggregate {
+              count: Count!
               node: ActorAggregateNode!
             }
 
             type ActorAggregateNode {
               city: StringAggregateSelection!
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -297,6 +297,12 @@ describe("Alias", () => {
             type ActorEdge {
               cursor: String!
               node: Actor!
+            }
+
+            type ActorMovieActedInAggregateSelection {
+              count: CountConnection!
+              edge: ActorMovieActedInEdgeAggregateSelection
+              node: ActorMovieActedInNodeAggregateSelection
             }
 
             type ActorMovieActedInAggregationSelection {
@@ -390,6 +396,15 @@ describe("Alias", () => {
               totalCount: Int!
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             type CreateActorsMutationResponse {
               actors: [Actor!]!
               info: CreateInfo!
@@ -436,11 +451,11 @@ describe("Alias", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               rating: FloatAggregateSelection!
               title: StringAggregateSelection!
             }

--- a/packages/graphql/tests/schema/directives/autogenerate.test.ts
+++ b/packages/graphql/tests/schema/directives/autogenerate.test.ts
@@ -39,6 +39,10 @@ describe("Autogenerate", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -71,11 +75,11 @@ describe("Autogenerate", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
               name: StringAggregateSelection!
             }

--- a/packages/graphql/tests/schema/directives/customResolver.test.ts
+++ b/packages/graphql/tests/schema/directives/customResolver.test.ts
@@ -54,6 +54,10 @@ describe("@customResolver directive", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -140,11 +144,11 @@ describe("@customResolver directive", () => {
             }
 
             type UserAggregate {
+              count: Count!
               node: UserAggregateNode!
             }
 
             type UserAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
               password: StringAggregateSelection!
               username: StringAggregateSelection!
@@ -173,11 +177,11 @@ describe("@customResolver directive", () => {
             }
 
             type UserInterfaceAggregate {
+              count: Count!
               node: UserInterfaceAggregateNode!
             }
 
             type UserInterfaceAggregateNode {
-              count: Int!
               customResolver: StringAggregateSelection!
             }
 

--- a/packages/graphql/tests/schema/directives/cypher.test.ts
+++ b/packages/graphql/tests/schema/directives/cypher.test.ts
@@ -137,11 +137,11 @@ describe("Cypher", () => {
             }
 
             type ActorAggregate {
+              count: Count!
               node: ActorAggregateNode!
             }
 
             type ActorAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -228,6 +228,10 @@ describe("Cypher", () => {
               z: Float
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             type CreateActorsMutationResponse {
               actors: [Actor!]!
               info: CreateInfo!
@@ -311,11 +315,11 @@ describe("Cypher", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
@@ -627,6 +631,10 @@ describe("Cypher", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -653,11 +661,7 @@ describe("Cypher", () => {
             }
 
             type MovieAggregate {
-              node: MovieAggregateNode!
-            }
-
-            type MovieAggregateNode {
-              count: Int!
+              count: Count!
             }
 
             type MovieAggregateSelection {
@@ -757,6 +761,10 @@ describe("Cypher", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -783,11 +791,7 @@ describe("Cypher", () => {
             }
 
             type MovieAggregate {
-              node: MovieAggregateNode!
-            }
-
-            type MovieAggregateNode {
-              count: Int!
+              count: Count!
             }
 
             type MovieAggregateSelection {
@@ -933,11 +937,11 @@ describe("Cypher", () => {
             }
 
             type BlogAggregate {
+              count: Count!
               node: BlogAggregateNode!
             }
 
             type BlogAggregateNode {
-              count: Int!
               title: StringAggregateSelection!
             }
 
@@ -1008,6 +1012,10 @@ describe("Cypher", () => {
               Post: PostWhere
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             type CreateBlogsMutationResponse {
               blogs: [Blog!]!
               info: CreateInfo!
@@ -1056,12 +1064,12 @@ describe("Cypher", () => {
             }
 
             type PostAggregate {
+              count: Count!
               node: PostAggregateNode!
             }
 
             type PostAggregateNode {
               content: StringAggregateSelection!
-              count: Int!
             }
 
             type PostAggregateSelection {
@@ -1233,11 +1241,11 @@ describe("Cypher", () => {
             }
 
             type ActorAggregate {
+              count: Count!
               node: ActorAggregateNode!
             }
 
             type ActorAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -1301,6 +1309,10 @@ describe("Cypher", () => {
               totalCount: Int!
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             type CreateActorsMutationResponse {
               actors: [Actor!]!
               info: CreateInfo!
@@ -1333,11 +1345,7 @@ describe("Cypher", () => {
             }
 
             type MovieAggregate {
-              node: MovieAggregateNode!
-            }
-
-            type MovieAggregateNode {
-              count: Int!
+              count: Count!
             }
 
             type MovieAggregateSelection {
@@ -1410,11 +1418,7 @@ describe("Cypher", () => {
             }
 
             type ProductionAggregate {
-              node: ProductionAggregateNode!
-            }
-
-            type ProductionAggregateNode {
-              count: Int!
+              count: Count!
             }
 
             type ProductionAggregateSelection {
@@ -1556,11 +1560,11 @@ describe("Cypher", () => {
             }
 
             type ActorAggregate {
+              count: Count!
               node: ActorAggregateNode!
             }
 
             type ActorAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -1624,6 +1628,10 @@ describe("Cypher", () => {
               totalCount: Int!
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             type CreateActorsMutationResponse {
               actors: [Actor!]!
               info: CreateInfo!
@@ -1656,11 +1664,7 @@ describe("Cypher", () => {
             }
 
             type MovieAggregate {
-              node: MovieAggregateNode!
-            }
-
-            type MovieAggregateNode {
-              count: Int!
+              count: Count!
             }
 
             type MovieAggregateSelection {
@@ -1813,11 +1817,11 @@ describe("Cypher", () => {
             }
 
             type ActorAggregate {
+              count: Count!
               node: ActorAggregateNode!
             }
 
             type ActorAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -1883,6 +1887,10 @@ describe("Cypher", () => {
               totalCount: Int!
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             type CreateActorsMutationResponse {
               actors: [Actor!]!
               info: CreateInfo!
@@ -1920,11 +1928,11 @@ describe("Cypher", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
@@ -2060,6 +2068,10 @@ describe("Cypher", () => {
               subscription: Subscription
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -2095,11 +2107,11 @@ describe("Cypher", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               title: StringAggregateSelection!
             }
 

--- a/packages/graphql/tests/schema/directives/default.test.ts
+++ b/packages/graphql/tests/schema/directives/default.test.ts
@@ -57,6 +57,10 @@ describe("@default directive", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -175,11 +179,11 @@ describe("@default directive", () => {
             }
 
             type UserAggregate {
+              count: Count!
               node: UserAggregateNode!
             }
 
             type UserAggregateNode {
-              count: Int!
               fromInterface: StringAggregateSelection!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
               name: StringAggregateSelection!
@@ -223,11 +227,11 @@ describe("@default directive", () => {
             }
 
             type UserInterfaceAggregate {
+              count: Count!
               node: UserInterfaceAggregateNode!
             }
 
             type UserInterfaceAggregateNode {
-              count: Int!
               fromInterface: StringAggregateSelection!
               toBeOverridden: StringAggregateSelection!
             }

--- a/packages/graphql/tests/schema/directives/filterable.test.ts
+++ b/packages/graphql/tests/schema/directives/filterable.test.ts
@@ -902,11 +902,11 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorAggregate {
+                      count: Count!
                       node: ActorAggregateNode!
                     }
 
                     type ActorAggregateNode {
-                      count: Int!
                       password: StringAggregateSelection!
                       username: StringAggregateSelection!
                     }
@@ -961,6 +961,11 @@ describe("@filterable directive", () => {
                       username: String!
                     }
 
+                    type ActorMovieMoviesAggregateSelection {
+                      count: CountConnection!
+                      node: ActorMovieMoviesNodeAggregateSelection
+                    }
+
                     type ActorMovieMoviesAggregationSelection {
                       count: Int!
                       node: ActorMovieMoviesNodeAggregateSelection
@@ -992,7 +997,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorMoviesConnection {
-                      aggregate: ActorMovieMoviesAggregationSelection!
+                      aggregate: ActorMovieMoviesAggregateSelection!
                       edges: [ActorMoviesRelationship!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -1146,6 +1151,15 @@ describe("@filterable directive", () => {
                       totalCount: Int!
                     }
 
+                    type Count {
+                      nodes: Int!
+                    }
+
+                    type CountConnection {
+                      edges: Int!
+                      nodes: Int!
+                    }
+
                     type CreateActorsMutationResponse {
                       actors: [Actor!]!
                       info: CreateInfo!
@@ -1187,6 +1201,11 @@ describe("@filterable directive", () => {
                       title: String
                     }
 
+                    type MovieActorActorsAggregateSelection {
+                      count: CountConnection!
+                      node: MovieActorActorsNodeAggregateSelection
+                    }
+
                     type MovieActorActorsAggregationSelection {
                       count: Int!
                       node: MovieActorActorsNodeAggregateSelection
@@ -1220,7 +1239,7 @@ describe("@filterable directive", () => {
                     }
 
                     type MovieActorsConnection {
-                      aggregate: MovieActorActorsAggregationSelection!
+                      aggregate: MovieActorActorsAggregateSelection!
                       edges: [MovieActorsRelationship!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -1311,11 +1330,11 @@ describe("@filterable directive", () => {
                     }
 
                     type MovieAggregate {
+                      count: Count!
                       node: MovieAggregateNode!
                     }
 
                     type MovieAggregateNode {
-                      count: Int!
                       title: StringAggregateSelection!
                     }
 
@@ -1558,11 +1577,11 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorAggregate {
+                      count: Count!
                       node: ActorAggregateNode!
                     }
 
                     type ActorAggregateNode {
-                      count: Int!
                       password: StringAggregateSelection!
                       username: StringAggregateSelection!
                     }
@@ -1617,6 +1636,11 @@ describe("@filterable directive", () => {
                       username: String!
                     }
 
+                    type ActorMovieMoviesAggregateSelection {
+                      count: CountConnection!
+                      node: ActorMovieMoviesNodeAggregateSelection
+                    }
+
                     type ActorMovieMoviesAggregationSelection {
                       count: Int!
                       node: ActorMovieMoviesNodeAggregateSelection
@@ -1649,7 +1673,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorMoviesConnection {
-                      aggregate: ActorMovieMoviesAggregationSelection!
+                      aggregate: ActorMovieMoviesAggregateSelection!
                       edges: [ActorMoviesRelationship!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -1824,6 +1848,15 @@ describe("@filterable directive", () => {
                       totalCount: Int!
                     }
 
+                    type Count {
+                      nodes: Int!
+                    }
+
+                    type CountConnection {
+                      edges: Int!
+                      nodes: Int!
+                    }
+
                     type CreateActorsMutationResponse {
                       actors: [Actor!]!
                       info: CreateInfo!
@@ -1865,6 +1898,11 @@ describe("@filterable directive", () => {
                       title: String
                     }
 
+                    type MovieActorActorsAggregateSelection {
+                      count: CountConnection!
+                      node: MovieActorActorsNodeAggregateSelection
+                    }
+
                     type MovieActorActorsAggregationSelection {
                       count: Int!
                       node: MovieActorActorsNodeAggregateSelection
@@ -1898,7 +1936,7 @@ describe("@filterable directive", () => {
                     }
 
                     type MovieActorsConnection {
-                      aggregate: MovieActorActorsAggregationSelection!
+                      aggregate: MovieActorActorsAggregateSelection!
                       edges: [MovieActorsRelationship!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -1989,11 +2027,11 @@ describe("@filterable directive", () => {
                     }
 
                     type MovieAggregate {
+                      count: Count!
                       node: MovieAggregateNode!
                     }
 
                     type MovieAggregateNode {
-                      count: Int!
                       title: StringAggregateSelection!
                     }
 
@@ -2236,11 +2274,11 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorAggregate {
+                      count: Count!
                       node: ActorAggregateNode!
                     }
 
                     type ActorAggregateNode {
-                      count: Int!
                       password: StringAggregateSelection!
                       username: StringAggregateSelection!
                     }
@@ -2295,6 +2333,11 @@ describe("@filterable directive", () => {
                       username: String!
                     }
 
+                    type ActorMovieMoviesAggregateSelection {
+                      count: CountConnection!
+                      node: ActorMovieMoviesNodeAggregateSelection
+                    }
+
                     type ActorMovieMoviesAggregationSelection {
                       count: Int!
                       node: ActorMovieMoviesNodeAggregateSelection
@@ -2327,7 +2370,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorMoviesConnection {
-                      aggregate: ActorMovieMoviesAggregationSelection!
+                      aggregate: ActorMovieMoviesAggregateSelection!
                       edges: [ActorMoviesRelationship!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -2502,6 +2545,15 @@ describe("@filterable directive", () => {
                       totalCount: Int!
                     }
 
+                    type Count {
+                      nodes: Int!
+                    }
+
+                    type CountConnection {
+                      edges: Int!
+                      nodes: Int!
+                    }
+
                     type CreateActorsMutationResponse {
                       actors: [Actor!]!
                       info: CreateInfo!
@@ -2543,6 +2595,11 @@ describe("@filterable directive", () => {
                       title: String
                     }
 
+                    type MovieActorActorsAggregateSelection {
+                      count: CountConnection!
+                      node: MovieActorActorsNodeAggregateSelection
+                    }
+
                     type MovieActorActorsAggregationSelection {
                       count: Int!
                       node: MovieActorActorsNodeAggregateSelection
@@ -2576,7 +2633,7 @@ describe("@filterable directive", () => {
                     }
 
                     type MovieActorsConnection {
-                      aggregate: MovieActorActorsAggregationSelection!
+                      aggregate: MovieActorActorsAggregateSelection!
                       edges: [MovieActorsRelationship!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -2667,11 +2724,11 @@ describe("@filterable directive", () => {
                     }
 
                     type MovieAggregate {
+                      count: Count!
                       node: MovieAggregateNode!
                     }
 
                     type MovieAggregateNode {
-                      count: Int!
                       title: StringAggregateSelection!
                     }
 
@@ -2899,11 +2956,11 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorAggregate {
+                      count: Count!
                       node: ActorAggregateNode!
                     }
 
                     type ActorAggregateNode {
-                      count: Int!
                       password: StringAggregateSelection!
                       username: StringAggregateSelection!
                     }
@@ -2958,6 +3015,11 @@ describe("@filterable directive", () => {
                       username: String!
                     }
 
+                    type ActorMovieMoviesAggregateSelection {
+                      count: CountConnection!
+                      node: ActorMovieMoviesNodeAggregateSelection
+                    }
+
                     type ActorMovieMoviesAggregationSelection {
                       count: Int!
                       node: ActorMovieMoviesNodeAggregateSelection
@@ -2990,7 +3052,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorMoviesConnection {
-                      aggregate: ActorMovieMoviesAggregationSelection!
+                      aggregate: ActorMovieMoviesAggregateSelection!
                       edges: [ActorMoviesRelationship!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -3165,6 +3227,15 @@ describe("@filterable directive", () => {
                       totalCount: Int!
                     }
 
+                    type Count {
+                      nodes: Int!
+                    }
+
+                    type CountConnection {
+                      edges: Int!
+                      nodes: Int!
+                    }
+
                     type CreateActorsMutationResponse {
                       actors: [Actor!]!
                       info: CreateInfo!
@@ -3206,6 +3277,11 @@ describe("@filterable directive", () => {
                       title: String
                     }
 
+                    type MovieActorActorsAggregateSelection {
+                      count: CountConnection!
+                      node: MovieActorActorsNodeAggregateSelection
+                    }
+
                     type MovieActorActorsAggregationSelection {
                       count: Int!
                       node: MovieActorActorsNodeAggregateSelection
@@ -3226,7 +3302,7 @@ describe("@filterable directive", () => {
                     }
 
                     type MovieActorsConnection {
-                      aggregate: MovieActorActorsAggregationSelection!
+                      aggregate: MovieActorActorsAggregateSelection!
                       edges: [MovieActorsRelationship!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -3281,11 +3357,11 @@ describe("@filterable directive", () => {
                     }
 
                     type MovieAggregate {
+                      count: Count!
                       node: MovieAggregateNode!
                     }
 
                     type MovieAggregateNode {
-                      count: Int!
                       title: StringAggregateSelection!
                     }
 
@@ -3529,11 +3605,11 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorAggregate {
+                      count: Count!
                       node: ActorAggregateNode!
                     }
 
                     type ActorAggregateNode {
-                      count: Int!
                       password: StringAggregateSelection!
                       username: StringAggregateSelection!
                     }
@@ -3588,6 +3664,11 @@ describe("@filterable directive", () => {
                       username: String!
                     }
 
+                    type ActorMovieMoviesAggregateSelection {
+                      count: CountConnection!
+                      node: ActorMovieMoviesNodeAggregateSelection
+                    }
+
                     type ActorMovieMoviesAggregationSelection {
                       count: Int!
                       node: ActorMovieMoviesNodeAggregateSelection
@@ -3620,7 +3701,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorMoviesConnection {
-                      aggregate: ActorMovieMoviesAggregationSelection!
+                      aggregate: ActorMovieMoviesAggregateSelection!
                       edges: [ActorMoviesRelationship!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -3795,6 +3876,15 @@ describe("@filterable directive", () => {
                       totalCount: Int!
                     }
 
+                    type Count {
+                      nodes: Int!
+                    }
+
+                    type CountConnection {
+                      edges: Int!
+                      nodes: Int!
+                    }
+
                     type CreateActorsMutationResponse {
                       actors: [Actor!]!
                       info: CreateInfo!
@@ -3836,6 +3926,11 @@ describe("@filterable directive", () => {
                       title: String
                     }
 
+                    type MovieActorActorsAggregateSelection {
+                      count: CountConnection!
+                      node: MovieActorActorsNodeAggregateSelection
+                    }
+
                     type MovieActorActorsAggregationSelection {
                       count: Int!
                       node: MovieActorActorsNodeAggregateSelection
@@ -3869,7 +3964,7 @@ describe("@filterable directive", () => {
                     }
 
                     type MovieActorsConnection {
-                      aggregate: MovieActorActorsAggregationSelection!
+                      aggregate: MovieActorActorsAggregateSelection!
                       edges: [MovieActorsRelationship!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -3960,11 +4055,11 @@ describe("@filterable directive", () => {
                     }
 
                     type MovieAggregate {
+                      count: Count!
                       node: MovieAggregateNode!
                     }
 
                     type MovieAggregateNode {
-                      count: Int!
                       title: StringAggregateSelection!
                     }
 
@@ -4209,11 +4304,11 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorAggregate {
+                      count: Count!
                       node: ActorAggregateNode!
                     }
 
                     type ActorAggregateNode {
-                      count: Int!
                       password: StringAggregateSelection!
                       username: StringAggregateSelection!
                     }
@@ -4268,6 +4363,11 @@ describe("@filterable directive", () => {
                       username: String!
                     }
 
+                    type ActorMovieMoviesAggregateSelection {
+                      count: CountConnection!
+                      node: ActorMovieMoviesNodeAggregateSelection
+                    }
+
                     type ActorMovieMoviesAggregationSelection {
                       count: Int!
                       node: ActorMovieMoviesNodeAggregateSelection
@@ -4300,7 +4400,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorMoviesConnection {
-                      aggregate: ActorMovieMoviesAggregationSelection!
+                      aggregate: ActorMovieMoviesAggregateSelection!
                       edges: [ActorMoviesRelationship!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -4475,6 +4575,15 @@ describe("@filterable directive", () => {
                       totalCount: Int!
                     }
 
+                    type Count {
+                      nodes: Int!
+                    }
+
+                    type CountConnection {
+                      edges: Int!
+                      nodes: Int!
+                    }
+
                     type CreateActorsMutationResponse {
                       actors: [Actor!]!
                       info: CreateInfo!
@@ -4516,6 +4625,11 @@ describe("@filterable directive", () => {
                       title: String
                     }
 
+                    type MovieActorActorsAggregateSelection {
+                      count: CountConnection!
+                      node: MovieActorActorsNodeAggregateSelection
+                    }
+
                     type MovieActorActorsAggregationSelection {
                       count: Int!
                       node: MovieActorActorsNodeAggregateSelection
@@ -4549,7 +4663,7 @@ describe("@filterable directive", () => {
                     }
 
                     type MovieActorsConnection {
-                      aggregate: MovieActorActorsAggregationSelection!
+                      aggregate: MovieActorActorsAggregateSelection!
                       edges: [MovieActorsRelationship!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -4640,11 +4754,11 @@ describe("@filterable directive", () => {
                     }
 
                     type MovieAggregate {
+                      count: Count!
                       node: MovieAggregateNode!
                     }
 
                     type MovieAggregateNode {
-                      count: Int!
                       title: StringAggregateSelection!
                     }
 
@@ -4865,11 +4979,11 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorAggregate {
+                      count: Count!
                       node: ActorAggregateNode!
                     }
 
                     type ActorAggregateNode {
-                      count: Int!
                       password: StringAggregateSelection!
                       username: StringAggregateSelection!
                     }
@@ -4924,6 +5038,11 @@ describe("@filterable directive", () => {
                       username: String!
                     }
 
+                    type ActorMovieMoviesAggregateSelection {
+                      count: CountConnection!
+                      node: ActorMovieMoviesNodeAggregateSelection
+                    }
+
                     type ActorMovieMoviesAggregationSelection {
                       count: Int!
                       node: ActorMovieMoviesNodeAggregateSelection
@@ -4956,7 +5075,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorMoviesConnection {
-                      aggregate: ActorMovieMoviesAggregationSelection!
+                      aggregate: ActorMovieMoviesAggregateSelection!
                       edges: [ActorMoviesRelationship!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -5131,6 +5250,15 @@ describe("@filterable directive", () => {
                       totalCount: Int!
                     }
 
+                    type Count {
+                      nodes: Int!
+                    }
+
+                    type CountConnection {
+                      edges: Int!
+                      nodes: Int!
+                    }
+
                     type CreateActorsMutationResponse {
                       actors: [Actor!]!
                       info: CreateInfo!
@@ -5172,6 +5300,11 @@ describe("@filterable directive", () => {
                       title: String
                     }
 
+                    type MovieActorActorsAggregateSelection {
+                      count: CountConnection!
+                      node: MovieActorActorsNodeAggregateSelection
+                    }
+
                     type MovieActorActorsAggregationSelection {
                       count: Int!
                       node: MovieActorActorsNodeAggregateSelection
@@ -5192,7 +5325,7 @@ describe("@filterable directive", () => {
                     }
 
                     type MovieActorsConnection {
-                      aggregate: MovieActorActorsAggregationSelection!
+                      aggregate: MovieActorActorsAggregateSelection!
                       edges: [MovieActorsRelationship!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -5247,11 +5380,11 @@ describe("@filterable directive", () => {
                     }
 
                     type MovieAggregate {
+                      count: Count!
                       node: MovieAggregateNode!
                     }
 
                     type MovieAggregateNode {
-                      count: Int!
                       title: StringAggregateSelection!
                     }
 
@@ -5500,11 +5633,11 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorAggregate {
+                      count: Count!
                       node: ActorAggregateNode!
                     }
 
                     type ActorAggregateNode {
-                      count: Int!
                       password: StringAggregateSelection!
                       username: StringAggregateSelection!
                     }
@@ -5547,6 +5680,11 @@ describe("@filterable directive", () => {
                       username: String!
                     }
 
+                    type ActorMovieMoviesAggregateSelection {
+                      count: CountConnection!
+                      node: ActorMovieMoviesNodeAggregateSelection
+                    }
+
                     type ActorMovieMoviesAggregationSelection {
                       count: Int!
                       node: ActorMovieMoviesNodeAggregateSelection
@@ -5579,7 +5717,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorMoviesConnection {
-                      aggregate: ActorMovieMoviesAggregationSelection!
+                      aggregate: ActorMovieMoviesAggregateSelection!
                       edges: [ActorMoviesRelationship!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -5754,6 +5892,15 @@ describe("@filterable directive", () => {
                       totalCount: Int!
                     }
 
+                    type Count {
+                      nodes: Int!
+                    }
+
+                    type CountConnection {
+                      edges: Int!
+                      nodes: Int!
+                    }
+
                     type CreateActorsMutationResponse {
                       actors: [Actor!]!
                       info: CreateInfo!
@@ -5800,7 +5947,7 @@ describe("@filterable directive", () => {
                     }
 
                     type MovieActorsConnection {
-                      aggregate: MoviePersonActorsAggregationSelection!
+                      aggregate: MoviePersonActorsAggregateSelection!
                       edges: [MovieActorsRelationship!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -5853,11 +6000,11 @@ describe("@filterable directive", () => {
                     }
 
                     type MovieAggregate {
+                      count: Count!
                       node: MovieAggregateNode!
                     }
 
                     type MovieAggregateNode {
-                      count: Int!
                       title: StringAggregateSelection!
                     }
 
@@ -5915,6 +6062,11 @@ describe("@filterable directive", () => {
                       Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array.
                       \\"\\"\\"
                       sort: [MovieSort!]
+                    }
+
+                    type MoviePersonActorsAggregateSelection {
+                      count: CountConnection!
+                      node: MoviePersonActorsNodeAggregateSelection
                     }
 
                     type MoviePersonActorsAggregationSelection {
@@ -6030,11 +6182,11 @@ describe("@filterable directive", () => {
                     }
 
                     type PersonAggregate {
+                      count: Count!
                       node: PersonAggregateNode!
                     }
 
                     type PersonAggregateNode {
-                      count: Int!
                       username: StringAggregateSelection!
                     }
 
@@ -6195,11 +6347,11 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorAggregate {
+                      count: Count!
                       node: ActorAggregateNode!
                     }
 
                     type ActorAggregateNode {
-                      count: Int!
                       password: StringAggregateSelection!
                       username: StringAggregateSelection!
                     }
@@ -6242,6 +6394,11 @@ describe("@filterable directive", () => {
                       username: String!
                     }
 
+                    type ActorMovieMoviesAggregateSelection {
+                      count: CountConnection!
+                      node: ActorMovieMoviesNodeAggregateSelection
+                    }
+
                     type ActorMovieMoviesAggregationSelection {
                       count: Int!
                       node: ActorMovieMoviesNodeAggregateSelection
@@ -6274,7 +6431,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorMoviesConnection {
-                      aggregate: ActorMovieMoviesAggregationSelection!
+                      aggregate: ActorMovieMoviesAggregateSelection!
                       edges: [ActorMoviesRelationship!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -6449,6 +6606,15 @@ describe("@filterable directive", () => {
                       totalCount: Int!
                     }
 
+                    type Count {
+                      nodes: Int!
+                    }
+
+                    type CountConnection {
+                      edges: Int!
+                      nodes: Int!
+                    }
+
                     type CreateActorsMutationResponse {
                       actors: [Actor!]!
                       info: CreateInfo!
@@ -6508,7 +6674,7 @@ describe("@filterable directive", () => {
                     }
 
                     type MovieActorsConnection {
-                      aggregate: MoviePersonActorsAggregationSelection!
+                      aggregate: MoviePersonActorsAggregateSelection!
                       edges: [MovieActorsRelationship!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -6582,11 +6748,11 @@ describe("@filterable directive", () => {
                     }
 
                     type MovieAggregate {
+                      count: Count!
                       node: MovieAggregateNode!
                     }
 
                     type MovieAggregateNode {
-                      count: Int!
                       title: StringAggregateSelection!
                     }
 
@@ -6644,6 +6810,11 @@ describe("@filterable directive", () => {
                       Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array.
                       \\"\\"\\"
                       sort: [MovieSort!]
+                    }
+
+                    type MoviePersonActorsAggregateSelection {
+                      count: CountConnection!
+                      node: MoviePersonActorsNodeAggregateSelection
                     }
 
                     type MoviePersonActorsAggregationSelection {
@@ -6760,11 +6931,11 @@ describe("@filterable directive", () => {
                     }
 
                     type PersonAggregate {
+                      count: Count!
                       node: PersonAggregateNode!
                     }
 
                     type PersonAggregateNode {
-                      count: Int!
                       username: StringAggregateSelection!
                     }
 
@@ -6925,11 +7096,11 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorAggregate {
+                      count: Count!
                       node: ActorAggregateNode!
                     }
 
                     type ActorAggregateNode {
-                      count: Int!
                       password: StringAggregateSelection!
                       username: StringAggregateSelection!
                     }
@@ -6972,6 +7143,11 @@ describe("@filterable directive", () => {
                       username: String!
                     }
 
+                    type ActorMovieMoviesAggregateSelection {
+                      count: CountConnection!
+                      node: ActorMovieMoviesNodeAggregateSelection
+                    }
+
                     type ActorMovieMoviesAggregationSelection {
                       count: Int!
                       node: ActorMovieMoviesNodeAggregateSelection
@@ -7004,7 +7180,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorMoviesConnection {
-                      aggregate: ActorMovieMoviesAggregationSelection!
+                      aggregate: ActorMovieMoviesAggregateSelection!
                       edges: [ActorMoviesRelationship!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -7179,6 +7355,15 @@ describe("@filterable directive", () => {
                       totalCount: Int!
                     }
 
+                    type Count {
+                      nodes: Int!
+                    }
+
+                    type CountConnection {
+                      edges: Int!
+                      nodes: Int!
+                    }
+
                     type CreateActorsMutationResponse {
                       actors: [Actor!]!
                       info: CreateInfo!
@@ -7225,7 +7410,7 @@ describe("@filterable directive", () => {
                     }
 
                     type MovieActorsConnection {
-                      aggregate: MoviePersonActorsAggregationSelection!
+                      aggregate: MoviePersonActorsAggregateSelection!
                       edges: [MovieActorsRelationship!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -7278,11 +7463,11 @@ describe("@filterable directive", () => {
                     }
 
                     type MovieAggregate {
+                      count: Count!
                       node: MovieAggregateNode!
                     }
 
                     type MovieAggregateNode {
-                      count: Int!
                       title: StringAggregateSelection!
                     }
 
@@ -7340,6 +7525,11 @@ describe("@filterable directive", () => {
                       Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array.
                       \\"\\"\\"
                       sort: [MovieSort!]
+                    }
+
+                    type MoviePersonActorsAggregateSelection {
+                      count: CountConnection!
+                      node: MoviePersonActorsNodeAggregateSelection
                     }
 
                     type MoviePersonActorsAggregationSelection {
@@ -7455,11 +7645,11 @@ describe("@filterable directive", () => {
                     }
 
                     type PersonAggregate {
+                      count: Count!
                       node: PersonAggregateNode!
                     }
 
                     type PersonAggregateNode {
-                      count: Int!
                       username: StringAggregateSelection!
                     }
 
@@ -7624,11 +7814,11 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorAggregate {
+                      count: Count!
                       node: ActorAggregateNode!
                     }
 
                     type ActorAggregateNode {
-                      count: Int!
                       password: StringAggregateSelection!
                       username: StringAggregateSelection!
                     }
@@ -7683,6 +7873,11 @@ describe("@filterable directive", () => {
                       username: String!
                     }
 
+                    type ActorMovieMoviesAggregateSelection {
+                      count: CountConnection!
+                      node: ActorMovieMoviesNodeAggregateSelection
+                    }
+
                     type ActorMovieMoviesAggregationSelection {
                       count: Int!
                       node: ActorMovieMoviesNodeAggregateSelection
@@ -7715,7 +7910,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorMoviesConnection {
-                      aggregate: ActorMovieMoviesAggregationSelection!
+                      aggregate: ActorMovieMoviesAggregateSelection!
                       edges: [ActorMoviesRelationship!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -7899,11 +8094,11 @@ describe("@filterable directive", () => {
                     }
 
                     type AppearanceAggregate {
+                      count: Count!
                       node: AppearanceAggregateNode!
                     }
 
                     type AppearanceAggregateNode {
-                      count: Int!
                       password: StringAggregateSelection!
                       username: StringAggregateSelection!
                     }
@@ -7958,6 +8153,11 @@ describe("@filterable directive", () => {
                       username: String!
                     }
 
+                    type AppearanceMovieMoviesAggregateSelection {
+                      count: CountConnection!
+                      node: AppearanceMovieMoviesNodeAggregateSelection
+                    }
+
                     type AppearanceMovieMoviesAggregationSelection {
                       count: Int!
                       node: AppearanceMovieMoviesNodeAggregateSelection
@@ -7990,7 +8190,7 @@ describe("@filterable directive", () => {
                     }
 
                     type AppearanceMoviesConnection {
-                      aggregate: AppearanceMovieMoviesAggregationSelection!
+                      aggregate: AppearanceMovieMoviesAggregateSelection!
                       edges: [AppearanceMoviesRelationship!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -8163,6 +8363,15 @@ describe("@filterable directive", () => {
                       edges: [AppearanceEdge!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
+                    }
+
+                    type Count {
+                      nodes: Int!
+                    }
+
+                    type CountConnection {
+                      edges: Int!
+                      nodes: Int!
                     }
 
                     type CreateActorsMutationResponse {
@@ -8340,11 +8549,11 @@ describe("@filterable directive", () => {
                     }
 
                     type MovieAggregate {
+                      count: Count!
                       node: MovieAggregateNode!
                     }
 
                     type MovieAggregateNode {
-                      count: Int!
                       title: StringAggregateSelection!
                     }
 
@@ -8625,11 +8834,11 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorAggregate {
+                      count: Count!
                       node: ActorAggregateNode!
                     }
 
                     type ActorAggregateNode {
-                      count: Int!
                       password: StringAggregateSelection!
                       username: StringAggregateSelection!
                     }
@@ -8684,6 +8893,11 @@ describe("@filterable directive", () => {
                       username: String!
                     }
 
+                    type ActorMovieMoviesAggregateSelection {
+                      count: CountConnection!
+                      node: ActorMovieMoviesNodeAggregateSelection
+                    }
+
                     type ActorMovieMoviesAggregationSelection {
                       count: Int!
                       node: ActorMovieMoviesNodeAggregateSelection
@@ -8716,7 +8930,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorMoviesConnection {
-                      aggregate: ActorMovieMoviesAggregationSelection!
+                      aggregate: ActorMovieMoviesAggregateSelection!
                       edges: [ActorMoviesRelationship!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -8900,11 +9114,11 @@ describe("@filterable directive", () => {
                     }
 
                     type AppearanceAggregate {
+                      count: Count!
                       node: AppearanceAggregateNode!
                     }
 
                     type AppearanceAggregateNode {
-                      count: Int!
                       password: StringAggregateSelection!
                       username: StringAggregateSelection!
                     }
@@ -8959,6 +9173,11 @@ describe("@filterable directive", () => {
                       username: String!
                     }
 
+                    type AppearanceMovieMoviesAggregateSelection {
+                      count: CountConnection!
+                      node: AppearanceMovieMoviesNodeAggregateSelection
+                    }
+
                     type AppearanceMovieMoviesAggregationSelection {
                       count: Int!
                       node: AppearanceMovieMoviesNodeAggregateSelection
@@ -8991,7 +9210,7 @@ describe("@filterable directive", () => {
                     }
 
                     type AppearanceMoviesConnection {
-                      aggregate: AppearanceMovieMoviesAggregationSelection!
+                      aggregate: AppearanceMovieMoviesAggregateSelection!
                       edges: [AppearanceMoviesRelationship!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -9164,6 +9383,15 @@ describe("@filterable directive", () => {
                       edges: [AppearanceEdge!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
+                    }
+
+                    type Count {
+                      nodes: Int!
+                    }
+
+                    type CountConnection {
+                      edges: Int!
+                      nodes: Int!
                     }
 
                     type CreateActorsMutationResponse {
@@ -9341,11 +9569,11 @@ describe("@filterable directive", () => {
                     }
 
                     type MovieAggregate {
+                      count: Count!
                       node: MovieAggregateNode!
                     }
 
                     type MovieAggregateNode {
-                      count: Int!
                       title: StringAggregateSelection!
                     }
 
@@ -9626,11 +9854,11 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorAggregate {
+                      count: Count!
                       node: ActorAggregateNode!
                     }
 
                     type ActorAggregateNode {
-                      count: Int!
                       password: StringAggregateSelection!
                       username: StringAggregateSelection!
                     }
@@ -9685,6 +9913,11 @@ describe("@filterable directive", () => {
                       username: String!
                     }
 
+                    type ActorMovieMoviesAggregateSelection {
+                      count: CountConnection!
+                      node: ActorMovieMoviesNodeAggregateSelection
+                    }
+
                     type ActorMovieMoviesAggregationSelection {
                       count: Int!
                       node: ActorMovieMoviesNodeAggregateSelection
@@ -9717,7 +9950,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorMoviesConnection {
-                      aggregate: ActorMovieMoviesAggregationSelection!
+                      aggregate: ActorMovieMoviesAggregateSelection!
                       edges: [ActorMoviesRelationship!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -9901,11 +10134,11 @@ describe("@filterable directive", () => {
                     }
 
                     type AppearanceAggregate {
+                      count: Count!
                       node: AppearanceAggregateNode!
                     }
 
                     type AppearanceAggregateNode {
-                      count: Int!
                       password: StringAggregateSelection!
                       username: StringAggregateSelection!
                     }
@@ -9960,6 +10193,11 @@ describe("@filterable directive", () => {
                       username: String!
                     }
 
+                    type AppearanceMovieMoviesAggregateSelection {
+                      count: CountConnection!
+                      node: AppearanceMovieMoviesNodeAggregateSelection
+                    }
+
                     type AppearanceMovieMoviesAggregationSelection {
                       count: Int!
                       node: AppearanceMovieMoviesNodeAggregateSelection
@@ -9992,7 +10230,7 @@ describe("@filterable directive", () => {
                     }
 
                     type AppearanceMoviesConnection {
-                      aggregate: AppearanceMovieMoviesAggregationSelection!
+                      aggregate: AppearanceMovieMoviesAggregateSelection!
                       edges: [AppearanceMoviesRelationship!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -10165,6 +10403,15 @@ describe("@filterable directive", () => {
                       edges: [AppearanceEdge!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
+                    }
+
+                    type Count {
+                      nodes: Int!
+                    }
+
+                    type CountConnection {
+                      edges: Int!
+                      nodes: Int!
                     }
 
                     type CreateActorsMutationResponse {
@@ -10342,11 +10589,11 @@ describe("@filterable directive", () => {
                     }
 
                     type MovieAggregate {
+                      count: Count!
                       node: MovieAggregateNode!
                     }
 
                     type MovieAggregateNode {
-                      count: Int!
                       title: StringAggregateSelection!
                     }
 

--- a/packages/graphql/tests/schema/directives/plural.test.ts
+++ b/packages/graphql/tests/schema/directives/plural.test.ts
@@ -42,6 +42,10 @@ describe("Plural option", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -102,11 +106,11 @@ describe("Plural option", () => {
             }
 
             type TechAggregate {
+              count: Count!
               node: TechAggregateNode!
             }
 
             type TechAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
               value: StringAggregateSelection!
             }
@@ -212,6 +216,10 @@ describe("Plural option", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -272,11 +280,11 @@ describe("Plural option", () => {
             }
 
             type TechAggregate {
+              count: Count!
               node: TechAggregateNode!
             }
 
             type TechAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
               value: StringAggregateSelection!
             }
@@ -382,6 +390,10 @@ describe("Plural option", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -442,11 +454,11 @@ describe("Plural option", () => {
             }
 
             type TechAggregate {
+              count: Count!
               node: TechAggregateNode!
             }
 
             type TechAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
               value: StringAggregateSelection!
             }
@@ -552,6 +564,10 @@ describe("Plural option", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -611,11 +627,11 @@ describe("Plural option", () => {
             }
 
             type TechsAggregate {
+              count: Count!
               node: TechsAggregateNode!
             }
 
             type TechsAggregateNode {
-              count: Int!
               value: StringAggregateSelection!
             }
 
@@ -709,6 +725,10 @@ describe("Plural option", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -790,11 +810,11 @@ describe("Plural option", () => {
             }
 
             type UserAggregate {
+              count: Count!
               node: UserAggregateNode!
             }
 
             type UserAggregateNode {
-              count: Int!
               value: StringAggregateSelection!
             }
 
@@ -864,6 +884,10 @@ describe("Plural option", () => {
             "schema {
               query: Query
               mutation: Mutation
+            }
+
+            type Count {
+              nodes: Int!
             }
 
             \\"\\"\\"
@@ -940,11 +964,11 @@ describe("Plural option", () => {
             }
 
             type UserAggregate {
+              count: Count!
               node: UserAggregateNode!
             }
 
             type UserAggregateNode {
-              count: Int!
               value: StringAggregateSelection!
             }
 
@@ -1023,6 +1047,10 @@ describe("Plural option", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -1097,11 +1125,11 @@ describe("Plural option", () => {
             }
 
             type UsersAggregate {
+              count: Count!
               node: UsersAggregateNode!
             }
 
             type UsersAggregateNode {
-              count: Int!
               value: StringAggregateSelection!
             }
 

--- a/packages/graphql/tests/schema/directives/populatedBy.test.ts
+++ b/packages/graphql/tests/schema/directives/populatedBy.test.ts
@@ -162,6 +162,10 @@ describe("@populatedBy tests", () => {
                   mutation: Mutation
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
                 \\"\\"\\"
                 Information about the number of nodes and relationships created during a create mutation
                 \\"\\"\\"
@@ -196,6 +200,7 @@ describe("@populatedBy tests", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
@@ -203,7 +208,6 @@ describe("@populatedBy tests", () => {
                   callback1: StringAggregateSelection!
                   callback2: StringAggregateSelection!
                   callback3: StringAggregateSelection!
-                  count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
                 }
 
@@ -373,6 +377,10 @@ describe("@populatedBy tests", () => {
                   mutation: Mutation
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
                 \\"\\"\\"
                 Information about the number of nodes and relationships created during a create mutation
                 \\"\\"\\"
@@ -414,6 +422,7 @@ describe("@populatedBy tests", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
@@ -421,7 +430,6 @@ describe("@populatedBy tests", () => {
                   callback1: IntAggregateSelection!
                   callback2: IntAggregateSelection!
                   callback3: IntAggregateSelection!
-                  count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
                 }
 
@@ -735,6 +743,15 @@ describe("@populatedBy tests", () => {
                   mutation: Mutation
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
+                type CountConnection {
+                  edges: Int!
+                  nodes: Int!
+                }
+
                 type CreateGenresMutationResponse {
                   genres: [Genre!]!
                   info: CreateInfo!
@@ -766,11 +783,11 @@ describe("@populatedBy tests", () => {
                 }
 
                 type GenreAggregate {
+                  count: Count!
                   node: GenreAggregateNode!
                 }
 
                 type GenreAggregateNode {
-                  count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
                 }
 
@@ -845,11 +862,11 @@ describe("@populatedBy tests", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
                 }
 
@@ -870,6 +887,12 @@ describe("@populatedBy tests", () => {
                 type MovieEdge {
                   cursor: String!
                   node: Movie!
+                }
+
+                type MovieGenreGenresAggregateSelection {
+                  count: CountConnection!
+                  edge: MovieGenreGenresEdgeAggregateSelection
+                  node: MovieGenreGenresNodeAggregateSelection
                 }
 
                 type MovieGenreGenresAggregationSelection {
@@ -913,7 +936,7 @@ describe("@populatedBy tests", () => {
                 }
 
                 type MovieGenresConnection {
-                  aggregate: MovieGenreGenresAggregationSelection!
+                  aggregate: MovieGenreGenresAggregateSelection!
                   edges: [MovieGenresRelationship!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -1278,6 +1301,15 @@ describe("@populatedBy tests", () => {
                   mutation: Mutation
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
+                type CountConnection {
+                  edges: Int!
+                  nodes: Int!
+                }
+
                 type CreateGenresMutationResponse {
                   genres: [Genre!]!
                   info: CreateInfo!
@@ -1309,11 +1341,11 @@ describe("@populatedBy tests", () => {
                 }
 
                 type GenreAggregate {
+                  count: Count!
                   node: GenreAggregateNode!
                 }
 
                 type GenreAggregateNode {
-                  count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
                 }
 
@@ -1395,11 +1427,11 @@ describe("@populatedBy tests", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
                 }
 
@@ -1420,6 +1452,12 @@ describe("@populatedBy tests", () => {
                 type MovieEdge {
                   cursor: String!
                   node: Movie!
+                }
+
+                type MovieGenreGenresAggregateSelection {
+                  count: CountConnection!
+                  edge: MovieGenreGenresEdgeAggregateSelection
+                  node: MovieGenreGenresNodeAggregateSelection
                 }
 
                 type MovieGenreGenresAggregationSelection {
@@ -1463,7 +1501,7 @@ describe("@populatedBy tests", () => {
                 }
 
                 type MovieGenresConnection {
-                  aggregate: MovieGenreGenresAggregationSelection!
+                  aggregate: MovieGenreGenresAggregateSelection!
                   edges: [MovieGenresRelationship!]!
                   pageInfo: PageInfo!
                   totalCount: Int!

--- a/packages/graphql/tests/schema/directives/private.test.ts
+++ b/packages/graphql/tests/schema/directives/private.test.ts
@@ -45,6 +45,10 @@ describe("@private directive", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -122,11 +126,11 @@ describe("@private directive", () => {
             }
 
             type UserAggregate {
+              count: Count!
               node: UserAggregateNode!
             }
 
             type UserAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
@@ -149,11 +153,11 @@ describe("@private directive", () => {
             }
 
             type UserInterfaceAggregate {
+              count: Count!
               node: UserInterfaceAggregateNode!
             }
 
             type UserInterfaceAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
@@ -272,6 +276,10 @@ describe("@private directive", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -355,11 +363,11 @@ describe("@private directive", () => {
             }
 
             type UserAggregate {
+              count: Count!
               node: UserAggregateNode!
             }
 
             type UserAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
               private: StringAggregateSelection!
             }
@@ -385,11 +393,11 @@ describe("@private directive", () => {
             }
 
             type UserInterfaceAggregate {
+              count: Count!
               node: UserInterfaceAggregateNode!
             }
 
             type UserInterfaceAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 

--- a/packages/graphql/tests/schema/directives/relationship-aggregate.test.ts
+++ b/packages/graphql/tests/schema/directives/relationship-aggregate.test.ts
@@ -233,11 +233,11 @@ describe("@relationship directive, aggregate argument", () => {
                 }
 
                 type ActorAggregate {
+                  count: Count!
                   node: ActorAggregateNode!
                 }
 
                 type ActorAggregateNode {
-                  count: Int!
                   password: StringAggregateSelection!
                   username: StringAggregateSelection!
                 }
@@ -309,6 +309,10 @@ describe("@relationship directive, aggregate argument", () => {
                   edges: [ActorEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
+                }
+
+                type Count {
+                  nodes: Int!
                 }
 
                 type CreateActorsMutationResponse {
@@ -453,11 +457,11 @@ describe("@relationship directive, aggregate argument", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   title: StringAggregateSelection!
                 }
 
@@ -635,11 +639,11 @@ describe("@relationship directive, aggregate argument", () => {
                 }
 
                 type ActorAggregate {
+                  count: Count!
                   node: ActorAggregateNode!
                 }
 
                 type ActorAggregateNode {
-                  count: Int!
                   password: StringAggregateSelection!
                   username: StringAggregateSelection!
                 }
@@ -713,6 +717,15 @@ describe("@relationship directive, aggregate argument", () => {
                   totalCount: Int!
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
+                type CountConnection {
+                  edges: Int!
+                  nodes: Int!
+                }
+
                 type CreateActorsMutationResponse {
                   actors: [Actor!]!
                   info: CreateInfo!
@@ -744,6 +757,11 @@ describe("@relationship directive, aggregate argument", () => {
                   actorsAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: ActorWhere): MovieActorActorsAggregationSelection @deprecated(reason: \\"Please use field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\" instead\\")
                   actorsConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [MovieActorsConnectionSort!], where: MovieActorsConnectionWhere): MovieActorsConnection!
                   title: String
+                }
+
+                type MovieActorActorsAggregateSelection {
+                  count: CountConnection!
+                  node: MovieActorActorsNodeAggregateSelection
                 }
 
                 type MovieActorActorsAggregationSelection {
@@ -778,7 +796,7 @@ describe("@relationship directive, aggregate argument", () => {
                 }
 
                 type MovieActorsConnection {
-                  aggregate: MovieActorActorsAggregationSelection!
+                  aggregate: MovieActorActorsAggregateSelection!
                   edges: [MovieActorsRelationship!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -867,11 +885,11 @@ describe("@relationship directive, aggregate argument", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   title: StringAggregateSelection!
                 }
 
@@ -1055,11 +1073,11 @@ describe("@relationship directive, aggregate argument", () => {
                     }
 
                     type ActorAggregate {
+                      count: Count!
                       node: ActorAggregateNode!
                     }
 
                     type ActorAggregateNode {
-                      count: Int!
                       password: StringAggregateSelection!
                       username: StringAggregateSelection!
                     }
@@ -1127,6 +1145,10 @@ describe("@relationship directive, aggregate argument", () => {
                       edges: [ActorEdge!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
+                    }
+
+                    type Count {
+                      nodes: Int!
                     }
 
                     type CreateActorsMutationResponse {
@@ -1267,11 +1289,11 @@ describe("@relationship directive, aggregate argument", () => {
                     }
 
                     type MovieAggregate {
+                      count: Count!
                       node: MovieAggregateNode!
                     }
 
                     type MovieAggregateNode {
-                      count: Int!
                       title: StringAggregateSelection!
                     }
 
@@ -1390,11 +1412,11 @@ describe("@relationship directive, aggregate argument", () => {
                     }
 
                     type PersonAggregate {
+                      count: Count!
                       node: PersonAggregateNode!
                     }
 
                     type PersonAggregateNode {
-                      count: Int!
                       password: StringAggregateSelection!
                       username: StringAggregateSelection!
                     }
@@ -1545,11 +1567,11 @@ describe("@relationship directive, aggregate argument", () => {
                     }
 
                     type ActorAggregate {
+                      count: Count!
                       node: ActorAggregateNode!
                     }
 
                     type ActorAggregateNode {
-                      count: Int!
                       password: StringAggregateSelection!
                       username: StringAggregateSelection!
                     }
@@ -1619,6 +1641,15 @@ describe("@relationship directive, aggregate argument", () => {
                       totalCount: Int!
                     }
 
+                    type Count {
+                      nodes: Int!
+                    }
+
+                    type CountConnection {
+                      edges: Int!
+                      nodes: Int!
+                    }
+
                     type CreateActorsMutationResponse {
                       actors: [Actor!]!
                       info: CreateInfo!
@@ -1670,7 +1701,7 @@ describe("@relationship directive, aggregate argument", () => {
                     }
 
                     type MovieActorsConnection {
-                      aggregate: MoviePersonActorsAggregationSelection!
+                      aggregate: MoviePersonActorsAggregateSelection!
                       edges: [MovieActorsRelationship!]!
                       pageInfo: PageInfo!
                       totalCount: Int!
@@ -1759,11 +1790,11 @@ describe("@relationship directive, aggregate argument", () => {
                     }
 
                     type MovieAggregate {
+                      count: Count!
                       node: MovieAggregateNode!
                     }
 
                     type MovieAggregateNode {
-                      count: Int!
                       title: StringAggregateSelection!
                     }
 
@@ -1793,6 +1824,11 @@ describe("@relationship directive, aggregate argument", () => {
                       Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array.
                       \\"\\"\\"
                       sort: [MovieSort!]
+                    }
+
+                    type MoviePersonActorsAggregateSelection {
+                      count: CountConnection!
+                      node: MoviePersonActorsNodeAggregateSelection
                     }
 
                     type MoviePersonActorsAggregationSelection {
@@ -1892,11 +1928,11 @@ describe("@relationship directive, aggregate argument", () => {
                     }
 
                     type PersonAggregate {
+                      count: Count!
                       node: PersonAggregateNode!
                     }
 
                     type PersonAggregateNode {
-                      count: Int!
                       password: StringAggregateSelection!
                       username: StringAggregateSelection!
                     }
@@ -2051,11 +2087,11 @@ describe("@relationship directive, aggregate argument", () => {
                     }
 
                     type ActorAggregate {
+                      count: Count!
                       node: ActorAggregateNode!
                     }
 
                     type ActorAggregateNode {
-                      count: Int!
                       password: StringAggregateSelection!
                       username: StringAggregateSelection!
                     }
@@ -2134,6 +2170,10 @@ describe("@relationship directive, aggregate argument", () => {
                     input CastMemberWhere {
                       Actor: ActorWhere
                       Person: PersonWhere
+                    }
+
+                    type Count {
+                      nodes: Int!
                     }
 
                     type CreateActorsMutationResponse {
@@ -2287,11 +2327,11 @@ describe("@relationship directive, aggregate argument", () => {
                     }
 
                     type MovieAggregate {
+                      count: Count!
                       node: MovieAggregateNode!
                     }
 
                     type MovieAggregateNode {
-                      count: Int!
                       title: StringAggregateSelection!
                     }
 
@@ -2411,11 +2451,11 @@ describe("@relationship directive, aggregate argument", () => {
                     }
 
                     type PersonAggregate {
+                      count: Count!
                       node: PersonAggregateNode!
                     }
 
                     type PersonAggregateNode {
-                      count: Int!
                       name: StringAggregateSelection!
                     }
 
@@ -2562,11 +2602,11 @@ describe("@relationship directive, aggregate argument", () => {
                     }
 
                     type ActorAggregate {
+                      count: Count!
                       node: ActorAggregateNode!
                     }
 
                     type ActorAggregateNode {
-                      count: Int!
                       password: StringAggregateSelection!
                       username: StringAggregateSelection!
                     }
@@ -2645,6 +2685,10 @@ describe("@relationship directive, aggregate argument", () => {
                     input CastMemberWhere {
                       Actor: ActorWhere
                       Person: PersonWhere
+                    }
+
+                    type Count {
+                      nodes: Int!
                     }
 
                     type CreateActorsMutationResponse {
@@ -2798,11 +2842,11 @@ describe("@relationship directive, aggregate argument", () => {
                     }
 
                     type MovieAggregate {
+                      count: Count!
                       node: MovieAggregateNode!
                     }
 
                     type MovieAggregateNode {
-                      count: Int!
                       title: StringAggregateSelection!
                     }
 
@@ -2922,11 +2966,11 @@ describe("@relationship directive, aggregate argument", () => {
                     }
 
                     type PersonAggregate {
+                      count: Count!
                       node: PersonAggregateNode!
                     }
 
                     type PersonAggregateNode {
-                      count: Int!
                       name: StringAggregateSelection!
                     }
 

--- a/packages/graphql/tests/schema/directives/relationship-nested-operations.test.ts
+++ b/packages/graphql/tests/schema/directives/relationship-nested-operations.test.ts
@@ -50,6 +50,15 @@ describe("Relationship nested operations", () => {
                   mutation: Mutation
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
+                type CountConnection {
+                  edges: Int!
+                  nodes: Int!
+                }
+
                 \\"\\"\\"
                 Information about the number of nodes and relationships created during a create mutation
                 \\"\\"\\"
@@ -102,7 +111,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MovieActorsConnection {
-                  aggregate: MoviePersonActorsAggregationSelection!
+                  aggregate: MoviePersonActorsAggregateSelection!
                   edges: [MovieActorsRelationship!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -146,11 +155,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
                 }
 
@@ -175,6 +184,11 @@ describe("Relationship nested operations", () => {
                   Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array.
                   \\"\\"\\"
                   sort: [MovieSort!]
+                }
+
+                type MoviePersonActorsAggregateSelection {
+                  count: CountConnection!
+                  node: MoviePersonActorsNodeAggregateSelection
                 }
 
                 type MoviePersonActorsAggregationSelection {
@@ -271,11 +285,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonAggregate {
+                  count: Count!
                   node: PersonAggregateNode!
                 }
 
                 type PersonAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -390,6 +404,15 @@ describe("Relationship nested operations", () => {
                   mutation: Mutation
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
+                type CountConnection {
+                  edges: Int!
+                  nodes: Int!
+                }
+
                 \\"\\"\\"
                 Information about the number of nodes and relationships created during a create mutation
                 \\"\\"\\"
@@ -442,7 +465,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MovieActorsConnection {
-                  aggregate: MoviePersonActorsAggregationSelection!
+                  aggregate: MoviePersonActorsAggregateSelection!
                   edges: [MovieActorsRelationship!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -499,11 +522,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
                 }
 
@@ -529,6 +552,11 @@ describe("Relationship nested operations", () => {
                   Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array.
                   \\"\\"\\"
                   sort: [MovieSort!]
+                }
+
+                type MoviePersonActorsAggregateSelection {
+                  count: CountConnection!
+                  node: MoviePersonActorsNodeAggregateSelection
                 }
 
                 type MoviePersonActorsAggregationSelection {
@@ -626,11 +654,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonAggregate {
+                  count: Count!
                   node: PersonAggregateNode!
                 }
 
                 type PersonAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -745,6 +773,15 @@ describe("Relationship nested operations", () => {
                   mutation: Mutation
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
+                type CountConnection {
+                  edges: Int!
+                  nodes: Int!
+                }
+
                 \\"\\"\\"
                 Information about the number of nodes and relationships created during a create mutation
                 \\"\\"\\"
@@ -805,7 +842,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MovieActorsConnection {
-                  aggregate: MoviePersonActorsAggregationSelection!
+                  aggregate: MoviePersonActorsAggregateSelection!
                   edges: [MovieActorsRelationship!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -858,11 +895,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
                 }
 
@@ -888,6 +925,11 @@ describe("Relationship nested operations", () => {
                   Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array.
                   \\"\\"\\"
                   sort: [MovieSort!]
+                }
+
+                type MoviePersonActorsAggregateSelection {
+                  count: CountConnection!
+                  node: MoviePersonActorsNodeAggregateSelection
                 }
 
                 type MoviePersonActorsAggregationSelection {
@@ -985,11 +1027,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonAggregate {
+                  count: Count!
                   node: PersonAggregateNode!
                 }
 
                 type PersonAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -1108,6 +1150,15 @@ describe("Relationship nested operations", () => {
                   mutation: Mutation
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
+                type CountConnection {
+                  edges: Int!
+                  nodes: Int!
+                }
+
                 \\"\\"\\"
                 Information about the number of nodes and relationships created during a create mutation
                 \\"\\"\\"
@@ -1160,7 +1211,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MovieActorsConnection {
-                  aggregate: MoviePersonActorsAggregationSelection!
+                  aggregate: MoviePersonActorsAggregateSelection!
                   edges: [MovieActorsRelationship!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -1213,11 +1264,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
                 }
 
@@ -1242,6 +1293,11 @@ describe("Relationship nested operations", () => {
                   Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array.
                   \\"\\"\\"
                   sort: [MovieSort!]
+                }
+
+                type MoviePersonActorsAggregateSelection {
+                  count: CountConnection!
+                  node: MoviePersonActorsNodeAggregateSelection
                 }
 
                 type MoviePersonActorsAggregationSelection {
@@ -1339,11 +1395,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonAggregate {
+                  count: Count!
                   node: PersonAggregateNode!
                 }
 
                 type PersonAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -1458,6 +1514,15 @@ describe("Relationship nested operations", () => {
                   mutation: Mutation
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
+                type CountConnection {
+                  edges: Int!
+                  nodes: Int!
+                }
+
                 \\"\\"\\"
                 Information about the number of nodes and relationships created during a create mutation
                 \\"\\"\\"
@@ -1510,7 +1575,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MovieActorsConnection {
-                  aggregate: MoviePersonActorsAggregationSelection!
+                  aggregate: MoviePersonActorsAggregateSelection!
                   edges: [MovieActorsRelationship!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -1563,11 +1628,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
                 }
 
@@ -1596,6 +1661,11 @@ describe("Relationship nested operations", () => {
                   Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array.
                   \\"\\"\\"
                   sort: [MovieSort!]
+                }
+
+                type MoviePersonActorsAggregateSelection {
+                  count: CountConnection!
+                  node: MoviePersonActorsNodeAggregateSelection
                 }
 
                 type MoviePersonActorsAggregationSelection {
@@ -1693,11 +1763,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonAggregate {
+                  count: Count!
                   node: PersonAggregateNode!
                 }
 
                 type PersonAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -1812,6 +1882,15 @@ describe("Relationship nested operations", () => {
                   mutation: Mutation
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
+                type CountConnection {
+                  edges: Int!
+                  nodes: Int!
+                }
+
                 \\"\\"\\"
                 Information about the number of nodes and relationships created during a create mutation
                 \\"\\"\\"
@@ -1864,7 +1943,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MovieActorsConnection {
-                  aggregate: MoviePersonActorsAggregationSelection!
+                  aggregate: MoviePersonActorsAggregateSelection!
                   edges: [MovieActorsRelationship!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -1917,11 +1996,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
                 }
 
@@ -1946,6 +2025,11 @@ describe("Relationship nested operations", () => {
                   Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array.
                   \\"\\"\\"
                   sort: [MovieSort!]
+                }
+
+                type MoviePersonActorsAggregateSelection {
+                  count: CountConnection!
+                  node: MoviePersonActorsNodeAggregateSelection
                 }
 
                 type MoviePersonActorsAggregationSelection {
@@ -2043,11 +2127,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonAggregate {
+                  count: Count!
                   node: PersonAggregateNode!
                 }
 
                 type PersonAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -2163,6 +2247,15 @@ describe("Relationship nested operations", () => {
                   mutation: Mutation
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
+                type CountConnection {
+                  edges: Int!
+                  nodes: Int!
+                }
+
                 \\"\\"\\"
                 Information about the number of nodes and relationships created during a create mutation
                 \\"\\"\\"
@@ -2215,7 +2308,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MovieActorsConnection {
-                  aggregate: MoviePersonActorsAggregationSelection!
+                  aggregate: MoviePersonActorsAggregateSelection!
                   edges: [MovieActorsRelationship!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -2259,11 +2352,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
                 }
 
@@ -2288,6 +2381,11 @@ describe("Relationship nested operations", () => {
                   Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array.
                   \\"\\"\\"
                   sort: [MovieSort!]
+                }
+
+                type MoviePersonActorsAggregateSelection {
+                  count: CountConnection!
+                  node: MoviePersonActorsNodeAggregateSelection
                 }
 
                 type MoviePersonActorsAggregationSelection {
@@ -2384,11 +2482,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonAggregate {
+                  count: Count!
                   node: PersonAggregateNode!
                 }
 
                 type PersonAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -2505,6 +2603,15 @@ describe("Relationship nested operations", () => {
                   mutation: Mutation
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
+                type CountConnection {
+                  edges: Int!
+                  nodes: Int!
+                }
+
                 \\"\\"\\"
                 Information about the number of nodes and relationships created during a create mutation
                 \\"\\"\\"
@@ -2566,7 +2673,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MovieActorsConnection {
-                  aggregate: MoviePersonActorsAggregationSelection!
+                  aggregate: MoviePersonActorsAggregateSelection!
                   edges: [MovieActorsRelationship!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -2629,11 +2736,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
                 }
 
@@ -2659,6 +2766,11 @@ describe("Relationship nested operations", () => {
                   Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array.
                   \\"\\"\\"
                   sort: [MovieSort!]
+                }
+
+                type MoviePersonActorsAggregateSelection {
+                  count: CountConnection!
+                  node: MoviePersonActorsNodeAggregateSelection
                 }
 
                 type MoviePersonActorsAggregationSelection {
@@ -2758,11 +2870,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonAggregate {
+                  count: Count!
                   node: PersonAggregateNode!
                 }
 
                 type PersonAggregateNode {
-                  count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
                   name: StringAggregateSelection!
                 }
@@ -2900,6 +3012,15 @@ describe("Relationship nested operations", () => {
                   mutation: Mutation
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
+                type CountConnection {
+                  edges: Int!
+                  nodes: Int!
+                }
+
                 \\"\\"\\"
                 Information about the number of nodes and relationships created during a create mutation
                 \\"\\"\\"
@@ -2963,7 +3084,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MovieActorsConnection {
-                  aggregate: MoviePersonActorsAggregationSelection!
+                  aggregate: MoviePersonActorsAggregateSelection!
                   edges: [MovieActorsRelationship!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -3037,11 +3158,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
                 }
 
@@ -3073,6 +3194,11 @@ describe("Relationship nested operations", () => {
                   sort: [MovieSort!]
                 }
 
+                type MoviePersonActorsAggregateSelection {
+                  count: CountConnection!
+                  node: MoviePersonActorsNodeAggregateSelection
+                }
+
                 type MoviePersonActorsAggregationSelection {
                   count: Int!
                   node: MoviePersonActorsNodeAggregateSelection
@@ -3080,6 +3206,11 @@ describe("Relationship nested operations", () => {
 
                 type MoviePersonActorsNodeAggregateSelection {
                   name: StringAggregateSelection!
+                }
+
+                type MoviePersonProducersAggregateSelection {
+                  count: CountConnection!
+                  node: MoviePersonProducersNodeAggregateSelection
                 }
 
                 type MoviePersonProducersAggregationSelection {
@@ -3105,7 +3236,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MovieProducersConnection {
-                  aggregate: MoviePersonProducersAggregationSelection!
+                  aggregate: MoviePersonProducersAggregateSelection!
                   edges: [MovieProducersRelationship!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -3269,11 +3400,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonAggregate {
+                  count: Count!
                   node: PersonAggregateNode!
                 }
 
                 type PersonAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -3393,6 +3524,15 @@ describe("Relationship nested operations", () => {
                   mutation: Mutation
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
+                type CountConnection {
+                  edges: Int!
+                  nodes: Int!
+                }
+
                 \\"\\"\\"
                 Information about the number of nodes and relationships created during a create mutation
                 \\"\\"\\"
@@ -3448,7 +3588,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MovieActorsConnection {
-                  aggregate: MoviePersonActorsAggregationSelection!
+                  aggregate: MoviePersonActorsAggregateSelection!
                   edges: [MovieActorsRelationship!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -3505,11 +3645,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
                 }
 
@@ -3537,6 +3677,11 @@ describe("Relationship nested operations", () => {
                   sort: [MovieSort!]
                 }
 
+                type MoviePersonActorsAggregateSelection {
+                  count: CountConnection!
+                  node: MoviePersonActorsNodeAggregateSelection
+                }
+
                 type MoviePersonActorsAggregationSelection {
                   count: Int!
                   node: MoviePersonActorsNodeAggregateSelection
@@ -3544,6 +3689,11 @@ describe("Relationship nested operations", () => {
 
                 type MoviePersonActorsNodeAggregateSelection {
                   name: StringAggregateSelection!
+                }
+
+                type MoviePersonProducersAggregateSelection {
+                  count: CountConnection!
+                  node: MoviePersonProducersNodeAggregateSelection
                 }
 
                 type MoviePersonProducersAggregationSelection {
@@ -3569,7 +3719,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MovieProducersConnection {
-                  aggregate: MoviePersonProducersAggregationSelection!
+                  aggregate: MoviePersonProducersAggregateSelection!
                   edges: [MovieProducersRelationship!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -3733,11 +3883,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonAggregate {
+                  count: Count!
                   node: PersonAggregateNode!
                 }
 
                 type PersonAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -3865,6 +4015,10 @@ describe("Relationship nested operations", () => {
                   mutation: Mutation
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
                 \\"\\"\\"
                 Information about the number of nodes and relationships created during a create mutation
                 \\"\\"\\"
@@ -3938,11 +4092,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
                 }
 
@@ -4051,11 +4205,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonOneAggregate {
+                  count: Count!
                   node: PersonOneAggregateNode!
                 }
 
                 type PersonOneAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -4118,11 +4272,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonTwoAggregate {
+                  count: Count!
                   node: PersonTwoAggregateNode!
                 }
 
                 type PersonTwoAggregateNode {
-                  count: Int!
                   nameTwo: StringAggregateSelection!
                 }
 
@@ -4270,6 +4424,10 @@ describe("Relationship nested operations", () => {
                   mutation: Mutation
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
                 \\"\\"\\"
                 Information about the number of nodes and relationships created during a create mutation
                 \\"\\"\\"
@@ -4379,11 +4537,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
                 }
 
@@ -4494,11 +4652,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonOneAggregate {
+                  count: Count!
                   node: PersonOneAggregateNode!
                 }
 
                 type PersonOneAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -4561,11 +4719,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonTwoAggregate {
+                  count: Count!
                   node: PersonTwoAggregateNode!
                 }
 
                 type PersonTwoAggregateNode {
-                  count: Int!
                   nameTwo: StringAggregateSelection!
                 }
 
@@ -4713,6 +4871,10 @@ describe("Relationship nested operations", () => {
                   mutation: Mutation
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
                 \\"\\"\\"
                 Information about the number of nodes and relationships created during a create mutation
                 \\"\\"\\"
@@ -4822,11 +4984,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
                 }
 
@@ -4937,11 +5099,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonOneAggregate {
+                  count: Count!
                   node: PersonOneAggregateNode!
                 }
 
                 type PersonOneAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -5008,11 +5170,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonTwoAggregate {
+                  count: Count!
                   node: PersonTwoAggregateNode!
                 }
 
                 type PersonTwoAggregateNode {
-                  count: Int!
                   nameTwo: StringAggregateSelection!
                 }
 
@@ -5164,6 +5326,10 @@ describe("Relationship nested operations", () => {
                   mutation: Mutation
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
                 \\"\\"\\"
                 Information about the number of nodes and relationships created during a create mutation
                 \\"\\"\\"
@@ -5260,11 +5426,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
                 }
 
@@ -5374,11 +5540,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonOneAggregate {
+                  count: Count!
                   node: PersonOneAggregateNode!
                 }
 
                 type PersonOneAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -5441,11 +5607,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonTwoAggregate {
+                  count: Count!
                   node: PersonTwoAggregateNode!
                 }
 
                 type PersonTwoAggregateNode {
-                  count: Int!
                   nameTwo: StringAggregateSelection!
                 }
 
@@ -5593,6 +5759,10 @@ describe("Relationship nested operations", () => {
                   mutation: Mutation
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
                 \\"\\"\\"
                 Information about the number of nodes and relationships created during a create mutation
                 \\"\\"\\"
@@ -5694,11 +5864,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
                 }
 
@@ -5812,11 +5982,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonOneAggregate {
+                  count: Count!
                   node: PersonOneAggregateNode!
                 }
 
                 type PersonOneAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -5879,11 +6049,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonTwoAggregate {
+                  count: Count!
                   node: PersonTwoAggregateNode!
                 }
 
                 type PersonTwoAggregateNode {
-                  count: Int!
                   nameTwo: StringAggregateSelection!
                 }
 
@@ -6031,6 +6201,10 @@ describe("Relationship nested operations", () => {
                   mutation: Mutation
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
                 \\"\\"\\"
                 Information about the number of nodes and relationships created during a create mutation
                 \\"\\"\\"
@@ -6127,11 +6301,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
                 }
 
@@ -6241,11 +6415,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonOneAggregate {
+                  count: Count!
                   node: PersonOneAggregateNode!
                 }
 
                 type PersonOneAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -6308,11 +6482,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonTwoAggregate {
+                  count: Count!
                   node: PersonTwoAggregateNode!
                 }
 
                 type PersonTwoAggregateNode {
-                  count: Int!
                   nameTwo: StringAggregateSelection!
                 }
 
@@ -6461,6 +6635,10 @@ describe("Relationship nested operations", () => {
                   mutation: Mutation
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
                 \\"\\"\\"
                 Information about the number of nodes and relationships created during a create mutation
                 \\"\\"\\"
@@ -6534,11 +6712,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
                 }
 
@@ -6647,11 +6825,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonOneAggregate {
+                  count: Count!
                   node: PersonOneAggregateNode!
                 }
 
                 type PersonOneAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -6714,11 +6892,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonTwoAggregate {
+                  count: Count!
                   node: PersonTwoAggregateNode!
                 }
 
                 type PersonTwoAggregateNode {
-                  count: Int!
                   nameTwo: StringAggregateSelection!
                 }
 
@@ -6869,6 +7047,10 @@ describe("Relationship nested operations", () => {
                   mutation: Mutation
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
                 \\"\\"\\"
                 Information about the number of nodes and relationships created during a create mutation
                 \\"\\"\\"
@@ -6988,11 +7170,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
                 }
 
@@ -7104,11 +7286,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonOneAggregate {
+                  count: Count!
                   node: PersonOneAggregateNode!
                 }
 
                 type PersonOneAggregateNode {
-                  count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
                   name: StringAggregateSelection!
                 }
@@ -7194,11 +7376,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonTwoAggregate {
+                  count: Count!
                   node: PersonTwoAggregateNode!
                 }
 
                 type PersonTwoAggregateNode {
-                  count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
                   nameTwo: StringAggregateSelection!
                 }
@@ -7369,6 +7551,10 @@ describe("Relationship nested operations", () => {
                   mutation: Mutation
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
                 \\"\\"\\"
                 Information about the number of nodes and relationships created during a create mutation
                 \\"\\"\\"
@@ -7527,11 +7713,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
                 }
 
@@ -7724,11 +7910,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonOneAggregate {
+                  count: Count!
                   node: PersonOneAggregateNode!
                 }
 
                 type PersonOneAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -7795,11 +7981,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonTwoAggregate {
+                  count: Count!
                   node: PersonTwoAggregateNode!
                 }
 
                 type PersonTwoAggregateNode {
-                  count: Int!
                   nameTwo: StringAggregateSelection!
                 }
 
@@ -7952,6 +8138,10 @@ describe("Relationship nested operations", () => {
                   mutation: Mutation
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
                 \\"\\"\\"
                 Information about the number of nodes and relationships created during a create mutation
                 \\"\\"\\"
@@ -8063,11 +8253,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
                 }
 
@@ -8256,11 +8446,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonOneAggregate {
+                  count: Count!
                   node: PersonOneAggregateNode!
                 }
 
                 type PersonOneAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -8323,11 +8513,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonTwoAggregate {
+                  count: Count!
                   node: PersonTwoAggregateNode!
                 }
 
                 type PersonTwoAggregateNode {
-                  count: Int!
                   nameTwo: StringAggregateSelection!
                 }
 
@@ -8485,6 +8675,15 @@ describe("Relationship nested operations", () => {
                   mutation: Mutation
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
+                type CountConnection {
+                  edges: Int!
+                  nodes: Int!
+                }
+
                 \\"\\"\\"
                 Information about the number of nodes and relationships created during a create mutation
                 \\"\\"\\"
@@ -8542,7 +8741,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MovieActorsConnection {
-                  aggregate: MoviePersonActorsAggregationSelection!
+                  aggregate: MoviePersonActorsAggregateSelection!
                   edges: [MovieActorsRelationship!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -8586,11 +8785,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
                 }
 
@@ -8615,6 +8814,11 @@ describe("Relationship nested operations", () => {
                   Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array.
                   \\"\\"\\"
                   sort: [MovieSort!]
+                }
+
+                type MoviePersonActorsAggregateSelection {
+                  count: CountConnection!
+                  node: MoviePersonActorsNodeAggregateSelection
                 }
 
                 type MoviePersonActorsAggregationSelection {
@@ -8714,11 +8918,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonAggregate {
+                  count: Count!
                   node: PersonAggregateNode!
                 }
 
                 type PersonAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -8743,11 +8947,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonOneAggregate {
+                  count: Count!
                   node: PersonOneAggregateNode!
                 }
 
                 type PersonOneAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -8834,11 +9038,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonTwoAggregate {
+                  count: Count!
                   node: PersonTwoAggregateNode!
                 }
 
                 type PersonTwoAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -8994,6 +9198,15 @@ describe("Relationship nested operations", () => {
                   mutation: Mutation
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
+                type CountConnection {
+                  edges: Int!
+                  nodes: Int!
+                }
+
                 \\"\\"\\"
                 Information about the number of nodes and relationships created during a create mutation
                 \\"\\"\\"
@@ -9051,7 +9264,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MovieActorsConnection {
-                  aggregate: MoviePersonActorsAggregationSelection!
+                  aggregate: MoviePersonActorsAggregateSelection!
                   edges: [MovieActorsRelationship!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -9108,11 +9321,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
                 }
 
@@ -9138,6 +9351,11 @@ describe("Relationship nested operations", () => {
                   Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array.
                   \\"\\"\\"
                   sort: [MovieSort!]
+                }
+
+                type MoviePersonActorsAggregateSelection {
+                  count: CountConnection!
+                  node: MoviePersonActorsNodeAggregateSelection
                 }
 
                 type MoviePersonActorsAggregationSelection {
@@ -9238,11 +9456,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonAggregate {
+                  count: Count!
                   node: PersonAggregateNode!
                 }
 
                 type PersonAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -9272,11 +9490,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonOneAggregate {
+                  count: Count!
                   node: PersonOneAggregateNode!
                 }
 
                 type PersonOneAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -9363,11 +9581,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonTwoAggregate {
+                  count: Count!
                   node: PersonTwoAggregateNode!
                 }
 
                 type PersonTwoAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -9523,6 +9741,15 @@ describe("Relationship nested operations", () => {
                   mutation: Mutation
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
+                type CountConnection {
+                  edges: Int!
+                  nodes: Int!
+                }
+
                 \\"\\"\\"
                 Information about the number of nodes and relationships created during a create mutation
                 \\"\\"\\"
@@ -9584,7 +9811,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MovieActorsConnection {
-                  aggregate: MoviePersonActorsAggregationSelection!
+                  aggregate: MoviePersonActorsAggregateSelection!
                   edges: [MovieActorsRelationship!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -9637,11 +9864,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
                 }
 
@@ -9667,6 +9894,11 @@ describe("Relationship nested operations", () => {
                   Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array.
                   \\"\\"\\"
                   sort: [MovieSort!]
+                }
+
+                type MoviePersonActorsAggregateSelection {
+                  count: CountConnection!
+                  node: MoviePersonActorsNodeAggregateSelection
                 }
 
                 type MoviePersonActorsAggregationSelection {
@@ -9767,11 +9999,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonAggregate {
+                  count: Count!
                   node: PersonAggregateNode!
                 }
 
                 type PersonAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -9800,11 +10032,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonOneAggregate {
+                  count: Count!
                   node: PersonOneAggregateNode!
                 }
 
                 type PersonOneAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -9891,11 +10123,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonTwoAggregate {
+                  count: Count!
                   node: PersonTwoAggregateNode!
                 }
 
                 type PersonTwoAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -10051,6 +10283,15 @@ describe("Relationship nested operations", () => {
                   mutation: Mutation
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
+                type CountConnection {
+                  edges: Int!
+                  nodes: Int!
+                }
+
                 \\"\\"\\"
                 Information about the number of nodes and relationships created during a create mutation
                 \\"\\"\\"
@@ -10108,7 +10349,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MovieActorsConnection {
-                  aggregate: MoviePersonActorsAggregationSelection!
+                  aggregate: MoviePersonActorsAggregateSelection!
                   edges: [MovieActorsRelationship!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -10161,11 +10402,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
                 }
 
@@ -10190,6 +10431,11 @@ describe("Relationship nested operations", () => {
                   Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array.
                   \\"\\"\\"
                   sort: [MovieSort!]
+                }
+
+                type MoviePersonActorsAggregateSelection {
+                  count: CountConnection!
+                  node: MoviePersonActorsNodeAggregateSelection
                 }
 
                 type MoviePersonActorsAggregationSelection {
@@ -10290,11 +10536,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonAggregate {
+                  count: Count!
                   node: PersonAggregateNode!
                 }
 
                 type PersonAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -10319,11 +10565,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonOneAggregate {
+                  count: Count!
                   node: PersonOneAggregateNode!
                 }
 
                 type PersonOneAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -10410,11 +10656,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonTwoAggregate {
+                  count: Count!
                   node: PersonTwoAggregateNode!
                 }
 
                 type PersonTwoAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -10575,6 +10821,15 @@ describe("Relationship nested operations", () => {
                   mutation: Mutation
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
+                type CountConnection {
+                  edges: Int!
+                  nodes: Int!
+                }
+
                 \\"\\"\\"
                 Information about the number of nodes and relationships created during a create mutation
                 \\"\\"\\"
@@ -10632,7 +10887,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MovieActorsConnection {
-                  aggregate: MoviePersonActorsAggregationSelection!
+                  aggregate: MoviePersonActorsAggregateSelection!
                   edges: [MovieActorsRelationship!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -10685,11 +10940,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
                 }
 
@@ -10718,6 +10973,11 @@ describe("Relationship nested operations", () => {
                   Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array.
                   \\"\\"\\"
                   sort: [MovieSort!]
+                }
+
+                type MoviePersonActorsAggregateSelection {
+                  count: CountConnection!
+                  node: MoviePersonActorsNodeAggregateSelection
                 }
 
                 type MoviePersonActorsAggregationSelection {
@@ -10818,11 +11078,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonAggregate {
+                  count: Count!
                   node: PersonAggregateNode!
                 }
 
                 type PersonAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -10847,11 +11107,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonOneAggregate {
+                  count: Count!
                   node: PersonOneAggregateNode!
                 }
 
                 type PersonOneAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -10938,11 +11198,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonTwoAggregate {
+                  count: Count!
                   node: PersonTwoAggregateNode!
                 }
 
                 type PersonTwoAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -11098,6 +11358,15 @@ describe("Relationship nested operations", () => {
                   mutation: Mutation
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
+                type CountConnection {
+                  edges: Int!
+                  nodes: Int!
+                }
+
                 \\"\\"\\"
                 Information about the number of nodes and relationships created during a create mutation
                 \\"\\"\\"
@@ -11155,7 +11424,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MovieActorsConnection {
-                  aggregate: MoviePersonActorsAggregationSelection!
+                  aggregate: MoviePersonActorsAggregateSelection!
                   edges: [MovieActorsRelationship!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -11208,11 +11477,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
                 }
 
@@ -11237,6 +11506,11 @@ describe("Relationship nested operations", () => {
                   Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array.
                   \\"\\"\\"
                   sort: [MovieSort!]
+                }
+
+                type MoviePersonActorsAggregateSelection {
+                  count: CountConnection!
+                  node: MoviePersonActorsNodeAggregateSelection
                 }
 
                 type MoviePersonActorsAggregationSelection {
@@ -11337,11 +11611,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonAggregate {
+                  count: Count!
                   node: PersonAggregateNode!
                 }
 
                 type PersonAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -11366,11 +11640,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonOneAggregate {
+                  count: Count!
                   node: PersonOneAggregateNode!
                 }
 
                 type PersonOneAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -11457,11 +11731,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonTwoAggregate {
+                  count: Count!
                   node: PersonTwoAggregateNode!
                 }
 
                 type PersonTwoAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -11618,6 +11892,15 @@ describe("Relationship nested operations", () => {
                   mutation: Mutation
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
+                type CountConnection {
+                  edges: Int!
+                  nodes: Int!
+                }
+
                 \\"\\"\\"
                 Information about the number of nodes and relationships created during a create mutation
                 \\"\\"\\"
@@ -11682,7 +11965,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MovieActorsConnection {
-                  aggregate: MoviePersonActorsAggregationSelection!
+                  aggregate: MoviePersonActorsAggregateSelection!
                   edges: [MovieActorsRelationship!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -11756,11 +12039,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
                 }
 
@@ -11792,6 +12075,11 @@ describe("Relationship nested operations", () => {
                   sort: [MovieSort!]
                 }
 
+                type MoviePersonActorsAggregateSelection {
+                  count: CountConnection!
+                  node: MoviePersonActorsNodeAggregateSelection
+                }
+
                 type MoviePersonActorsAggregationSelection {
                   count: Int!
                   node: MoviePersonActorsNodeAggregateSelection
@@ -11799,6 +12087,11 @@ describe("Relationship nested operations", () => {
 
                 type MoviePersonActorsNodeAggregateSelection {
                   name: StringAggregateSelection!
+                }
+
+                type MoviePersonProducersAggregateSelection {
+                  count: CountConnection!
+                  node: MoviePersonProducersNodeAggregateSelection
                 }
 
                 type MoviePersonProducersAggregationSelection {
@@ -11824,7 +12117,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MovieProducersConnection {
-                  aggregate: MoviePersonProducersAggregationSelection!
+                  aggregate: MoviePersonProducersAggregateSelection!
                   edges: [MovieProducersRelationship!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -11991,11 +12284,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonAggregate {
+                  count: Count!
                   node: PersonAggregateNode!
                 }
 
                 type PersonAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -12029,11 +12322,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonOneAggregate {
+                  count: Count!
                   node: PersonOneAggregateNode!
                 }
 
                 type PersonOneAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -12120,11 +12413,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonTwoAggregate {
+                  count: Count!
                   node: PersonTwoAggregateNode!
                 }
 
                 type PersonTwoAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -12287,6 +12580,15 @@ describe("Relationship nested operations", () => {
                   mutation: Mutation
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
+                type CountConnection {
+                  edges: Int!
+                  nodes: Int!
+                }
+
                 \\"\\"\\"
                 Information about the number of nodes and relationships created during a create mutation
                 \\"\\"\\"
@@ -12347,7 +12649,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MovieActorsConnection {
-                  aggregate: MoviePersonActorsAggregationSelection!
+                  aggregate: MoviePersonActorsAggregateSelection!
                   edges: [MovieActorsRelationship!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -12409,11 +12711,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
                 }
 
@@ -12445,6 +12747,11 @@ describe("Relationship nested operations", () => {
                   sort: [MovieSort!]
                 }
 
+                type MoviePersonActorsAggregateSelection {
+                  count: CountConnection!
+                  node: MoviePersonActorsNodeAggregateSelection
+                }
+
                 type MoviePersonActorsAggregationSelection {
                   count: Int!
                   node: MoviePersonActorsNodeAggregateSelection
@@ -12452,6 +12759,11 @@ describe("Relationship nested operations", () => {
 
                 type MoviePersonActorsNodeAggregateSelection {
                   name: StringAggregateSelection!
+                }
+
+                type MoviePersonProducersAggregateSelection {
+                  count: CountConnection!
+                  node: MoviePersonProducersNodeAggregateSelection
                 }
 
                 type MoviePersonProducersAggregationSelection {
@@ -12477,7 +12789,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MovieProducersConnection {
-                  aggregate: MoviePersonProducersAggregationSelection!
+                  aggregate: MoviePersonProducersAggregateSelection!
                   edges: [MovieProducersRelationship!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -12644,11 +12956,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonAggregate {
+                  count: Count!
                   node: PersonAggregateNode!
                 }
 
                 type PersonAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -12678,11 +12990,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonOneAggregate {
+                  count: Count!
                   node: PersonOneAggregateNode!
                 }
 
                 type PersonOneAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -12769,11 +13081,11 @@ describe("Relationship nested operations", () => {
                 }
 
                 type PersonTwoAggregate {
+                  count: Count!
                   node: PersonTwoAggregateNode!
                 }
 
                 type PersonTwoAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 

--- a/packages/graphql/tests/schema/directives/relationship-properties.test.ts
+++ b/packages/graphql/tests/schema/directives/relationship-properties.test.ts
@@ -140,11 +140,11 @@ describe("Relationship-properties", () => {
             }
 
             type ActorAggregate {
+              count: Count!
               node: ActorAggregateNode!
             }
 
             type ActorAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -177,6 +177,12 @@ describe("Relationship-properties", () => {
             type ActorEdge {
               cursor: String!
               node: Actor!
+            }
+
+            type ActorMovieMoviesAggregateSelection {
+              count: CountConnection!
+              edge: ActorMovieMoviesEdgeAggregateSelection
+              node: ActorMovieMoviesNodeAggregateSelection
             }
 
             type ActorMovieMoviesAggregationSelection {
@@ -218,7 +224,7 @@ describe("Relationship-properties", () => {
             }
 
             type ActorMoviesConnection {
-              aggregate: ActorMovieMoviesAggregationSelection!
+              aggregate: ActorMovieMoviesAggregateSelection!
               edges: [ActorMoviesRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -364,6 +370,15 @@ describe("Relationship-properties", () => {
               totalCount: Int!
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             type CreateActorsMutationResponse {
               actors: [Actor!]!
               info: CreateInfo!
@@ -407,6 +422,12 @@ describe("Relationship-properties", () => {
               title: String!
             }
 
+            type MovieActorActorsAggregateSelection {
+              count: CountConnection!
+              edge: MovieActorActorsEdgeAggregateSelection
+              node: MovieActorActorsNodeAggregateSelection
+            }
+
             type MovieActorActorsAggregationSelection {
               count: Int!
               edge: MovieActorActorsEdgeAggregateSelection
@@ -446,7 +467,7 @@ describe("Relationship-properties", () => {
             }
 
             type MovieActorsConnection {
-              aggregate: MovieActorActorsAggregationSelection!
+              aggregate: MovieActorActorsAggregateSelection!
               edges: [MovieActorsRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -527,11 +548,11 @@ describe("Relationship-properties", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               title: StringAggregateSelection!
             }
 
@@ -828,11 +849,11 @@ describe("Relationship-properties", () => {
             }
 
             type ActorAggregate {
+              count: Count!
               node: ActorAggregateNode!
             }
 
             type ActorAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -865,6 +886,12 @@ describe("Relationship-properties", () => {
             type ActorEdge {
               cursor: String!
               node: Actor!
+            }
+
+            type ActorMovieMoviesAggregateSelection {
+              count: CountConnection!
+              edge: ActorMovieMoviesEdgeAggregateSelection
+              node: ActorMovieMoviesNodeAggregateSelection
             }
 
             type ActorMovieMoviesAggregationSelection {
@@ -908,7 +935,7 @@ describe("Relationship-properties", () => {
             }
 
             type ActorMoviesConnection {
-              aggregate: ActorMovieMoviesAggregationSelection!
+              aggregate: ActorMovieMoviesAggregateSelection!
               edges: [ActorMoviesRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1054,6 +1081,15 @@ describe("Relationship-properties", () => {
               totalCount: Int!
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             type CreateActorsMutationResponse {
               actors: [Actor!]!
               info: CreateInfo!
@@ -1107,6 +1143,12 @@ describe("Relationship-properties", () => {
               title: String!
             }
 
+            type MovieActorActorsAggregateSelection {
+              count: CountConnection!
+              edge: MovieActorActorsEdgeAggregateSelection
+              node: MovieActorActorsNodeAggregateSelection
+            }
+
             type MovieActorActorsAggregationSelection {
               count: Int!
               edge: MovieActorActorsEdgeAggregateSelection
@@ -1148,7 +1190,7 @@ describe("Relationship-properties", () => {
             }
 
             type MovieActorsConnection {
-              aggregate: MovieActorActorsAggregationSelection!
+              aggregate: MovieActorActorsAggregateSelection!
               edges: [MovieActorsRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1229,11 +1271,11 @@ describe("Relationship-properties", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               title: StringAggregateSelection!
             }
 
@@ -1489,11 +1531,11 @@ describe("Relationship-properties", () => {
             }
 
             type ActorAggregate {
+              count: Count!
               node: ActorAggregateNode!
             }
 
             type ActorAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -1526,6 +1568,12 @@ describe("Relationship-properties", () => {
             type ActorEdge {
               cursor: String!
               node: Actor!
+            }
+
+            type ActorMovieMoviesAggregateSelection {
+              count: CountConnection!
+              edge: ActorMovieMoviesEdgeAggregateSelection
+              node: ActorMovieMoviesNodeAggregateSelection
             }
 
             type ActorMovieMoviesAggregationSelection {
@@ -1567,7 +1615,7 @@ describe("Relationship-properties", () => {
             }
 
             type ActorMoviesConnection {
-              aggregate: ActorMovieMoviesAggregationSelection!
+              aggregate: ActorMovieMoviesAggregateSelection!
               edges: [ActorMoviesRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1711,6 +1759,15 @@ describe("Relationship-properties", () => {
               totalCount: Int!
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             type CreateActorsMutationResponse {
               actors: [Actor!]!
               info: CreateInfo!
@@ -1757,6 +1814,12 @@ describe("Relationship-properties", () => {
               title: String!
             }
 
+            type MovieActorActorsAggregateSelection {
+              count: CountConnection!
+              edge: MovieActorActorsEdgeAggregateSelection
+              node: MovieActorActorsNodeAggregateSelection
+            }
+
             type MovieActorActorsAggregationSelection {
               count: Int!
               edge: MovieActorActorsEdgeAggregateSelection
@@ -1796,7 +1859,7 @@ describe("Relationship-properties", () => {
             }
 
             type MovieActorsConnection {
-              aggregate: MovieActorActorsAggregationSelection!
+              aggregate: MovieActorActorsAggregateSelection!
               edges: [MovieActorsRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1875,11 +1938,11 @@ describe("Relationship-properties", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               title: StringAggregateSelection!
             }
 

--- a/packages/graphql/tests/schema/directives/relationship.test.ts
+++ b/packages/graphql/tests/schema/directives/relationship.test.ts
@@ -48,11 +48,11 @@ describe("Relationship", () => {
             }
 
             type ActorAggregate {
+              count: Count!
               node: ActorAggregateNode!
             }
 
             type ActorAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -114,6 +114,15 @@ describe("Relationship", () => {
               totalCount: Int!
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             type CreateActorsMutationResponse {
               actors: [Actor!]!
               info: CreateInfo!
@@ -152,6 +161,11 @@ describe("Relationship", () => {
               id: ID
             }
 
+            type MovieActorActorsAggregateSelection {
+              count: CountConnection!
+              node: MovieActorActorsNodeAggregateSelection
+            }
+
             type MovieActorActorsAggregationSelection {
               count: Int!
               node: MovieActorActorsNodeAggregateSelection
@@ -183,7 +197,7 @@ describe("Relationship", () => {
             }
 
             type MovieActorsConnection {
-              aggregate: MovieActorActorsAggregationSelection!
+              aggregate: MovieActorActorsAggregateSelection!
               edges: [MovieActorsRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -257,11 +271,11 @@ describe("Relationship", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
@@ -440,11 +454,11 @@ describe("Relationship", () => {
             }
 
             type ActorAggregate {
+              count: Count!
               node: ActorAggregateNode!
             }
 
             type ActorAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -479,6 +493,11 @@ describe("Relationship", () => {
               node: Actor!
             }
 
+            type ActorMovieMoviesAggregateSelection {
+              count: CountConnection!
+              node: ActorMovieMoviesNodeAggregateSelection
+            }
+
             type ActorMovieMoviesAggregationSelection {
               count: Int!
               node: ActorMovieMoviesNodeAggregateSelection
@@ -511,7 +530,7 @@ describe("Relationship", () => {
             }
 
             type ActorMoviesConnection {
-              aggregate: ActorMovieMoviesAggregationSelection!
+              aggregate: ActorMovieMoviesAggregateSelection!
               edges: [ActorMoviesRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -647,6 +666,15 @@ describe("Relationship", () => {
               totalCount: Int!
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             type CreateActorsMutationResponse {
               actors: [Actor!]!
               info: CreateInfo!
@@ -685,6 +713,11 @@ describe("Relationship", () => {
               id: ID
             }
 
+            type MovieActorActorsAggregateSelection {
+              count: CountConnection!
+              node: MovieActorActorsNodeAggregateSelection
+            }
+
             type MovieActorActorsAggregationSelection {
               count: Int!
               node: MovieActorActorsNodeAggregateSelection
@@ -717,7 +750,7 @@ describe("Relationship", () => {
             }
 
             type MovieActorsConnection {
-              aggregate: MovieActorActorsAggregationSelection!
+              aggregate: MovieActorActorsAggregateSelection!
               edges: [MovieActorsRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -793,11 +826,11 @@ describe("Relationship", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 

--- a/packages/graphql/tests/schema/directives/selectable.test.ts
+++ b/packages/graphql/tests/schema/directives/selectable.test.ts
@@ -39,6 +39,10 @@ describe("@selectable", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -65,11 +69,11 @@ describe("@selectable", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               description: StringAggregateSelection!
               title: StringAggregateSelection!
             }
@@ -204,6 +208,10 @@ describe("@selectable", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -231,11 +239,11 @@ describe("@selectable", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               title: StringAggregateSelection!
             }
 
@@ -368,6 +376,10 @@ describe("@selectable", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -394,11 +406,11 @@ describe("@selectable", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               title: StringAggregateSelection!
             }
 
@@ -532,6 +544,10 @@ describe("@selectable", () => {
               subscription: Subscription
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -566,11 +582,11 @@ describe("@selectable", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               description: StringAggregateSelection!
               title: StringAggregateSelection!
             }
@@ -860,11 +876,11 @@ describe("@selectable", () => {
                 }
 
                 type ActorAggregate {
+                  count: Count!
                   node: ActorAggregateNode!
                 }
 
                 type ActorAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -963,6 +979,10 @@ describe("@selectable", () => {
                   totalCount: Int!
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
                 type CreateActorsMutationResponse {
                   actors: [Actor!]!
                   info: CreateInfo!
@@ -995,11 +1015,11 @@ describe("@selectable", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   description: StringAggregateSelection!
                   title: StringAggregateSelection!
                 }
@@ -1184,7 +1204,7 @@ describe("@selectable", () => {
                 }
 
                 type ActorActedInConnection {
-                  aggregate: ActorMovieActedInAggregationSelection!
+                  aggregate: ActorMovieActedInAggregateSelection!
                   edges: [ActorActedInRelationship!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -1273,11 +1293,11 @@ describe("@selectable", () => {
                 }
 
                 type ActorAggregate {
+                  count: Count!
                   node: ActorAggregateNode!
                 }
 
                 type ActorAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -1298,6 +1318,11 @@ describe("@selectable", () => {
                 type ActorEdge {
                   cursor: String!
                   node: Actor!
+                }
+
+                type ActorMovieActedInAggregateSelection {
+                  count: CountConnection!
+                  node: ActorMovieActedInNodeAggregateSelection
                 }
 
                 type ActorMovieActedInAggregationSelection {
@@ -1376,6 +1401,15 @@ describe("@selectable", () => {
                   totalCount: Int!
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
+                type CountConnection {
+                  edges: Int!
+                  nodes: Int!
+                }
+
                 type CreateActorsMutationResponse {
                   actors: [Actor!]!
                   info: CreateInfo!
@@ -1408,11 +1442,11 @@ describe("@selectable", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   description: StringAggregateSelection!
                   title: StringAggregateSelection!
                 }
@@ -1685,11 +1719,11 @@ describe("@selectable", () => {
                 }
 
                 type ActorAggregate {
+                  count: Count!
                   node: ActorAggregateNode!
                 }
 
                 type ActorAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -1777,6 +1811,10 @@ describe("@selectable", () => {
                   totalCount: Int!
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
                 type CreateActorsMutationResponse {
                   actors: [Actor!]!
                   info: CreateInfo!
@@ -1814,11 +1852,11 @@ describe("@selectable", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   description: StringAggregateSelection!
                   title: StringAggregateSelection!
                 }
@@ -1944,11 +1982,11 @@ describe("@selectable", () => {
                 }
 
                 type SeriesAggregate {
+                  count: Count!
                   node: SeriesAggregateNode!
                 }
 
                 type SeriesAggregateNode {
-                  count: Int!
                   description: StringAggregateSelection!
                   name: StringAggregateSelection!
                 }
@@ -2210,11 +2248,11 @@ describe("@selectable", () => {
                 }
 
                 type ActorAggregate {
+                  count: Count!
                   node: ActorAggregateNode!
                 }
 
                 type ActorAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -2302,6 +2340,10 @@ describe("@selectable", () => {
                   totalCount: Int!
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
                 type CreateActorsMutationResponse {
                   actors: [Actor!]!
                   info: CreateInfo!
@@ -2339,11 +2381,11 @@ describe("@selectable", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   description: StringAggregateSelection!
                   title: StringAggregateSelection!
                 }
@@ -2469,11 +2511,11 @@ describe("@selectable", () => {
                 }
 
                 type SeriesAggregate {
+                  count: Count!
                   node: SeriesAggregateNode!
                 }
 
                 type SeriesAggregateNode {
-                  count: Int!
                   description: StringAggregateSelection!
                   name: StringAggregateSelection!
                 }
@@ -2717,11 +2759,11 @@ describe("@selectable", () => {
                 }
 
                 type ActorAggregate {
+                  count: Count!
                   node: ActorAggregateNode!
                 }
 
                 type ActorAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -2820,6 +2862,10 @@ describe("@selectable", () => {
                   totalCount: Int!
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
                 type CreateActorsMutationResponse {
                   actors: [Actor!]!
                   info: CreateInfo!
@@ -2857,11 +2903,11 @@ describe("@selectable", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   description: StringAggregateSelection!
                   title: StringAggregateSelection!
                 }
@@ -2957,11 +3003,11 @@ describe("@selectable", () => {
                 }
 
                 type ProductionAggregate {
+                  count: Count!
                   node: ProductionAggregateNode!
                 }
 
                 type ProductionAggregateNode {
-                  count: Int!
                   description: StringAggregateSelection!
                   title: StringAggregateSelection!
                 }
@@ -3063,11 +3109,11 @@ describe("@selectable", () => {
                 }
 
                 type SeriesAggregate {
+                  count: Count!
                   node: SeriesAggregateNode!
                 }
 
                 type SeriesAggregateNode {
-                  count: Int!
                   description: StringAggregateSelection!
                   title: StringAggregateSelection!
                 }
@@ -3321,11 +3367,11 @@ describe("@selectable", () => {
                 }
 
                 type ActorAggregate {
+                  count: Count!
                   node: ActorAggregateNode!
                 }
 
                 type ActorAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -3424,6 +3470,10 @@ describe("@selectable", () => {
                   totalCount: Int!
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
                 type CreateActorsMutationResponse {
                   actors: [Actor!]!
                   info: CreateInfo!
@@ -3461,11 +3511,11 @@ describe("@selectable", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   description: StringAggregateSelection!
                   title: StringAggregateSelection!
                 }
@@ -3561,11 +3611,11 @@ describe("@selectable", () => {
                 }
 
                 type ProductionAggregate {
+                  count: Count!
                   node: ProductionAggregateNode!
                 }
 
                 type ProductionAggregateNode {
-                  count: Int!
                   description: StringAggregateSelection!
                   title: StringAggregateSelection!
                 }
@@ -3667,11 +3717,11 @@ describe("@selectable", () => {
                 }
 
                 type SeriesAggregate {
+                  count: Count!
                   node: SeriesAggregateNode!
                 }
 
                 type SeriesAggregateNode {
-                  count: Int!
                   description: StringAggregateSelection!
                   title: StringAggregateSelection!
                 }

--- a/packages/graphql/tests/schema/directives/settable.test.ts
+++ b/packages/graphql/tests/schema/directives/settable.test.ts
@@ -39,6 +39,10 @@ describe("@settable", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -66,11 +70,11 @@ describe("@settable", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               description: StringAggregateSelection!
               title: StringAggregateSelection!
             }
@@ -204,6 +208,10 @@ describe("@settable", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -231,11 +239,11 @@ describe("@settable", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               description: StringAggregateSelection!
               title: StringAggregateSelection!
             }
@@ -369,6 +377,10 @@ describe("@settable", () => {
               subscription: Subscription
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -404,11 +416,11 @@ describe("@settable", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               description: StringAggregateSelection!
               title: StringAggregateSelection!
             }
@@ -625,7 +637,7 @@ describe("@settable", () => {
                 }
 
                 type ActorActedInConnection {
-                  aggregate: ActorMovieActedInAggregationSelection!
+                  aggregate: ActorMovieActedInAggregateSelection!
                   edges: [ActorActedInRelationship!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -709,11 +721,11 @@ describe("@settable", () => {
                 }
 
                 type ActorAggregate {
+                  count: Count!
                   node: ActorAggregateNode!
                 }
 
                 type ActorAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -733,6 +745,11 @@ describe("@settable", () => {
                 type ActorEdge {
                   cursor: String!
                   node: Actor!
+                }
+
+                type ActorMovieActedInAggregateSelection {
+                  count: CountConnection!
+                  node: ActorMovieActedInNodeAggregateSelection
                 }
 
                 type ActorMovieActedInAggregationSelection {
@@ -811,6 +828,15 @@ describe("@settable", () => {
                   totalCount: Int!
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
+                type CountConnection {
+                  edges: Int!
+                  nodes: Int!
+                }
+
                 type CreateActorsMutationResponse {
                   actors: [Actor!]!
                   info: CreateInfo!
@@ -843,11 +869,11 @@ describe("@settable", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   description: StringAggregateSelection!
                   title: StringAggregateSelection!
                 }
@@ -1033,7 +1059,7 @@ describe("@settable", () => {
                 }
 
                 type ActorActedInConnection {
-                  aggregate: ActorMovieActedInAggregationSelection!
+                  aggregate: ActorMovieActedInAggregateSelection!
                   edges: [ActorActedInRelationship!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -1105,11 +1131,11 @@ describe("@settable", () => {
                 }
 
                 type ActorAggregate {
+                  count: Count!
                   node: ActorAggregateNode!
                 }
 
                 type ActorAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -1130,6 +1156,11 @@ describe("@settable", () => {
                 type ActorEdge {
                   cursor: String!
                   node: Actor!
+                }
+
+                type ActorMovieActedInAggregateSelection {
+                  count: CountConnection!
+                  node: ActorMovieActedInNodeAggregateSelection
                 }
 
                 type ActorMovieActedInAggregationSelection {
@@ -1207,6 +1238,15 @@ describe("@settable", () => {
                   totalCount: Int!
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
+                type CountConnection {
+                  edges: Int!
+                  nodes: Int!
+                }
+
                 type CreateActorsMutationResponse {
                   actors: [Actor!]!
                   info: CreateInfo!
@@ -1239,11 +1279,11 @@ describe("@settable", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   description: StringAggregateSelection!
                   title: StringAggregateSelection!
                 }
@@ -1429,7 +1469,7 @@ describe("@settable", () => {
                 }
 
                 type ActorActedInConnection {
-                  aggregate: ActorMovieActedInAggregationSelection!
+                  aggregate: ActorMovieActedInAggregateSelection!
                   edges: [ActorActedInRelationship!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -1507,11 +1547,11 @@ describe("@settable", () => {
                 }
 
                 type ActorAggregate {
+                  count: Count!
                   node: ActorAggregateNode!
                 }
 
                 type ActorAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -1544,6 +1584,11 @@ describe("@settable", () => {
                 type ActorEdge {
                   cursor: String!
                   node: Actor!
+                }
+
+                type ActorMovieActedInAggregateSelection {
+                  count: CountConnection!
+                  node: ActorMovieActedInNodeAggregateSelection
                 }
 
                 type ActorMovieActedInAggregationSelection {
@@ -1621,6 +1666,15 @@ describe("@settable", () => {
                   totalCount: Int!
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
+                type CountConnection {
+                  edges: Int!
+                  nodes: Int!
+                }
+
                 type CreateActorsMutationResponse {
                   actors: [Actor!]!
                   info: CreateInfo!
@@ -1655,6 +1709,11 @@ describe("@settable", () => {
                   title: String!
                 }
 
+                type MovieActorActorsAggregateSelection {
+                  count: CountConnection!
+                  node: MovieActorActorsNodeAggregateSelection
+                }
+
                 type MovieActorActorsAggregationSelection {
                   count: Int!
                   node: MovieActorActorsNodeAggregateSelection
@@ -1687,7 +1746,7 @@ describe("@settable", () => {
                 }
 
                 type MovieActorsConnection {
-                  aggregate: MovieActorActorsAggregationSelection!
+                  aggregate: MovieActorActorsAggregateSelection!
                   edges: [MovieActorsRelationship!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -1763,11 +1822,11 @@ describe("@settable", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   description: StringAggregateSelection!
                   title: StringAggregateSelection!
                 }
@@ -1992,7 +2051,7 @@ describe("@settable", () => {
                 }
 
                 type ActorActedInConnection {
-                  aggregate: ActorMovieActedInAggregationSelection!
+                  aggregate: ActorMovieActedInAggregateSelection!
                   edges: [ActorActedInRelationship!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -2078,11 +2137,11 @@ describe("@settable", () => {
                 }
 
                 type ActorAggregate {
+                  count: Count!
                   node: ActorAggregateNode!
                 }
 
                 type ActorAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -2114,6 +2173,11 @@ describe("@settable", () => {
                 type ActorEdge {
                   cursor: String!
                   node: Actor!
+                }
+
+                type ActorMovieActedInAggregateSelection {
+                  count: CountConnection!
+                  node: ActorMovieActedInNodeAggregateSelection
                 }
 
                 type ActorMovieActedInAggregationSelection {
@@ -2192,6 +2256,15 @@ describe("@settable", () => {
                   totalCount: Int!
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
+                type CountConnection {
+                  edges: Int!
+                  nodes: Int!
+                }
+
                 type CreateActorsMutationResponse {
                   actors: [Actor!]!
                   info: CreateInfo!
@@ -2226,6 +2299,11 @@ describe("@settable", () => {
                   title: String!
                 }
 
+                type MovieActorActorsAggregateSelection {
+                  count: CountConnection!
+                  node: MovieActorActorsNodeAggregateSelection
+                }
+
                 type MovieActorActorsAggregationSelection {
                   count: Int!
                   node: MovieActorActorsNodeAggregateSelection
@@ -2258,7 +2336,7 @@ describe("@settable", () => {
                 }
 
                 type MovieActorsConnection {
-                  aggregate: MovieActorActorsAggregationSelection!
+                  aggregate: MovieActorActorsAggregateSelection!
                   edges: [MovieActorsRelationship!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -2334,11 +2412,11 @@ describe("@settable", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   description: StringAggregateSelection!
                   title: StringAggregateSelection!
                 }
@@ -2647,11 +2725,11 @@ describe("@settable", () => {
                 }
 
                 type ActorAggregate {
+                  count: Count!
                   node: ActorAggregateNode!
                 }
 
                 type ActorAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -2738,6 +2816,10 @@ describe("@settable", () => {
                   totalCount: Int!
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
                 type CreateActorsMutationResponse {
                   actors: [Actor!]!
                   info: CreateInfo!
@@ -2775,11 +2857,11 @@ describe("@settable", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   description: StringAggregateSelection!
                   title: StringAggregateSelection!
                 }
@@ -2905,11 +2987,11 @@ describe("@settable", () => {
                 }
 
                 type SeriesAggregate {
+                  count: Count!
                   node: SeriesAggregateNode!
                 }
 
                 type SeriesAggregateNode {
-                  count: Int!
                   description: StringAggregateSelection!
                   name: StringAggregateSelection!
                 }
@@ -3133,11 +3215,11 @@ describe("@settable", () => {
                 }
 
                 type ActorAggregate {
+                  count: Count!
                   node: ActorAggregateNode!
                 }
 
                 type ActorAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -3224,6 +3306,10 @@ describe("@settable", () => {
                   totalCount: Int!
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
                 type CreateActorsMutationResponse {
                   actors: [Actor!]!
                   info: CreateInfo!
@@ -3261,11 +3347,11 @@ describe("@settable", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   description: StringAggregateSelection!
                   title: StringAggregateSelection!
                 }
@@ -3391,11 +3477,11 @@ describe("@settable", () => {
                 }
 
                 type SeriesAggregate {
+                  count: Count!
                   node: SeriesAggregateNode!
                 }
 
                 type SeriesAggregateNode {
-                  count: Int!
                   description: StringAggregateSelection!
                   name: StringAggregateSelection!
                 }
@@ -3639,11 +3725,11 @@ describe("@settable", () => {
                 }
 
                 type ActorAggregate {
+                  count: Count!
                   node: ActorAggregateNode!
                 }
 
                 type ActorAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -3742,6 +3828,15 @@ describe("@settable", () => {
                   totalCount: Int!
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
+                type CountConnection {
+                  edges: Int!
+                  nodes: Int!
+                }
+
                 type CreateActorsMutationResponse {
                   actors: [Actor!]!
                   info: CreateInfo!
@@ -3781,6 +3876,11 @@ describe("@settable", () => {
                   title: String!
                 }
 
+                type MovieActorActorsAggregateSelection {
+                  count: CountConnection!
+                  node: MovieActorActorsNodeAggregateSelection
+                }
+
                 type MovieActorActorsAggregationSelection {
                   count: Int!
                   node: MovieActorActorsNodeAggregateSelection
@@ -3813,7 +3913,7 @@ describe("@settable", () => {
                 }
 
                 type MovieActorsConnection {
-                  aggregate: MovieActorActorsAggregationSelection!
+                  aggregate: MovieActorActorsAggregateSelection!
                   edges: [MovieActorsRelationship!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -3889,11 +3989,11 @@ describe("@settable", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   description: StringAggregateSelection!
                   title: StringAggregateSelection!
                 }
@@ -4058,11 +4158,11 @@ describe("@settable", () => {
                 }
 
                 type SeriesAggregate {
+                  count: Count!
                   node: SeriesAggregateNode!
                 }
 
                 type SeriesAggregateNode {
-                  count: Int!
                   description: StringAggregateSelection!
                   name: StringAggregateSelection!
                 }
@@ -4322,11 +4422,11 @@ describe("@settable", () => {
                 }
 
                 type ActorAggregate {
+                  count: Count!
                   node: ActorAggregateNode!
                 }
 
                 type ActorAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -4425,6 +4525,15 @@ describe("@settable", () => {
                   totalCount: Int!
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
+                type CountConnection {
+                  edges: Int!
+                  nodes: Int!
+                }
+
                 type CreateActorsMutationResponse {
                   actors: [Actor!]!
                   info: CreateInfo!
@@ -4464,6 +4573,11 @@ describe("@settable", () => {
                   title: String!
                 }
 
+                type MovieActorActorsAggregateSelection {
+                  count: CountConnection!
+                  node: MovieActorActorsNodeAggregateSelection
+                }
+
                 type MovieActorActorsAggregationSelection {
                   count: Int!
                   node: MovieActorActorsNodeAggregateSelection
@@ -4496,7 +4610,7 @@ describe("@settable", () => {
                 }
 
                 type MovieActorsConnection {
-                  aggregate: MovieActorActorsAggregationSelection!
+                  aggregate: MovieActorActorsAggregateSelection!
                   edges: [MovieActorsRelationship!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -4572,11 +4686,11 @@ describe("@settable", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   description: StringAggregateSelection!
                   title: StringAggregateSelection!
                 }
@@ -4741,11 +4855,11 @@ describe("@settable", () => {
                 }
 
                 type SeriesAggregate {
+                  count: Count!
                   node: SeriesAggregateNode!
                 }
 
                 type SeriesAggregateNode {
-                  count: Int!
                   description: StringAggregateSelection!
                   name: StringAggregateSelection!
                 }
@@ -4918,7 +5032,7 @@ describe("@settable", () => {
                 }
 
                 type ActorActedInConnection {
-                  aggregate: ActorProductionActedInAggregationSelection!
+                  aggregate: ActorProductionActedInAggregateSelection!
                   edges: [ActorActedInRelationship!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -5002,11 +5116,11 @@ describe("@settable", () => {
                 }
 
                 type ActorAggregate {
+                  count: Count!
                   node: ActorAggregateNode!
                 }
 
                 type ActorAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -5035,6 +5149,11 @@ describe("@settable", () => {
                   Specify one or more ActorSort objects to sort Actors by. The sorts will be applied in the order in which they are arranged in the array.
                   \\"\\"\\"
                   sort: [ActorSort!]
+                }
+
+                type ActorProductionActedInAggregateSelection {
+                  count: CountConnection!
+                  node: ActorProductionActedInNodeAggregateSelection
                 }
 
                 type ActorProductionActedInAggregationSelection {
@@ -5104,6 +5223,15 @@ describe("@settable", () => {
                   totalCount: Int!
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
+                type CountConnection {
+                  edges: Int!
+                  nodes: Int!
+                }
+
                 type CreateActorsMutationResponse {
                   actors: [Actor!]!
                   info: CreateInfo!
@@ -5141,11 +5269,11 @@ describe("@settable", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   description: StringAggregateSelection!
                   title: StringAggregateSelection!
                 }
@@ -5241,11 +5369,11 @@ describe("@settable", () => {
                 }
 
                 type ProductionAggregate {
+                  count: Count!
                   node: ProductionAggregateNode!
                 }
 
                 type ProductionAggregateNode {
-                  count: Int!
                   description: StringAggregateSelection!
                   title: StringAggregateSelection!
                 }
@@ -5347,11 +5475,11 @@ describe("@settable", () => {
                 }
 
                 type SeriesAggregate {
+                  count: Count!
                   node: SeriesAggregateNode!
                 }
 
                 type SeriesAggregateNode {
-                  count: Int!
                   description: StringAggregateSelection!
                   title: StringAggregateSelection!
                 }
@@ -5518,7 +5646,7 @@ describe("@settable", () => {
                 }
 
                 type ActorActedInConnection {
-                  aggregate: ActorProductionActedInAggregationSelection!
+                  aggregate: ActorProductionActedInAggregateSelection!
                   edges: [ActorActedInRelationship!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -5590,11 +5718,11 @@ describe("@settable", () => {
                 }
 
                 type ActorAggregate {
+                  count: Count!
                   node: ActorAggregateNode!
                 }
 
                 type ActorAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -5624,6 +5752,11 @@ describe("@settable", () => {
                   Specify one or more ActorSort objects to sort Actors by. The sorts will be applied in the order in which they are arranged in the array.
                   \\"\\"\\"
                   sort: [ActorSort!]
+                }
+
+                type ActorProductionActedInAggregateSelection {
+                  count: CountConnection!
+                  node: ActorProductionActedInNodeAggregateSelection
                 }
 
                 type ActorProductionActedInAggregationSelection {
@@ -5692,6 +5825,15 @@ describe("@settable", () => {
                   totalCount: Int!
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
+                type CountConnection {
+                  edges: Int!
+                  nodes: Int!
+                }
+
                 type CreateActorsMutationResponse {
                   actors: [Actor!]!
                   info: CreateInfo!
@@ -5729,11 +5871,11 @@ describe("@settable", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   description: StringAggregateSelection!
                   title: StringAggregateSelection!
                 }
@@ -5829,11 +5971,11 @@ describe("@settable", () => {
                 }
 
                 type ProductionAggregate {
+                  count: Count!
                   node: ProductionAggregateNode!
                 }
 
                 type ProductionAggregateNode {
-                  count: Int!
                   description: StringAggregateSelection!
                   title: StringAggregateSelection!
                 }
@@ -5928,11 +6070,11 @@ describe("@settable", () => {
                 }
 
                 type SeriesAggregate {
+                  count: Count!
                   node: SeriesAggregateNode!
                 }
 
                 type SeriesAggregateNode {
-                  count: Int!
                   description: StringAggregateSelection!
                   title: StringAggregateSelection!
                 }
@@ -6101,7 +6243,7 @@ describe("@settable", () => {
                 }
 
                 type ActorActedInConnection {
-                  aggregate: ActorProductionActedInAggregationSelection!
+                  aggregate: ActorProductionActedInAggregateSelection!
                   edges: [ActorActedInRelationship!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -6179,11 +6321,11 @@ describe("@settable", () => {
                 }
 
                 type ActorAggregate {
+                  count: Count!
                   node: ActorAggregateNode!
                 }
 
                 type ActorAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -6225,6 +6367,11 @@ describe("@settable", () => {
                   Specify one or more ActorSort objects to sort Actors by. The sorts will be applied in the order in which they are arranged in the array.
                   \\"\\"\\"
                   sort: [ActorSort!]
+                }
+
+                type ActorProductionActedInAggregateSelection {
+                  count: CountConnection!
+                  node: ActorProductionActedInNodeAggregateSelection
                 }
 
                 type ActorProductionActedInAggregationSelection {
@@ -6291,6 +6438,15 @@ describe("@settable", () => {
                   edges: [ActorEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
+                }
+
+                type Count {
+                  nodes: Int!
+                }
+
+                type CountConnection {
+                  edges: Int!
+                  nodes: Int!
                 }
 
                 type CreateActorsMutationResponse {
@@ -6407,11 +6563,11 @@ describe("@settable", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   description: StringAggregateSelection!
                   title: StringAggregateSelection!
                 }
@@ -6615,11 +6771,11 @@ describe("@settable", () => {
                 }
 
                 type ProductionAggregate {
+                  count: Count!
                   node: ProductionAggregateNode!
                 }
 
                 type ProductionAggregateNode {
-                  count: Int!
                   description: StringAggregateSelection!
                   title: StringAggregateSelection!
                 }
@@ -6828,11 +6984,11 @@ describe("@settable", () => {
                 }
 
                 type SeriesAggregate {
+                  count: Count!
                   node: SeriesAggregateNode!
                 }
 
                 type SeriesAggregateNode {
-                  count: Int!
                   description: StringAggregateSelection!
                   title: StringAggregateSelection!
                 }
@@ -7032,7 +7188,7 @@ describe("@settable", () => {
                 }
 
                 type ActorActedInConnection {
-                  aggregate: ActorProductionActedInAggregationSelection!
+                  aggregate: ActorProductionActedInAggregateSelection!
                   edges: [ActorActedInRelationship!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -7118,11 +7274,11 @@ describe("@settable", () => {
                 }
 
                 type ActorAggregate {
+                  count: Count!
                   node: ActorAggregateNode!
                 }
 
                 type ActorAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -7163,6 +7319,11 @@ describe("@settable", () => {
                   Specify one or more ActorSort objects to sort Actors by. The sorts will be applied in the order in which they are arranged in the array.
                   \\"\\"\\"
                   sort: [ActorSort!]
+                }
+
+                type ActorProductionActedInAggregateSelection {
+                  count: CountConnection!
+                  node: ActorProductionActedInNodeAggregateSelection
                 }
 
                 type ActorProductionActedInAggregationSelection {
@@ -7230,6 +7391,15 @@ describe("@settable", () => {
                   edges: [ActorEdge!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
+                }
+
+                type Count {
+                  nodes: Int!
+                }
+
+                type CountConnection {
+                  edges: Int!
+                  nodes: Int!
                 }
 
                 type CreateActorsMutationResponse {
@@ -7346,11 +7516,11 @@ describe("@settable", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   description: StringAggregateSelection!
                   title: StringAggregateSelection!
                 }
@@ -7571,11 +7741,11 @@ describe("@settable", () => {
                 }
 
                 type ProductionAggregate {
+                  count: Count!
                   node: ProductionAggregateNode!
                 }
 
                 type ProductionAggregateNode {
-                  count: Int!
                   description: StringAggregateSelection!
                   title: StringAggregateSelection!
                 }
@@ -7792,11 +7962,11 @@ describe("@settable", () => {
                 }
 
                 type SeriesAggregate {
+                  count: Count!
                   node: SeriesAggregateNode!
                 }
 
                 type SeriesAggregateNode {
-                  count: Int!
                   description: StringAggregateSelection!
                   title: StringAggregateSelection!
                 }

--- a/packages/graphql/tests/schema/directives/timestamps.test.ts
+++ b/packages/graphql/tests/schema/directives/timestamps.test.ts
@@ -40,6 +40,10 @@ describe("Timestamps", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -81,11 +85,11 @@ describe("Timestamps", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               createdAt: DateTimeAggregateSelection!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
               updatedAt: DateTimeAggregateSelection!

--- a/packages/graphql/tests/schema/enum.test.ts
+++ b/packages/graphql/tests/schema/enum.test.ts
@@ -44,6 +44,10 @@ describe("Enum", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -70,11 +74,7 @@ describe("Enum", () => {
             }
 
             type MovieAggregate {
-              node: MovieAggregateNode!
-            }
-
-            type MovieAggregateNode {
-              count: Int!
+              count: Count!
             }
 
             type MovieAggregateSelection {

--- a/packages/graphql/tests/schema/extend.test.ts
+++ b/packages/graphql/tests/schema/extend.test.ts
@@ -42,6 +42,10 @@ describe("Extend", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -74,11 +78,11 @@ describe("Extend", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
               name: StringAggregateSelection!
             }

--- a/packages/graphql/tests/schema/federation.test.ts
+++ b/packages/graphql/tests/schema/federation.test.ts
@@ -69,6 +69,15 @@ describe("Apollo Federation", () => {
 
             directive @shareable on FIELD_DEFINITION | OBJECT
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -120,12 +129,12 @@ describe("Apollo Federation", () => {
             }
 
             type PostAggregate {
+              count: Count!
               node: PostAggregateNode!
             }
 
             type PostAggregateNode {
               content: StringAggregateSelection!
-              count: Int!
             }
 
             type PostAggregateSelection {
@@ -156,7 +165,7 @@ describe("Apollo Federation", () => {
             }
 
             type PostAuthorConnection {
-              aggregate: PostUserAuthorAggregationSelection!
+              aggregate: PostUserAuthorAggregateSelection!
               edges: [PostAuthorRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -279,6 +288,11 @@ describe("Apollo Federation", () => {
               content_SET: String
             }
 
+            type PostUserAuthorAggregateSelection {
+              count: CountConnection!
+              node: PostUserAuthorNodeAggregateSelection
+            }
+
             type PostUserAuthorAggregationSelection {
               count: Int!
               node: PostUserAuthorNodeAggregateSelection
@@ -361,11 +375,11 @@ describe("Apollo Federation", () => {
             }
 
             type UserAggregate @shareable {
+              count: Count!
               node: UserAggregateNode!
             }
 
             type UserAggregateNode @shareable {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -409,6 +423,11 @@ describe("Apollo Federation", () => {
               sort: [UserSort!]
             }
 
+            type UserPostPostsAggregateSelection {
+              count: CountConnection!
+              node: UserPostPostsNodeAggregateSelection
+            }
+
             type UserPostPostsAggregationSelection {
               count: Int!
               node: UserPostPostsNodeAggregateSelection
@@ -441,7 +460,7 @@ describe("Apollo Federation", () => {
             }
 
             type UserPostsConnection {
-              aggregate: UserPostPostsAggregationSelection!
+              aggregate: UserPostPostsAggregateSelection!
               edges: [UserPostsRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -641,6 +660,15 @@ describe("Apollo Federation", () => {
 
             directive @link(as: String, for: link__Purpose, import: [link__Import], url: String) repeatable on SCHEMA
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -692,12 +720,12 @@ describe("Apollo Federation", () => {
             }
 
             type PostAggregate {
+              count: Count!
               node: PostAggregateNode!
             }
 
             type PostAggregateNode {
               content: StringAggregateSelection!
-              count: Int!
             }
 
             type PostAggregateSelection {
@@ -727,7 +755,7 @@ describe("Apollo Federation", () => {
             }
 
             type PostAuthorConnection {
-              aggregate: PostUserAuthorAggregationSelection!
+              aggregate: PostUserAuthorAggregateSelection!
               edges: [PostAuthorRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -836,6 +864,11 @@ describe("Apollo Federation", () => {
               content_SET: String
             }
 
+            type PostUserAuthorAggregateSelection {
+              count: CountConnection!
+              node: PostUserAuthorNodeAggregateSelection
+            }
+
             type PostUserAuthorAggregationSelection {
               count: Int!
               node: PostUserAuthorNodeAggregateSelection
@@ -916,11 +949,11 @@ describe("Apollo Federation", () => {
             }
 
             type UserAggregate {
+              count: Count!
               node: UserAggregateNode!
             }
 
             type UserAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 

--- a/packages/graphql/tests/schema/fulltext.test.ts
+++ b/packages/graphql/tests/schema/fulltext.test.ts
@@ -47,6 +47,10 @@ describe("@fulltext schema", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -80,11 +84,11 @@ describe("@fulltext schema", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               description: StringAggregateSelection!
               title: StringAggregateSelection!
             }

--- a/packages/graphql/tests/schema/global-node.test.ts
+++ b/packages/graphql/tests/schema/global-node.test.ts
@@ -39,6 +39,10 @@ describe("Node Interface Types", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -72,11 +76,11 @@ describe("Node Interface Types", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               imdb: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
               title: StringAggregateSelection!
             }

--- a/packages/graphql/tests/schema/inheritance.test.ts
+++ b/packages/graphql/tests/schema/inheritance.test.ts
@@ -66,11 +66,11 @@ describe("inheritance", () => {
             }
 
             type ActorAggregate {
+              count: Count!
               node: ActorAggregateNode!
             }
 
             type ActorAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -248,6 +248,10 @@ describe("inheritance", () => {
               totalCount: Int!
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             type CreateActorsMutationResponse {
               actors: [Actor!]!
               info: CreateInfo!
@@ -366,11 +370,11 @@ describe("inheritance", () => {
             }
 
             type PersonAggregate {
+              count: Count!
               node: PersonAggregateNode!
             }
 
             type PersonAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 

--- a/packages/graphql/tests/schema/inputs.test.ts
+++ b/packages/graphql/tests/schema/inputs.test.ts
@@ -46,6 +46,10 @@ describe("Inputs", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -77,11 +81,11 @@ describe("Inputs", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 

--- a/packages/graphql/tests/schema/interface-relationships.test.ts
+++ b/packages/graphql/tests/schema/interface-relationships.test.ts
@@ -146,7 +146,7 @@ describe("Interface Relationships", () => {
             }
 
             type ActorActedInConnection {
-              aggregate: ActorProductionActedInAggregationSelection!
+              aggregate: ActorProductionActedInAggregateSelection!
               edges: [ActorActedInRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -225,11 +225,11 @@ describe("Interface Relationships", () => {
             }
 
             type ActorAggregate {
+              count: Count!
               node: ActorAggregateNode!
             }
 
             type ActorAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -259,6 +259,12 @@ describe("Interface Relationships", () => {
               Specify one or more ActorSort objects to sort Actors by. The sorts will be applied in the order in which they are arranged in the array.
               \\"\\"\\"
               sort: [ActorSort!]
+            }
+
+            type ActorProductionActedInAggregateSelection {
+              count: CountConnection!
+              edge: ActorProductionActedInEdgeAggregateSelection
+              node: ActorProductionActedInNodeAggregateSelection
             }
 
             type ActorProductionActedInAggregationSelection {
@@ -332,6 +338,15 @@ describe("Interface Relationships", () => {
               totalCount: Int!
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             type CreateActorsMutationResponse {
               actors: [Actor!]!
               info: CreateInfo!
@@ -376,11 +391,11 @@ describe("Interface Relationships", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               runtime: IntAggregateSelection!
               title: StringAggregateSelection!
             }
@@ -478,11 +493,11 @@ describe("Interface Relationships", () => {
             }
 
             type ProductionAggregate {
+              count: Count!
               node: ProductionAggregateNode!
             }
 
             type ProductionAggregateNode {
-              count: Int!
               title: StringAggregateSelection!
             }
 
@@ -573,11 +588,11 @@ describe("Interface Relationships", () => {
             }
 
             type SeriesAggregate {
+              count: Count!
               node: SeriesAggregateNode!
             }
 
             type SeriesAggregateNode {
-              count: Int!
               episodes: IntAggregateSelection!
               title: StringAggregateSelection!
             }
@@ -825,7 +840,7 @@ describe("Interface Relationships", () => {
             }
 
             type ActorActedInConnection {
-              aggregate: ActorProductionActedInAggregationSelection!
+              aggregate: ActorProductionActedInAggregateSelection!
               edges: [ActorActedInRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -906,11 +921,11 @@ describe("Interface Relationships", () => {
             }
 
             type ActorAggregate {
+              count: Count!
               node: ActorAggregateNode!
             }
 
             type ActorAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -952,6 +967,12 @@ describe("Interface Relationships", () => {
               Specify one or more ActorSort objects to sort Actors by. The sorts will be applied in the order in which they are arranged in the array.
               \\"\\"\\"
               sort: [ActorSort!]
+            }
+
+            type ActorProductionActedInAggregateSelection {
+              count: CountConnection!
+              edge: ActorProductionActedInEdgeAggregateSelection
+              node: ActorProductionActedInNodeAggregateSelection
             }
 
             type ActorProductionActedInAggregationSelection {
@@ -1025,6 +1046,15 @@ describe("Interface Relationships", () => {
               totalCount: Int!
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             type CreateActorsMutationResponse {
               actors: [Actor!]!
               info: CreateInfo!
@@ -1069,11 +1099,11 @@ describe("Interface Relationships", () => {
             }
 
             type EpisodeAggregate {
+              count: Count!
               node: EpisodeAggregateNode!
             }
 
             type EpisodeAggregateNode {
-              count: Int!
               runtime: IntAggregateSelection!
             }
 
@@ -1140,7 +1170,7 @@ describe("Interface Relationships", () => {
             }
 
             type EpisodeSeriesConnection {
-              aggregate: EpisodeSeriesSeriesAggregationSelection!
+              aggregate: EpisodeSeriesSeriesAggregateSelection!
               edges: [EpisodeSeriesRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1220,6 +1250,11 @@ describe("Interface Relationships", () => {
             type EpisodeSeriesRelationship {
               cursor: String!
               node: Series!
+            }
+
+            type EpisodeSeriesSeriesAggregateSelection {
+              count: CountConnection!
+              node: EpisodeSeriesSeriesNodeAggregateSelection
             }
 
             type EpisodeSeriesSeriesAggregationSelection {
@@ -1382,11 +1417,11 @@ describe("Interface Relationships", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               runtime: IntAggregateSelection!
               title: StringAggregateSelection!
             }
@@ -1666,11 +1701,11 @@ describe("Interface Relationships", () => {
             }
 
             type ProductionAggregate {
+              count: Count!
               node: ProductionAggregateNode!
             }
 
             type ProductionAggregateNode {
-              count: Int!
               title: StringAggregateSelection!
             }
 
@@ -1891,11 +1926,11 @@ describe("Interface Relationships", () => {
             }
 
             type SeriesAggregate {
+              count: Count!
               node: SeriesAggregateNode!
             }
 
             type SeriesAggregateNode {
-              count: Int!
               episodeCount: IntAggregateSelection!
               title: StringAggregateSelection!
             }
@@ -1944,6 +1979,11 @@ describe("Interface Relationships", () => {
               node: Series!
             }
 
+            type SeriesEpisodeEpisodesAggregateSelection {
+              count: CountConnection!
+              node: SeriesEpisodeEpisodesNodeAggregateSelection
+            }
+
             type SeriesEpisodeEpisodesAggregationSelection {
               count: Int!
               node: SeriesEpisodeEpisodesNodeAggregateSelection
@@ -1976,7 +2016,7 @@ describe("Interface Relationships", () => {
             }
 
             type SeriesEpisodesConnection {
-              aggregate: SeriesEpisodeEpisodesAggregationSelection!
+              aggregate: SeriesEpisodeEpisodesAggregateSelection!
               edges: [SeriesEpisodesRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -2336,7 +2376,7 @@ describe("Interface Relationships", () => {
             }
 
             type ActorActedInConnection {
-              aggregate: ActorProductionActedInAggregationSelection!
+              aggregate: ActorProductionActedInAggregateSelection!
               edges: [ActorActedInRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -2417,11 +2457,11 @@ describe("Interface Relationships", () => {
             }
 
             type ActorAggregate {
+              count: Count!
               node: ActorAggregateNode!
             }
 
             type ActorAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -2463,6 +2503,12 @@ describe("Interface Relationships", () => {
               Specify one or more ActorSort objects to sort Actors by. The sorts will be applied in the order in which they are arranged in the array.
               \\"\\"\\"
               sort: [ActorSort!]
+            }
+
+            type ActorProductionActedInAggregateSelection {
+              count: CountConnection!
+              edge: ActorProductionActedInEdgeAggregateSelection
+              node: ActorProductionActedInNodeAggregateSelection
             }
 
             type ActorProductionActedInAggregationSelection {
@@ -2536,6 +2582,15 @@ describe("Interface Relationships", () => {
               totalCount: Int!
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             type CreateActorsMutationResponse {
               actors: [Actor!]!
               info: CreateInfo!
@@ -2580,11 +2635,11 @@ describe("Interface Relationships", () => {
             }
 
             type EpisodeAggregate {
+              count: Count!
               node: EpisodeAggregateNode!
             }
 
             type EpisodeAggregateNode {
-              count: Int!
               runtime: IntAggregateSelection!
             }
 
@@ -2651,7 +2706,7 @@ describe("Interface Relationships", () => {
             }
 
             type EpisodeSeriesConnection {
-              aggregate: EpisodeSeriesSeriesAggregationSelection!
+              aggregate: EpisodeSeriesSeriesAggregateSelection!
               edges: [EpisodeSeriesRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -2731,6 +2786,11 @@ describe("Interface Relationships", () => {
             type EpisodeSeriesRelationship {
               cursor: String!
               node: Series!
+            }
+
+            type EpisodeSeriesSeriesAggregateSelection {
+              count: CountConnection!
+              node: EpisodeSeriesSeriesNodeAggregateSelection
             }
 
             type EpisodeSeriesSeriesAggregationSelection {
@@ -2893,11 +2953,11 @@ describe("Interface Relationships", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               runtime: IntAggregateSelection!
               title: StringAggregateSelection!
             }
@@ -3197,11 +3257,11 @@ describe("Interface Relationships", () => {
             }
 
             type ProductionAggregate {
+              count: Count!
               node: ProductionAggregateNode!
             }
 
             type ProductionAggregateNode {
-              count: Int!
               title: StringAggregateSelection!
             }
 
@@ -3422,11 +3482,11 @@ describe("Interface Relationships", () => {
             }
 
             type SeriesAggregate {
+              count: Count!
               node: SeriesAggregateNode!
             }
 
             type SeriesAggregateNode {
-              count: Int!
               episodeCount: IntAggregateSelection!
               title: StringAggregateSelection!
             }
@@ -3475,6 +3535,11 @@ describe("Interface Relationships", () => {
               node: Series!
             }
 
+            type SeriesEpisodeEpisodesAggregateSelection {
+              count: CountConnection!
+              node: SeriesEpisodeEpisodesNodeAggregateSelection
+            }
+
             type SeriesEpisodeEpisodesAggregationSelection {
               count: Int!
               node: SeriesEpisodeEpisodesNodeAggregateSelection
@@ -3507,7 +3572,7 @@ describe("Interface Relationships", () => {
             }
 
             type SeriesEpisodesConnection {
-              aggregate: SeriesEpisodeEpisodesAggregationSelection!
+              aggregate: SeriesEpisodeEpisodesAggregateSelection!
               edges: [SeriesEpisodesRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -3835,6 +3900,15 @@ describe("Interface Relationships", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -3883,11 +3957,11 @@ describe("Interface Relationships", () => {
             }
 
             type Interface1Aggregate {
+              count: Count!
               node: Interface1AggregateNode!
             }
 
             type Interface1AggregateNode {
-              count: Int!
               field1: StringAggregateSelection!
             }
 
@@ -4093,11 +4167,11 @@ describe("Interface Relationships", () => {
             }
 
             type Interface2Aggregate {
+              count: Count!
               node: Interface2AggregateNode!
             }
 
             type Interface2AggregateNode {
-              count: Int!
               field2: StringAggregateSelection!
             }
 
@@ -4238,11 +4312,11 @@ describe("Interface Relationships", () => {
             }
 
             type Type1Aggregate {
+              count: Count!
               node: Type1AggregateNode!
             }
 
             type Type1AggregateNode {
-              count: Int!
               field1: StringAggregateSelection!
             }
 
@@ -4273,6 +4347,7 @@ describe("Interface Relationships", () => {
             }
 
             type Type1Interface1Aggregate {
+              count: Count!
               node: Type1Interface1AggregateNode!
             }
 
@@ -4290,7 +4365,6 @@ describe("Interface Relationships", () => {
             }
 
             type Type1Interface1AggregateNode {
-              count: Int!
               field1: StringAggregateSelection!
             }
 
@@ -4305,7 +4379,7 @@ describe("Interface Relationships", () => {
             }
 
             type Type1Interface1Connection {
-              aggregate: Type1Interface1Interface1AggregationSelection!
+              aggregate: Type1Interface1Interface1AggregateSelection!
               edges: [Type1Interface1Relationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -4353,6 +4427,11 @@ describe("Interface Relationships", () => {
             input Type1Interface1FieldInput {
               connect: [Type1Interface1ConnectFieldInput!]
               create: [Type1Interface1CreateFieldInput!]
+            }
+
+            type Type1Interface1Interface1AggregateSelection {
+              count: CountConnection!
+              node: Type1Interface1Interface1NodeAggregateSelection
             }
 
             type Type1Interface1Interface1AggregationSelection {
@@ -4559,11 +4638,11 @@ describe("Interface Relationships", () => {
             }
 
             type Type1Interface2Aggregate {
+              count: Count!
               node: Type1Interface2AggregateNode!
             }
 
             type Type1Interface2AggregateNode {
-              count: Int!
               field2: StringAggregateSelection!
             }
 
@@ -4695,11 +4774,11 @@ describe("Interface Relationships", () => {
             }
 
             type Type2Interface1Aggregate {
+              count: Count!
               node: Type2Interface1AggregateNode!
             }
 
             type Type2Interface1AggregateNode {
-              count: Int!
               field1: StringAggregateSelection!
             }
 
@@ -4878,11 +4957,11 @@ describe("Interface Relationships", () => {
             }
 
             type Type2Interface2Aggregate {
+              count: Count!
               node: Type2Interface2AggregateNode!
             }
 
             type Type2Interface2AggregateNode {
-              count: Int!
               field2: StringAggregateSelection!
             }
 
@@ -5030,6 +5109,15 @@ describe("Interface Relationships", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -5085,11 +5173,11 @@ describe("Interface Relationships", () => {
             }
 
             type Interface1Aggregate {
+              count: Count!
               node: Interface1AggregateNode!
             }
 
             type Interface1AggregateNode {
-              count: Int!
               field1: StringAggregateSelection!
             }
 
@@ -5349,11 +5437,11 @@ describe("Interface Relationships", () => {
             }
 
             type Interface2Aggregate {
+              count: Count!
               node: Interface2AggregateNode!
             }
 
             type Interface2AggregateNode {
-              count: Int!
               field2: StringAggregateSelection!
             }
 
@@ -5557,11 +5645,11 @@ describe("Interface Relationships", () => {
             }
 
             type Type1Aggregate {
+              count: Count!
               node: Type1AggregateNode!
             }
 
             type Type1AggregateNode {
-              count: Int!
               field1: StringAggregateSelection!
             }
 
@@ -5592,6 +5680,7 @@ describe("Interface Relationships", () => {
             }
 
             type Type1Interface1Aggregate {
+              count: Count!
               node: Type1Interface1AggregateNode!
             }
 
@@ -5609,7 +5698,6 @@ describe("Interface Relationships", () => {
             }
 
             type Type1Interface1AggregateNode {
-              count: Int!
               field1: StringAggregateSelection!
             }
 
@@ -5624,7 +5712,7 @@ describe("Interface Relationships", () => {
             }
 
             type Type1Interface1Connection {
-              aggregate: Type1Interface1Interface1AggregationSelection!
+              aggregate: Type1Interface1Interface1AggregateSelection!
               edges: [Type1Interface1Relationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -5672,6 +5760,11 @@ describe("Interface Relationships", () => {
             input Type1Interface1FieldInput {
               connect: [Type1Interface1ConnectFieldInput!]
               create: [Type1Interface1CreateFieldInput!]
+            }
+
+            type Type1Interface1Interface1AggregateSelection {
+              count: CountConnection!
+              node: Type1Interface1Interface1NodeAggregateSelection
             }
 
             type Type1Interface1Interface1AggregationSelection {
@@ -5887,11 +5980,11 @@ describe("Interface Relationships", () => {
             }
 
             type Type1Interface2Aggregate {
+              count: Count!
               node: Type1Interface2AggregateNode!
             }
 
             type Type1Interface2AggregateNode {
-              count: Int!
               field2: StringAggregateSelection!
             }
 
@@ -6023,11 +6116,11 @@ describe("Interface Relationships", () => {
             }
 
             type Type2Interface1Aggregate {
+              count: Count!
               node: Type2Interface1AggregateNode!
             }
 
             type Type2Interface1AggregateNode {
-              count: Int!
               field1: StringAggregateSelection!
             }
 
@@ -6215,11 +6308,11 @@ describe("Interface Relationships", () => {
             }
 
             type Type2Interface2Aggregate {
+              count: Count!
               node: Type2Interface2AggregateNode!
             }
 
             type Type2Interface2AggregateNode {
-              count: Int!
               field2: StringAggregateSelection!
             }
 
@@ -6373,6 +6466,15 @@ describe("Interface Relationships", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -6428,11 +6530,11 @@ describe("Interface Relationships", () => {
             }
 
             type Interface1Aggregate {
+              count: Count!
               node: Interface1AggregateNode!
             }
 
             type Interface1AggregateNode {
-              count: Int!
               field1: StringAggregateSelection!
             }
 
@@ -6712,11 +6814,11 @@ describe("Interface Relationships", () => {
             }
 
             type Interface2Aggregate {
+              count: Count!
               node: Interface2AggregateNode!
             }
 
             type Interface2AggregateNode {
-              count: Int!
               field2: StringAggregateSelection!
             }
 
@@ -6857,11 +6959,11 @@ describe("Interface Relationships", () => {
             }
 
             type Type1Aggregate {
+              count: Count!
               node: Type1AggregateNode!
             }
 
             type Type1AggregateNode {
-              count: Int!
               field1: StringAggregateSelection!
             }
 
@@ -6892,6 +6994,7 @@ describe("Interface Relationships", () => {
             }
 
             type Type1Interface1Aggregate {
+              count: Count!
               node: Type1Interface1AggregateNode!
             }
 
@@ -6909,7 +7012,6 @@ describe("Interface Relationships", () => {
             }
 
             type Type1Interface1AggregateNode {
-              count: Int!
               field1: StringAggregateSelection!
             }
 
@@ -6924,7 +7026,7 @@ describe("Interface Relationships", () => {
             }
 
             type Type1Interface1Connection {
-              aggregate: Type1Interface1Interface1AggregationSelection!
+              aggregate: Type1Interface1Interface1AggregateSelection!
               edges: [Type1Interface1Relationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -6972,6 +7074,11 @@ describe("Interface Relationships", () => {
             input Type1Interface1FieldInput {
               connect: [Type1Interface1ConnectFieldInput!]
               create: [Type1Interface1CreateFieldInput!]
+            }
+
+            type Type1Interface1Interface1AggregateSelection {
+              count: CountConnection!
+              node: Type1Interface1Interface1NodeAggregateSelection
             }
 
             type Type1Interface1Interface1AggregationSelection {
@@ -7187,11 +7294,11 @@ describe("Interface Relationships", () => {
             }
 
             type Type1Interface2Aggregate {
+              count: Count!
               node: Type1Interface2AggregateNode!
             }
 
             type Type1Interface2AggregateNode {
-              count: Int!
               field2: StringAggregateSelection!
             }
 
@@ -7385,11 +7492,11 @@ describe("Interface Relationships", () => {
             }
 
             type Type2Interface1Aggregate {
+              count: Count!
               node: Type2Interface1AggregateNode!
             }
 
             type Type2Interface1AggregateNode {
-              count: Int!
               field1: StringAggregateSelection!
             }
 
@@ -7577,11 +7684,11 @@ describe("Interface Relationships", () => {
             }
 
             type Type2Interface2Aggregate {
+              count: Count!
               node: Type2Interface2AggregateNode!
             }
 
             type Type2Interface2AggregateNode {
-              count: Int!
               field2: StringAggregateSelection!
             }
 
@@ -7793,12 +7900,12 @@ describe("Interface Relationships", () => {
             }
 
             type CommentAggregate {
+              count: Count!
               node: CommentAggregateNode!
             }
 
             type CommentAggregateNode {
               content: StringAggregateSelection!
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
@@ -7946,7 +8053,7 @@ describe("Interface Relationships", () => {
             }
 
             type CommentPostConnection {
-              aggregate: CommentPostPostAggregationSelection!
+              aggregate: CommentPostPostAggregateSelection!
               edges: [CommentPostRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -8011,6 +8118,11 @@ describe("Interface Relationships", () => {
               id_MIN_GTE: ID @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
               id_MIN_LT: ID @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
               id_MIN_LTE: ID @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+            }
+
+            type CommentPostPostAggregateSelection {
+              count: CountConnection!
+              node: CommentPostPostNodeAggregateSelection
             }
 
             type CommentPostPostAggregationSelection {
@@ -8107,12 +8219,12 @@ describe("Interface Relationships", () => {
             }
 
             type ContentAggregate {
+              count: Count!
               node: ContentAggregateNode!
             }
 
             type ContentAggregateNode {
               content: StringAggregateSelection!
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
@@ -8310,6 +8422,15 @@ describe("Interface Relationships", () => {
               totalCount: Int!
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             type CreateCommentsMutationResponse {
               comments: [Comment!]!
               info: CreateInfo!
@@ -8378,12 +8499,12 @@ describe("Interface Relationships", () => {
             }
 
             type PostAggregate {
+              count: Count!
               node: PostAggregateNode!
             }
 
             type PostAggregateNode {
               content: StringAggregateSelection!
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
@@ -8391,6 +8512,11 @@ describe("Interface Relationships", () => {
               content: StringAggregateSelection!
               count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+            }
+
+            type PostCommentCommentsAggregateSelection {
+              count: CountConnection!
+              node: PostCommentCommentsNodeAggregateSelection
             }
 
             type PostCommentCommentsAggregationSelection {
@@ -8426,7 +8552,7 @@ describe("Interface Relationships", () => {
             }
 
             type PostCommentsConnection {
-              aggregate: PostCommentCommentsAggregationSelection!
+              aggregate: PostCommentCommentsAggregateSelection!
               edges: [PostCommentsRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -8768,11 +8894,11 @@ describe("Interface Relationships", () => {
             }
 
             type UserAggregate {
+              count: Count!
               node: UserAggregateNode!
             }
 
             type UserAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
               name: StringAggregateSelection!
             }
@@ -8810,7 +8936,7 @@ describe("Interface Relationships", () => {
             }
 
             type UserContentConnection {
-              aggregate: UserContentContentAggregationSelection!
+              aggregate: UserContentContentAggregateSelection!
               edges: [UserContentRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -8825,6 +8951,11 @@ describe("Interface Relationships", () => {
               NOT: UserContentConnectionWhere
               OR: [UserContentConnectionWhere!]
               node: ContentWhere
+            }
+
+            type UserContentContentAggregateSelection {
+              count: CountConnection!
+              node: UserContentContentNodeAggregateSelection
             }
 
             type UserContentContentAggregationSelection {
@@ -9139,7 +9270,7 @@ describe("Interface Relationships", () => {
             }
 
             type ActorActedInConnection {
-              aggregate: ActorShowActedInAggregationSelection!
+              aggregate: ActorShowActedInAggregateSelection!
               edges: [ActorActedInRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -9220,11 +9351,11 @@ describe("Interface Relationships", () => {
             }
 
             type ActorAggregate {
+              count: Count!
               node: ActorAggregateNode!
             }
 
             type ActorAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -9266,6 +9397,12 @@ describe("Interface Relationships", () => {
               Specify one or more ActorSort objects to sort Actors by. The sorts will be applied in the order in which they are arranged in the array.
               \\"\\"\\"
               sort: [ActorSort!]
+            }
+
+            type ActorShowActedInAggregateSelection {
+              count: CountConnection!
+              edge: ActorShowActedInEdgeAggregateSelection
+              node: ActorShowActedInNodeAggregateSelection
             }
 
             type ActorShowActedInAggregationSelection {
@@ -9337,6 +9474,15 @@ describe("Interface Relationships", () => {
               edges: [ActorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
+            }
+
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
             }
 
             type CreateActorsMutationResponse {
@@ -9469,11 +9615,11 @@ describe("Interface Relationships", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               runtime: IntAggregateSelection!
               title: StringAggregateSelection!
             }
@@ -9603,11 +9749,11 @@ describe("Interface Relationships", () => {
             }
 
             type ProductionAggregate {
+              count: Count!
               node: ProductionAggregateNode!
             }
 
             type ProductionAggregateNode {
-              count: Int!
               title: StringAggregateSelection!
             }
 
@@ -9773,11 +9919,11 @@ describe("Interface Relationships", () => {
             }
 
             type SeriesAggregate {
+              count: Count!
               node: SeriesAggregateNode!
             }
 
             type SeriesAggregateNode {
-              count: Int!
               episodeCount: IntAggregateSelection!
               title: StringAggregateSelection!
             }
@@ -10054,11 +10200,11 @@ describe("Interface Relationships", () => {
             }
 
             type ShowAggregate {
+              count: Count!
               node: ShowAggregateNode!
             }
 
             type ShowAggregateNode {
-              count: Int!
               title: StringAggregateSelection!
             }
 

--- a/packages/graphql/tests/schema/interfaces.test.ts
+++ b/packages/graphql/tests/schema/interfaces.test.ts
@@ -54,6 +54,10 @@ describe("Interfaces", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -90,11 +94,11 @@ describe("Interfaces", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
@@ -206,11 +210,11 @@ describe("Interfaces", () => {
             }
 
             type MovieNodeAggregate {
+              count: Count!
               node: MovieNodeAggregateNode!
             }
 
             type MovieNodeAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
@@ -504,6 +508,10 @@ describe("Interfaces", () => {
 
             directive @something(something: String) on INTERFACE
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -540,11 +548,11 @@ describe("Interfaces", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
@@ -656,11 +664,11 @@ describe("Interfaces", () => {
             }
 
             type MovieNodeAggregate {
+              count: Count!
               node: MovieNodeAggregateNode!
             }
 
             type MovieNodeAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 

--- a/packages/graphql/tests/schema/issues/1038.test.ts
+++ b/packages/graphql/tests/schema/issues/1038.test.ts
@@ -50,13 +50,13 @@ describe("https://github.com/neo4j/graphql/issues/1038", () => {
             }
 
             type AWSAccountAggregate {
+              count: Count!
               node: AWSAccountAggregateNode!
             }
 
             type AWSAccountAggregateNode {
               accountName: StringAggregateSelection!
               code: StringAggregateSelection!
-              count: Int!
             }
 
             type AWSAccountAggregateSelection {
@@ -124,6 +124,10 @@ describe("https://github.com/neo4j/graphql/issues/1038", () => {
               totalCount: Int!
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             type CreateAwsAccountsMutationResponse {
               awsAccounts: [AWSAccount!]!
               info: CreateInfo!
@@ -148,12 +152,12 @@ describe("https://github.com/neo4j/graphql/issues/1038", () => {
             }
 
             type DNSZoneAggregate {
+              count: Count!
               node: DNSZoneAggregateNode!
             }
 
             type DNSZoneAggregateNode {
               awsId: StringAggregateSelection!
-              count: Int!
               zoneType: StringAggregateSelection!
             }
 

--- a/packages/graphql/tests/schema/issues/1182.test.ts
+++ b/packages/graphql/tests/schema/issues/1182.test.ts
@@ -55,11 +55,11 @@ describe("https://github.com/neo4j/graphql/issues/1182", () => {
             }
 
             type ActorAggregate {
+              count: Count!
               node: ActorAggregateNode!
             }
 
             type ActorAggregateNode {
-              count: Int!
               dob: DateTimeAggregateSelection!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
               name: StringAggregateSelection!
@@ -170,6 +170,15 @@ describe("https://github.com/neo4j/graphql/issues/1182", () => {
               totalCount: Int!
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             type CreateActorsMutationResponse {
               actors: [Actor!]!
               info: CreateInfo!
@@ -217,6 +226,11 @@ describe("https://github.com/neo4j/graphql/issues/1182", () => {
               title: String!
             }
 
+            type MovieActorActorsAggregateSelection {
+              count: CountConnection!
+              node: MovieActorActorsNodeAggregateSelection
+            }
+
             type MovieActorActorsAggregationSelection {
               count: Int!
               node: MovieActorActorsNodeAggregateSelection
@@ -259,7 +273,7 @@ describe("https://github.com/neo4j/graphql/issues/1182", () => {
             }
 
             type MovieActorsConnection {
-              aggregate: MovieActorActorsAggregationSelection!
+              aggregate: MovieActorActorsAggregateSelection!
               edges: [MovieActorsRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -355,11 +369,11 @@ describe("https://github.com/neo4j/graphql/issues/1182", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
               title: StringAggregateSelection!
             }

--- a/packages/graphql/tests/schema/issues/1575.test.ts
+++ b/packages/graphql/tests/schema/issues/1575.test.ts
@@ -38,6 +38,10 @@ describe("https://github.com/neo4j/graphql/issues/1575", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             type CreateFoosMutationResponse {
               foos: [Foo!]!
               info: CreateInfo!
@@ -65,11 +69,7 @@ describe("https://github.com/neo4j/graphql/issues/1575", () => {
             }
 
             type FooAggregate {
-              node: FooAggregateNode!
-            }
-
-            type FooAggregateNode {
-              count: Int!
+              count: Count!
             }
 
             type FooAggregateSelection {

--- a/packages/graphql/tests/schema/issues/1614.test.ts
+++ b/packages/graphql/tests/schema/issues/1614.test.ts
@@ -53,6 +53,15 @@ describe("https://github.com/neo4j/graphql/issues/1614", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             type CreateCrewMembersMutationResponse {
               crewMembers: [CrewMember!]!
               info: CreateInfo!
@@ -78,11 +87,7 @@ describe("https://github.com/neo4j/graphql/issues/1614", () => {
             }
 
             type CrewMemberAggregate {
-              node: CrewMemberAggregateNode!
-            }
-
-            type CrewMemberAggregateNode {
-              count: Int!
+              count: Count!
             }
 
             type CrewMemberAggregateSelection {
@@ -100,6 +105,11 @@ describe("https://github.com/neo4j/graphql/issues/1614", () => {
             type CrewMemberEdge {
               cursor: String!
               node: CrewMember!
+            }
+
+            type CrewMemberMovieMoviesAggregateSelection {
+              count: CountConnection!
+              node: CrewMemberMovieMoviesNodeAggregateSelection
             }
 
             type CrewMemberMovieMoviesAggregationSelection {
@@ -134,7 +144,7 @@ describe("https://github.com/neo4j/graphql/issues/1614", () => {
             }
 
             type CrewMemberMoviesConnection {
-              aggregate: CrewMemberMovieMoviesAggregationSelection!
+              aggregate: CrewMemberMovieMoviesAggregateSelection!
               edges: [CrewMemberMoviesRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -286,11 +296,11 @@ describe("https://github.com/neo4j/graphql/issues/1614", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 

--- a/packages/graphql/tests/schema/issues/162.test.ts
+++ b/packages/graphql/tests/schema/issues/162.test.ts
@@ -48,6 +48,15 @@ describe("162", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -136,11 +145,11 @@ describe("162", () => {
             }
 
             type TigerAggregate {
+              count: Count!
               node: TigerAggregateNode!
             }
 
             type TigerAggregateNode {
-              count: Int!
               x: IntAggregateSelection!
             }
 
@@ -170,11 +179,11 @@ describe("162", () => {
             }
 
             type TigerJawLevel2Aggregate {
+              count: Count!
               node: TigerJawLevel2AggregateNode!
             }
 
             type TigerJawLevel2AggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
@@ -214,6 +223,7 @@ describe("162", () => {
             }
 
             type TigerJawLevel2Part1Aggregate {
+              count: Count!
               node: TigerJawLevel2Part1AggregateNode!
             }
 
@@ -231,7 +241,6 @@ describe("162", () => {
             }
 
             type TigerJawLevel2Part1AggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
@@ -258,7 +267,7 @@ describe("162", () => {
             }
 
             type TigerJawLevel2Part1Connection {
-              aggregate: TigerJawLevel2TigerJawLevel2Part1Part1AggregationSelection!
+              aggregate: TigerJawLevel2TigerJawLevel2Part1Part1AggregateSelection!
               edges: [TigerJawLevel2Part1Relationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -371,7 +380,7 @@ describe("162", () => {
             }
 
             type TigerJawLevel2Part1TigerConnection {
-              aggregate: TigerJawLevel2Part1TigerTigerAggregationSelection!
+              aggregate: TigerJawLevel2Part1TigerTigerAggregateSelection!
               edges: [TigerJawLevel2Part1TigerRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -434,6 +443,11 @@ describe("162", () => {
             type TigerJawLevel2Part1TigerRelationship {
               cursor: String!
               node: Tiger!
+            }
+
+            type TigerJawLevel2Part1TigerTigerAggregateSelection {
+              count: CountConnection!
+              node: TigerJawLevel2Part1TigerTigerNodeAggregateSelection
             }
 
             type TigerJawLevel2Part1TigerTigerAggregationSelection {
@@ -504,6 +518,11 @@ describe("162", () => {
             \\"\\"\\"
             input TigerJawLevel2Sort {
               id: SortDirection
+            }
+
+            type TigerJawLevel2TigerJawLevel2Part1Part1AggregateSelection {
+              count: CountConnection!
+              node: TigerJawLevel2TigerJawLevel2Part1Part1NodeAggregateSelection
             }
 
             type TigerJawLevel2TigerJawLevel2Part1Part1AggregationSelection {

--- a/packages/graphql/tests/schema/issues/200.test.ts
+++ b/packages/graphql/tests/schema/issues/200.test.ts
@@ -56,12 +56,12 @@ describe("200", () => {
             }
 
             type CategoryAggregate {
+              count: Count!
               node: CategoryAggregateNode!
             }
 
             type CategoryAggregateNode {
               categoryId: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
-              count: Int!
               description: StringAggregateSelection!
               name: StringAggregateSelection!
             }
@@ -138,6 +138,10 @@ describe("200", () => {
               name_EQ: String
               name_IN: [String!]
               name_STARTS_WITH: String
+            }
+
+            type Count {
+              nodes: Int!
             }
 
             type CreateCategoriesMutationResponse {

--- a/packages/graphql/tests/schema/issues/2187.test.ts
+++ b/packages/graphql/tests/schema/issues/2187.test.ts
@@ -48,6 +48,15 @@ describe("https://github.com/neo4j/graphql/issues/2187", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             type CreateGenresMutationResponse {
               genres: [Genre!]!
               info: CreateInfo!
@@ -89,11 +98,11 @@ describe("https://github.com/neo4j/graphql/issues/2187", () => {
             }
 
             type GenreAggregate {
+              count: Count!
               node: GenreAggregateNode!
             }
 
             type GenreAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -126,6 +135,11 @@ describe("https://github.com/neo4j/graphql/issues/2187", () => {
             type GenreEdge {
               cursor: String!
               node: Genre!
+            }
+
+            type GenreMovieMoviesAggregateSelection {
+              count: CountConnection!
+              node: GenreMovieMoviesNodeAggregateSelection
             }
 
             type GenreMovieMoviesAggregationSelection {
@@ -162,7 +176,7 @@ describe("https://github.com/neo4j/graphql/issues/2187", () => {
             }
 
             type GenreMoviesConnection {
-              aggregate: GenreMovieMoviesAggregationSelection!
+              aggregate: GenreMovieMoviesAggregateSelection!
               edges: [GenreMoviesRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -360,11 +374,11 @@ describe("https://github.com/neo4j/graphql/issues/2187", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               imdbRating: FloatAggregateSelection!
               title: StringAggregateSelection!
               year: IntAggregateSelection!
@@ -405,6 +419,11 @@ describe("https://github.com/neo4j/graphql/issues/2187", () => {
               node: Movie!
             }
 
+            type MovieGenreGenresAggregateSelection {
+              count: CountConnection!
+              node: MovieGenreGenresNodeAggregateSelection
+            }
+
             type MovieGenreGenresAggregationSelection {
               count: Int!
               node: MovieGenreGenresNodeAggregateSelection
@@ -437,7 +456,7 @@ describe("https://github.com/neo4j/graphql/issues/2187", () => {
             }
 
             type MovieGenresConnection {
-              aggregate: MovieGenreGenresAggregationSelection!
+              aggregate: MovieGenreGenresAggregateSelection!
               edges: [MovieGenresRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/issues/2377.test.ts
+++ b/packages/graphql/tests/schema/issues/2377.test.ts
@@ -84,6 +84,15 @@ describe("https://github.com/neo4j/graphql/issues/2377", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -166,11 +175,11 @@ describe("https://github.com/neo4j/graphql/issues/2377", () => {
             }
 
             type ResourceAggregate {
+              count: Count!
               node: ResourceAggregateNode!
             }
 
             type ResourceAggregateNode {
-              count: Int!
               createdAt: DateTimeAggregateSelection!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
               name: StringAggregateSelection!
@@ -229,7 +238,7 @@ describe("https://github.com/neo4j/graphql/issues/2377", () => {
             }
 
             type ResourceContainedByConnection {
-              aggregate: ResourceResourceContainedByAggregationSelection!
+              aggregate: ResourceResourceContainedByAggregateSelection!
               edges: [ResourceContainedByRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -378,11 +387,11 @@ describe("https://github.com/neo4j/graphql/issues/2377", () => {
             }
 
             type ResourceEntityAggregate {
+              count: Count!
               node: ResourceEntityAggregateNode!
             }
 
             type ResourceEntityAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
               name: StringAggregateSelection!
             }
@@ -466,6 +475,11 @@ describe("https://github.com/neo4j/graphql/issues/2377", () => {
               Specify one or more ResourceSort objects to sort Resources by. The sorts will be applied in the order in which they are arranged in the array.
               \\"\\"\\"
               sort: [ResourceSort!]
+            }
+
+            type ResourceResourceContainedByAggregateSelection {
+              count: CountConnection!
+              node: ResourceResourceContainedByNodeAggregateSelection
             }
 
             type ResourceResourceContainedByAggregationSelection {

--- a/packages/graphql/tests/schema/issues/2969.test.ts
+++ b/packages/graphql/tests/schema/issues/2969.test.ts
@@ -45,6 +45,15 @@ describe("https://github.com/neo4j/graphql/issues/2969", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -101,12 +110,12 @@ describe("https://github.com/neo4j/graphql/issues/2969", () => {
             }
 
             type PostAggregate {
+              count: Count!
               node: PostAggregateNode!
             }
 
             type PostAggregateNode {
               content: StringAggregateSelection!
-              count: Int!
             }
 
             type PostAggregateSelection {
@@ -137,7 +146,7 @@ describe("https://github.com/neo4j/graphql/issues/2969", () => {
             }
 
             type PostAuthorConnection {
-              aggregate: PostUserAuthorAggregationSelection!
+              aggregate: PostUserAuthorAggregateSelection!
               edges: [PostAuthorRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -270,6 +279,11 @@ describe("https://github.com/neo4j/graphql/issues/2969", () => {
               content_SET: String
             }
 
+            type PostUserAuthorAggregateSelection {
+              count: CountConnection!
+              node: PostUserAuthorNodeAggregateSelection
+            }
+
             type PostUserAuthorAggregationSelection {
               count: Int!
               node: PostUserAuthorNodeAggregateSelection
@@ -353,11 +367,11 @@ describe("https://github.com/neo4j/graphql/issues/2969", () => {
             }
 
             type UserAggregate {
+              count: Count!
               node: UserAggregateNode!
             }
 
             type UserAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
               name: StringAggregateSelection!
             }
@@ -404,6 +418,11 @@ describe("https://github.com/neo4j/graphql/issues/2969", () => {
               sort: [UserSort!]
             }
 
+            type UserPostPostsAggregateSelection {
+              count: CountConnection!
+              node: UserPostPostsNodeAggregateSelection
+            }
+
             type UserPostPostsAggregationSelection {
               count: Int!
               node: UserPostPostsNodeAggregateSelection
@@ -436,7 +455,7 @@ describe("https://github.com/neo4j/graphql/issues/2969", () => {
             }
 
             type UserPostsConnection {
-              aggregate: UserPostPostsAggregationSelection!
+              aggregate: UserPostPostsAggregateSelection!
               edges: [UserPostsRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/issues/2981.test.ts
+++ b/packages/graphql/tests/schema/issues/2981.test.ts
@@ -60,11 +60,11 @@ describe("https://github.com/neo4j/graphql/issues/2981", () => {
             }
 
             type BookAggregate {
+              count: Count!
               node: BookAggregateNode!
             }
 
             type BookAggregateNode {
-              count: Int!
               isbn: StringAggregateSelection!
               originalTitle: StringAggregateSelection!
             }
@@ -148,11 +148,11 @@ describe("https://github.com/neo4j/graphql/issues/2981", () => {
             }
 
             type BookTitle_ENAggregate {
+              count: Count!
               node: BookTitle_ENAggregateNode!
             }
 
             type BookTitle_ENAggregateNode {
-              count: Int!
               value: StringAggregateSelection!
             }
 
@@ -172,6 +172,11 @@ describe("https://github.com/neo4j/graphql/issues/2981", () => {
               count_LT: Int
               count_LTE: Int
               node: BookTitle_ENBookNodeAggregationWhereInput
+            }
+
+            type BookTitle_ENBookBookAggregateSelection {
+              count: CountConnection!
+              node: BookTitle_ENBookBookNodeAggregateSelection
             }
 
             type BookTitle_ENBookBookAggregationSelection {
@@ -194,7 +199,7 @@ describe("https://github.com/neo4j/graphql/issues/2981", () => {
             }
 
             type BookTitle_ENBookConnection {
-              aggregate: BookTitle_ENBookBookAggregationSelection!
+              aggregate: BookTitle_ENBookBookAggregateSelection!
               edges: [BookTitle_ENBookRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -355,11 +360,11 @@ describe("https://github.com/neo4j/graphql/issues/2981", () => {
             }
 
             type BookTitle_SVAggregate {
+              count: Count!
               node: BookTitle_SVAggregateNode!
             }
 
             type BookTitle_SVAggregateNode {
-              count: Int!
               value: StringAggregateSelection!
             }
 
@@ -379,6 +384,11 @@ describe("https://github.com/neo4j/graphql/issues/2981", () => {
               count_LT: Int
               count_LTE: Int
               node: BookTitle_SVBookNodeAggregationWhereInput
+            }
+
+            type BookTitle_SVBookBookAggregateSelection {
+              count: CountConnection!
+              node: BookTitle_SVBookBookNodeAggregateSelection
             }
 
             type BookTitle_SVBookBookAggregationSelection {
@@ -401,7 +411,7 @@ describe("https://github.com/neo4j/graphql/issues/2981", () => {
             }
 
             type BookTitle_SVBookConnection {
-              aggregate: BookTitle_SVBookBookAggregationSelection!
+              aggregate: BookTitle_SVBookBookAggregateSelection!
               edges: [BookTitle_SVBookRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -716,6 +726,15 @@ describe("https://github.com/neo4j/graphql/issues/2981", () => {
               edges: [BookEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
+            }
+
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
             }
 
             type CreateBookTitleEnsMutationResponse {

--- a/packages/graphql/tests/schema/issues/2993.test.ts
+++ b/packages/graphql/tests/schema/issues/2993.test.ts
@@ -50,6 +50,15 @@ describe("https://github.com/neo4j/graphql/issues/2993", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -150,11 +159,11 @@ describe("https://github.com/neo4j/graphql/issues/2993", () => {
             }
 
             type ProfileAggregate {
+              count: Count!
               node: ProfileAggregateNode!
             }
 
             type ProfileAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
               userName: StringAggregateSelection!
             }
@@ -279,11 +288,11 @@ describe("https://github.com/neo4j/graphql/issues/2993", () => {
             }
 
             type UserAggregate {
+              count: Count!
               node: UserAggregateNode!
             }
 
             type UserAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
               userName: StringAggregateSelection!
             }
@@ -327,7 +336,7 @@ describe("https://github.com/neo4j/graphql/issues/2993", () => {
             }
 
             type UserFollowingConnection {
-              aggregate: UserProfileFollowingAggregationSelection!
+              aggregate: UserProfileFollowingAggregateSelection!
               edges: [UserFollowingRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -421,6 +430,12 @@ describe("https://github.com/neo4j/graphql/issues/2993", () => {
               Specify one or more UserSort objects to sort Users by. The sorts will be applied in the order in which they are arranged in the array.
               \\"\\"\\"
               sort: [UserSort!]
+            }
+
+            type UserProfileFollowingAggregateSelection {
+              count: CountConnection!
+              edge: UserProfileFollowingEdgeAggregateSelection
+              node: UserProfileFollowingNodeAggregateSelection
             }
 
             type UserProfileFollowingAggregationSelection {

--- a/packages/graphql/tests/schema/issues/3428.test.ts
+++ b/packages/graphql/tests/schema/issues/3428.test.ts
@@ -44,6 +44,15 @@ describe("Relationship nested operations", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -96,7 +105,7 @@ describe("Relationship nested operations", () => {
             }
 
             type MovieActorsConnection {
-              aggregate: MoviePersonActorsAggregationSelection!
+              aggregate: MoviePersonActorsAggregateSelection!
               edges: [MovieActorsRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -150,11 +159,11 @@ describe("Relationship nested operations", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
@@ -179,6 +188,11 @@ describe("Relationship nested operations", () => {
               Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array.
               \\"\\"\\"
               sort: [MovieSort!]
+            }
+
+            type MoviePersonActorsAggregateSelection {
+              count: CountConnection!
+              node: MoviePersonActorsNodeAggregateSelection
             }
 
             type MoviePersonActorsAggregationSelection {
@@ -277,11 +291,11 @@ describe("Relationship nested operations", () => {
             }
 
             type PersonAggregate {
+              count: Count!
               node: PersonAggregateNode!
             }
 
             type PersonAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
               name: StringAggregateSelection!
             }
@@ -411,6 +425,10 @@ describe("Relationship nested operations", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -484,11 +502,11 @@ describe("Relationship nested operations", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
@@ -597,11 +615,11 @@ describe("Relationship nested operations", () => {
             }
 
             type PersonOneAggregate {
+              count: Count!
               node: PersonOneAggregateNode!
             }
 
             type PersonOneAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -664,11 +682,11 @@ describe("Relationship nested operations", () => {
             }
 
             type PersonTwoAggregate {
+              count: Count!
               node: PersonTwoAggregateNode!
             }
 
             type PersonTwoAggregateNode {
-              count: Int!
               nameTwo: StringAggregateSelection!
             }
 

--- a/packages/graphql/tests/schema/issues/3439.test.ts
+++ b/packages/graphql/tests/schema/issues/3439.test.ts
@@ -73,6 +73,15 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               subscription: Subscription
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             type CreateGenresMutationResponse {
               genres: [Genre!]!
               info: CreateInfo!
@@ -120,11 +129,11 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type GenreAggregate {
+              count: Count!
               node: GenreAggregateNode!
             }
 
             type GenreAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -179,6 +188,11 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               name: String!
             }
 
+            type GenreIProductProductAggregateSelection {
+              count: CountConnection!
+              node: GenreIProductProductNodeAggregateSelection
+            }
+
             type GenreIProductProductAggregationSelection {
               count: Int!
               node: GenreIProductProductNodeAggregateSelection
@@ -220,7 +234,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type GenreProductConnection {
-              aggregate: GenreIProductProductAggregationSelection!
+              aggregate: GenreIProductProductAggregateSelection!
               edges: [GenreProductRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -394,11 +408,11 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type INodeAggregate {
+              count: Count!
               node: INodeAggregateNode!
             }
 
             type INodeAggregateNode {
-              count: Int!
               id: StringAggregateSelection!
             }
 
@@ -461,11 +475,11 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type IProductAggregate {
+              count: Count!
               node: IProductAggregateNode!
             }
 
             type IProductAggregateNode {
-              count: Int!
               id: StringAggregateSelection!
               name: StringAggregateSelection!
             }
@@ -555,11 +569,11 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               id: StringAggregateSelection!
               name: StringAggregateSelection!
             }
@@ -634,7 +648,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type MovieGenreConnection {
-              aggregate: MovieGenreGenreAggregationSelection!
+              aggregate: MovieGenreGenreAggregateSelection!
               edges: [MovieGenreRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -669,6 +683,11 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               connect: MovieGenreConnectFieldInput
               connectOrCreate: MovieGenreConnectOrCreateFieldInput @deprecated(reason: \\"The connectOrCreate operation is deprecated and will be removed\\")
               create: MovieGenreCreateFieldInput
+            }
+
+            type MovieGenreGenreAggregateSelection {
+              count: CountConnection!
+              node: MovieGenreGenreNodeAggregateSelection
             }
 
             type MovieGenreGenreAggregationSelection {
@@ -845,11 +864,11 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type SeriesAggregate {
+              count: Count!
               node: SeriesAggregateNode!
             }
 
             type SeriesAggregateNode {
-              count: Int!
               id: StringAggregateSelection!
               name: StringAggregateSelection!
             }
@@ -931,7 +950,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type SeriesGenreConnection {
-              aggregate: SeriesGenreGenreAggregationSelection!
+              aggregate: SeriesGenreGenreAggregateSelection!
               edges: [SeriesGenreRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -966,6 +985,11 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               connect: SeriesGenreConnectFieldInput
               connectOrCreate: SeriesGenreConnectOrCreateFieldInput @deprecated(reason: \\"The connectOrCreate operation is deprecated and will be removed\\")
               create: SeriesGenreCreateFieldInput
+            }
+
+            type SeriesGenreGenreAggregateSelection {
+              count: CountConnection!
+              node: SeriesGenreGenreNodeAggregateSelection
             }
 
             type SeriesGenreGenreAggregationSelection {
@@ -1184,6 +1208,15 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               subscription: Subscription
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             type CreateGenresMutationResponse {
               genres: [Genre!]!
               info: CreateInfo!
@@ -1231,11 +1264,11 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type GenreAggregate {
+              count: Count!
               node: GenreAggregateNode!
             }
 
             type GenreAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -1290,6 +1323,11 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               name: String!
             }
 
+            type GenreIProductProductAggregateSelection {
+              count: CountConnection!
+              node: GenreIProductProductNodeAggregateSelection
+            }
+
             type GenreIProductProductAggregationSelection {
               count: Int!
               node: GenreIProductProductNodeAggregateSelection
@@ -1331,7 +1369,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type GenreProductConnection {
-              aggregate: GenreIProductProductAggregationSelection!
+              aggregate: GenreIProductProductAggregateSelection!
               edges: [GenreProductRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1507,11 +1545,11 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type IProductAggregate {
+              count: Count!
               node: IProductAggregateNode!
             }
 
             type IProductAggregateNode {
-              count: Int!
               id: StringAggregateSelection!
               name: StringAggregateSelection!
             }
@@ -1601,11 +1639,11 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               id: StringAggregateSelection!
               name: StringAggregateSelection!
             }
@@ -1680,7 +1718,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type MovieGenreConnection {
-              aggregate: MovieGenreGenreAggregationSelection!
+              aggregate: MovieGenreGenreAggregateSelection!
               edges: [MovieGenreRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1715,6 +1753,11 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               connect: MovieGenreConnectFieldInput
               connectOrCreate: MovieGenreConnectOrCreateFieldInput @deprecated(reason: \\"The connectOrCreate operation is deprecated and will be removed\\")
               create: MovieGenreCreateFieldInput
+            }
+
+            type MovieGenreGenreAggregateSelection {
+              count: CountConnection!
+              node: MovieGenreGenreNodeAggregateSelection
             }
 
             type MovieGenreGenreAggregationSelection {
@@ -1888,11 +1931,11 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type SeriesAggregate {
+              count: Count!
               node: SeriesAggregateNode!
             }
 
             type SeriesAggregateNode {
-              count: Int!
               id: StringAggregateSelection!
               name: StringAggregateSelection!
             }
@@ -1974,7 +2017,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type SeriesGenreConnection {
-              aggregate: SeriesGenreGenreAggregationSelection!
+              aggregate: SeriesGenreGenreAggregateSelection!
               edges: [SeriesGenreRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -2009,6 +2052,11 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               connect: SeriesGenreConnectFieldInput
               connectOrCreate: SeriesGenreConnectOrCreateFieldInput @deprecated(reason: \\"The connectOrCreate operation is deprecated and will be removed\\")
               create: SeriesGenreCreateFieldInput
+            }
+
+            type SeriesGenreGenreAggregateSelection {
+              count: CountConnection!
+              node: SeriesGenreGenreNodeAggregateSelection
             }
 
             type SeriesGenreGenreAggregationSelection {
@@ -2235,6 +2283,15 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               subscription: Subscription
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             type CreateGenresMutationResponse {
               genres: [Genre!]!
               info: CreateInfo!
@@ -2282,11 +2339,11 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type GenreAggregate {
+              count: Count!
               node: GenreAggregateNode!
             }
 
             type GenreAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -2341,6 +2398,11 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               name: String!
             }
 
+            type GenreIProductProductAggregateSelection {
+              count: CountConnection!
+              node: GenreIProductProductNodeAggregateSelection
+            }
+
             type GenreIProductProductAggregationSelection {
               count: Int!
               node: GenreIProductProductNodeAggregateSelection
@@ -2383,7 +2445,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type GenreProductConnection {
-              aggregate: GenreIProductProductAggregationSelection!
+              aggregate: GenreIProductProductAggregateSelection!
               edges: [GenreProductRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -2562,11 +2624,11 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type IProductAggregate {
+              count: Count!
               node: IProductAggregateNode!
             }
 
             type IProductAggregateNode {
-              count: Int!
               id: StringAggregateSelection!
               name: StringAggregateSelection!
             }
@@ -2856,11 +2918,11 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               id: StringAggregateSelection!
               name: StringAggregateSelection!
             }
@@ -3182,11 +3244,11 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type SeriesAggregate {
+              count: Count!
               node: SeriesAggregateNode!
             }
 
             type SeriesAggregateNode {
-              count: Int!
               id: StringAggregateSelection!
               name: StringAggregateSelection!
             }
@@ -3575,6 +3637,15 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               subscription: Subscription
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             type CreateGenresMutationResponse {
               genres: [Genre!]!
               info: CreateInfo!
@@ -3627,11 +3698,11 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type GenreAggregate {
+              count: Count!
               node: GenreAggregateNode!
             }
 
             type GenreAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -3686,6 +3757,11 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               name: String!
             }
 
+            type GenreIProductProductAggregateSelection {
+              count: CountConnection!
+              node: GenreIProductProductNodeAggregateSelection
+            }
+
             type GenreIProductProductAggregationSelection {
               count: Int!
               node: GenreIProductProductNodeAggregateSelection
@@ -3728,7 +3804,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type GenreProductConnection {
-              aggregate: GenreIProductProductAggregationSelection!
+              aggregate: GenreIProductProductAggregateSelection!
               edges: [GenreProductRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -3907,11 +3983,11 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type IProductAggregate {
+              count: Count!
               node: IProductAggregateNode!
             }
 
             type IProductAggregateNode {
-              count: Int!
               id: StringAggregateSelection!
               name: StringAggregateSelection!
             }
@@ -4225,11 +4301,11 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               id: StringAggregateSelection!
               name: StringAggregateSelection!
             }
@@ -4540,11 +4616,11 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type RatingAggregate {
+              count: Count!
               node: RatingAggregateNode!
             }
 
             type RatingAggregateNode {
-              count: Int!
               number: IntAggregateSelection!
             }
 
@@ -4599,6 +4675,11 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               number: Int!
             }
 
+            type RatingIProductProductAggregateSelection {
+              count: CountConnection!
+              node: RatingIProductProductNodeAggregateSelection
+            }
+
             type RatingIProductProductAggregationSelection {
               count: Int!
               node: RatingIProductProductNodeAggregateSelection
@@ -4641,7 +4722,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type RatingProductConnection {
-              aggregate: RatingIProductProductAggregationSelection!
+              aggregate: RatingIProductProductAggregateSelection!
               edges: [RatingProductRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -4824,11 +4905,11 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type SeriesAggregate {
+              count: Count!
               node: SeriesAggregateNode!
             }
 
             type SeriesAggregateNode {
-              count: Int!
               id: StringAggregateSelection!
               name: StringAggregateSelection!
             }

--- a/packages/graphql/tests/schema/issues/3537.test.ts
+++ b/packages/graphql/tests/schema/issues/3537.test.ts
@@ -336,11 +336,11 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
             }
 
             type ActorAggregate {
+              count: Count!
               node: ActorAggregateNode!
             }
 
             type ActorAggregateNode {
-              count: Int!
               password: StringAggregateSelection!
               username: StringAggregateSelection!
             }
@@ -398,16 +398,20 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
               totalCount: Int!
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             type Movie {
               title: String
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               title: StringAggregateSelection!
             }
 
@@ -562,11 +566,11 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
             }
 
             type ActorAggregate {
+              count: Count!
               node: ActorAggregateNode!
             }
 
             type ActorAggregateNode {
-              count: Int!
               password: StringAggregateSelection!
               username: StringAggregateSelection!
             }
@@ -666,6 +670,10 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
               totalCount: Int!
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             type CreateActorsMutationResponse {
               actors: [Actor!]!
               info: CreateInfo!
@@ -705,11 +713,11 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               title: StringAggregateSelection!
             }
 

--- a/packages/graphql/tests/schema/issues/3541.test.ts
+++ b/packages/graphql/tests/schema/issues/3541.test.ts
@@ -70,11 +70,11 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
             }
 
             type ActorAggregate {
+              count: Count!
               node: ActorAggregateNode!
             }
 
             type ActorAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -123,11 +123,25 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
               totalCount: Int!
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             type Movie @key(fields: \\"title\\") @shareable {
               actors(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
               actorsAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: ActorWhere): MovieActorActorsAggregationSelection @deprecated(reason: \\"Please use field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\" instead\\")
               actorsConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [MovieActorsConnectionSort!], where: MovieActorsConnectionWhere): MovieActorsConnection!
               title: String!
+            }
+
+            type MovieActorActorsAggregateSelection {
+              count: CountConnection!
+              node: MovieActorActorsNodeAggregateSelection
             }
 
             type MovieActorActorsAggregationSelection {
@@ -153,7 +167,7 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
             }
 
             type MovieActorsConnection {
-              aggregate: MovieActorActorsAggregationSelection!
+              aggregate: MovieActorActorsAggregateSelection!
               edges: [MovieActorsRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -197,11 +211,11 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
             }
 
             type MovieAggregate @shareable {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode @shareable {
-              count: Int!
               title: StringAggregateSelection!
             }
 
@@ -381,11 +395,11 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
             }
 
             type ActorAggregate {
+              count: Count!
               node: ActorAggregateNode!
             }
 
             type ActorAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -447,6 +461,15 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
               totalCount: Int!
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             type CreateActorsMutationResponse {
               actors: [Actor!]!
               info: CreateInfo!
@@ -481,6 +504,11 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
               title: String!
             }
 
+            type MovieActorActorsAggregateSelection {
+              count: CountConnection!
+              node: MovieActorActorsNodeAggregateSelection
+            }
+
             type MovieActorActorsAggregationSelection {
               count: Int!
               node: MovieActorActorsNodeAggregateSelection
@@ -512,7 +540,7 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
             }
 
             type MovieActorsConnection {
-              aggregate: MovieActorActorsAggregationSelection!
+              aggregate: MovieActorActorsAggregateSelection!
               edges: [MovieActorsRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!

--- a/packages/graphql/tests/schema/issues/3698.test.ts
+++ b/packages/graphql/tests/schema/issues/3698.test.ts
@@ -71,6 +71,15 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
               subscription: Subscription
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             type CreateGenresMutationResponse {
               genres: [Genre!]!
               info: CreateInfo!
@@ -113,11 +122,11 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
             }
 
             type GenreAggregate {
+              count: Count!
               node: GenreAggregateNode!
             }
 
             type GenreAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -172,6 +181,11 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
               name: String!
             }
 
+            type GenreIProductProductAggregateSelection {
+              count: CountConnection!
+              node: GenreIProductProductNodeAggregateSelection
+            }
+
             type GenreIProductProductAggregationSelection {
               count: Int!
               node: GenreIProductProductNodeAggregateSelection
@@ -214,7 +228,7 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
             }
 
             type GenreProductConnection {
-              aggregate: GenreIProductProductAggregationSelection!
+              aggregate: GenreIProductProductAggregateSelection!
               edges: [GenreProductRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -406,11 +420,11 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
             }
 
             type IProductAggregate {
+              count: Count!
               node: IProductAggregateNode!
             }
 
             type IProductAggregateNode {
-              count: Int!
               id: StringAggregateSelection!
               info: StringAggregateSelection!
               name: StringAggregateSelection!
@@ -510,11 +524,11 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               id: StringAggregateSelection!
               name: StringAggregateSelection!
             }
@@ -589,7 +603,7 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
             }
 
             type MovieGenreConnection {
-              aggregate: MovieGenreGenreAggregationSelection!
+              aggregate: MovieGenreGenreAggregateSelection!
               edges: [MovieGenreRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -624,6 +638,11 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
               connect: MovieGenreConnectFieldInput
               connectOrCreate: MovieGenreConnectOrCreateFieldInput @deprecated(reason: \\"The connectOrCreate operation is deprecated and will be removed\\")
               create: MovieGenreCreateFieldInput
+            }
+
+            type MovieGenreGenreAggregateSelection {
+              count: CountConnection!
+              node: MovieGenreGenreNodeAggregateSelection
             }
 
             type MovieGenreGenreAggregationSelection {
@@ -872,6 +891,15 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
               subscription: Subscription
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             type CreateGenresMutationResponse {
               genres: [Genre!]!
               info: CreateInfo!
@@ -914,11 +942,11 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
             }
 
             type GenreAggregate {
+              count: Count!
               node: GenreAggregateNode!
             }
 
             type GenreAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -973,6 +1001,11 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
               name: String!
             }
 
+            type GenreIProductProductAggregateSelection {
+              count: CountConnection!
+              node: GenreIProductProductNodeAggregateSelection
+            }
+
             type GenreIProductProductAggregationSelection {
               count: Int!
               node: GenreIProductProductNodeAggregateSelection
@@ -1016,7 +1049,7 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
             }
 
             type GenreProductConnection {
-              aggregate: GenreIProductProductAggregationSelection!
+              aggregate: GenreIProductProductAggregateSelection!
               edges: [GenreProductRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1211,11 +1244,11 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
             }
 
             type IProductAggregate {
+              count: Count!
               node: IProductAggregateNode!
             }
 
             type IProductAggregateNode {
-              count: Int!
               id: StringAggregateSelection!
               info: StringAggregateSelection!
               name: StringAggregateSelection!
@@ -1433,11 +1466,11 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               id: StringAggregateSelection!
               name: StringAggregateSelection!
             }
@@ -1770,6 +1803,15 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
               subscription: Subscription
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             type CreateGenresMutationResponse {
               genres: [Genre!]!
               info: CreateInfo!
@@ -1817,11 +1859,11 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
             }
 
             type GenreAggregate {
+              count: Count!
               node: GenreAggregateNode!
             }
 
             type GenreAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -1876,6 +1918,11 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
               name: String!
             }
 
+            type GenreIProductProductAggregateSelection {
+              count: CountConnection!
+              node: GenreIProductProductNodeAggregateSelection
+            }
+
             type GenreIProductProductAggregationSelection {
               count: Int!
               node: GenreIProductProductNodeAggregateSelection
@@ -1919,7 +1966,7 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
             }
 
             type GenreProductConnection {
-              aggregate: GenreIProductProductAggregationSelection!
+              aggregate: GenreIProductProductAggregateSelection!
               edges: [GenreProductRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -2114,11 +2161,11 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
             }
 
             type IProductAggregate {
+              count: Count!
               node: IProductAggregateNode!
             }
 
             type IProductAggregateNode {
-              count: Int!
               id: StringAggregateSelection!
               info: StringAggregateSelection!
               name: StringAggregateSelection!
@@ -2338,11 +2385,11 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               id: StringAggregateSelection!
               name: StringAggregateSelection!
             }
@@ -2593,11 +2640,11 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
             }
 
             type SeriesAggregate {
+              count: Count!
               node: SeriesAggregateNode!
             }
 
             type SeriesAggregateNode {
-              count: Int!
               id: StringAggregateSelection!
               info: StringAggregateSelection!
               name: StringAggregateSelection!

--- a/packages/graphql/tests/schema/issues/3816.test.ts
+++ b/packages/graphql/tests/schema/issues/3816.test.ts
@@ -45,6 +45,15 @@ describe("https://github.com/neo4j/graphql/issues/3816", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             type CreateGenresMutationResponse {
               genres: [Genre!]!
               info: CreateInfo!
@@ -79,11 +88,11 @@ describe("https://github.com/neo4j/graphql/issues/3816", () => {
             }
 
             type GenreAggregate {
+              count: Count!
               node: GenreAggregateNode!
             }
 
             type GenreAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -118,6 +127,11 @@ describe("https://github.com/neo4j/graphql/issues/3816", () => {
               node: Genre!
             }
 
+            type GenreMovieMoviesAggregateSelection {
+              count: CountConnection!
+              node: GenreMovieMoviesNodeAggregateSelection
+            }
+
             type GenreMovieMoviesAggregationSelection {
               count: Int!
               node: GenreMovieMoviesNodeAggregateSelection
@@ -150,7 +164,7 @@ describe("https://github.com/neo4j/graphql/issues/3816", () => {
             }
 
             type GenreMoviesConnection {
-              aggregate: GenreMovieMoviesAggregationSelection!
+              aggregate: GenreMovieMoviesAggregateSelection!
               edges: [GenreMoviesRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -298,11 +312,11 @@ describe("https://github.com/neo4j/graphql/issues/3816", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -356,7 +370,7 @@ describe("https://github.com/neo4j/graphql/issues/3816", () => {
             }
 
             type MovieGenreConnection {
-              aggregate: MovieGenreGenreAggregationSelection!
+              aggregate: MovieGenreGenreAggregateSelection!
               edges: [MovieGenreRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -380,6 +394,11 @@ describe("https://github.com/neo4j/graphql/issues/3816", () => {
 
             input MovieGenreFieldInput {
               connect: MovieGenreConnectFieldInput
+            }
+
+            type MovieGenreGenreAggregateSelection {
+              count: CountConnection!
+              node: MovieGenreGenreNodeAggregateSelection
             }
 
             type MovieGenreGenreAggregationSelection {
@@ -550,6 +569,15 @@ describe("https://github.com/neo4j/graphql/issues/3816", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             type CreateGenresMutationResponse {
               genres: [Genre!]!
               info: CreateInfo!
@@ -584,11 +612,11 @@ describe("https://github.com/neo4j/graphql/issues/3816", () => {
             }
 
             type GenreAggregate {
+              count: Count!
               node: GenreAggregateNode!
             }
 
             type GenreAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -609,6 +637,11 @@ describe("https://github.com/neo4j/graphql/issues/3816", () => {
             type GenreEdge {
               cursor: String!
               node: Genre!
+            }
+
+            type GenreMovieMoviesAggregateSelection {
+              count: CountConnection!
+              node: GenreMovieMoviesNodeAggregateSelection
             }
 
             type GenreMovieMoviesAggregationSelection {
@@ -642,7 +675,7 @@ describe("https://github.com/neo4j/graphql/issues/3816", () => {
             }
 
             type GenreMoviesConnection {
-              aggregate: GenreMovieMoviesAggregationSelection!
+              aggregate: GenreMovieMoviesAggregateSelection!
               edges: [GenreMoviesRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -789,11 +822,11 @@ describe("https://github.com/neo4j/graphql/issues/3816", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -829,7 +862,7 @@ describe("https://github.com/neo4j/graphql/issues/3816", () => {
             }
 
             type MovieGenreConnection {
-              aggregate: MovieGenreGenreAggregationSelection!
+              aggregate: MovieGenreGenreAggregateSelection!
               edges: [MovieGenreRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -844,6 +877,11 @@ describe("https://github.com/neo4j/graphql/issues/3816", () => {
               NOT: MovieGenreConnectionWhere
               OR: [MovieGenreConnectionWhere!]
               node: GenreWhere
+            }
+
+            type MovieGenreGenreAggregateSelection {
+              count: CountConnection!
+              node: MovieGenreGenreNodeAggregateSelection
             }
 
             type MovieGenreGenreAggregationSelection {

--- a/packages/graphql/tests/schema/issues/3817.test.ts
+++ b/packages/graphql/tests/schema/issues/3817.test.ts
@@ -66,6 +66,15 @@ describe("3817", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -171,11 +180,11 @@ describe("3817", () => {
             }
 
             type PersonAggregate {
+              count: Count!
               node: PersonAggregateNode!
             }
 
             type PersonAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
@@ -246,7 +255,7 @@ describe("3817", () => {
             }
 
             type PersonFriendsConnection {
-              aggregate: PersonPersonFriendsAggregationSelection!
+              aggregate: PersonPersonFriendsAggregateSelection!
               edges: [PersonFriendsRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -336,6 +345,12 @@ describe("3817", () => {
               Specify one or more PersonSort objects to sort People by. The sorts will be applied in the order in which they are arranged in the array.
               \\"\\"\\"
               sort: [PersonSort!]
+            }
+
+            type PersonPersonFriendsAggregateSelection {
+              count: CountConnection!
+              edge: PersonPersonFriendsEdgeAggregateSelection
+              node: PersonPersonFriendsNodeAggregateSelection
             }
 
             type PersonPersonFriendsAggregationSelection {

--- a/packages/graphql/tests/schema/issues/4511.test.ts
+++ b/packages/graphql/tests/schema/issues/4511.test.ts
@@ -64,6 +64,10 @@ describe("https://github.com/neo4j/graphql/issues/4511", () => {
               subscription: Subscription
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -93,11 +97,7 @@ describe("https://github.com/neo4j/graphql/issues/4511", () => {
             }
 
             type CreatureAggregate {
-              node: CreatureAggregateNode!
-            }
-
-            type CreatureAggregateNode {
-              count: Int!
+              count: Count!
             }
 
             type CreatureAggregateSelection {
@@ -280,11 +280,11 @@ describe("https://github.com/neo4j/graphql/issues/4511", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
               title: StringAggregateSelection!
             }
@@ -450,11 +450,7 @@ describe("https://github.com/neo4j/graphql/issues/4511", () => {
             }
 
             type PersonAggregate {
-              node: PersonAggregateNode!
-            }
-
-            type PersonAggregateNode {
-              count: Int!
+              count: Count!
             }
 
             type PersonAggregateSelection {
@@ -589,11 +585,11 @@ describe("https://github.com/neo4j/graphql/issues/4511", () => {
             }
 
             type ProductionAggregate {
+              count: Count!
               node: ProductionAggregateNode!
             }
 
             type ProductionAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
@@ -769,11 +765,11 @@ describe("https://github.com/neo4j/graphql/issues/4511", () => {
             }
 
             type SeriesAggregate {
+              count: Count!
               node: SeriesAggregateNode!
             }
 
             type SeriesAggregateNode {
-              count: Int!
               episode: IntAggregateSelection!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
               title: StringAggregateSelection!

--- a/packages/graphql/tests/schema/issues/4615.test.ts
+++ b/packages/graphql/tests/schema/issues/4615.test.ts
@@ -155,7 +155,7 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
             }
 
             type ActorActedInConnection {
-              aggregate: ActorShowActedInAggregationSelection!
+              aggregate: ActorShowActedInAggregateSelection!
               edges: [ActorActedInRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -236,11 +236,11 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
             }
 
             type ActorAggregate {
+              count: Count!
               node: ActorAggregateNode!
             }
 
             type ActorAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -282,6 +282,12 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
               Specify one or more ActorSort objects to sort Actors by. The sorts will be applied in the order in which they are arranged in the array.
               \\"\\"\\"
               sort: [ActorSort!]
+            }
+
+            type ActorShowActedInAggregateSelection {
+              count: CountConnection!
+              edge: ActorShowActedInEdgeAggregateSelection
+              node: ActorShowActedInNodeAggregateSelection
             }
 
             type ActorShowActedInAggregationSelection {
@@ -353,6 +359,15 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
               edges: [ActorEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
+            }
+
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
             }
 
             type CreateActorsMutationResponse {
@@ -494,11 +509,11 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               release: DateTimeAggregateSelection!
               runtime: IntAggregateSelection!
               title: StringAggregateSelection!
@@ -742,11 +757,11 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
             }
 
             type SeriesAggregate {
+              count: Count!
               node: SeriesAggregateNode!
             }
 
             type SeriesAggregateNode {
-              count: Int!
               episodes: IntAggregateSelection!
               title: StringAggregateSelection!
             }
@@ -1003,11 +1018,11 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
             }
 
             type ShowAggregate {
+              count: Count!
               node: ShowAggregateNode!
             }
 
             type ShowAggregateNode {
-              count: Int!
               title: StringAggregateSelection!
             }
 

--- a/packages/graphql/tests/schema/issues/5428.test.ts
+++ b/packages/graphql/tests/schema/issues/5428.test.ts
@@ -40,6 +40,10 @@ describe("https://github.com/neo4j/graphql/issues/5428", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -99,12 +103,12 @@ describe("https://github.com/neo4j/graphql/issues/5428", () => {
             }
 
             type TestAggregate {
+              count: Count!
               node: TestAggregateNode!
             }
 
             type TestAggregateNode {
               Name: StringAggregateSelection!
-              count: Int!
             }
 
             type TestAggregateSelection {

--- a/packages/graphql/tests/schema/issues/5631.test.ts
+++ b/packages/graphql/tests/schema/issues/5631.test.ts
@@ -64,11 +64,7 @@ describe("https://github.com/neo4j/graphql/issues/5631", () => {
             }
 
             type ActorAggregate {
-              node: ActorAggregateNode!
-            }
-
-            type ActorAggregateNode {
-              count: Int!
+              count: Count!
             }
 
             type ActorAggregateSelection {
@@ -130,6 +126,10 @@ describe("https://github.com/neo4j/graphql/issues/5631", () => {
               totalCount: Int!
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             type CreateActorsMutationResponse {
               actors: [Actor!]!
               info: CreateInfo!
@@ -163,11 +163,7 @@ describe("https://github.com/neo4j/graphql/issues/5631", () => {
             }
 
             type MovieAggregate {
-              node: MovieAggregateNode!
-            }
-
-            type MovieAggregateNode {
-              count: Int!
+              count: Count!
             }
 
             type MovieAggregateSelection {

--- a/packages/graphql/tests/schema/issues/609.test.ts
+++ b/packages/graphql/tests/schema/issues/609.test.ts
@@ -38,6 +38,10 @@ describe("609", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             type CreateDeprecatedsMutationResponse {
               deprecateds: [Deprecated!]!
               info: CreateInfo!
@@ -64,11 +68,11 @@ describe("609", () => {
             }
 
             type DeprecatedAggregate {
+              count: Count!
               node: DeprecatedAggregateNode!
             }
 
             type DeprecatedAggregateNode {
-              count: Int!
               deprecatedField: StringAggregateSelection!
             }
 

--- a/packages/graphql/tests/schema/issues/872.test.ts
+++ b/packages/graphql/tests/schema/issues/872.test.ts
@@ -64,11 +64,11 @@ describe("https://github.com/neo4j/graphql/issues/872", () => {
             }
 
             type Actor2Aggregate {
+              count: Count!
               node: Actor2AggregateNode!
             }
 
             type Actor2AggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -89,6 +89,11 @@ describe("https://github.com/neo4j/graphql/issues/872", () => {
             type Actor2Edge {
               cursor: String!
               node: Actor2!
+            }
+
+            type Actor2MovieMoviesAggregateSelection {
+              count: CountConnection!
+              node: Actor2MovieMoviesNodeAggregateSelection
             }
 
             type Actor2MovieMoviesAggregationSelection {
@@ -132,7 +137,7 @@ describe("https://github.com/neo4j/graphql/issues/872", () => {
             }
 
             type Actor2MoviesConnection {
-              aggregate: Actor2MovieMoviesAggregationSelection!
+              aggregate: Actor2MovieMoviesAggregateSelection!
               edges: [Actor2MoviesRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -284,11 +289,11 @@ describe("https://github.com/neo4j/graphql/issues/872", () => {
             }
 
             type ActorAggregate {
+              count: Count!
               node: ActorAggregateNode!
             }
 
             type ActorAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -309,6 +314,11 @@ describe("https://github.com/neo4j/graphql/issues/872", () => {
             type ActorEdge {
               cursor: String!
               node: Actor!
+            }
+
+            type ActorMovieMoviesAggregateSelection {
+              count: CountConnection!
+              node: ActorMovieMoviesNodeAggregateSelection
             }
 
             type ActorMovieMoviesAggregationSelection {
@@ -352,7 +362,7 @@ describe("https://github.com/neo4j/graphql/issues/872", () => {
             }
 
             type ActorMoviesConnection {
-              aggregate: ActorMovieMoviesAggregationSelection!
+              aggregate: ActorMovieMoviesAggregateSelection!
               edges: [ActorMoviesRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -503,6 +513,15 @@ describe("https://github.com/neo4j/graphql/issues/872", () => {
               totalCount: Int!
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             type CreateActor2sMutationResponse {
               actor2s: [Actor2!]!
               info: CreateInfo!
@@ -545,11 +564,11 @@ describe("https://github.com/neo4j/graphql/issues/872", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
               title: StringAggregateSelection!
             }

--- a/packages/graphql/tests/schema/lowercase-type-names.test.ts
+++ b/packages/graphql/tests/schema/lowercase-type-names.test.ts
@@ -57,6 +57,15 @@ describe("lower case type names", () => {
               totalCount: Int!
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             type CreateActorsMutationResponse {
               actors: [actor!]!
               info: CreateInfo!
@@ -174,11 +183,11 @@ describe("lower case type names", () => {
             }
 
             type actorAggregate {
+              count: Count!
               node: actorAggregateNode!
             }
 
             type actorAggregateNode {
-              count: Int!
               createdAt: DateTimeAggregateSelection!
               name: StringAggregateSelection!
               year: IntAggregateSelection!
@@ -242,7 +251,7 @@ describe("lower case type names", () => {
             }
 
             type actorMoviesConnection {
-              aggregate: actormovieMoviesAggregationSelection!
+              aggregate: actormovieMoviesAggregateSelection!
               edges: [actorMoviesRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -443,6 +452,11 @@ describe("lower case type names", () => {
               year_LTE: Int
             }
 
+            type actormovieMoviesAggregateSelection {
+              count: CountConnection!
+              node: actormovieMoviesNodeAggregateSelection
+            }
+
             type actormovieMoviesAggregationSelection {
               count: Int!
               node: actormovieMoviesNodeAggregateSelection
@@ -488,7 +502,7 @@ describe("lower case type names", () => {
             }
 
             type movieActorsConnection {
-              aggregate: movieactorActorsAggregationSelection!
+              aggregate: movieactorActorsAggregateSelection!
               edges: [movieActorsRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -594,11 +608,11 @@ describe("lower case type names", () => {
             }
 
             type movieAggregate {
+              count: Count!
               node: movieAggregateNode!
             }
 
             type movieAggregateNode {
-              count: Int!
               createdAt: DateTimeAggregateSelection!
               name: StringAggregateSelection!
               testId: StringAggregateSelection!
@@ -730,6 +744,11 @@ describe("lower case type names", () => {
               year_IN: [Int]
               year_LT: Int
               year_LTE: Int
+            }
+
+            type movieactorActorsAggregateSelection {
+              count: CountConnection!
+              node: movieactorActorsNodeAggregateSelection
             }
 
             type movieactorActorsAggregationSelection {

--- a/packages/graphql/tests/schema/math.test.ts
+++ b/packages/graphql/tests/schema/math.test.ts
@@ -38,6 +38,10 @@ describe("Algebraic", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -77,11 +81,11 @@ describe("Algebraic", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
               viewers: IntAggregateSelection!
             }
@@ -226,6 +230,10 @@ describe("Algebraic", () => {
               sum: BigInt
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -258,11 +266,11 @@ describe("Algebraic", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
               viewers: BigIntAggregateSelection!
             }
@@ -396,6 +404,10 @@ describe("Algebraic", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -435,11 +447,11 @@ describe("Algebraic", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
               viewers: FloatAggregateSelection!
             }
@@ -580,6 +592,15 @@ describe("Algebraic", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             type CreateDirectorsMutationResponse {
               directors: [Director!]!
               info: CreateInfo!
@@ -614,11 +635,11 @@ describe("Algebraic", () => {
             }
 
             type DirectorAggregate {
+              count: Count!
               node: DirectorAggregateNode!
             }
 
             type DirectorAggregateNode {
-              count: Int!
               lastName: StringAggregateSelection!
             }
 
@@ -667,7 +688,7 @@ describe("Algebraic", () => {
             }
 
             type DirectorDirectsConnection {
-              aggregate: DirectorMovieDirectsAggregationSelection!
+              aggregate: DirectorMovieDirectsAggregateSelection!
               edges: [DirectorDirectsRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -764,6 +785,11 @@ describe("Algebraic", () => {
             type DirectorEdge {
               cursor: String!
               node: Director!
+            }
+
+            type DirectorMovieDirectsAggregateSelection {
+              count: CountConnection!
+              node: DirectorMovieDirectsNodeAggregateSelection
             }
 
             type DirectorMovieDirectsAggregationSelection {
@@ -863,11 +889,11 @@ describe("Algebraic", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
               viewers: IntAggregateSelection!
             }
@@ -919,7 +945,7 @@ describe("Algebraic", () => {
             }
 
             type MovieDirectedByConnection {
-              aggregate: MovieDirectorDirectedByAggregationSelection!
+              aggregate: MovieDirectorDirectedByAggregateSelection!
               edges: [MovieDirectedByRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -992,6 +1018,11 @@ describe("Algebraic", () => {
               disconnect: MovieDirectedByDisconnectFieldInput
               update: MovieDirectedByUpdateConnectionInput
               where: MovieDirectedByConnectionWhere
+            }
+
+            type MovieDirectorDirectedByAggregateSelection {
+              count: CountConnection!
+              node: MovieDirectorDirectedByNodeAggregateSelection
             }
 
             type MovieDirectorDirectedByAggregationSelection {
@@ -1154,6 +1185,15 @@ describe("Algebraic", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -1201,11 +1241,11 @@ describe("Algebraic", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
               viewers: IntAggregateSelection!
             }
@@ -1238,6 +1278,11 @@ describe("Algebraic", () => {
               Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array.
               \\"\\"\\"
               sort: [MovieSort!]
+            }
+
+            type MoviePersonWorkersAggregateSelection {
+              count: CountConnection!
+              node: MoviePersonWorkersNodeAggregateSelection
             }
 
             type MoviePersonWorkersAggregationSelection {
@@ -1334,7 +1379,7 @@ describe("Algebraic", () => {
             }
 
             type MovieWorkersConnection {
-              aggregate: MoviePersonWorkersAggregationSelection!
+              aggregate: MoviePersonWorkersAggregateSelection!
               edges: [MovieWorkersRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1448,11 +1493,11 @@ describe("Algebraic", () => {
             }
 
             type PersonAggregate {
+              count: Count!
               node: PersonAggregateNode!
             }
 
             type PersonAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -1494,6 +1539,11 @@ describe("Algebraic", () => {
               Specify one or more PersonSort objects to sort People by. The sorts will be applied in the order in which they are arranged in the array.
               \\"\\"\\"
               sort: [PersonSort!]
+            }
+
+            type PersonProductionWorksInProductionAggregateSelection {
+              count: CountConnection!
+              node: PersonProductionWorksInProductionNodeAggregateSelection
             }
 
             type PersonProductionWorksInProductionAggregationSelection {
@@ -1573,7 +1623,7 @@ describe("Algebraic", () => {
             }
 
             type PersonWorksInProductionConnection {
-              aggregate: PersonProductionWorksInProductionAggregationSelection!
+              aggregate: PersonProductionWorksInProductionAggregateSelection!
               edges: [PersonWorksInProductionRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1656,11 +1706,11 @@ describe("Algebraic", () => {
             }
 
             type ProductionAggregate {
+              count: Count!
               node: ProductionAggregateNode!
             }
 
             type ProductionAggregateNode {
-              count: Int!
               viewers: IntAggregateSelection!
             }
 
@@ -1879,6 +1929,15 @@ describe("Algebraic", () => {
               roles_INCLUDES: String
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -1944,7 +2003,7 @@ describe("Algebraic", () => {
             }
 
             type MovieActorsConnection {
-              aggregate: MoviePersonActorsAggregationSelection!
+              aggregate: MoviePersonActorsAggregateSelection!
               edges: [MovieActorsRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -2025,11 +2084,11 @@ describe("Algebraic", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               title: StringAggregateSelection!
             }
 
@@ -2071,6 +2130,12 @@ describe("Algebraic", () => {
               Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array.
               \\"\\"\\"
               sort: [MovieSort!]
+            }
+
+            type MoviePersonActorsAggregateSelection {
+              count: CountConnection!
+              edge: MoviePersonActorsEdgeAggregateSelection
+              node: MoviePersonActorsNodeAggregateSelection
             }
 
             type MoviePersonActorsAggregationSelection {
@@ -2200,7 +2265,7 @@ describe("Algebraic", () => {
             }
 
             type PersonActedInMoviesConnection {
-              aggregate: PersonMovieActedInMoviesAggregationSelection!
+              aggregate: PersonMovieActedInMoviesAggregateSelection!
               edges: [PersonActedInMoviesRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -2281,11 +2346,11 @@ describe("Algebraic", () => {
             }
 
             type PersonAggregate {
+              count: Count!
               node: PersonAggregateNode!
             }
 
             type PersonAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -2318,6 +2383,12 @@ describe("Algebraic", () => {
             type PersonEdge {
               cursor: String!
               node: Person!
+            }
+
+            type PersonMovieActedInMoviesAggregateSelection {
+              count: CountConnection!
+              edge: PersonMovieActedInMoviesEdgeAggregateSelection
+              node: PersonMovieActedInMoviesNodeAggregateSelection
             }
 
             type PersonMovieActedInMoviesAggregationSelection {

--- a/packages/graphql/tests/schema/nested-aggregation-on-type.test.ts
+++ b/packages/graphql/tests/schema/nested-aggregation-on-type.test.ts
@@ -123,7 +123,7 @@ describe("nested aggregation on interface", () => {
             }
 
             type ActorActedInConnection {
-              aggregate: ActorMovieActedInAggregationSelection!
+              aggregate: ActorMovieActedInAggregateSelection!
               edges: [ActorActedInRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -242,11 +242,11 @@ describe("nested aggregation on interface", () => {
             }
 
             type ActorAggregate {
+              count: Count!
               node: ActorAggregateNode!
             }
 
             type ActorAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -267,6 +267,12 @@ describe("nested aggregation on interface", () => {
             type ActorEdge {
               cursor: String!
               node: Actor!
+            }
+
+            type ActorMovieActedInAggregateSelection {
+              count: CountConnection!
+              edge: ActorMovieActedInEdgeAggregateSelection
+              node: ActorMovieActedInNodeAggregateSelection
             }
 
             type ActorMovieActedInAggregationSelection {
@@ -351,6 +357,15 @@ describe("nested aggregation on interface", () => {
               totalCount: Int!
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             type CreateActorsMutationResponse {
               actors: [Actor!]!
               info: CreateInfo!
@@ -398,12 +413,12 @@ describe("nested aggregation on interface", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
               cost: FloatAggregateSelection!
-              count: Int!
               runtime: IntAggregateSelection!
               title: StringAggregateSelection!
             }

--- a/packages/graphql/tests/schema/null.test.ts
+++ b/packages/graphql/tests/schema/null.test.ts
@@ -50,6 +50,10 @@ describe("Null", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -115,13 +119,13 @@ describe("Null", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
               actorCount: IntAggregateSelection!
               averageRating: FloatAggregateSelection!
-              count: Int!
               createdAt: DateTimeAggregateSelection!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
               name: StringAggregateSelection!

--- a/packages/graphql/tests/schema/pluralize-consistency.test.ts
+++ b/packages/graphql/tests/schema/pluralize-consistency.test.ts
@@ -43,6 +43,15 @@ describe("Pluralize consistency", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -147,11 +156,11 @@ describe("Pluralize consistency", () => {
             }
 
             type super_friendAggregate {
+              count: Count!
               node: super_friendAggregateNode!
             }
 
             type super_friendAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -214,11 +223,11 @@ describe("Pluralize consistency", () => {
             }
 
             type super_userAggregate {
+              count: Count!
               node: super_userAggregateNode!
             }
 
             type super_userAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -263,7 +272,7 @@ describe("Pluralize consistency", () => {
             }
 
             type super_userMy_friendConnection {
-              aggregate: super_usersuper_friendMy_friendAggregationSelection!
+              aggregate: super_usersuper_friendMy_friendAggregateSelection!
               edges: [super_userMy_friendRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -401,6 +410,11 @@ describe("Pluralize consistency", () => {
               name_EQ: String
               name_IN: [String!]
               name_STARTS_WITH: String
+            }
+
+            type super_usersuper_friendMy_friendAggregateSelection {
+              count: CountConnection!
+              node: super_usersuper_friendMy_friendNodeAggregateSelection
             }
 
             type super_usersuper_friendMy_friendAggregationSelection {

--- a/packages/graphql/tests/schema/query-direction.test.ts
+++ b/packages/graphql/tests/schema/query-direction.test.ts
@@ -39,6 +39,15 @@ describe("Query Direction", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -116,11 +125,11 @@ describe("Query Direction", () => {
             }
 
             type UserAggregate {
+              count: Count!
               node: UserAggregateNode!
             }
 
             type UserAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -178,7 +187,7 @@ describe("Query Direction", () => {
             }
 
             type UserFriendsConnection {
-              aggregate: UserUserFriendsAggregationSelection!
+              aggregate: UserUserFriendsAggregateSelection!
               edges: [UserFriendsRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -273,6 +282,11 @@ describe("Query Direction", () => {
               friends: [UserFriendsUpdateFieldInput!]
               name: String @deprecated(reason: \\"Please use the explicit _SET field\\")
               name_SET: String
+            }
+
+            type UserUserFriendsAggregateSelection {
+              count: CountConnection!
+              node: UserUserFriendsNodeAggregateSelection
             }
 
             type UserUserFriendsAggregationSelection {
@@ -346,6 +360,15 @@ describe("Query Direction", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -423,11 +446,11 @@ describe("Query Direction", () => {
             }
 
             type UserAggregate {
+              count: Count!
               node: UserAggregateNode!
             }
 
             type UserAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -485,7 +508,7 @@ describe("Query Direction", () => {
             }
 
             type UserFriendsConnection {
-              aggregate: UserUserFriendsAggregationSelection!
+              aggregate: UserUserFriendsAggregateSelection!
               edges: [UserFriendsRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -580,6 +603,11 @@ describe("Query Direction", () => {
               friends: [UserFriendsUpdateFieldInput!]
               name: String @deprecated(reason: \\"Please use the explicit _SET field\\")
               name_SET: String
+            }
+
+            type UserUserFriendsAggregateSelection {
+              count: CountConnection!
+              node: UserUserFriendsNodeAggregateSelection
             }
 
             type UserUserFriendsAggregationSelection {

--- a/packages/graphql/tests/schema/remove-deprecated/aggregate-operations.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/aggregate-operations.test.ts
@@ -51,6 +51,15 @@ describe("Aggregate operations", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -188,11 +197,11 @@ describe("Aggregate operations", () => {
             }
 
             type PostAggregate {
+              count: Count!
               node: PostAggregateNode!
             }
 
             type PostAggregateNode {
-              count: Int!
               title: StringAggregateSelection!
             }
 
@@ -234,7 +243,7 @@ describe("Aggregate operations", () => {
             }
 
             type PostLikesConnection {
-              aggregate: PostUserLikesAggregationSelection!
+              aggregate: PostUserLikesAggregateSelection!
               edges: [PostLikesRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -354,8 +363,8 @@ describe("Aggregate operations", () => {
               title_SET: String
             }
 
-            type PostUserLikesAggregationSelection {
-              count: Int!
+            type PostUserLikesAggregateSelection {
+              count: CountConnection!
               edge: PostUserLikesEdgeAggregateSelection
               node: PostUserLikesNodeAggregateSelection
             }
@@ -460,11 +469,11 @@ describe("Aggregate operations", () => {
             }
 
             type UserAggregate {
+              count: Count!
               node: UserAggregateNode!
             }
 
             type UserAggregateNode {
-              count: Int!
               someID: IntAggregateSelection!
               someString: StringAggregateSelection!
             }

--- a/packages/graphql/tests/schema/remove-deprecated/array-methods.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/array-methods.test.ts
@@ -116,7 +116,7 @@ describe("Arrays Methods", () => {
             }
 
             type ActorActedInConnection {
-              aggregate: ActorMovieActedInAggregationSelection!
+              aggregate: ActorMovieActedInAggregateSelection!
               edges: [ActorActedInRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -212,11 +212,11 @@ describe("Arrays Methods", () => {
             }
 
             type ActorAggregate {
+              count: Count!
               node: ActorAggregateNode!
             }
 
             type ActorAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -249,6 +249,11 @@ describe("Arrays Methods", () => {
             type ActorEdge {
               cursor: String!
               node: Actor!
+            }
+
+            type ActorMovieActedInAggregateSelection {
+              count: CountConnection!
+              node: ActorMovieActedInNodeAggregateSelection
             }
 
             type ActorMovieActedInAggregationSelection {
@@ -327,6 +332,15 @@ describe("Arrays Methods", () => {
               totalCount: Int!
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             type CreateActorsMutationResponse {
               actors: [Actor!]!
               info: CreateInfo!
@@ -374,6 +388,11 @@ describe("Arrays Methods", () => {
               ratings: [Float!]!
             }
 
+            type MovieActorActorsAggregateSelection {
+              count: CountConnection!
+              node: MovieActorActorsNodeAggregateSelection
+            }
+
             type MovieActorActorsAggregationSelection {
               count: Int!
               node: MovieActorActorsNodeAggregateSelection
@@ -407,7 +426,7 @@ describe("Arrays Methods", () => {
             }
 
             type MovieActorsConnection {
-              aggregate: MovieActorActorsAggregationSelection!
+              aggregate: MovieActorActorsAggregateSelection!
               edges: [MovieActorsRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -488,12 +507,12 @@ describe("Arrays Methods", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
               averageRating: FloatAggregateSelection!
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 

--- a/packages/graphql/tests/schema/remove-deprecated/comments.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/comments.test.ts
@@ -67,6 +67,10 @@ describe("Comments", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -135,13 +139,13 @@ describe("Comments", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
               actorCount: IntAggregateSelection!
               averageRating: FloatAggregateSelection!
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
@@ -323,11 +327,11 @@ describe("Comments", () => {
                 }
 
                 type ActorAggregate {
+                  count: Count!
                   node: ActorAggregateNode!
                 }
 
                 type ActorAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -389,6 +393,15 @@ describe("Comments", () => {
                   totalCount: Int!
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
+                type CountConnection {
+                  edges: Int!
+                  nodes: Int!
+                }
+
                 type CreateActorsMutationResponse {
                   actors: [Actor!]!
                   info: CreateInfo!
@@ -428,6 +441,11 @@ describe("Comments", () => {
                   id: ID
                 }
 
+                type MovieActorActorsAggregateSelection {
+                  count: CountConnection!
+                  node: MovieActorActorsNodeAggregateSelection
+                }
+
                 type MovieActorActorsAggregationSelection {
                   count: Int!
                   node: MovieActorActorsNodeAggregateSelection
@@ -459,7 +477,7 @@ describe("Comments", () => {
                 }
 
                 type MovieActorsConnection {
-                  aggregate: MovieActorActorsAggregationSelection!
+                  aggregate: MovieActorActorsAggregateSelection!
                   edges: [MovieActorsRelationship!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -533,11 +551,11 @@ describe("Comments", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
                 }
 
@@ -814,7 +832,7 @@ describe("Comments", () => {
                 }
 
                 type ActorActedInConnection {
-                  aggregate: ActorProductionActedInAggregationSelection!
+                  aggregate: ActorProductionActedInAggregateSelection!
                   edges: [ActorActedInRelationship!]!
                   pageInfo: PageInfo!
                   totalCount: Int!
@@ -893,11 +911,11 @@ describe("Comments", () => {
                 }
 
                 type ActorAggregate {
+                  count: Count!
                   node: ActorAggregateNode!
                 }
 
                 type ActorAggregateNode {
-                  count: Int!
                   name: StringAggregateSelection!
                 }
 
@@ -927,6 +945,12 @@ describe("Comments", () => {
                   Specify one or more ActorSort objects to sort Actors by. The sorts will be applied in the order in which they are arranged in the array.
                   \\"\\"\\"
                   sort: [ActorSort!]
+                }
+
+                type ActorProductionActedInAggregateSelection {
+                  count: CountConnection!
+                  edge: ActorProductionActedInEdgeAggregateSelection
+                  node: ActorProductionActedInNodeAggregateSelection
                 }
 
                 type ActorProductionActedInAggregationSelection {
@@ -1000,6 +1024,15 @@ describe("Comments", () => {
                   totalCount: Int!
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
+                type CountConnection {
+                  edges: Int!
+                  nodes: Int!
+                }
+
                 type CreateActorsMutationResponse {
                   actors: [Actor!]!
                   info: CreateInfo!
@@ -1044,11 +1077,11 @@ describe("Comments", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   runtime: IntAggregateSelection!
                   title: StringAggregateSelection!
                 }
@@ -1146,11 +1179,11 @@ describe("Comments", () => {
                 }
 
                 type ProductionAggregate {
+                  count: Count!
                   node: ProductionAggregateNode!
                 }
 
                 type ProductionAggregateNode {
-                  count: Int!
                   title: StringAggregateSelection!
                 }
 
@@ -1241,11 +1274,11 @@ describe("Comments", () => {
                 }
 
                 type SeriesAggregate {
+                  count: Count!
                   node: SeriesAggregateNode!
                 }
 
                 type SeriesAggregateNode {
-                  count: Int!
                   episodes: IntAggregateSelection!
                   title: StringAggregateSelection!
                 }
@@ -1383,6 +1416,10 @@ describe("Comments", () => {
                   mutation: Mutation
                 }
 
+                type Count {
+                  nodes: Int!
+                }
+
                 type CreateGenresMutationResponse {
                   genres: [Genre!]!
                   info: CreateInfo!
@@ -1414,11 +1451,11 @@ describe("Comments", () => {
                 }
 
                 type GenreAggregate {
+                  count: Count!
                   node: GenreAggregateNode!
                 }
 
                 type GenreAggregateNode {
-                  count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
                 }
 
@@ -1493,11 +1530,11 @@ describe("Comments", () => {
                 }
 
                 type MovieAggregate {
+                  count: Count!
                   node: MovieAggregateNode!
                 }
 
                 type MovieAggregateNode {
-                  count: Int!
                   id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
                 }
 

--- a/packages/graphql/tests/schema/remove-deprecated/connect-or-create.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/connect-or-create.test.ts
@@ -55,11 +55,11 @@ describe("Connect Or Create", () => {
             }
 
             type ActorAggregate {
+              count: Count!
               node: ActorAggregateNode!
             }
 
             type ActorAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -80,6 +80,11 @@ describe("Connect Or Create", () => {
             type ActorEdge {
               cursor: String!
               node: Actor!
+            }
+
+            type ActorMovieMoviesAggregateSelection {
+              count: CountConnection!
+              node: ActorMovieMoviesNodeAggregateSelection
             }
 
             type ActorMovieMoviesAggregationSelection {
@@ -114,7 +119,7 @@ describe("Connect Or Create", () => {
             }
 
             type ActorMoviesConnection {
-              aggregate: ActorMovieMoviesAggregationSelection!
+              aggregate: ActorMovieMoviesAggregateSelection!
               edges: [ActorMoviesRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -268,6 +273,15 @@ describe("Connect Or Create", () => {
               totalCount: Int!
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             type CreateActorsMutationResponse {
               actors: [Actor!]!
               info: CreateInfo!
@@ -300,11 +314,11 @@ describe("Connect Or Create", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               isan: StringAggregateSelection!
               title: StringAggregateSelection!
             }

--- a/packages/graphql/tests/schema/remove-deprecated/directed-argument.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/directed-argument.test.ts
@@ -168,11 +168,11 @@ describe("Deprecated directed argument", () => {
             }
 
             type ActorAggregate {
+              count: Count!
               node: ActorAggregateNode!
             }
 
             type ActorAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -205,6 +205,12 @@ describe("Deprecated directed argument", () => {
             type ActorEdge {
               cursor: String!
               node: Actor!
+            }
+
+            type ActorMovieMoviesAggregateSelection {
+              count: CountConnection!
+              edge: ActorMovieMoviesEdgeAggregateSelection
+              node: ActorMovieMoviesNodeAggregateSelection
             }
 
             type ActorMovieMoviesAggregationSelection {
@@ -246,7 +252,7 @@ describe("Deprecated directed argument", () => {
             }
 
             type ActorMoviesConnection {
-              aggregate: ActorMovieMoviesAggregationSelection!
+              aggregate: ActorMovieMoviesAggregateSelection!
               edges: [ActorMoviesRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -392,6 +398,15 @@ describe("Deprecated directed argument", () => {
               totalCount: Int!
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             type CreateActorsMutationResponse {
               actors: [Actor!]!
               info: CreateInfo!
@@ -431,11 +446,11 @@ describe("Deprecated directed argument", () => {
             }
 
             type GenreAggregate {
+              count: Count!
               node: GenreAggregateNode!
             }
 
             type GenreAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
@@ -512,6 +527,12 @@ describe("Deprecated directed argument", () => {
               title: String!
             }
 
+            type MovieActorActorsAggregateSelection {
+              count: CountConnection!
+              edge: MovieActorActorsEdgeAggregateSelection
+              node: MovieActorActorsNodeAggregateSelection
+            }
+
             type MovieActorActorsAggregationSelection {
               count: Int!
               edge: MovieActorActorsEdgeAggregateSelection
@@ -551,7 +572,7 @@ describe("Deprecated directed argument", () => {
             }
 
             type MovieActorsConnection {
-              aggregate: MovieActorActorsAggregationSelection!
+              aggregate: MovieActorActorsAggregateSelection!
               edges: [MovieActorsRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -632,11 +653,11 @@ describe("Deprecated directed argument", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               title: StringAggregateSelection!
             }
 
@@ -762,11 +783,11 @@ describe("Deprecated directed argument", () => {
             }
 
             type ProductionAggregate {
+              count: Count!
               node: ProductionAggregateNode!
             }
 
             type ProductionAggregateNode {
-              count: Int!
               title: StringAggregateSelection!
             }
 

--- a/packages/graphql/tests/schema/remove-deprecated/id-aggregations.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/id-aggregations.test.ts
@@ -52,6 +52,15 @@ describe("Aggregations id", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -169,11 +178,11 @@ describe("Aggregations id", () => {
             }
 
             type PostAggregate {
+              count: Count!
               node: PostAggregateNode!
             }
 
             type PostAggregateNode {
-              count: Int!
               title: StringAggregateSelection!
             }
 
@@ -221,7 +230,7 @@ describe("Aggregations id", () => {
             }
 
             type PostLikesConnection {
-              aggregate: PostUserLikesAggregationSelection!
+              aggregate: PostUserLikesAggregateSelection!
               edges: [PostLikesRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -322,6 +331,12 @@ describe("Aggregations id", () => {
               someID_SET: ID
               title: String @deprecated(reason: \\"Please use the explicit _SET field\\")
               title_SET: String
+            }
+
+            type PostUserLikesAggregateSelection {
+              count: CountConnection!
+              edge: PostUserLikesEdgeAggregateSelection
+              node: PostUserLikesNodeAggregateSelection
             }
 
             type PostUserLikesAggregationSelection {
@@ -436,11 +451,11 @@ describe("Aggregations id", () => {
             }
 
             type UserAggregate {
+              count: Count!
               node: UserAggregateNode!
             }
 
             type UserAggregateNode {
-              count: Int!
               someString: StringAggregateSelection!
             }
 

--- a/packages/graphql/tests/schema/remove-deprecated/implicit-equality.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/implicit-equality.test.ts
@@ -117,11 +117,11 @@ describe("Implicit Equality filters", () => {
             }
 
             type ActorAggregate {
+              count: Count!
               node: ActorAggregateNode!
             }
 
             type ActorAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -154,6 +154,12 @@ describe("Implicit Equality filters", () => {
             type ActorEdge {
               cursor: String!
               node: Actor!
+            }
+
+            type ActorMovieMoviesAggregateSelection {
+              count: CountConnection!
+              edge: ActorMovieMoviesEdgeAggregateSelection
+              node: ActorMovieMoviesNodeAggregateSelection
             }
 
             type ActorMovieMoviesAggregationSelection {
@@ -195,7 +201,7 @@ describe("Implicit Equality filters", () => {
             }
 
             type ActorMoviesConnection {
-              aggregate: ActorMovieMoviesAggregationSelection!
+              aggregate: ActorMovieMoviesAggregateSelection!
               edges: [ActorMoviesRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -327,6 +333,15 @@ describe("Implicit Equality filters", () => {
               totalCount: Int!
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             type CreateActorsMutationResponse {
               actors: [Actor!]!
               info: CreateInfo!
@@ -363,6 +378,12 @@ describe("Implicit Equality filters", () => {
               actorsAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: ActorWhere): MovieActorActorsAggregationSelection @deprecated(reason: \\"Please use field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\" instead\\")
               actorsConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [MovieActorsConnectionSort!], where: MovieActorsConnectionWhere): MovieActorsConnection!
               id: ID
+            }
+
+            type MovieActorActorsAggregateSelection {
+              count: CountConnection!
+              edge: MovieActorActorsEdgeAggregateSelection
+              node: MovieActorActorsNodeAggregateSelection
             }
 
             type MovieActorActorsAggregationSelection {
@@ -404,7 +425,7 @@ describe("Implicit Equality filters", () => {
             }
 
             type MovieActorsConnection {
-              aggregate: MovieActorActorsAggregationSelection!
+              aggregate: MovieActorActorsAggregateSelection!
               edges: [MovieActorsRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -485,11 +506,11 @@ describe("Implicit Equality filters", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 

--- a/packages/graphql/tests/schema/remove-deprecated/implicit-set.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/implicit-set.test.ts
@@ -116,11 +116,11 @@ describe("Implicit SET field", () => {
             }
 
             type ActorAggregate {
+              count: Count!
               node: ActorAggregateNode!
             }
 
             type ActorAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -153,6 +153,12 @@ describe("Implicit SET field", () => {
             type ActorEdge {
               cursor: String!
               node: Actor!
+            }
+
+            type ActorMovieMoviesAggregateSelection {
+              count: CountConnection!
+              edge: ActorMovieMoviesEdgeAggregateSelection
+              node: ActorMovieMoviesNodeAggregateSelection
             }
 
             type ActorMovieMoviesAggregationSelection {
@@ -194,7 +200,7 @@ describe("Implicit SET field", () => {
             }
 
             type ActorMoviesConnection {
-              aggregate: ActorMovieMoviesAggregationSelection!
+              aggregate: ActorMovieMoviesAggregateSelection!
               edges: [ActorMoviesRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -334,6 +340,15 @@ describe("Implicit SET field", () => {
               totalCount: Int!
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             type CreateActorsMutationResponse {
               actors: [Actor!]!
               info: CreateInfo!
@@ -370,6 +385,12 @@ describe("Implicit SET field", () => {
               actorsAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: ActorWhere): MovieActorActorsAggregationSelection @deprecated(reason: \\"Please use field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\" instead\\")
               actorsConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [MovieActorsConnectionSort!], where: MovieActorsConnectionWhere): MovieActorsConnection!
               id: ID
+            }
+
+            type MovieActorActorsAggregateSelection {
+              count: CountConnection!
+              edge: MovieActorActorsEdgeAggregateSelection
+              node: MovieActorActorsNodeAggregateSelection
             }
 
             type MovieActorActorsAggregationSelection {
@@ -411,7 +432,7 @@ describe("Implicit SET field", () => {
             }
 
             type MovieActorsConnection {
-              aggregate: MovieActorActorsAggregationSelection!
+              aggregate: MovieActorActorsAggregateSelection!
               edges: [MovieActorsRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -492,11 +513,11 @@ describe("Implicit SET field", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 

--- a/packages/graphql/tests/schema/remove-deprecated/options-argument.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/options-argument.test.ts
@@ -156,11 +156,11 @@ describe("Deprecated options argument", () => {
             }
 
             type ActorAggregate {
+              count: Count!
               node: ActorAggregateNode!
             }
 
             type ActorAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -193,6 +193,12 @@ describe("Deprecated options argument", () => {
             type ActorEdge {
               cursor: String!
               node: Actor!
+            }
+
+            type ActorMovieMoviesAggregateSelection {
+              count: CountConnection!
+              edge: ActorMovieMoviesEdgeAggregateSelection
+              node: ActorMovieMoviesNodeAggregateSelection
             }
 
             type ActorMovieMoviesAggregationSelection {
@@ -234,7 +240,7 @@ describe("Deprecated options argument", () => {
             }
 
             type ActorMoviesConnection {
-              aggregate: ActorMovieMoviesAggregationSelection!
+              aggregate: ActorMovieMoviesAggregateSelection!
               edges: [ActorMoviesRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -371,6 +377,15 @@ describe("Deprecated options argument", () => {
               totalCount: Int!
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             type CreateActorsMutationResponse {
               actors: [Actor!]!
               info: CreateInfo!
@@ -410,11 +425,11 @@ describe("Deprecated options argument", () => {
             }
 
             type GenreAggregate {
+              count: Count!
               node: GenreAggregateNode!
             }
 
             type GenreAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
@@ -482,6 +497,12 @@ describe("Deprecated options argument", () => {
               title: String!
             }
 
+            type MovieActorActorsAggregateSelection {
+              count: CountConnection!
+              edge: MovieActorActorsEdgeAggregateSelection
+              node: MovieActorActorsNodeAggregateSelection
+            }
+
             type MovieActorActorsAggregationSelection {
               count: Int!
               edge: MovieActorActorsEdgeAggregateSelection
@@ -521,7 +542,7 @@ describe("Deprecated options argument", () => {
             }
 
             type MovieActorsConnection {
-              aggregate: MovieActorActorsAggregationSelection!
+              aggregate: MovieActorActorsAggregateSelection!
               edges: [MovieActorsRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -602,11 +623,11 @@ describe("Deprecated options argument", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               title: StringAggregateSelection!
             }
 
@@ -723,11 +744,11 @@ describe("Deprecated options argument", () => {
             }
 
             type ProductionAggregate {
+              count: Count!
               node: ProductionAggregateNode!
             }
 
             type ProductionAggregateNode {
-              count: Int!
               title: StringAggregateSelection!
             }
 

--- a/packages/graphql/tests/schema/remove-deprecated/query-direction.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/query-direction.test.ts
@@ -40,6 +40,15 @@ describe("Query Direction", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -117,11 +126,11 @@ describe("Query Direction", () => {
             }
 
             type UserAggregate {
+              count: Count!
               node: UserAggregateNode!
             }
 
             type UserAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -179,7 +188,7 @@ describe("Query Direction", () => {
             }
 
             type UserFriendsConnection {
-              aggregate: UserUserFriendsAggregationSelection!
+              aggregate: UserUserFriendsAggregateSelection!
               edges: [UserFriendsRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -274,6 +283,11 @@ describe("Query Direction", () => {
               friends: [UserFriendsUpdateFieldInput!]
               name: String @deprecated(reason: \\"Please use the explicit _SET field\\")
               name_SET: String
+            }
+
+            type UserUserFriendsAggregateSelection {
+              count: CountConnection!
+              node: UserUserFriendsNodeAggregateSelection
             }
 
             type UserUserFriendsAggregationSelection {
@@ -347,6 +361,15 @@ describe("Query Direction", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -424,11 +447,11 @@ describe("Query Direction", () => {
             }
 
             type UserAggregate {
+              count: Count!
               node: UserAggregateNode!
             }
 
             type UserAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -486,7 +509,7 @@ describe("Query Direction", () => {
             }
 
             type UserFriendsConnection {
-              aggregate: UserUserFriendsAggregationSelection!
+              aggregate: UserUserFriendsAggregateSelection!
               edges: [UserFriendsRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -581,6 +604,11 @@ describe("Query Direction", () => {
               friends: [UserFriendsUpdateFieldInput!]
               name: String @deprecated(reason: \\"Please use the explicit _SET field\\")
               name_SET: String
+            }
+
+            type UserUserFriendsAggregateSelection {
+              count: CountConnection!
+              node: UserUserFriendsNodeAggregateSelection
             }
 
             type UserUserFriendsAggregationSelection {
@@ -654,6 +682,15 @@ describe("Query Direction", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -731,11 +768,11 @@ describe("Query Direction", () => {
             }
 
             type UserAggregate {
+              count: Count!
               node: UserAggregateNode!
             }
 
             type UserAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -793,7 +830,7 @@ describe("Query Direction", () => {
             }
 
             type UserFriendsConnection {
-              aggregate: UserUserFriendsAggregationSelection!
+              aggregate: UserUserFriendsAggregateSelection!
               edges: [UserFriendsRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -888,6 +925,11 @@ describe("Query Direction", () => {
               friends: [UserFriendsUpdateFieldInput!]
               name: String @deprecated(reason: \\"Please use the explicit _SET field\\")
               name_SET: String
+            }
+
+            type UserUserFriendsAggregateSelection {
+              count: CountConnection!
+              node: UserUserFriendsNodeAggregateSelection
             }
 
             type UserUserFriendsAggregationSelection {

--- a/packages/graphql/tests/schema/remove-deprecated/typename_IN.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/typename_IN.test.ts
@@ -57,6 +57,10 @@ describe("typename_IN", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -101,11 +105,11 @@ describe("typename_IN", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
               title: StringAggregateSelection!
             }
@@ -198,11 +202,11 @@ describe("typename_IN", () => {
             }
 
             type ProductionAggregate {
+              count: Count!
               node: ProductionAggregateNode!
             }
 
             type ProductionAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
               title: StringAggregateSelection!
             }
@@ -285,11 +289,11 @@ describe("typename_IN", () => {
             }
 
             type SeriesAggregate {
+              count: Count!
               node: SeriesAggregateNode!
             }
 
             type SeriesAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
               numberOfEpisodes: IntAggregateSelection!
               title: StringAggregateSelection!

--- a/packages/graphql/tests/schema/scalar.test.ts
+++ b/packages/graphql/tests/schema/scalar.test.ts
@@ -43,6 +43,10 @@ describe("Scalar", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -79,11 +83,11 @@ describe("Scalar", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 

--- a/packages/graphql/tests/schema/simple.test.ts
+++ b/packages/graphql/tests/schema/simple.test.ts
@@ -41,6 +41,11 @@ describe("Simple", () => {
               mutation: Mutation
             }
 
+            type Count {
+              edges: Int!
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -89,6 +94,7 @@ describe("Simple", () => {
             }
 
             type MovieAggregate {
+              count: Count
               node: MovieAggregateNode!
             }
 

--- a/packages/graphql/tests/schema/simple.test.ts
+++ b/packages/graphql/tests/schema/simple.test.ts
@@ -42,7 +42,6 @@ describe("Simple", () => {
             }
 
             type Count {
-              edges: Int!
               nodes: Int!
             }
 
@@ -94,14 +93,13 @@ describe("Simple", () => {
             }
 
             type MovieAggregate {
-              count: Count
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
               actorCount: IntAggregateSelection!
               averageRating: FloatAggregateSelection!
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 

--- a/packages/graphql/tests/schema/string-comparators.test.ts
+++ b/packages/graphql/tests/schema/string-comparators.test.ts
@@ -50,6 +50,10 @@ describe("String Comparators", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -76,11 +80,11 @@ describe("String Comparators", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               title: StringAggregateSelection!
             }
 
@@ -209,6 +213,10 @@ describe("String Comparators", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -235,11 +243,11 @@ describe("String Comparators", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               title: StringAggregateSelection!
             }
 
@@ -373,6 +381,10 @@ describe("String Comparators", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -399,11 +411,11 @@ describe("String Comparators", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               title: StringAggregateSelection!
             }
 
@@ -642,7 +654,7 @@ describe("String Comparators", () => {
             }
 
             type ActorActedInConnection {
-              aggregate: ActorMovieActedInAggregationSelection!
+              aggregate: ActorMovieActedInAggregateSelection!
               edges: [ActorActedInRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -723,11 +735,11 @@ describe("String Comparators", () => {
             }
 
             type ActorAggregate {
+              count: Count!
               node: ActorAggregateNode!
             }
 
             type ActorAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -760,6 +772,12 @@ describe("String Comparators", () => {
             type ActorEdge {
               cursor: String!
               node: Actor!
+            }
+
+            type ActorMovieActedInAggregateSelection {
+              count: CountConnection!
+              edge: ActorMovieActedInEdgeAggregateSelection
+              node: ActorMovieActedInNodeAggregateSelection
             }
 
             type ActorMovieActedInAggregationSelection {
@@ -846,6 +864,15 @@ describe("String Comparators", () => {
               totalCount: Int!
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             type CreateActorsMutationResponse {
               actors: [Actor!]!
               info: CreateInfo!
@@ -877,6 +904,12 @@ describe("String Comparators", () => {
               actorsAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: ActorWhere): MovieActorActorsAggregationSelection @deprecated(reason: \\"Please use field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\" instead\\")
               actorsConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [MovieActorsConnectionSort!], where: MovieActorsConnectionWhere): MovieActorsConnection!
               title: String
+            }
+
+            type MovieActorActorsAggregateSelection {
+              count: CountConnection!
+              edge: MovieActorActorsEdgeAggregateSelection
+              node: MovieActorActorsNodeAggregateSelection
             }
 
             type MovieActorActorsAggregationSelection {
@@ -918,7 +951,7 @@ describe("String Comparators", () => {
             }
 
             type MovieActorsConnection {
-              aggregate: MovieActorActorsAggregationSelection!
+              aggregate: MovieActorActorsAggregateSelection!
               edges: [MovieActorsRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -999,11 +1032,11 @@ describe("String Comparators", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               title: StringAggregateSelection!
             }
 

--- a/packages/graphql/tests/schema/subscriptions.test.ts
+++ b/packages/graphql/tests/schema/subscriptions.test.ts
@@ -58,11 +58,11 @@ describe("Subscriptions", () => {
             }
 
             type ActorAggregate {
+              count: Count!
               node: ActorAggregateNode!
             }
 
             type ActorAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -159,6 +159,15 @@ describe("Subscriptions", () => {
               totalCount: Int!
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             type CreateActorsMutationResponse {
               actors: [Actor!]!
               info: CreateInfo!
@@ -222,6 +231,11 @@ describe("Subscriptions", () => {
               isActive: Boolean
             }
 
+            type MovieActorActorsAggregateSelection {
+              count: CountConnection!
+              node: MovieActorActorsNodeAggregateSelection
+            }
+
             type MovieActorActorsAggregationSelection {
               count: Int!
               node: MovieActorActorsNodeAggregateSelection
@@ -253,7 +267,7 @@ describe("Subscriptions", () => {
             }
 
             type MovieActorsConnection {
-              aggregate: MovieActorActorsAggregationSelection!
+              aggregate: MovieActorActorsAggregateSelection!
               edges: [MovieActorsRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -327,13 +341,13 @@ describe("Subscriptions", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
               actorCount: IntAggregateSelection!
               averageRating: FloatAggregateSelection!
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
@@ -620,11 +634,7 @@ describe("Subscriptions", () => {
             }
 
             type ActorAggregate {
-              node: ActorAggregateNode!
-            }
-
-            type ActorAggregateNode {
-              count: Int!
+              count: Count!
             }
 
             type ActorAggregateSelection {
@@ -666,6 +676,11 @@ describe("Subscriptions", () => {
               node: Actor!
             }
 
+            type ActorMovieMoviesAggregateSelection {
+              count: CountConnection!
+              node: ActorMovieMoviesNodeAggregateSelection
+            }
+
             type ActorMovieMoviesAggregationSelection {
               count: Int!
               node: ActorMovieMoviesNodeAggregateSelection
@@ -700,7 +715,7 @@ describe("Subscriptions", () => {
             }
 
             type ActorMoviesConnection {
-              aggregate: ActorMovieMoviesAggregationSelection!
+              aggregate: ActorMovieMoviesAggregateSelection!
               edges: [ActorMoviesRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -862,6 +877,15 @@ describe("Subscriptions", () => {
               totalCount: Int!
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             type CreateActorsMutationResponse {
               actors: [Actor!]!
               info: CreateInfo!
@@ -925,6 +949,10 @@ describe("Subscriptions", () => {
               isActive: Boolean
             }
 
+            type MovieActorActorsAggregateSelection {
+              count: CountConnection!
+            }
+
             type MovieActorActorsAggregationSelection {
               count: Int!
             }
@@ -951,7 +979,7 @@ describe("Subscriptions", () => {
             }
 
             type MovieActorsConnection {
-              aggregate: MovieActorActorsAggregationSelection!
+              aggregate: MovieActorActorsAggregateSelection!
               edges: [MovieActorsRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1002,13 +1030,13 @@ describe("Subscriptions", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
               actorCount: IntAggregateSelection!
               averageRating: FloatAggregateSelection!
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
@@ -1307,6 +1335,15 @@ describe("Subscriptions", () => {
               Star: StarWhere
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -1504,13 +1541,13 @@ describe("Subscriptions", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
               actorCount: IntAggregateSelection!
               averageRating: FloatAggregateSelection!
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
@@ -1734,11 +1771,7 @@ describe("Subscriptions", () => {
             }
 
             type PersonAggregate {
-              node: PersonAggregateNode!
-            }
-
-            type PersonAggregateNode {
-              count: Int!
+              count: Count!
             }
 
             type PersonAggregateSelection {
@@ -1780,6 +1813,11 @@ describe("Subscriptions", () => {
               node: Person!
             }
 
+            type PersonMovieMoviesAggregateSelection {
+              count: CountConnection!
+              node: PersonMovieMoviesNodeAggregateSelection
+            }
+
             type PersonMovieMoviesAggregationSelection {
               count: Int!
               node: PersonMovieMoviesNodeAggregateSelection
@@ -1814,7 +1852,7 @@ describe("Subscriptions", () => {
             }
 
             type PersonMoviesConnection {
-              aggregate: PersonMovieMoviesAggregationSelection!
+              aggregate: PersonMovieMoviesAggregateSelection!
               edges: [PersonMoviesRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -2003,11 +2041,7 @@ describe("Subscriptions", () => {
             }
 
             type StarAggregate {
-              node: StarAggregateNode!
-            }
-
-            type StarAggregateNode {
-              count: Int!
+              count: Count!
             }
 
             type StarAggregateSelection {
@@ -2049,6 +2083,11 @@ describe("Subscriptions", () => {
               node: Star!
             }
 
+            type StarMovieMoviesAggregateSelection {
+              count: CountConnection!
+              node: StarMovieMoviesNodeAggregateSelection
+            }
+
             type StarMovieMoviesAggregationSelection {
               count: Int!
               node: StarMovieMoviesNodeAggregateSelection
@@ -2083,7 +2122,7 @@ describe("Subscriptions", () => {
             }
 
             type StarMoviesConnection {
-              aggregate: StarMovieMoviesAggregationSelection!
+              aggregate: StarMovieMoviesAggregateSelection!
               edges: [StarMoviesRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -2388,11 +2427,7 @@ describe("Subscriptions", () => {
             }
 
             type ActorAggregate {
-              node: ActorAggregateNode!
-            }
-
-            type ActorAggregateNode {
-              count: Int!
+              count: Count!
             }
 
             type ActorAggregateSelection {
@@ -2434,6 +2469,11 @@ describe("Subscriptions", () => {
               node: Actor!
             }
 
+            type ActorMovieMoviesAggregateSelection {
+              count: CountConnection!
+              node: ActorMovieMoviesNodeAggregateSelection
+            }
+
             type ActorMovieMoviesAggregationSelection {
               count: Int!
               node: ActorMovieMoviesNodeAggregateSelection
@@ -2468,7 +2508,7 @@ describe("Subscriptions", () => {
             }
 
             type ActorMoviesConnection {
-              aggregate: ActorMovieMoviesAggregationSelection!
+              aggregate: ActorMovieMoviesAggregateSelection!
               edges: [ActorMoviesRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -2630,6 +2670,15 @@ describe("Subscriptions", () => {
               totalCount: Int!
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             type CreateActorsMutationResponse {
               actors: [Actor!]!
               info: CreateInfo!
@@ -2693,6 +2742,11 @@ describe("Subscriptions", () => {
               isActive: Boolean
             }
 
+            type MovieActorActorsAggregateSelection {
+              count: CountConnection!
+              edge: MovieActorActorsEdgeAggregateSelection
+            }
+
             type MovieActorActorsAggregationSelection {
               count: Int!
               edge: MovieActorActorsEdgeAggregateSelection
@@ -2726,7 +2780,7 @@ describe("Subscriptions", () => {
             }
 
             type MovieActorsConnection {
-              aggregate: MovieActorActorsAggregationSelection!
+              aggregate: MovieActorActorsAggregateSelection!
               edges: [MovieActorsRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -2785,13 +2839,13 @@ describe("Subscriptions", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
               actorCount: IntAggregateSelection!
               averageRating: FloatAggregateSelection!
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
@@ -3081,11 +3135,11 @@ describe("Subscriptions", () => {
             }
 
             type ActorAggregate {
+              count: Count!
               node: ActorAggregateNode!
             }
 
             type ActorAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
             }
 
@@ -3182,6 +3236,15 @@ describe("Subscriptions", () => {
               totalCount: Int!
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             type CreateActorsMutationResponse {
               actors: [Actor!]!
               info: CreateInfo!
@@ -3245,6 +3308,11 @@ describe("Subscriptions", () => {
               isActive: Boolean
             }
 
+            type MovieActorActorsAggregateSelection {
+              count: CountConnection!
+              node: MovieActorActorsNodeAggregateSelection
+            }
+
             type MovieActorActorsAggregationSelection {
               count: Int!
               node: MovieActorActorsNodeAggregateSelection
@@ -3276,7 +3344,7 @@ describe("Subscriptions", () => {
             }
 
             type MovieActorsConnection {
-              aggregate: MovieActorActorsAggregationSelection!
+              aggregate: MovieActorActorsAggregateSelection!
               edges: [MovieActorsRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -3350,13 +3418,13 @@ describe("Subscriptions", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
               actorCount: IntAggregateSelection!
               averageRating: FloatAggregateSelection!
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
@@ -3584,11 +3652,11 @@ describe("Subscriptions", () => {
             }
 
             type AgreementAggregate {
+              count: Count!
               node: AgreementAggregateNode!
             }
 
             type AgreementAggregateNode {
-              count: Int!
               id: IntAggregateSelection!
               name: StringAggregateSelection!
             }
@@ -3662,7 +3730,7 @@ describe("Subscriptions", () => {
             }
 
             type AgreementOwnerConnection {
-              aggregate: AgreementUserOwnerAggregationSelection!
+              aggregate: AgreementUserOwnerAggregateSelection!
               edges: [AgreementOwnerRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -3794,6 +3862,11 @@ describe("Subscriptions", () => {
               updatedAgreement: AgreementEventPayload!
             }
 
+            type AgreementUserOwnerAggregateSelection {
+              count: CountConnection!
+              node: AgreementUserOwnerNodeAggregateSelection
+            }
+
             type AgreementUserOwnerAggregationSelection {
               count: Int!
               node: AgreementUserOwnerNodeAggregateSelection
@@ -3831,6 +3904,15 @@ describe("Subscriptions", () => {
               edges: [AgreementEdge!]!
               pageInfo: PageInfo!
               totalCount: Int!
+            }
+
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
             }
 
             type CreateAgreementsMutationResponse {
@@ -3932,11 +4014,11 @@ describe("Subscriptions", () => {
             }
 
             type UserAggregate {
+              count: Count!
               node: UserAggregateNode!
             }
 
             type UserAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
               username: StringAggregateSelection!
             }
@@ -4053,6 +4135,15 @@ describe("Subscriptions", () => {
             input ActorWhere {
               Person: PersonWhere
               Star: StarWhere
+            }
+
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
             }
 
             \\"\\"\\"
@@ -4252,13 +4343,13 @@ describe("Subscriptions", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
               actorCount: IntAggregateSelection!
               averageRating: FloatAggregateSelection!
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
@@ -4482,11 +4573,7 @@ describe("Subscriptions", () => {
             }
 
             type PersonAggregate {
-              node: PersonAggregateNode!
-            }
-
-            type PersonAggregateNode {
-              count: Int!
+              count: Count!
             }
 
             type PersonAggregateSelection {
@@ -4528,6 +4615,11 @@ describe("Subscriptions", () => {
               node: Person!
             }
 
+            type PersonMovieMoviesAggregateSelection {
+              count: CountConnection!
+              node: PersonMovieMoviesNodeAggregateSelection
+            }
+
             type PersonMovieMoviesAggregationSelection {
               count: Int!
               node: PersonMovieMoviesNodeAggregateSelection
@@ -4562,7 +4654,7 @@ describe("Subscriptions", () => {
             }
 
             type PersonMoviesConnection {
-              aggregate: PersonMovieMoviesAggregationSelection!
+              aggregate: PersonMovieMoviesAggregateSelection!
               edges: [PersonMoviesRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -4751,11 +4843,7 @@ describe("Subscriptions", () => {
             }
 
             type StarAggregate {
-              node: StarAggregateNode!
-            }
-
-            type StarAggregateNode {
-              count: Int!
+              count: Count!
             }
 
             type StarAggregateSelection {
@@ -4785,6 +4873,11 @@ describe("Subscriptions", () => {
             type StarEdge {
               cursor: String!
               node: Star!
+            }
+
+            type StarMovieMoviesAggregateSelection {
+              count: CountConnection!
+              node: StarMovieMoviesNodeAggregateSelection
             }
 
             type StarMovieMoviesAggregationSelection {
@@ -4821,7 +4914,7 @@ describe("Subscriptions", () => {
             }
 
             type StarMoviesConnection {
-              aggregate: StarMovieMoviesAggregationSelection!
+              aggregate: StarMovieMoviesAggregateSelection!
               edges: [StarMoviesRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -5059,6 +5152,10 @@ describe("Subscriptions", () => {
               subscription: Subscription
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -5088,11 +5185,7 @@ describe("Subscriptions", () => {
             }
 
             type CreatureAggregate {
-              node: CreatureAggregateNode!
-            }
-
-            type CreatureAggregateNode {
-              count: Int!
+              count: Count!
             }
 
             type CreatureAggregateSelection {
@@ -5275,11 +5368,11 @@ describe("Subscriptions", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
               title: StringAggregateSelection!
             }
@@ -5445,11 +5538,7 @@ describe("Subscriptions", () => {
             }
 
             type PersonAggregate {
-              node: PersonAggregateNode!
-            }
-
-            type PersonAggregateNode {
-              count: Int!
+              count: Count!
             }
 
             type PersonAggregateSelection {
@@ -5584,11 +5673,11 @@ describe("Subscriptions", () => {
             }
 
             type ProductionAggregate {
+              count: Count!
               node: ProductionAggregateNode!
             }
 
             type ProductionAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
@@ -5764,11 +5853,11 @@ describe("Subscriptions", () => {
             }
 
             type SeriesAggregate {
+              count: Count!
               node: SeriesAggregateNode!
             }
 
             type SeriesAggregateNode {
-              count: Int!
               episode: IntAggregateSelection!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
               title: StringAggregateSelection!

--- a/packages/graphql/tests/schema/types/bigint.test.ts
+++ b/packages/graphql/tests/schema/types/bigint.test.ts
@@ -51,6 +51,10 @@ describe("Bigint", () => {
               sum: BigInt
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             type CreateFilesMutationResponse {
               files: [File!]!
               info: CreateInfo!
@@ -78,11 +82,11 @@ describe("Bigint", () => {
             }
 
             type FileAggregate {
+              count: Count!
               node: FileAggregateNode!
             }
 
             type FileAggregateNode {
-              count: Int!
               name: StringAggregateSelection!
               size: BigIntAggregateSelection!
             }

--- a/packages/graphql/tests/schema/types/date.test.ts
+++ b/packages/graphql/tests/schema/types/date.test.ts
@@ -39,6 +39,10 @@ describe("Date", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -74,11 +78,11 @@ describe("Date", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 

--- a/packages/graphql/tests/schema/types/datetime.test.ts
+++ b/packages/graphql/tests/schema/types/datetime.test.ts
@@ -39,6 +39,10 @@ describe("Datetime", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -79,11 +83,11 @@ describe("Datetime", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               datetime: DateTimeAggregateSelection!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }

--- a/packages/graphql/tests/schema/types/duration.test.ts
+++ b/packages/graphql/tests/schema/types/duration.test.ts
@@ -39,6 +39,10 @@ describe("Duration", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -79,11 +83,11 @@ describe("Duration", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               duration: DurationAggregateSelection!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }

--- a/packages/graphql/tests/schema/types/localdatetime.test.ts
+++ b/packages/graphql/tests/schema/types/localdatetime.test.ts
@@ -39,6 +39,10 @@ describe("Localdatetime", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -79,11 +83,11 @@ describe("Localdatetime", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
               localDT: LocalDateTimeAggregateSelection!
             }

--- a/packages/graphql/tests/schema/types/localtime.test.ts
+++ b/packages/graphql/tests/schema/types/localtime.test.ts
@@ -39,6 +39,10 @@ describe("Localtime", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -81,11 +85,11 @@ describe("Localtime", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
               time: LocalTimeAggregateSelection!
             }

--- a/packages/graphql/tests/schema/types/point.test.ts
+++ b/packages/graphql/tests/schema/types/point.test.ts
@@ -38,6 +38,10 @@ describe("Point", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -64,11 +68,7 @@ describe("Point", () => {
             }
 
             type MovieAggregate {
-              node: MovieAggregateNode!
-            }
-
-            type MovieAggregateNode {
-              count: Int!
+              count: Count!
             }
 
             type MovieAggregateSelection {
@@ -235,6 +235,10 @@ describe("Point", () => {
               z: Float
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -261,11 +265,7 @@ describe("Point", () => {
             }
 
             type MachineAggregate {
-              node: MachineAggregateNode!
-            }
-
-            type MachineAggregateNode {
-              count: Int!
+              count: Count!
             }
 
             type MachineAggregateSelection {
@@ -383,6 +383,10 @@ describe("Point", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -409,11 +413,7 @@ describe("Point", () => {
             }
 
             type MovieAggregate {
-              node: MovieAggregateNode!
-            }
-
-            type MovieAggregateNode {
-              count: Int!
+              count: Count!
             }
 
             type MovieAggregateSelection {
@@ -545,6 +545,10 @@ describe("Point", () => {
               z: Float
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -571,11 +575,7 @@ describe("Point", () => {
             }
 
             type MachineAggregate {
-              node: MachineAggregateNode!
-            }
-
-            type MachineAggregateNode {
-              count: Int!
+              count: Count!
             }
 
             type MachineAggregateSelection {

--- a/packages/graphql/tests/schema/types/time.test.ts
+++ b/packages/graphql/tests/schema/types/time.test.ts
@@ -39,6 +39,10 @@ describe("Time", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -71,11 +75,11 @@ describe("Time", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
               time: TimeAggregateSelection!
             }

--- a/packages/graphql/tests/schema/union-interface-relationship.test.ts
+++ b/packages/graphql/tests/schema/union-interface-relationship.test.ts
@@ -152,11 +152,11 @@ describe("Union Interface Relationships", () => {
             }
 
             type ActorAggregate {
+              count: Count!
               node: ActorAggregateNode!
             }
 
             type ActorAggregateNode {
-              count: Int!
               id: IntAggregateSelection!
               name: StringAggregateSelection!
             }
@@ -196,6 +196,12 @@ describe("Union Interface Relationships", () => {
             type ActorEdge {
               cursor: String!
               node: Actor!
+            }
+
+            type ActorMovieMoviesAggregateSelection {
+              count: CountConnection!
+              edge: ActorMovieMoviesEdgeAggregateSelection
+              node: ActorMovieMoviesNodeAggregateSelection
             }
 
             type ActorMovieMoviesAggregationSelection {
@@ -248,7 +254,7 @@ describe("Union Interface Relationships", () => {
             }
 
             type ActorMoviesConnection {
-              aggregate: ActorMovieMoviesAggregationSelection!
+              aggregate: ActorMovieMoviesAggregateSelection!
               edges: [ActorMoviesRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -438,6 +444,15 @@ describe("Union Interface Relationships", () => {
               totalCount: Int!
             }
 
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
             type CreateActorsMutationResponse {
               actors: [Actor!]!
               info: CreateInfo!
@@ -524,11 +539,11 @@ describe("Union Interface Relationships", () => {
             }
 
             type InfluencerAggregate {
+              count: Count!
               node: InfluencerAggregateNode!
             }
 
             type InfluencerAggregateNode {
-              count: Int!
               reputation: IntAggregateSelection!
               reviewerId: IntAggregateSelection!
               url: StringAggregateSelection!
@@ -636,6 +651,12 @@ describe("Union Interface Relationships", () => {
               title: String!
             }
 
+            type MovieActorActorsAggregateSelection {
+              count: CountConnection!
+              edge: MovieActorActorsEdgeAggregateSelection
+              node: MovieActorActorsNodeAggregateSelection
+            }
+
             type MovieActorActorsAggregationSelection {
               count: Int!
               edge: MovieActorActorsEdgeAggregateSelection
@@ -686,7 +707,7 @@ describe("Union Interface Relationships", () => {
             }
 
             type MovieActorsConnection {
-              aggregate: MovieActorActorsAggregationSelection!
+              aggregate: MovieActorActorsAggregateSelection!
               edges: [MovieActorsRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -789,11 +810,11 @@ describe("Union Interface Relationships", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               imdbId: IntAggregateSelection!
               title: StringAggregateSelection!
             }
@@ -1023,6 +1044,12 @@ describe("Union Interface Relationships", () => {
               sort: [MovieSort!]
             }
 
+            type MovieReviewerReviewersAggregateSelection {
+              count: CountConnection!
+              edge: MovieReviewerReviewersEdgeAggregateSelection
+              node: MovieReviewerReviewersNodeAggregateSelection
+            }
+
             type MovieReviewerReviewersAggregationSelection {
               count: Int!
               edge: MovieReviewerReviewersEdgeAggregateSelection
@@ -1058,7 +1085,7 @@ describe("Union Interface Relationships", () => {
             }
 
             type MovieReviewersConnection {
-              aggregate: MovieReviewerReviewersAggregationSelection!
+              aggregate: MovieReviewerReviewersAggregateSelection!
               edges: [MovieReviewersRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1327,11 +1354,11 @@ describe("Union Interface Relationships", () => {
             }
 
             type PersonAggregate {
+              count: Count!
               node: PersonAggregateNode!
             }
 
             type PersonAggregateNode {
-              count: Int!
               id: IntAggregateSelection!
               name: StringAggregateSelection!
               reputation: IntAggregateSelection!
@@ -1377,6 +1404,12 @@ describe("Union Interface Relationships", () => {
             type PersonEdge {
               cursor: String!
               node: Person!
+            }
+
+            type PersonMovieMoviesAggregateSelection {
+              count: CountConnection!
+              edge: PersonMovieMoviesEdgeAggregateSelection
+              node: PersonMovieMoviesNodeAggregateSelection
             }
 
             type PersonMovieMoviesAggregationSelection {
@@ -1429,7 +1462,7 @@ describe("Union Interface Relationships", () => {
             }
 
             type PersonMoviesConnection {
-              aggregate: PersonMovieMoviesAggregationSelection!
+              aggregate: PersonMovieMoviesAggregateSelection!
               edges: [PersonMoviesRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
@@ -1734,11 +1767,11 @@ describe("Union Interface Relationships", () => {
             }
 
             type ReviewerAggregate {
+              count: Count!
               node: ReviewerAggregateNode!
             }
 
             type ReviewerAggregateNode {
-              count: Int!
               reputation: IntAggregateSelection!
               reviewerId: IntAggregateSelection!
             }

--- a/packages/graphql/tests/schema/unions.test.ts
+++ b/packages/graphql/tests/schema/unions.test.ts
@@ -46,6 +46,10 @@ describe("Unions", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             type CreateGenresMutationResponse {
               genres: [Genre!]!
               info: CreateInfo!
@@ -77,11 +81,11 @@ describe("Unions", () => {
             }
 
             type GenreAggregate {
+              count: Count!
               node: GenreAggregateNode!
             }
 
             type GenreAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 
@@ -156,11 +160,11 @@ describe("Unions", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
             }
 

--- a/packages/graphql/tests/schema/vector.test.ts
+++ b/packages/graphql/tests/schema/vector.test.ts
@@ -51,6 +51,10 @@ describe("@vector schema", () => {
               mutation: Mutation
             }
 
+            type Count {
+              nodes: Int!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -84,11 +88,11 @@ describe("@vector schema", () => {
             }
 
             type MovieAggregate {
+              count: Count!
               node: MovieAggregateNode!
             }
 
             type MovieAggregateNode {
-              count: Int!
               description: StringAggregateSelection!
               title: StringAggregateSelection!
             }


### PR DESCRIPTION
# Description

Add count fields in aggregations with support for nodes and edges count:

```graphql
query {
    moviesConnection {
        aggregate {
            count {
                nodes
            }
        }
    }
}
```

```graphql
query {
    movies {
        actorsConnection {
            aggregate {
                count {
                    nodes
                    edges
                }
            }
        }
    }
}
```