### PR TITLE
Allow `app` to be overwritten in transaction metadata

### DIFF
--- a/.changeset/two-boxes-cheer.md
+++ b/.changeset/two-boxes-cheer.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+Allow `app` to be overwritten in transaction metadata

--- a/packages/graphql/src/classes/Executor.ts
+++ b/packages/graphql/src/classes/Executor.ts
@@ -209,8 +209,8 @@ export class Executor {
     private getTransactionConfig(info?: GraphQLResolveInfo): TransactionConfig {
         const transactionConfig: TransactionConfig = {
             metadata: {
-                ...this.transactionMetadata,
                 app: APP_ID,
+                ...this.transactionMetadata,
                 type: "user-transpiled",
             },
         };


### PR DESCRIPTION
# Description

Allow `app` to be overwritten in transaction metadata

## Complexity

Complexity: Low
