### PR TITLE
Remove distinct from non-count aggregations

### DIFF
--- a/packages/graphql/src/translate/queryAST/ast/fields/aggregation-fields/AggregationAttributeField.ts
+++ b/packages/graphql/src/translate/queryAST/ast/fields/aggregation-fields/AggregationAttributeField.ts
@@ -67,7 +67,7 @@ export class AggregationAttributeField extends AggregationField {
                 .return(projection);
         }
 
-        return new Cypher.With(target).distinct().return([this.getAggregationExpr(target), returnVar]);
+        return new Cypher.With(target).return([this.getAggregationExpr(target), returnVar]);
     }
 
     private createAggregationExpr(target: Cypher.Variable | Cypher.Property): Cypher.Expr {

--- a/packages/graphql/tests/integration/aggregations/field-level/field-level-aggregations.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/field-level/field-level-aggregations.int.test.ts
@@ -205,8 +205,8 @@ describe("Field Level Aggregations", () => {
                                     age: {
                                         max: 54,
                                         min: 37,
-                                        average: 45.5,
-                                        sum: 91,
+                                        average: expect.closeTo(48.33),
+                                        sum: 145,
                                     },
                                 },
                             },

--- a/packages/graphql/tests/tck/aggregations/alias-directive.test.ts
+++ b/packages/graphql/tests/tck/aggregations/alias-directive.test.ts
@@ -69,7 +69,7 @@ describe("Cypher Aggregations Many with Alias directive", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CALL {
                 MATCH (this:Movie)
-                WITH DISTINCT this
+                WITH this
                 RETURN { shortest: min(this._id), longest: max(this._id) } AS var0
             }
             CALL {
@@ -81,12 +81,12 @@ describe("Cypher Aggregations Many with Alias directive", () => {
             }
             CALL {
                 MATCH (this:Movie)
-                WITH DISTINCT this
+                WITH this
                 RETURN { min: min(this.\`_imdb Rating\`), max: max(this.\`_imdb Rating\`), average: avg(this.\`_imdb Rating\`) } AS var2
             }
             CALL {
                 MATCH (this:Movie)
-                WITH DISTINCT this
+                WITH this
                 RETURN { min: apoc.date.convertFormat(toString(min(this._createdAt)), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\"), max: apoc.date.convertFormat(toString(max(this._createdAt)), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\") } AS var3
             }
             RETURN { id: var0, title: var1, imdbRating: var2, createdAt: var3 }"

--- a/packages/graphql/tests/tck/aggregations/alias.test.ts
+++ b/packages/graphql/tests/tck/aggregations/alias.test.ts
@@ -74,7 +74,7 @@ describe("Cypher Aggregations Many while Alias fields", () => {
             }
             CALL {
                 MATCH (this:Movie)
-                WITH DISTINCT this
+                WITH this
                 RETURN { _shortest: min(this.id), _longest: max(this.id) } AS var1
             }
             CALL {
@@ -86,12 +86,12 @@ describe("Cypher Aggregations Many while Alias fields", () => {
             }
             CALL {
                 MATCH (this:Movie)
-                WITH DISTINCT this
+                WITH this
                 RETURN { _min: min(this.imdbRating), _max: max(this.imdbRating), _average: avg(this.imdbRating) } AS var3
             }
             CALL {
                 MATCH (this:Movie)
-                WITH DISTINCT this
+                WITH this
                 RETURN { _min: apoc.date.convertFormat(toString(min(this.createdAt)), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\"), _max: apoc.date.convertFormat(toString(max(this.createdAt)), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\") } AS var4
             }
             RETURN { _count: var0, _id: var1, _title: var2, _imdbRating: var3, _createdAt: var4 }"

--- a/packages/graphql/tests/tck/aggregations/auth.test.ts
+++ b/packages/graphql/tests/tck/aggregations/auth.test.ts
@@ -152,7 +152,7 @@ describe("Cypher Aggregations with Auth", () => {
             "CALL {
                 MATCH (this:User)
                 WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
-                WITH DISTINCT this
+                WITH this
                 RETURN { min: min(this.imdbRatingInt), max: max(this.imdbRatingInt) } AS var0
             }
             RETURN { imdbRatingInt: var0 }"
@@ -188,7 +188,7 @@ describe("Cypher Aggregations with Auth", () => {
             "CALL {
                 MATCH (this:User)
                 WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
-                WITH DISTINCT this
+                WITH this
                 RETURN { min: min(this.imdbRatingFloat), max: max(this.imdbRatingFloat) } AS var0
             }
             RETURN { imdbRatingFloat: var0 }"
@@ -224,7 +224,7 @@ describe("Cypher Aggregations with Auth", () => {
             "CALL {
                 MATCH (this:User)
                 WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
-                WITH DISTINCT this
+                WITH this
                 RETURN { min: min(this.imdbRatingBigInt), max: max(this.imdbRatingBigInt) } AS var0
             }
             RETURN { imdbRatingBigInt: var0 }"
@@ -260,7 +260,7 @@ describe("Cypher Aggregations with Auth", () => {
             "CALL {
                 MATCH (this:User)
                 WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
-                WITH DISTINCT this
+                WITH this
                 RETURN { shortest: min(this.id), longest: max(this.id) } AS var0
             }
             RETURN { id: var0 }"
@@ -334,7 +334,7 @@ describe("Cypher Aggregations with Auth", () => {
             "CALL {
                 MATCH (this:User)
                 WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
-                WITH DISTINCT this
+                WITH this
                 RETURN { min: apoc.date.convertFormat(toString(min(this.createdAt)), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\"), max: apoc.date.convertFormat(toString(max(this.createdAt)), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\") } AS var0
             }
             RETURN { createdAt: var0 }"

--- a/packages/graphql/tests/tck/aggregations/bigint.test.ts
+++ b/packages/graphql/tests/tck/aggregations/bigint.test.ts
@@ -52,7 +52,7 @@ describe("Cypher Aggregations BigInt", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CALL {
                 MATCH (this:File)
-                WITH DISTINCT this
+                WITH this
                 RETURN { min: min(this.size) } AS var0
             }
             RETURN { size: var0 }"
@@ -77,7 +77,7 @@ describe("Cypher Aggregations BigInt", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CALL {
                 MATCH (this:File)
-                WITH DISTINCT this
+                WITH this
                 RETURN { max: max(this.size) } AS var0
             }
             RETURN { size: var0 }"
@@ -102,7 +102,7 @@ describe("Cypher Aggregations BigInt", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CALL {
                 MATCH (this:File)
-                WITH DISTINCT this
+                WITH this
                 RETURN { average: avg(this.size) } AS var0
             }
             RETURN { size: var0 }"
@@ -127,7 +127,7 @@ describe("Cypher Aggregations BigInt", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CALL {
                 MATCH (this:File)
-                WITH DISTINCT this
+                WITH this
                 RETURN { sum: sum(this.size) } AS var0
             }
             RETURN { size: var0 }"
@@ -155,7 +155,7 @@ describe("Cypher Aggregations BigInt", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CALL {
                 MATCH (this:File)
-                WITH DISTINCT this
+                WITH this
                 RETURN { min: min(this.size), max: max(this.size), average: avg(this.size), sum: sum(this.size) } AS var0
             }
             RETURN { size: var0 }"

--- a/packages/graphql/tests/tck/aggregations/datetime.test.ts
+++ b/packages/graphql/tests/tck/aggregations/datetime.test.ts
@@ -52,7 +52,7 @@ describe("Cypher Aggregations DateTime", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CALL {
                 MATCH (this:Movie)
-                WITH DISTINCT this
+                WITH this
                 RETURN { min: apoc.date.convertFormat(toString(min(this.createdAt)), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\") } AS var0
             }
             RETURN { createdAt: var0 }"
@@ -77,7 +77,7 @@ describe("Cypher Aggregations DateTime", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CALL {
                 MATCH (this:Movie)
-                WITH DISTINCT this
+                WITH this
                 RETURN { max: apoc.date.convertFormat(toString(max(this.createdAt)), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\") } AS var0
             }
             RETURN { createdAt: var0 }"
@@ -103,7 +103,7 @@ describe("Cypher Aggregations DateTime", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CALL {
                 MATCH (this:Movie)
-                WITH DISTINCT this
+                WITH this
                 RETURN { min: apoc.date.convertFormat(toString(min(this.createdAt)), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\"), max: apoc.date.convertFormat(toString(max(this.createdAt)), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\") } AS var0
             }
             RETURN { createdAt: var0 }"

--- a/packages/graphql/tests/tck/aggregations/duration.test.ts
+++ b/packages/graphql/tests/tck/aggregations/duration.test.ts
@@ -52,7 +52,7 @@ describe("Cypher Aggregations Duration", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CALL {
                 MATCH (this:Movie)
-                WITH DISTINCT this
+                WITH this
                 RETURN { min: min(this.screenTime) } AS var0
             }
             RETURN { screenTime: var0 }"
@@ -77,7 +77,7 @@ describe("Cypher Aggregations Duration", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CALL {
                 MATCH (this:Movie)
-                WITH DISTINCT this
+                WITH this
                 RETURN { max: max(this.screenTime) } AS var0
             }
             RETURN { screenTime: var0 }"
@@ -103,7 +103,7 @@ describe("Cypher Aggregations Duration", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CALL {
                 MATCH (this:Movie)
-                WITH DISTINCT this
+                WITH this
                 RETURN { min: min(this.screenTime), max: max(this.screenTime) } AS var0
             }
             RETURN { screenTime: var0 }"

--- a/packages/graphql/tests/tck/aggregations/field-level-aggregations/field-level-aggregations-alias.test.ts
+++ b/packages/graphql/tests/tck/aggregations/field-level-aggregations/field-level-aggregations-alias.test.ts
@@ -102,7 +102,7 @@ describe("Field Level Aggregations Alias", () => {
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WITH DISTINCT this0
+                WITH this0
                 RETURN { max: max(this0.screentime) } AS var2
             }
             RETURN this { actorsAggregate: { edge: { time: var2 } } } AS this"

--- a/packages/graphql/tests/tck/aggregations/field-level-aggregations/field-level-aggregations-edge.test.ts
+++ b/packages/graphql/tests/tck/aggregations/field-level-aggregations/field-level-aggregations-edge.test.ts
@@ -72,7 +72,7 @@ describe("Field Level Aggregations", () => {
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WITH DISTINCT this0
+                WITH this0
                 RETURN { min: min(this0.screentime), max: max(this0.screentime), average: avg(this0.screentime), sum: sum(this0.screentime) } AS var2
             }
             RETURN this { actorsAggregate: { edge: { screentime: var2 } } } AS this"

--- a/packages/graphql/tests/tck/aggregations/field-level-aggregations/field-level-aggregations.test.ts
+++ b/packages/graphql/tests/tck/aggregations/field-level-aggregations/field-level-aggregations.test.ts
@@ -158,7 +158,7 @@ describe("Field Level Aggregations", () => {
             CALL {
                 WITH this
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WITH DISTINCT this1
+                WITH this1
                 RETURN { min: min(this1.age), max: max(this1.age), average: avg(this1.age), sum: sum(this1.age) } AS var2
             }
             RETURN this { actorsAggregate: { node: { age: var2 } } } AS this"
@@ -224,7 +224,7 @@ describe("Field Level Aggregations", () => {
             CALL {
                 WITH this
                 MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                WITH DISTINCT this1
+                WITH this1
                 RETURN { min: apoc.date.convertFormat(toString(min(this1.released)), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\") } AS var2
             }
             RETURN this { moviesAggregate: { node: { released: var2 } } } AS this"
@@ -270,7 +270,7 @@ describe("Field Level Aggregations", () => {
             CALL {
                 WITH this
                 MATCH (this)<-[this3:ACTED_IN]-(this4:Actor)
-                WITH DISTINCT this4
+                WITH this4
                 RETURN { min: min(this4.age), max: max(this4.age), average: avg(this4.age), sum: sum(this4.age) } AS var5
             }
             RETURN this { actorsAggregate: { node: { name: var2, age: var5 } } } AS this"

--- a/packages/graphql/tests/tck/aggregations/float.test.ts
+++ b/packages/graphql/tests/tck/aggregations/float.test.ts
@@ -52,7 +52,7 @@ describe("Cypher Aggregations Float", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CALL {
                 MATCH (this:Movie)
-                WITH DISTINCT this
+                WITH this
                 RETURN { min: min(this.actorCount) } AS var0
             }
             RETURN { actorCount: var0 }"
@@ -77,7 +77,7 @@ describe("Cypher Aggregations Float", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CALL {
                 MATCH (this:Movie)
-                WITH DISTINCT this
+                WITH this
                 RETURN { max: max(this.actorCount) } AS var0
             }
             RETURN { actorCount: var0 }"
@@ -102,7 +102,7 @@ describe("Cypher Aggregations Float", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CALL {
                 MATCH (this:Movie)
-                WITH DISTINCT this
+                WITH this
                 RETURN { average: avg(this.actorCount) } AS var0
             }
             RETURN { actorCount: var0 }"
@@ -127,7 +127,7 @@ describe("Cypher Aggregations Float", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CALL {
                 MATCH (this:Movie)
-                WITH DISTINCT this
+                WITH this
                 RETURN { sum: sum(this.actorCount) } AS var0
             }
             RETURN { actorCount: var0 }"
@@ -155,7 +155,7 @@ describe("Cypher Aggregations Float", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CALL {
                 MATCH (this:Movie)
-                WITH DISTINCT this
+                WITH this
                 RETURN { min: min(this.actorCount), max: max(this.actorCount), average: avg(this.actorCount), sum: sum(this.actorCount) } AS var0
             }
             RETURN { actorCount: var0 }"
@@ -188,7 +188,7 @@ describe("Cypher Aggregations Float", () => {
             }
             CALL {
                 MATCH (this:Movie)
-                WITH DISTINCT this
+                WITH this
                 RETURN { min: min(this.actorCount), max: max(this.actorCount), average: avg(this.actorCount), sum: sum(this.actorCount) } AS var1
             }
             RETURN { count: var0, actorCount: var1 }"

--- a/packages/graphql/tests/tck/aggregations/id.test.ts
+++ b/packages/graphql/tests/tck/aggregations/id.test.ts
@@ -52,7 +52,7 @@ describe("Cypher Aggregations ID", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CALL {
                 MATCH (this:Movie)
-                WITH DISTINCT this
+                WITH this
                 RETURN { shortest: min(this.id) } AS var0
             }
             RETURN { id: var0 }"
@@ -77,7 +77,7 @@ describe("Cypher Aggregations ID", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CALL {
                 MATCH (this:Movie)
-                WITH DISTINCT this
+                WITH this
                 RETURN { longest: max(this.id) } AS var0
             }
             RETURN { id: var0 }"
@@ -103,7 +103,7 @@ describe("Cypher Aggregations ID", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CALL {
                 MATCH (this:Movie)
-                WITH DISTINCT this
+                WITH this
                 RETURN { shortest: min(this.id), longest: max(this.id) } AS var0
             }
             RETURN { id: var0 }"

--- a/packages/graphql/tests/tck/aggregations/int.test.ts
+++ b/packages/graphql/tests/tck/aggregations/int.test.ts
@@ -52,7 +52,7 @@ describe("Cypher Aggregations Int", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CALL {
                 MATCH (this:Movie)
-                WITH DISTINCT this
+                WITH this
                 RETURN { min: min(this.imdbRating) } AS var0
             }
             RETURN { imdbRating: var0 }"
@@ -77,7 +77,7 @@ describe("Cypher Aggregations Int", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CALL {
                 MATCH (this:Movie)
-                WITH DISTINCT this
+                WITH this
                 RETURN { max: max(this.imdbRating) } AS var0
             }
             RETURN { imdbRating: var0 }"
@@ -102,7 +102,7 @@ describe("Cypher Aggregations Int", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CALL {
                 MATCH (this:Movie)
-                WITH DISTINCT this
+                WITH this
                 RETURN { average: avg(this.imdbRating) } AS var0
             }
             RETURN { imdbRating: var0 }"
@@ -127,7 +127,7 @@ describe("Cypher Aggregations Int", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CALL {
                 MATCH (this:Movie)
-                WITH DISTINCT this
+                WITH this
                 RETURN { sum: sum(this.imdbRating) } AS var0
             }
             RETURN { imdbRating: var0 }"
@@ -155,7 +155,7 @@ describe("Cypher Aggregations Int", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CALL {
                 MATCH (this:Movie)
-                WITH DISTINCT this
+                WITH this
                 RETURN { min: min(this.imdbRating), max: max(this.imdbRating), average: avg(this.imdbRating), sum: sum(this.imdbRating) } AS var0
             }
             RETURN { imdbRating: var0 }"

--- a/packages/graphql/tests/tck/aggregations/label.test.ts
+++ b/packages/graphql/tests/tck/aggregations/label.test.ts
@@ -76,7 +76,7 @@ describe("Cypher Aggregations Many while Alias fields", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CALL {
                 MATCH (this:Film)
-                WITH DISTINCT this
+                WITH this
                 RETURN { _shortest: min(this.id), _longest: max(this.id) } AS var0
             }
             CALL {
@@ -88,12 +88,12 @@ describe("Cypher Aggregations Many while Alias fields", () => {
             }
             CALL {
                 MATCH (this:Film)
-                WITH DISTINCT this
+                WITH this
                 RETURN { _min: min(this.imdbRating), _max: max(this.imdbRating), _average: avg(this.imdbRating) } AS var2
             }
             CALL {
                 MATCH (this:Film)
-                WITH DISTINCT this
+                WITH this
                 RETURN { _min: apoc.date.convertFormat(toString(min(this.createdAt)), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\"), _max: apoc.date.convertFormat(toString(max(this.createdAt)), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\") } AS var3
             }
             RETURN { _id: var0, _title: var1, _imdbRating: var2, _createdAt: var3 }"
@@ -132,7 +132,7 @@ describe("Cypher Aggregations Many while Alias fields", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CALL {
                 MATCH (this:Actor:Person:Alien)
-                WITH DISTINCT this
+                WITH this
                 RETURN { _shortest: min(this.id), _longest: max(this.id) } AS var0
             }
             CALL {
@@ -144,12 +144,12 @@ describe("Cypher Aggregations Many while Alias fields", () => {
             }
             CALL {
                 MATCH (this:Actor:Person:Alien)
-                WITH DISTINCT this
+                WITH this
                 RETURN { _min: min(this.imdbRating), _max: max(this.imdbRating), _average: avg(this.imdbRating) } AS var2
             }
             CALL {
                 MATCH (this:Actor:Person:Alien)
-                WITH DISTINCT this
+                WITH this
                 RETURN { _min: apoc.date.convertFormat(toString(min(this.createdAt)), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\"), _max: apoc.date.convertFormat(toString(max(this.createdAt)), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\") } AS var3
             }
             RETURN { _id: var0, _name: var1, _imdbRating: var2, _createdAt: var3 }"

--- a/packages/graphql/tests/tck/aggregations/localdatetime.test.ts
+++ b/packages/graphql/tests/tck/aggregations/localdatetime.test.ts
@@ -52,7 +52,7 @@ describe("Cypher Aggregations LocalDateTime", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CALL {
                 MATCH (this:Movie)
-                WITH DISTINCT this
+                WITH this
                 RETURN { min: min(this.createdAt) } AS var0
             }
             RETURN { createdAt: var0 }"
@@ -77,7 +77,7 @@ describe("Cypher Aggregations LocalDateTime", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CALL {
                 MATCH (this:Movie)
-                WITH DISTINCT this
+                WITH this
                 RETURN { max: max(this.createdAt) } AS var0
             }
             RETURN { createdAt: var0 }"
@@ -103,7 +103,7 @@ describe("Cypher Aggregations LocalDateTime", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CALL {
                 MATCH (this:Movie)
-                WITH DISTINCT this
+                WITH this
                 RETURN { min: min(this.createdAt), max: max(this.createdAt) } AS var0
             }
             RETURN { createdAt: var0 }"

--- a/packages/graphql/tests/tck/aggregations/localtime.test.ts
+++ b/packages/graphql/tests/tck/aggregations/localtime.test.ts
@@ -52,7 +52,7 @@ describe("Cypher Aggregations LocalTime", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CALL {
                 MATCH (this:Movie)
-                WITH DISTINCT this
+                WITH this
                 RETURN { min: min(this.createdAt) } AS var0
             }
             RETURN { createdAt: var0 }"
@@ -77,7 +77,7 @@ describe("Cypher Aggregations LocalTime", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CALL {
                 MATCH (this:Movie)
-                WITH DISTINCT this
+                WITH this
                 RETURN { max: max(this.createdAt) } AS var0
             }
             RETURN { createdAt: var0 }"
@@ -103,7 +103,7 @@ describe("Cypher Aggregations LocalTime", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CALL {
                 MATCH (this:Movie)
-                WITH DISTINCT this
+                WITH this
                 RETURN { min: min(this.createdAt), max: max(this.createdAt) } AS var0
             }
             RETURN { createdAt: var0 }"

--- a/packages/graphql/tests/tck/aggregations/many.test.ts
+++ b/packages/graphql/tests/tck/aggregations/many.test.ts
@@ -69,7 +69,7 @@ describe("Cypher Aggregations Many", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CALL {
                 MATCH (this:Movie)
-                WITH DISTINCT this
+                WITH this
                 RETURN { shortest: min(this.id), longest: max(this.id) } AS var0
             }
             CALL {
@@ -81,12 +81,12 @@ describe("Cypher Aggregations Many", () => {
             }
             CALL {
                 MATCH (this:Movie)
-                WITH DISTINCT this
+                WITH this
                 RETURN { min: min(this.imdbRating), max: max(this.imdbRating), average: avg(this.imdbRating) } AS var2
             }
             CALL {
                 MATCH (this:Movie)
-                WITH DISTINCT this
+                WITH this
                 RETURN { min: apoc.date.convertFormat(toString(min(this.createdAt)), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\"), max: apoc.date.convertFormat(toString(max(this.createdAt)), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\") } AS var3
             }
             RETURN { id: var0, title: var1, imdbRating: var2, createdAt: var3 }"

--- a/packages/graphql/tests/tck/aggregations/time.test.ts
+++ b/packages/graphql/tests/tck/aggregations/time.test.ts
@@ -52,7 +52,7 @@ describe("Cypher Aggregations Time", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CALL {
                 MATCH (this:Movie)
-                WITH DISTINCT this
+                WITH this
                 RETURN { min: min(this.createdAt) } AS var0
             }
             RETURN { createdAt: var0 }"
@@ -77,7 +77,7 @@ describe("Cypher Aggregations Time", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CALL {
                 MATCH (this:Movie)
-                WITH DISTINCT this
+                WITH this
                 RETURN { max: max(this.createdAt) } AS var0
             }
             RETURN { createdAt: var0 }"
@@ -103,7 +103,7 @@ describe("Cypher Aggregations Time", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CALL {
                 MATCH (this:Movie)
-                WITH DISTINCT this
+                WITH this
                 RETURN { min: min(this.createdAt), max: max(this.createdAt) } AS var0
             }
             RETURN { createdAt: var0 }"

--- a/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-aggregation.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-aggregation.test.ts
@@ -130,7 +130,7 @@ describe("cypher directive filtering - Aggregation", () => {
                 }
                 WITH *
                 WHERE var1 > $param0
-                WITH DISTINCT this
+                WITH this
                 RETURN { min: min(this.released) } AS var2
             }
             RETURN { released: var2 }"

--- a/packages/graphql/tests/tck/issues/1933.test.ts
+++ b/packages/graphql/tests/tck/issues/1933.test.ts
@@ -93,7 +93,7 @@ describe("https://github.com/neo4j/graphql/issues/1933", () => {
             CALL {
                 WITH this
                 MATCH (this)-[this6:PARTICIPATES]->(this7:Project)
-                WITH DISTINCT this6
+                WITH this6
                 RETURN { min: min(this6.allocation), max: max(this6.allocation), average: avg(this6.allocation), sum: sum(this6.allocation) } AS var8
             }
             RETURN this { .employeeId, .firstName, .lastName, projectsAggregate: { count: var5, edge: { allocation: var8 } } } AS this"


### PR DESCRIPTION
# Description

Remove distinct from non count aggregations to avoid breaking changes. This will be reverted in 7.x
