### PR TITLE
Enable distinct for new aggregations

### DIFF
--- a/packages/graphql/src/translate/queryAST/ast/fields/aggregation-fields/DeprecatedAggregationAttributeField.ts
+++ b/packages/graphql/src/translate/queryAST/ast/fields/aggregation-fields/DeprecatedAggregationAttributeField.ts
@@ -23,7 +23,7 @@ import { filterFields, renameFields } from "../../../../../utils/utils";
 import type { QueryASTNode } from "../../QueryASTNode";
 import { AggregationField } from "./AggregationField";
 
-export class AggregationAttributeField extends AggregationField {
+export class DeprecatedAggregationAttributeField extends AggregationField {
     private attribute: AttributeAdapter;
     private aggregationProjection: Record<string, string>;
 
@@ -62,13 +62,12 @@ export class AggregationAttributeField extends AggregationField {
             const projection = new Cypher.Return([this.createAggregationExpr(listVar), returnVar]);
 
             return new Cypher.With(target)
-                .distinct()
                 .orderBy([Cypher.size(aggrProp), "DESC"])
                 .with([Cypher.collect(aggrProp), listVar])
                 .return(projection);
         }
 
-        return new Cypher.With(target).distinct().return([this.getAggregationExpr(target), returnVar]);
+        return new Cypher.With(target).return([this.getAggregationExpr(target), returnVar]);
     }
 
     private createAggregationExpr(target: Cypher.Variable | Cypher.Property): Cypher.Expr {

--- a/packages/graphql/src/translate/queryAST/factory/FieldFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/FieldFactory.ts
@@ -35,6 +35,7 @@ import { OperationField } from "../ast/fields/OperationField";
 import { AggregationAttributeField } from "../ast/fields/aggregation-fields/AggregationAttributeField";
 import type { AggregationField } from "../ast/fields/aggregation-fields/AggregationField";
 import { CountField } from "../ast/fields/aggregation-fields/CountField";
+import { DeprecatedAggregationAttributeField } from "../ast/fields/aggregation-fields/DeprecatedAggregationAttributeField";
 import { DeprecatedCountField } from "../ast/fields/aggregation-fields/DeprecatedCountField";
 import { AttributeField } from "../ast/fields/attribute-fields/AttributeField";
 import { DateTimeField } from "../ast/fields/attribute-fields/DateTimeField";
@@ -134,7 +135,8 @@ export class FieldFactory {
 
     public createAggregationFields(
         entity: ConcreteEntityAdapter | RelationshipAdapter | InterfaceEntityAdapter,
-        rawFields: Record<string, ResolveTree>
+        rawFields: Record<string, ResolveTree>,
+        useDeprecatedAttribute = false
     ): AggregationField[] {
         return filterTruthy(
             Object.values(rawFields).map((field) => {
@@ -169,11 +171,19 @@ export class FieldFactory {
                         return acc;
                     }, {});
 
-                    return new AggregationAttributeField({
-                        attribute,
-                        alias: field.alias,
-                        aggregationProjection,
-                    });
+                    if (useDeprecatedAttribute) {
+                        return new DeprecatedAggregationAttributeField({
+                            attribute,
+                            alias: field.alias,
+                            aggregationProjection,
+                        });
+                    } else {
+                        return new AggregationAttributeField({
+                            attribute,
+                            alias: field.alias,
+                            aggregationProjection,
+                        });
+                    }
                 }
             })
         );

--- a/packages/graphql/src/translate/queryAST/factory/Operations/AggregateFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/Operations/AggregateFactory.ts
@@ -48,11 +48,13 @@ export class AggregateFactory {
         resolveTree,
         context,
         extraWhereArgs = {},
+        isInConnection = false,
     }: {
         entityOrRel: ConcreteEntityAdapter | RelationshipAdapter | InterfaceEntityAdapter;
         resolveTree: ResolveTree;
         context: Neo4jGraphQLTranslationContext;
         extraWhereArgs?: Record<string, any>;
+        isInConnection?: boolean;
     }): AggregationOperation | CompositeAggregationOperation {
         let entity: ConcreteEntityAdapter | InterfaceEntityAdapter;
         if (entityOrRel instanceof RelationshipAdapter) {
@@ -92,6 +94,7 @@ export class AggregateFactory {
                     resolveTree,
                     context,
                     whereArgs: resolveTreeWhere,
+                    deprecatedAttributes: !isInConnection,
                 });
             } else {
                 // RELATIONSHIP WITH INTERFACE TARGET
@@ -139,6 +142,7 @@ export class AggregateFactory {
                     context,
                     operation: compositeAggregationOp,
                     whereArgs: resolveTreeWhere,
+                    deprecatedAttributes: !isInConnection,
                 });
 
                 return compositeAggregationOp;
@@ -169,6 +173,7 @@ export class AggregateFactory {
                     resolveTree,
                     context,
                     whereArgs: resolveTreeWhere,
+                    deprecatedAttributes: !isInConnection,
                 });
             } else {
                 // TOP level interface/union
@@ -208,6 +213,7 @@ export class AggregateFactory {
                     context,
                     operation: compositeAggregationOp,
                     whereArgs: resolveTreeWhere,
+                    deprecatedAttributes: !isInConnection,
                 });
             }
         }
