### PR TITLE
fix: remove comma dangle linting rule (lts)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,16 +36,6 @@ module.exports = {
                 project: "./**/tsconfig.json",
             },
             rules: {
-                "comma-dangle": "off",
-                "@typescript-eslint/comma-dangle": [
-                    "error",
-                    {
-                        ...commaDangle,
-                        enums: "always-multiline",
-                        generics: "always-multiline",
-                        tuples: "never", // Removed due to conflict with prettier
-                    },
-                ],
                 "@typescript-eslint/ban-ts-comment": ["error", { "ts-ignore": "allow-with-description" }],
                 "@typescript-eslint/restrict-template-expressions": "off",
                 "@typescript-eslint/no-explicit-any": "off",


### PR DESCRIPTION
# Description

This removes some linting rules which are no longer working. Essentially a copy of https://github.com/neo4j/graphql/pull/5956 but for LTS.