### PR TITLE
Add unsafeEscapeOptions

### DIFF
--- a/.changeset/plenty-pants-fold.md
+++ b/.changeset/plenty-pants-fold.md
@@ -1,0 +1,67 @@
+---
+"@neo4j/graphql": patch
+---
+
+Add `unsafeEscapeOptions` to `Neo4jGraphQL` features with the following flags:
+
+-   `disableRelationshipTypeEscaping` (default to `false`)
+-   `disableLabelEscaping` (defaults to `false`)
+
+These flags remove the automatic escaping of node labels and relationship types in the generated Cypher.
+
+For example, given the following schema:
+
+```graphql
+type Actor {
+    name: String!
+}
+
+type Movie {
+    title: String!
+    actors: [${Actor}!]! @relationship(type: "FROM_PRODUCTION]->(:Production)-[:ACTED_IN", direction: OUT)
+}
+```
+
+A GraphQL query going through the `actors` relationship:
+
+```graphql
+query {
+    movies {
+        title
+        actors {
+            name
+        }
+    }
+}
+```
+
+Will normally generate the following Cypher for the relationship:
+
+```cypher
+MATCH (this:Movie)-[this0:`FROM_PRODUCTION]->(:Production)-[:ACTED_IN`]->(this1:Actor)
+```
+
+The label `FROM_PRODUCTION]->(:Production)-[:ACTED_IN` is escaped by placing it inside backticks (`\``), as some characters in it are susceptible of code injection.
+
+If the option `disableRelationshipTypeEscaping` is set in `Neo4jGraphQL`, this safety mechanism will be disabled:
+
+```js
+new Neo4jGraphQL({
+    typeDefs,
+    features: {
+        unsafeEscapeOptions: {
+            disableRelationshipTypeEscaping: true,
+        },
+    },
+});
+```
+
+Generating the following Cypher instead:
+
+```cypher
+MATCH (this:Movie)-[this0:FROM_PRODUCTION]->(:Production)-[:ACTED_IN]->(this1:Actor)
+```
+
+This can be useful in very custom scenarios where the Cypher needs to be tweaked or if the labels and types have already been escaped.
+
+> Warning: This is a safety mechanism to avoid Cypher injection. Changing these options may lead to code injection and an unsafe server.

--- a/.changeset/plenty-pants-fold.md
+++ b/.changeset/plenty-pants-fold.md
@@ -4,8 +4,8 @@
 
 Add `unsafeEscapeOptions` to `Neo4jGraphQL` features with the following flags:
 
--   `disableRelationshipTypeEscaping` (default to `false`)
--   `disableLabelEscaping` (defaults to `false`)
+- `disableRelationshipTypeEscaping` (default to `false`)
+- `disableLabelEscaping` (defaults to `false`)
 
 These flags remove the automatic escaping of node labels and relationship types in the generated Cypher.
 
@@ -18,7 +18,7 @@ type Actor {
 
 type Movie {
     title: String!
-    actors: [${Actor}!]! @relationship(type: "FROM_PRODUCTION]->(:Production)-[:ACTED_IN", direction: OUT)
+    actors: [Actor!]! @relationship(type: "ACTED IN", direction: OUT)
 }
 ```
 
@@ -38,10 +38,10 @@ query {
 Will normally generate the following Cypher for the relationship:
 
 ```cypher
-MATCH (this:Movie)-[this0:`FROM_PRODUCTION]->(:Production)-[:ACTED_IN`]->(this1:Actor)
+MATCH (this:Movie)-[this0:`ACTED IN`]->(this1:Actor)
 ```
 
-The label `FROM_PRODUCTION]->(:Production)-[:ACTED_IN` is escaped by placing it inside backticks (`\``), as some characters in it are susceptible of code injection.
+The label `ACTED IN` is escaped by placing it inside backticks (`\``), as some characters in it are susceptible of code injection.
 
 If the option `disableRelationshipTypeEscaping` is set in `Neo4jGraphQL`, this safety mechanism will be disabled:
 
@@ -56,10 +56,10 @@ new Neo4jGraphQL({
 });
 ```
 
-Generating the following Cypher instead:
+Generating the following (incorrect) Cypher instead:
 
 ```cypher
-MATCH (this:Movie)-[this0:FROM_PRODUCTION]->(:Production)-[:ACTED_IN]->(this1:Actor)
+MATCH (this:Movie)-[this0:ACTED IN]->(this1:Actor)
 ```
 
 This can be useful in very custom scenarios where the Cypher needs to be tweaked or if the labels and types have already been escaped.

--- a/.changeset/plenty-pants-fold.md
+++ b/.changeset/plenty-pants-fold.md
@@ -5,7 +5,7 @@
 Add `unsafeEscapeOptions` to `Neo4jGraphQL` features with the following flags:
 
 - `disableRelationshipTypeEscaping` (default to `false`)
-- `disableLabelEscaping` (defaults to `false`)
+- `disableNodeLabelEscaping` (defaults to `false`)
 
 These flags remove the automatic escaping of node labels and relationship types in the generated Cypher.
 

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -79,7 +79,7 @@
         "@graphql-tools/resolvers-composition": "^7.0.0",
         "@graphql-tools/schema": "^10.0.0",
         "@graphql-tools/utils": "10.6.1",
-        "@neo4j/cypher-builder": "^2.3.1",
+        "@neo4j/cypher-builder": "^2.3.2",
         "camelcase": "^6.3.0",
         "debug": "^4.3.4",
         "dot-prop": "^6.0.1",

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -79,7 +79,7 @@
         "@graphql-tools/resolvers-composition": "^7.0.0",
         "@graphql-tools/schema": "^10.0.0",
         "@graphql-tools/utils": "10.6.1",
-        "@neo4j/cypher-builder": "^2.3.2",
+        "@neo4j/cypher-builder": "^2.4.0",
         "camelcase": "^6.3.0",
         "debug": "^4.3.4",
         "dot-prop": "^6.0.1",

--- a/packages/graphql/src/translate/authorization/compatibility/compile-predicate-return.ts
+++ b/packages/graphql/src/translate/authorization/compatibility/compile-predicate-return.ts
@@ -35,11 +35,15 @@ type CompiledPredicateReturn = {
  * The subqueries contain variables required by the predicate, and if they are not compiled with the same
  * environment, the predicate will be referring to non-existent variables and will re-assign variable from the subqueries.
  */
-export function compilePredicateReturn(
-    predicateReturn: PredicateReturn,
-    indexPrefix: string | undefined,
-    context: Neo4jGraphQLTranslationContext
-): CompiledPredicateReturn {
+export function compilePredicateReturn({
+    predicateReturn,
+    indexPrefix,
+    context,
+}: {
+    predicateReturn: PredicateReturn;
+    indexPrefix: string | undefined;
+    context: Neo4jGraphQLTranslationContext;
+}): CompiledPredicateReturn {
     const result: CompiledPredicateReturn = { cypher: "", params: {} };
 
     const { predicate, preComputedSubqueries } = predicateReturn;

--- a/packages/graphql/src/translate/authorization/compatibility/compile-predicate-return.ts
+++ b/packages/graphql/src/translate/authorization/compatibility/compile-predicate-return.ts
@@ -19,7 +19,9 @@
 
 import Cypher from "@neo4j/cypher-builder";
 import type { PredicateReturn } from "../../../types";
+import type { Neo4jGraphQLTranslationContext } from "../../../types/neo4j-graphql-translation-context";
 import { compileCypher } from "../../../utils/compile-cypher";
+import { buildClause } from "../../utils/build-clause";
 
 type CompiledPredicateReturn = {
     cypher: string;
@@ -35,7 +37,8 @@ type CompiledPredicateReturn = {
  */
 export function compilePredicateReturn(
     predicateReturn: PredicateReturn,
-    indexPrefix?: string
+    indexPrefix: string | undefined,
+    context: Neo4jGraphQLTranslationContext
 ): CompiledPredicateReturn {
     const result: CompiledPredicateReturn = { cypher: "", params: {} };
 
@@ -52,7 +55,10 @@ export function compilePredicateReturn(
             }
             return predicateStr;
         });
-        const { cypher, params } = predicateCypher.build({ prefix: `authorization_${indexPrefix || ""}` });
+        const { cypher, params } = buildClause(predicateCypher, {
+            context,
+            prefix: `authorization_${indexPrefix || ""}`,
+        });
         result.cypher = cypher;
         result.params = params;
         result.subqueries = subqueries;

--- a/packages/graphql/src/translate/authorization/compatibility/create-authorization-after-and-params.ts
+++ b/packages/graphql/src/translate/authorization/compatibility/create-authorization-after-and-params.ts
@@ -18,15 +18,15 @@
  */
 
 import Cypher from "@neo4j/cypher-builder";
-import type { Node } from "../../../types";
 import type { AuthorizationOperation } from "../../../schema-model/annotation/AuthorizationAnnotation";
+import type { Node } from "../../../types";
+import type { Neo4jGraphQLTranslationContext } from "../../../types/neo4j-graphql-translation-context";
 import {
-    createAuthorizationAfterPredicateField,
     createAuthorizationAfterPredicate,
+    createAuthorizationAfterPredicateField,
 } from "../create-authorization-after-predicate";
 import type { NodeMap } from "../types/node-map";
 import { compilePredicateReturn } from "./compile-predicate-return";
-import type { Neo4jGraphQLTranslationContext } from "../../../types/neo4j-graphql-translation-context";
 
 type AuthorizationAfterAndParams = {
     cypher: string;
@@ -68,7 +68,7 @@ export function createAuthorizationAfterAndParams({
     });
 
     if (predicateReturn) {
-        return compilePredicateReturn(predicateReturn, `${indexPrefix || "_"}after_`);
+        return compilePredicateReturn(predicateReturn, `${indexPrefix || "_"}after_`, context);
     }
 
     return undefined;
@@ -94,7 +94,7 @@ export function createAuthorizationAfterAndParamsField({
     });
 
     if (predicateReturn) {
-        return compilePredicateReturn(predicateReturn, `${indexPrefix || "_"}after_`);
+        return compilePredicateReturn(predicateReturn, `${indexPrefix || "_"}after_`, context);
     }
 
     return undefined;

--- a/packages/graphql/src/translate/authorization/compatibility/create-authorization-after-and-params.ts
+++ b/packages/graphql/src/translate/authorization/compatibility/create-authorization-after-and-params.ts
@@ -68,7 +68,7 @@ export function createAuthorizationAfterAndParams({
     });
 
     if (predicateReturn) {
-        return compilePredicateReturn(predicateReturn, `${indexPrefix || "_"}after_`, context);
+        return compilePredicateReturn({ predicateReturn, indexPrefix: `${indexPrefix || "_"}after_`, context });
     }
 
     return undefined;
@@ -94,7 +94,7 @@ export function createAuthorizationAfterAndParamsField({
     });
 
     if (predicateReturn) {
-        return compilePredicateReturn(predicateReturn, `${indexPrefix || "_"}after_`, context);
+        return compilePredicateReturn({ predicateReturn, indexPrefix: `${indexPrefix || "_"}after_`, context });
     }
 
     return undefined;

--- a/packages/graphql/src/translate/authorization/compatibility/create-authorization-before-and-params.ts
+++ b/packages/graphql/src/translate/authorization/compatibility/create-authorization-before-and-params.ts
@@ -18,15 +18,15 @@
  */
 
 import Cypher from "@neo4j/cypher-builder";
-import type { Node } from "../../../types";
 import type { AuthorizationOperation } from "../../../schema-model/annotation/AuthorizationAnnotation";
+import type { Node } from "../../../types";
+import type { Neo4jGraphQLTranslationContext } from "../../../types/neo4j-graphql-translation-context";
 import {
-    createAuthorizationBeforePredicateField,
     createAuthorizationBeforePredicate,
+    createAuthorizationBeforePredicateField,
 } from "../create-authorization-before-predicate";
 import type { NodeMap } from "../types/node-map";
 import { compilePredicateReturn } from "./compile-predicate-return";
-import type { Neo4jGraphQLTranslationContext } from "../../../types/neo4j-graphql-translation-context";
 
 type AuthorizationBeforeAndParams = {
     cypher: string;
@@ -69,7 +69,7 @@ export function createAuthorizationBeforeAndParams({
     });
 
     if (predicateReturn) {
-        return compilePredicateReturn(predicateReturn, `${indexPrefix || "_"}before_`);
+        return compilePredicateReturn(predicateReturn, `${indexPrefix || "_"}before_`, context);
     }
 
     return undefined;
@@ -93,7 +93,7 @@ export function createAuthorizationBeforeAndParamsField({
     });
 
     if (predicateReturn) {
-        return compilePredicateReturn(predicateReturn, "_before_");
+        return compilePredicateReturn(predicateReturn, "_before_", context);
     }
 
     return undefined;

--- a/packages/graphql/src/translate/authorization/compatibility/create-authorization-before-and-params.ts
+++ b/packages/graphql/src/translate/authorization/compatibility/create-authorization-before-and-params.ts
@@ -69,7 +69,7 @@ export function createAuthorizationBeforeAndParams({
     });
 
     if (predicateReturn) {
-        return compilePredicateReturn(predicateReturn, `${indexPrefix || "_"}before_`, context);
+        return compilePredicateReturn({ predicateReturn, indexPrefix: `${indexPrefix || "_"}before_`, context });
     }
 
     return undefined;
@@ -93,7 +93,7 @@ export function createAuthorizationBeforeAndParamsField({
     });
 
     if (predicateReturn) {
-        return compilePredicateReturn(predicateReturn, "_before_", context);
+        return compilePredicateReturn({ predicateReturn, indexPrefix: "_before_", context });
     }
 
     return undefined;

--- a/packages/graphql/src/translate/create-connect-and-params.ts
+++ b/packages/graphql/src/translate/create-connect-and-params.ts
@@ -37,6 +37,7 @@ import { createRelationshipValidationString } from "./create-relationship-valida
 import createSetRelationshipPropertiesAndParams from "./create-set-relationship-properties-and-params";
 import { createConnectionEventMetaObject } from "./subscriptions/create-connection-event-meta";
 import { filterMetaVariable } from "./subscriptions/filter-meta-variable";
+import { buildClause } from "./utils/build-clause";
 import { createWhereNodePredicate } from "./where/create-where-predicate";
 
 interface Res {
@@ -154,7 +155,7 @@ function createConnectAndParams({
             if (filters?.preComputedSubqueries?.length) {
                 const columns = [new Cypher.NamedVariable(nodeName)];
                 const caseWhereClause = caseWhere(new Cypher.Raw(predicate), columns);
-                const { cypher } = caseWhereClause.build({ prefix: "aggregateWhereFilter" });
+                const { cypher } = buildClause(caseWhereClause, { context, prefix: "aggregateWhereFilter" });
                 subquery.push(cypher);
             } else {
                 subquery.push(`\tWHERE ${predicate}`);
@@ -468,7 +469,7 @@ function getFilters({
         return [cypher, {}];
     });
 
-    const result = whereCypher.build({ prefix: `${nodeName}_` });
+    const result = buildClause(whereCypher, { context, prefix: `${nodeName}_` });
 
     if (result.cypher) {
         return {

--- a/packages/graphql/src/translate/create-connect-or-create-and-params.ts
+++ b/packages/graphql/src/translate/create-connect-or-create-and-params.ts
@@ -32,6 +32,7 @@ import { createAuthorizationAfterPredicate } from "./authorization/create-author
 import { createAuthorizationBeforePredicate } from "./authorization/create-authorization-before-predicate";
 import { createConnectionEventMeta } from "./subscriptions/create-connection-event-meta";
 import { filterMetaVariable } from "./subscriptions/filter-meta-variable";
+import { buildClause } from "./utils/build-clause";
 import { addCallbackAndSetParamCypher } from "./utils/callback-utils";
 
 type CreateOrConnectInput = {
@@ -117,7 +118,7 @@ export function createConnectOrCreateAndParams({
     });
 
     const query = Cypher.utils.concat(...wrappedQueries);
-    return query.build({ prefix: `${varName}_` });
+    return buildClause(query, { context, prefix: `${varName}_` });
 }
 
 function createConnectOrCreatePartialStatement({

--- a/packages/graphql/src/translate/create-delete-and-params.ts
+++ b/packages/graphql/src/translate/create-delete-and-params.ts
@@ -27,6 +27,7 @@ import { createAuthorizationBeforeAndParams } from "./authorization/compatibilit
 import { createConnectionEventMetaObject } from "./subscriptions/create-connection-event-meta";
 import { createEventMetaObject } from "./subscriptions/create-event-meta";
 import { filterMetaVariable } from "./subscriptions/filter-meta-variable";
+import { buildClause } from "./utils/build-clause";
 import createConnectionWhereAndParams from "./where/create-connection-where-and-params";
 
 interface Res {
@@ -183,7 +184,10 @@ function createDeleteAndParams({
                                 new Cypher.NamedVariable(variableName),
                             ];
                             const caseWhereClause = caseWhere(new Cypher.Raw(predicate), columns);
-                            const { cypher } = caseWhereClause.build({ prefix: "aggregateWhereFilter" });
+                            const { cypher } = buildClause(caseWhereClause, {
+                                context,
+                                prefix: "aggregateWhereFilter",
+                            });
                             innerStrs.push(cypher);
                         } else {
                             innerStrs.push(`WHERE ${predicate}`);

--- a/packages/graphql/src/translate/create-disconnect-and-params.ts
+++ b/packages/graphql/src/translate/create-disconnect-and-params.ts
@@ -27,6 +27,7 @@ import { createAuthorizationAfterAndParams } from "./authorization/compatibility
 import { createAuthorizationBeforeAndParams } from "./authorization/compatibility/create-authorization-before-and-params";
 import { createConnectionEventMetaObject } from "./subscriptions/create-connection-event-meta";
 import { filterMetaVariable } from "./subscriptions/filter-meta-variable";
+import { buildClause } from "./utils/build-clause";
 import createConnectionWhereAndParams from "./where/create-connection-where-and-params";
 
 interface Res {
@@ -140,7 +141,7 @@ function createDisconnectAndParams({
             if (aggregationWhere) {
                 const columns = [new Cypher.NamedVariable(relVarName), new Cypher.NamedVariable(variableName)];
                 const caseWhereClause = caseWhere(new Cypher.Raw(predicate), columns);
-                const { cypher } = caseWhereClause.build({ prefix: "aggregateWhereFilter" });
+                const { cypher } = buildClause(caseWhereClause, { context, prefix: "aggregateWhereFilter" });
                 subquery.push(cypher);
             } else {
                 subquery.push(`WHERE ${predicate}`);

--- a/packages/graphql/src/translate/create-update-and-params.ts
+++ b/packages/graphql/src/translate/create-update-and-params.ts
@@ -48,6 +48,7 @@ import createSetRelationshipProperties from "./create-set-relationship-propertie
 import { createConnectionEventMeta } from "./subscriptions/create-connection-event-meta";
 import { createEventMeta } from "./subscriptions/create-event-meta";
 import { filterMetaVariable } from "./subscriptions/filter-meta-variable";
+import { buildClause } from "./utils/build-clause";
 import { addCallbackAndSetParam } from "./utils/callback-utils";
 import { getAuthorizationStatements } from "./utils/get-authorization-statements";
 import { indentBlock } from "./utils/indent-block";
@@ -268,7 +269,10 @@ export default function createUpdateAndParams({
                                     new Cypher.NamedVariable(variableName),
                                 ];
                                 const caseWhereClause = caseWhere(new Cypher.Raw(predicate), columns);
-                                const { cypher } = caseWhereClause.build({ prefix: "aggregateWhereFilter" });
+                                const { cypher } = buildClause(caseWhereClause, {
+                                    context,
+                                    prefix: "aggregateWhereFilter",
+                                });
                                 innerUpdate.push(cypher);
                             } else {
                                 innerUpdate.push(`WHERE ${predicate}`);

--- a/packages/graphql/src/translate/translate-aggregate.ts
+++ b/packages/graphql/src/translate/translate-aggregate.ts
@@ -23,6 +23,7 @@ import { DEBUG_TRANSLATE } from "../constants";
 import type { EntityAdapter } from "../schema-model/entity/EntityAdapter";
 import type { Neo4jGraphQLTranslationContext } from "../types/neo4j-graphql-translation-context";
 import { QueryASTFactory } from "./queryAST/factory/QueryASTFactory";
+import { buildClause } from "./utils/build-clause";
 
 const debug = Debug(DEBUG_TRANSLATE);
 
@@ -43,5 +44,5 @@ export function translateAggregate({
     const queryAST = queryASTFactory.createQueryAST({ resolveTree, entityAdapter, context });
     debug(queryAST.print());
     const clause = queryAST.buildNew(context);
-    return clause.build();
+    return buildClause(clause, { context });
 }

--- a/packages/graphql/src/translate/translate-create.ts
+++ b/packages/graphql/src/translate/translate-create.ts
@@ -30,6 +30,7 @@ import { QueryASTContext, QueryASTEnv } from "./queryAST/ast/QueryASTContext";
 import { QueryASTFactory } from "./queryAST/factory/QueryASTFactory";
 import { isUnwindCreateSupported } from "./queryAST/factory/parsers/is-unwind-create-supported";
 import unwindCreate from "./unwind-create";
+import { buildClause } from "./utils/build-clause";
 import { getAuthorizationStatements } from "./utils/get-authorization-statements";
 
 const debug = Debug(DEBUG_TRANSLATE);
@@ -164,7 +165,7 @@ export default async function translateCreate({
         ];
     });
 
-    const createQueryCypher = createQuery.build({ prefix: "create_" });
+    const createQueryCypher = buildClause(createQuery, { context, prefix: "create_" });
     const { cypher, params: resolvedCallbacks } = await callbackBucket.resolveCallbacksAndFilterCypher({
         cypher: createQueryCypher.cypher,
     });

--- a/packages/graphql/src/translate/translate-delete.ts
+++ b/packages/graphql/src/translate/translate-delete.ts
@@ -32,6 +32,7 @@ import { createEventMeta } from "./subscriptions/create-event-meta";
 import { translateTopLevelMatch } from "./translate-top-level-match";
 
 import type { ResolveTree } from "graphql-parse-resolve-info";
+import { buildClause } from "./utils/build-clause";
 
 const debug = Debug(DEBUG_TRANSLATE);
 
@@ -59,7 +60,7 @@ function translateUsingQueryAST({
     });
     debug(operationsTree.print());
     const clause = operationsTree.build(context, varName);
-    return clause.build();
+    return buildClause(clause, { context });
 }
 export function translateDelete({
     context,
@@ -143,8 +144,7 @@ export function translateDelete({
         return [cypher.filter(Boolean).join("\n"), cypherParams];
     });
 
-    const result = deleteQuery.build({ prefix: varName });
-    return result;
+    return buildClause(deleteQuery, { context, prefix: varName });
 }
 
 function getDeleteReturn(context: Neo4jGraphQLTranslationContext): Array<string> {

--- a/packages/graphql/src/translate/translate-read.ts
+++ b/packages/graphql/src/translate/translate-read.ts
@@ -23,6 +23,7 @@ import { DEBUG_TRANSLATE } from "../constants";
 import type { EntityAdapter } from "../schema-model/entity/EntityAdapter";
 import type { Neo4jGraphQLTranslationContext } from "../types/neo4j-graphql-translation-context";
 import { QueryASTFactory } from "./queryAST/factory/QueryASTFactory";
+import { buildClause } from "./utils/build-clause";
 
 const debug = Debug(DEBUG_TRANSLATE);
 
@@ -45,5 +46,5 @@ export function translateRead({
     });
     debug(operationsTree.print());
     const clause = operationsTree.build(context, varName);
-    return clause.build();
+    return buildClause(clause, { context });
 }

--- a/packages/graphql/src/translate/translate-resolve-reference.ts
+++ b/packages/graphql/src/translate/translate-resolve-reference.ts
@@ -23,6 +23,7 @@ import { DEBUG_TRANSLATE } from "../constants";
 import type { EntityAdapter } from "../schema-model/entity/EntityAdapter";
 import type { Neo4jGraphQLTranslationContext } from "../types/neo4j-graphql-translation-context";
 import { QueryASTFactory } from "./queryAST/factory/QueryASTFactory";
+import { buildClause } from "./utils/build-clause";
 
 const debug = Debug(DEBUG_TRANSLATE);
 
@@ -46,5 +47,5 @@ export function translateResolveReference({
     });
     debug(operationsTree.print());
     const clause = operationsTree.build(context, "this");
-    return clause.build();
+    return buildClause(clause, { context });
 }

--- a/packages/graphql/src/translate/translate-top-level-cypher.ts
+++ b/packages/graphql/src/translate/translate-top-level-cypher.ts
@@ -27,6 +27,7 @@ import type { Neo4jGraphQLTranslationContext } from "../types/neo4j-graphql-tran
 import { applyAuthentication } from "./authorization/utils/apply-authentication";
 import { QueryASTContext, QueryASTEnv } from "./queryAST/ast/QueryASTContext";
 import { QueryASTFactory } from "./queryAST/factory/QueryASTFactory";
+import { buildClause } from "./utils/build-clause";
 
 const debug = Debug(DEBUG_TRANSLATE);
 
@@ -84,5 +85,5 @@ export function translateTopLevelCypher({
     const projectionStatements = queryASTResult.clauses.length
         ? Cypher.utils.concat(...queryASTResult.clauses)
         : new Cypher.Return(new Cypher.Literal("Query cannot conclude with CALL"));
-    return projectionStatements.build();
+    return buildClause(projectionStatements, { context });
 }

--- a/packages/graphql/src/translate/translate-top-level-match.ts
+++ b/packages/graphql/src/translate/translate-top-level-match.ts
@@ -25,6 +25,7 @@ import type { GraphQLWhereArg } from "../types";
 import type { Neo4jGraphQLTranslationContext } from "../types/neo4j-graphql-translation-context";
 import { getEntityAdapterFromNode } from "../utils/get-entity-adapter-from-node";
 import { createAuthorizationBeforePredicate } from "./authorization/create-authorization-before-predicate";
+import { buildClause } from "./utils/build-clause";
 import { createWhereNodePredicate } from "./where/create-where-predicate";
 
 export function translateTopLevelMatch({
@@ -51,7 +52,7 @@ export function translateTopLevelMatch({
         where,
     });
 
-    return Cypher.utils.concat(matchClause, preComputedWhereFieldSubqueries, whereClause).build();
+    return buildClause(Cypher.utils.concat(matchClause, preComputedWhereFieldSubqueries, whereClause), { context });
 }
 
 type CreateMatchClauseReturn = {

--- a/packages/graphql/src/translate/translate-update.ts
+++ b/packages/graphql/src/translate/translate-update.ts
@@ -38,6 +38,7 @@ import createUpdateAndParams from "./create-update-and-params";
 import { QueryASTContext, QueryASTEnv } from "./queryAST/ast/QueryASTContext";
 import { QueryASTFactory } from "./queryAST/factory/QueryASTFactory";
 import { translateTopLevelMatch } from "./translate-top-level-match";
+import { buildClause } from "./utils/build-clause";
 import { getAuthorizationStatements } from "./utils/get-authorization-statements";
 
 const debug = Debug(DEBUG_TRANSLATE);
@@ -514,7 +515,7 @@ export default async function translateUpdate({
         ];
     });
 
-    const cypherResult = updateQuery.build({ prefix: "update_" });
+    const cypherResult = buildClause(updateQuery, { context, prefix: "update_" });
     const { cypher, params: resolvedCallbacks } = await callbackBucket.resolveCallbacksAndFilterCypher({
         cypher: cypherResult.cypher,
     });

--- a/packages/graphql/src/translate/unwind-create.ts
+++ b/packages/graphql/src/translate/unwind-create.ts
@@ -22,6 +22,7 @@ import { DEBUG_TRANSLATE } from "../constants";
 import type { EntityAdapter } from "../schema-model/entity/EntityAdapter";
 import type { Neo4jGraphQLTranslationContext } from "../types/neo4j-graphql-translation-context";
 import { QueryASTFactory } from "./queryAST/factory/QueryASTFactory";
+import { buildClause } from "./utils/build-clause";
 
 const debug = Debug(DEBUG_TRANSLATE);
 
@@ -44,5 +45,5 @@ export default function unwindCreate({
 
     const clauses = queryAST.build(context);
 
-    return clauses.build({ prefix: "create_" });
+    return buildClause(clauses, { context, prefix: "create_" });
 }

--- a/packages/graphql/src/translate/utils/build-clause.ts
+++ b/packages/graphql/src/translate/utils/build-clause.ts
@@ -27,7 +27,7 @@ export function buildClause(
     return clause.build({
         prefix,
         unsafeEscapeOptions: {
-            disableLabelEscaping: Boolean(context.features.unsafeEscapeOptions?.disableLabelEscaping),
+            disableNodeLabelEscaping: Boolean(context.features.unsafeEscapeOptions?.disableNodeLabelEscaping),
             disableRelationshipTypeEscaping: Boolean(
                 context.features.unsafeEscapeOptions?.disableRelationshipTypeEscaping
             ),

--- a/packages/graphql/src/translate/utils/build-clause.ts
+++ b/packages/graphql/src/translate/utils/build-clause.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type Cypher from "@neo4j/cypher-builder";
+import type { Neo4jGraphQLTranslationContext } from "../../types/neo4j-graphql-translation-context";
+
+export function buildClause(
+    clause: Cypher.Clause,
+    { context, prefix }: { context: Neo4jGraphQLTranslationContext; prefix?: string }
+): Cypher.CypherResult {
+    return clause.build({
+        prefix,
+        unsafeEscapeOptions: {
+            disableLabelEscaping: Boolean(context.features.unsafeEscapeOptions?.disableLabelEscaping),
+            disableRelationshipTypeEscaping: Boolean(
+                context.features.unsafeEscapeOptions?.disableRelationshipTypeEscaping
+            ),
+        },
+    });
+}

--- a/packages/graphql/src/translate/where/create-connection-where-and-params.ts
+++ b/packages/graphql/src/translate/where/create-connection-where-and-params.ts
@@ -22,6 +22,7 @@ import type { Node, Relationship } from "../../classes";
 import type { ConnectionWhereArg } from "../../types";
 import type { Neo4jGraphQLTranslationContext } from "../../types/neo4j-graphql-translation-context";
 import { compileCypher } from "../../utils/compile-cypher";
+import { buildClause } from "../utils/build-clause";
 import { createConnectionWherePropertyOperation } from "./property-operations/create-connection-operation";
 
 export default function createConnectionWhereAndParams({
@@ -63,7 +64,8 @@ export default function createConnectionWhereAndParams({
     });
 
     // NOTE: the following prefix is just to avoid collision until this is refactored into a single cypher ast
-    const result = whereCypher.build({
+    const result = buildClause(whereCypher, {
+        context,
         prefix: `${parameterPrefix.replace(/\./g, "_").replace(/\[|\]/g, "")}_${nodeVariable}`,
     });
     return { cypher: result.cypher, subquery, params: result.params };

--- a/packages/graphql/src/types/index.ts
+++ b/packages/graphql/src/types/index.ts
@@ -496,7 +496,7 @@ export type Neo4jFeaturesSettings = {
          *
          * **WARNING**: Disabling label escaping may lead to code injection and unsafe Cypher.
          */
-        disableLabelEscaping?: boolean;
+        disableNodeLabelEscaping?: boolean;
         /** Disables automatic escaping of relationship types.
          *
          * **WARNING**: Disabling type escaping may lead to code injection and unsafe Cypher.

--- a/packages/graphql/src/types/index.ts
+++ b/packages/graphql/src/types/index.ts
@@ -486,6 +486,23 @@ export type Neo4jFeaturesSettings = {
         aggregationFilters?: boolean;
         nestedUpdateOperationsFields?: boolean;
     };
+
+    /** Options for disabling automatic escaping of potentially unsafe strings.
+     *
+     * **WARNING**: Changing these options may lead to code injection and unsafe Cypher.
+     */
+    unsafeEscapeOptions?: {
+        /** Disables automatic escaping of node labels.
+         *
+         * **WARNING**: Disabling label escaping may lead to code injection and unsafe Cypher.
+         */
+        disableLabelEscaping?: boolean;
+        /** Disables automatic escaping of relationship types.
+         *
+         * **WARNING**: Disabling type escaping may lead to code injection and unsafe Cypher.
+         */
+        disableRelationshipTypeEscaping?: boolean;
+    };
     vector?: Neo4jVectorSettings;
 };
 
@@ -495,6 +512,7 @@ export type ContextFeatures = {
     populatedBy?: Neo4jPopulatedBySettings;
     authorization?: Neo4jAuthorizationSettings;
     subscriptions?: Neo4jGraphQLSubscriptionsEngine;
+    unsafeEscapeOptions?: Neo4jFeaturesSettings["unsafeEscapeOptions"];
 };
 
 export type PredicateReturn = {

--- a/packages/graphql/tests/integration/disable-escaping.int.test.ts
+++ b/packages/graphql/tests/integration/disable-escaping.int.test.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { UniqueType } from "../utils/graphql-types";
+import { TestHelper } from "../utils/tests-helper";
+
+describe("Disable escaping", () => {
+    const testHelper = new TestHelper();
+
+    let Movie: UniqueType;
+    let Actor: UniqueType;
+    let Production: UniqueType;
+
+    beforeAll(async () => {
+        Movie = testHelper.createUniqueType("Movie");
+        Actor = testHelper.createUniqueType("Actor");
+        Production = testHelper.createUniqueType("Production");
+
+        const typeDefs = /* GraphQL */ `
+            type ${Actor} {
+                name: String!
+            }
+
+            type ${Movie} {
+                title: String!
+                actors: [${Actor}!]! @relationship(type: "FROM_PRODUCTION]->(:${Production})-[:ACTED_IN", direction: OUT)
+            }
+        `;
+
+        await testHelper.executeCypher(
+            `
+        CREATE (:${Movie} {title: "Matrix"})-[:FROM_PRODUCTION]->(:${Production})-[:ACTED_IN]->(:${Actor} {name: "Keanu"})
+        `
+        );
+        await testHelper.initNeo4jGraphQL({
+            typeDefs,
+            features: {
+                unsafeEscapeOptions: {
+                    disableRelationshipTypeEscaping: true,
+                },
+            },
+        });
+    });
+
+    afterAll(async () => {
+        await testHelper.close();
+    });
+
+    test("should match with unescaped type in relationship", async () => {
+        const query = `
+            query {
+                ${Movie.plural} {
+                    title
+                    actors {
+                        name
+                    }
+                }
+            }
+        `;
+
+        const gqlResult = await testHelper.executeGraphQL(query);
+
+        expect(gqlResult.errors).toBeFalsy();
+        expect(gqlResult.data).toEqual({
+            [Movie.plural]: [
+                {
+                    title: "Matrix",
+                    actors: [
+                        {
+                            name: "Keanu",
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+});

--- a/packages/graphql/tests/tck/disable-escaping.test.ts
+++ b/packages/graphql/tests/tck/disable-escaping.test.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Neo4jGraphQL } from "../../src";
+import { formatCypher, formatParams, translateQuery } from "./utils/tck-test-utils";
+
+describe("Disable escaping", () => {
+    let typeDefs: string;
+    let neoSchema: Neo4jGraphQL;
+
+    beforeAll(() => {
+        typeDefs = /* GraphQL */ `
+            type Actor {
+                name: String!
+            }
+
+            type Movie @node(labels: ["A Movie"]) {
+                title: String!
+                actors: [Actor!]! @relationship(type: "ACTED IN", direction: IN)
+            }
+        `;
+    });
+
+    test("disableRelationshipTypeEscaping", async () => {
+        neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            features: {
+                unsafeEscapeOptions: {
+                    disableRelationshipTypeEscaping: true,
+                },
+            },
+        });
+        const query = /* GraphQL */ `
+            {
+                movies {
+                    actors {
+                        name
+                    }
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`A Movie\`)
+            CALL {
+                WITH this
+                MATCH (this)<-[this0:ACTED IN]-(this1:Actor)
+                WITH this1 { .name } AS this1
+                RETURN collect(this1) AS var2
+            }
+            RETURN this { actors: var2 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
+    });
+
+    test("disableLabelEscaping", async () => {
+        neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            features: {
+                unsafeEscapeOptions: {
+                    disableLabelEscaping: true,
+                },
+            },
+        });
+        const query = /* GraphQL */ `
+            {
+                movies {
+                    actors {
+                        name
+                    }
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:A Movie)
+            CALL {
+                WITH this
+                MATCH (this)<-[this0:\`ACTED IN\`]-(this1:Actor)
+                WITH this1 { .name } AS this1
+                RETURN collect(this1) AS var2
+            }
+            RETURN this { actors: var2 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
+    });
+});

--- a/packages/graphql/tests/tck/disable-escaping.test.ts
+++ b/packages/graphql/tests/tck/disable-escaping.test.ts
@@ -72,12 +72,12 @@ describe("Disable escaping", () => {
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
     });
 
-    test("disableLabelEscaping", async () => {
+    test("disableNodeLabelEscaping", async () => {
         neoSchema = new Neo4jGraphQL({
             typeDefs,
             features: {
                 unsafeEscapeOptions: {
-                    disableLabelEscaping: true,
+                    disableNodeLabelEscaping: true,
                 },
             },
         });

--- a/packages/graphql/tests/tck/disable-escaping.test.ts
+++ b/packages/graphql/tests/tck/disable-escaping.test.ts
@@ -30,9 +30,9 @@ describe("Disable escaping", () => {
                 name: String!
             }
 
-            type Movie @node(labels: ["A Movie"]) {
+            type Movie @node(labels: ["Movie:Film"]) {
                 title: String!
-                actors: [Actor!]! @relationship(type: "ACTED IN", direction: IN)
+                actors: [Actor!]! @relationship(type: "ACTED_IN|PATICIPATED", direction: IN)
             }
         `;
     });
@@ -59,10 +59,10 @@ describe("Disable escaping", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`A Movie\`)
+            "MATCH (this:\`Movie:Film\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED IN]-(this1:Actor)
+                MATCH (this)<-[this0:ACTED_IN|PATICIPATED]-(this1:Actor)
                 WITH this1 { .name } AS this1
                 RETURN collect(this1) AS var2
             }
@@ -94,10 +94,10 @@ describe("Disable escaping", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:A Movie)
+            "MATCH (this:Movie:Film)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:\`ACTED IN\`]-(this1:Actor)
+                MATCH (this)<-[this0:\`ACTED_IN|PATICIPATED\`]-(this1:Actor)
                 WITH this1 { .name } AS this1
                 RETURN collect(this1) AS var2
             }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2839,10 +2839,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@neo4j/cypher-builder@npm:^2.3.1":
-  version: 2.4.0
-  resolution: "@neo4j/cypher-builder@npm:2.4.0"
-  checksum: 10c0/c1745ee165596b7bd38db87bb3f4c9786e2ce8670f40e4ac8f10dd3ffe8d7a0c4eb4c76cf55a5695ed1e60744d5fdd74763506c6061f53419d966e0155ba5971
+"@neo4j/cypher-builder@npm:^2.3.2":
+  version: 2.3.2
+  resolution: "@neo4j/cypher-builder@npm:2.3.2"
+  checksum: 10c0/d6b351859524bf769713a0efec70a534c024d029760b32ce0250db991566d6d3fdd7ae56e850482d5379e5d50efb8ce27f9997e7655cd620a4bfa5f2a9160581
   languageName: node
   linkType: hard
 
@@ -2919,7 +2919,7 @@ __metadata:
     "@graphql-tools/resolvers-composition": "npm:^7.0.0"
     "@graphql-tools/schema": "npm:^10.0.0"
     "@graphql-tools/utils": "npm:10.6.1"
-    "@neo4j/cypher-builder": "npm:^2.3.1"
+    "@neo4j/cypher-builder": "npm:^2.3.2"
     "@types/deep-equal": "npm:1.0.4"
     "@types/is-uuid": "npm:1.0.2"
     "@types/jest": "npm:29.5.14"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2839,10 +2839,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@neo4j/cypher-builder@npm:^2.3.2":
-  version: 2.3.2
-  resolution: "@neo4j/cypher-builder@npm:2.3.2"
-  checksum: 10c0/d6b351859524bf769713a0efec70a534c024d029760b32ce0250db991566d6d3fdd7ae56e850482d5379e5d50efb8ce27f9997e7655cd620a4bfa5f2a9160581
+"@neo4j/cypher-builder@npm:^2.4.0":
+  version: 2.4.0
+  resolution: "@neo4j/cypher-builder@npm:2.4.0"
+  checksum: 10c0/c1745ee165596b7bd38db87bb3f4c9786e2ce8670f40e4ac8f10dd3ffe8d7a0c4eb4c76cf55a5695ed1e60744d5fdd74763506c6061f53419d966e0155ba5971
   languageName: node
   linkType: hard
 
@@ -2919,7 +2919,7 @@ __metadata:
     "@graphql-tools/resolvers-composition": "npm:^7.0.0"
     "@graphql-tools/schema": "npm:^10.0.0"
     "@graphql-tools/utils": "npm:10.6.1"
-    "@neo4j/cypher-builder": "npm:^2.3.2"
+    "@neo4j/cypher-builder": "npm:^2.4.0"
     "@types/deep-equal": "npm:1.0.4"
     "@types/is-uuid": "npm:1.0.2"
     "@types/jest": "npm:29.5.14"


### PR DESCRIPTION
# Description


Add `unsafeEscapeOptions` to `Neo4jGraphQL` features with the following flags:

-   `disableRelationshipTypeEscaping` (default to `false`)
-   `disableNodeLabelEscaping` (defaults to `false`)

These flags remove the automatic escaping of node labels and relationship types in the generated Cypher.

For example, given the following schema:

```graphql
type Actor {
    name: String!
}

type Movie {
    title: String!
    actors: [Actor!]! @relationship(type: "FROM_PRODUCTION]->(:Production)-[:ACTED_IN", direction: OUT)
}
```

A GraphQL query going through the `actors` relationship:

```graphql
query {
    movies {
        title
        actors {
            name
        }
    }
}
```

Will normally generate the following Cypher for the relationship:

```cypher
MATCH (this:Movie)-[this0:`FROM_PRODUCTION]->(:Production)-[:ACTED_IN`]->(this1:Actor)
```

The label `FROM_PRODUCTION]->(:Production)-[:ACTED_IN` is escaped by placing it inside backticks (`\``), as some characters in it are susceptible of code injection.

If the option `disableRelationshipTypeEscaping` is set in `Neo4jGraphQL`, this safety mechanism will be disabled:

```js
new Neo4jGraphQL({
    typeDefs,
    features: {
        unsafeEscapeOptions: {
            disableRelationshipTypeEscaping: true,
        },
    },
});
```

Generating the following Cypher instead:

```cypher
MATCH (this:Movie)-[this0:FROM_PRODUCTION]->(:Production)-[:ACTED_IN]->(this1:Actor)
```

This can be useful in very custom scenarios where the Cypher needs to be tweaked or if the labels and types have already been escaped.

> Warning: This is a safety mechanism to avoid Cypher injection. Changing these options may lead to code injection and an unsafe server.