@@ -248,6 +254,7 @@ export class AggregateFactory {
         resolveTree,
         context,
         whereArgs,
+        deprecatedAttributes,
     }: {
         relationship?: RelationshipAdapter;
         entity: ConcreteEntityAdapter | InterfaceEntityAdapter;
@@ -255,6 +262,7 @@ export class AggregateFactory {
         resolveTree: ResolveTree;
         context: Neo4jGraphQLTranslationContext;
         whereArgs: Record<string, any>;
+        deprecatedAttributes: boolean;
     }): T {
         if (relationship) {
             const parsedProjectionFields = this.getAggregationParsedProjectionFields(relationship, resolveTree);
@@ -273,10 +281,19 @@ export class AggregateFactory {
 
             const fields = this.queryASTFactory.fieldFactory.createAggregationFields(
                 entity,
-                parsedProjectionFields.fields
+                parsedProjectionFields.fields,
+                deprecatedAttributes
             );
-            const nodeFields = this.queryASTFactory.fieldFactory.createAggregationFields(entity, nodeRawFields);
-            const edgeFields = this.queryASTFactory.fieldFactory.createAggregationFields(relationship, edgeRawFields);
+            const nodeFields = this.queryASTFactory.fieldFactory.createAggregationFields(
+                entity,
+                nodeRawFields,
+                deprecatedAttributes
+            );
+            const edgeFields = this.queryASTFactory.fieldFactory.createAggregationFields(
+                relationship,
+                edgeRawFields,
+                deprecatedAttributes
+            );
             if (isInterfaceEntity(entity)) {
                 const filters = this.queryASTFactory.filterFactory.createInterfaceNodeFilters({
                     entity,
@@ -308,7 +325,11 @@ export class AggregateFactory {
                 ...resolveTree.fieldsByTypeName[entity.operations.aggregateTypeNames.node], // Handles both, deprecated and new aggregation parsing
             };
 
-            const fields = this.queryASTFactory.fieldFactory.createAggregationFields(entity, rawProjectionFields);
+            const fields = this.queryASTFactory.fieldFactory.createAggregationFields(
+                entity,
+                rawProjectionFields,
+                deprecatedAttributes
+            );
             // TOP Level aggregate in connection
             const connectionFields = {
                 // TOP level connection fields
@@ -320,14 +341,22 @@ export class AggregateFactory {
                 ...nodeResolveTree?.fieldsByTypeName[entity.operations.aggregateTypeNames.node],
             };
 
-            const nodeFields = this.queryASTFactory.fieldFactory.createAggregationFields(entity, nodeRawFields);
+            const nodeFields = this.queryASTFactory.fieldFactory.createAggregationFields(
+                entity,
+                nodeRawFields,
+                deprecatedAttributes
+            );
             operation.setNodeFields(nodeFields);
             const countResolveTree = findFieldsByNameInFieldsByTypeNameField(connectionFields, "count")[0];
 
             if (countResolveTree) {
-                const connetionTopFields = this.queryASTFactory.fieldFactory.createAggregationFields(entity, {
-                    count: countResolveTree,
-                });
+                const connetionTopFields = this.queryASTFactory.fieldFactory.createAggregationFields(
+                    entity,
+                    {
+                        count: countResolveTree,
+                    },
+                    deprecatedAttributes
+                );
                 fields.push(...connetionTopFields);
             }
 

--- a/packages/graphql/src/translate/queryAST/factory/Operations/ConnectionFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/Operations/ConnectionFactory.ts
@@ -267,6 +267,7 @@ export class ConnectionFactory {
                     resolveTree: resolveTreeAggregate,
                     context,
                     extraWhereArgs: whereArgs,
+                    isInConnection: true,
                 });
                 // NOTE: This will always be true on 7.x and this attribute should be removed
                 aggregationOperation.isInConnectionField = true;
@@ -288,6 +289,7 @@ export class ConnectionFactory {
                     resolveTree: resolveTreeAggregate,
                     context,
                     extraWhereArgs: whereArgs,
+                    isInConnection: true,
                 });
                 // NOTE: This will always be true on 7.x and this attribute should be removed
                 aggregationOperation.isInConnectionField = true;

--- a/packages/graphql/tests/integration/aggregations/field-level/field-level-aggregations.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/field-level/field-level-aggregations.int.test.ts
@@ -57,6 +57,7 @@ describe("Field Level Aggregations", () => {
             CREATE (m)<-[:ACTED_IN { screentime: 60, character: "Terminator" }]-(a1:${typeActor.name} { name: "Arnold", age: 54, born: datetime('1980-07-02')})
             CREATE (m)<-[:ACTED_IN { screentime: 50, character: "someone" }]-(a1)
             CREATE (m)<-[:ACTED_IN { screentime: 120, character: "Sarah" }]-(:${typeActor.name} {name: "Linda", age:37, born: datetime('2000-02-02')})
+            CREATE (m)<-[:ACTED_IN { screentime: 120, character: "Sarah" }]-(:${typeActor.name} {name: "John", age:37, born: datetime('2000-02-02')})
         `);
     });
 
@@ -89,7 +90,7 @@ describe("Field Level Aggregations", () => {
                     actorsConnection: {
                         aggregate: {
                             count: {
-                                nodes: 2,
+                                nodes: 3,
                             },
                         },
                     },
@@ -124,8 +125,8 @@ describe("Field Level Aggregations", () => {
                     actorsConnection: {
                         aggregate: {
                             count: {
-                                nodes: 2,
-                                edges: 3,
+                                nodes: 3,
+                                edges: 4,
                             },
                         },
                     },
@@ -163,7 +164,7 @@ describe("Field Level Aggregations", () => {
                                 node: {
                                     name: {
                                         longest: "Arnold",
-                                        shortest: "Linda",
+                                        shortest: "John",
                                     },
                                 },
                             },
@@ -205,8 +206,8 @@ describe("Field Level Aggregations", () => {
                                     age: {
                                         max: 54,
                                         min: 37,
-                                        average: expect.closeTo(45.5),
-                                        sum: 91,
+                                        average: expect.closeTo(42.67),
+                                        sum: 128,
                                     },
                                 },
                             },
@@ -289,8 +290,8 @@ describe("Field Level Aggregations", () => {
                                     screentime: {
                                         max: 120,
                                         min: 50,
-                                        average: expect.closeTo(76.67),
-                                        sum: 230,
+                                        average: expect.closeTo(87.5),
+                                        sum: 350,
                                     },
                                 },
                             },

--- a/packages/graphql/tests/integration/aggregations/field-level/field-level-aggregations.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/field-level/field-level-aggregations.int.test.ts
@@ -205,8 +205,8 @@ describe("Field Level Aggregations", () => {
                                     age: {
                                         max: 54,
                                         min: 37,
-                                        average: expect.closeTo(48.33),
-                                        sum: 145,
+                                        average: expect.closeTo(45.5),
+                                        sum: 91,
                                     },
                                 },
                             },

--- a/packages/graphql/tests/integration/deprecations/aggregations/field-level/field-level-aggregations.int.test.ts
+++ b/packages/graphql/tests/integration/deprecations/aggregations/field-level/field-level-aggregations.int.test.ts
@@ -54,7 +54,8 @@ describe("Field Level Aggregations", () => {
 
         await testHelper.executeCypher(`
             CREATE (m:${typeMovie.name} { title: "Terminator"})
-            CREATE(m)<-[:ACTED_IN { screentime: 60, character: "Terminator" }]-(:${typeActor.name} { name: "Arnold", age: 54, born: datetime('1980-07-02')})
+            CREATE (m)<-[:ACTED_IN { screentime: 60, character: "Terminator" }]-(a1:${typeActor.name} { name: "Arnold", age: 54, born: datetime('1980-07-02')})
+            CREATE (m)<-[:ACTED_IN { screentime: 50, character: "someone" }]-(a1)
             CREATE (m)<-[:ACTED_IN { screentime: 120, character: "Sarah" }]-(:${typeActor.name} {name: "Linda", age:37, born: datetime('2000-02-02')})
         `);
     });
@@ -78,7 +79,7 @@ describe("Field Level Aggregations", () => {
 
         expect(gqlResult.errors).toBeUndefined();
         expect((gqlResult as any).data[typeMovie.plural][0][`${typeActor.plural}Aggregate`]).toEqual({
-            count: 2,
+            count: 3,
         });
     });
 
@@ -138,8 +139,8 @@ describe("Field Level Aggregations", () => {
                     age: {
                         max: 54,
                         min: 37,
-                        average: 45.5,
-                        sum: 91,
+                        average: expect.closeTo(48.33),
+                        sum: 145,
                     },
                 },
             });
@@ -201,9 +202,9 @@ describe("Field Level Aggregations", () => {
                 edge: {
                     screentime: {
                         max: 120,
-                        min: 60,
-                        average: 90,
-                        sum: 180,
+                        min: 50,
+                        average: expect.closeTo(76.67),
+                        sum: 230,
                     },
                 },
             });


### PR DESCRIPTION
# Description

This enable `DISTINCT` for aggregation attributes. This is only enabled for new aggregations, a new "DeprecatedAggregationAttributeField" has been added to legacy aggregations
