### PR TITLE
Add unsafeEscapeOptions - Cherry Pick from 5 LTS

### DIFF
--- a/.changeset/plenty-pants-fold.md
+++ b/.changeset/plenty-pants-fold.md
@@ -1,0 +1,67 @@
+---
+"@neo4j/graphql": patch
+---
+
+Add `unsafeEscapeOptions` to `Neo4jGraphQL` features with the following flags:
+
+- `disableRelationshipTypeEscaping` (default to `false`)
+- `disableNodeLabelEscaping` (defaults to `false`)
+
+These flags remove the automatic escaping of node labels and relationship types in the generated Cypher.
+
+For example, given the following schema:
+
+```graphql
+type Actor {
+    name: String!
+}
+
+type Movie {
+    title: String!
+    actors: [Actor!]! @relationship(type: "ACTED IN", direction: OUT)
+}
+```
+
+A GraphQL query going through the `actors` relationship:
+
+```graphql
+query {
+    movies {
+        title
+        actors {
+            name
+        }
+    }
+}
+```
+
+Will normally generate the following Cypher for the relationship:
+
+```cypher
+MATCH (this:Movie)-[this0:`ACTED IN`]->(this1:Actor)
+```
+
+The label `ACTED IN` is escaped by placing it inside backticks (`\``), as some characters in it are susceptible of code injection.
+
+If the option `disableRelationshipTypeEscaping` is set in `Neo4jGraphQL`, this safety mechanism will be disabled:
+
+```js
+new Neo4jGraphQL({
+    typeDefs,
+    features: {
+        unsafeEscapeOptions: {
+            disableRelationshipTypeEscaping: true,
+        },
+    },
+});
+```
+
+Generating the following (incorrect) Cypher instead:
+
+```cypher
+MATCH (this:Movie)-[this0:ACTED IN]->(this1:Actor)
+```
+
+This can be useful in very custom scenarios where the Cypher needs to be tweaked or if the labels and types have already been escaped.
+
+> Warning: This is a safety mechanism to avoid Cypher injection. Changing these options may lead to code injection and an unsafe server.

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -79,7 +79,7 @@
         "@graphql-tools/resolvers-composition": "^7.0.0",
         "@graphql-tools/schema": "^10.0.0",
         "@graphql-tools/utils": "10.6.1",
-        "@neo4j/cypher-builder": "2.3.0",
+        "@neo4j/cypher-builder": "^2.4.0",
         "camelcase": "^6.3.0",
         "debug": "^4.3.4",
         "dot-prop": "^6.0.1",

--- a/packages/graphql/src/translate/authorization/compatibility/compile-predicate-return.ts
+++ b/packages/graphql/src/translate/authorization/compatibility/compile-predicate-return.ts
@@ -19,7 +19,9 @@
 
 import Cypher from "@neo4j/cypher-builder";
 import type { PredicateReturn } from "../../../types";
+import type { Neo4jGraphQLTranslationContext } from "../../../types/neo4j-graphql-translation-context";
 import { compileCypher } from "../../../utils/compile-cypher";
+import { buildClause } from "../../utils/build-clause";
 
 type CompiledPredicateReturn = {
     cypher: string;
@@ -33,10 +35,15 @@ type CompiledPredicateReturn = {
  * The subqueries contain variables required by the predicate, and if they are not compiled with the same
  * environment, the predicate will be referring to non-existent variables and will re-assign variable from the subqueries.
  */
-export function compilePredicateReturn(
-    predicateReturn: PredicateReturn,
-    indexPrefix?: string
-): CompiledPredicateReturn {
+export function compilePredicateReturn({
+    predicateReturn,
+    indexPrefix,
+    context,
+}: {
+    predicateReturn: PredicateReturn;
+    indexPrefix: string | undefined;
+    context: Neo4jGraphQLTranslationContext;
+}): CompiledPredicateReturn {
     const result: CompiledPredicateReturn = { cypher: "", params: {} };
 
     const { predicate, preComputedSubqueries } = predicateReturn;
@@ -52,7 +59,10 @@ export function compilePredicateReturn(
             }
             return predicateStr;
         });
-        const { cypher, params } = predicateCypher.build({ prefix: `authorization_${indexPrefix || ""}` });
+        const { cypher, params } = buildClause(predicateCypher, {
+            context,
+            prefix: `authorization_${indexPrefix || ""}`,
+        });
         result.cypher = cypher;
         result.params = params;
         result.subqueries = subqueries;

--- a/packages/graphql/src/translate/authorization/compatibility/create-authorization-after-and-params.ts
+++ b/packages/graphql/src/translate/authorization/compatibility/create-authorization-after-and-params.ts
@@ -18,15 +18,15 @@
  */
 
 import Cypher from "@neo4j/cypher-builder";
-import type { Node } from "../../../types";
 import type { AuthorizationOperation } from "../../../schema-model/annotation/AuthorizationAnnotation";
+import type { Node } from "../../../types";
+import type { Neo4jGraphQLTranslationContext } from "../../../types/neo4j-graphql-translation-context";
 import {
-    createAuthorizationAfterPredicateField,
     createAuthorizationAfterPredicate,
+    createAuthorizationAfterPredicateField,
 } from "../create-authorization-after-predicate";
 import type { NodeMap } from "../types/node-map";
 import { compilePredicateReturn } from "./compile-predicate-return";
-import type { Neo4jGraphQLTranslationContext } from "../../../types/neo4j-graphql-translation-context";
 
 type AuthorizationAfterAndParams = {
     cypher: string;
@@ -68,7 +68,7 @@ export function createAuthorizationAfterAndParams({
     });
 
     if (predicateReturn) {
-        return compilePredicateReturn(predicateReturn, `${indexPrefix || "_"}after_`);
+        return compilePredicateReturn({ predicateReturn, indexPrefix: `${indexPrefix || "_"}after_`, context });
     }
 
     return undefined;
@@ -94,7 +94,7 @@ export function createAuthorizationAfterAndParamsField({
     });
 
     if (predicateReturn) {
-        return compilePredicateReturn(predicateReturn, `${indexPrefix || "_"}after_`);
+        return compilePredicateReturn({ predicateReturn, indexPrefix: `${indexPrefix || "_"}after_`, context });
     }
 
     return undefined;

--- a/packages/graphql/src/translate/authorization/compatibility/create-authorization-before-and-params.ts
+++ b/packages/graphql/src/translate/authorization/compatibility/create-authorization-before-and-params.ts
@@ -18,15 +18,15 @@
  */
 
 import Cypher from "@neo4j/cypher-builder";
-import type { Node } from "../../../types";
 import type { AuthorizationOperation } from "../../../schema-model/annotation/AuthorizationAnnotation";
+import type { Node } from "../../../types";
+import type { Neo4jGraphQLTranslationContext } from "../../../types/neo4j-graphql-translation-context";
 import {
-    createAuthorizationBeforePredicateField,
     createAuthorizationBeforePredicate,
+    createAuthorizationBeforePredicateField,
 } from "../create-authorization-before-predicate";
 import type { NodeMap } from "../types/node-map";
 import { compilePredicateReturn } from "./compile-predicate-return";
-import type { Neo4jGraphQLTranslationContext } from "../../../types/neo4j-graphql-translation-context";
 
 type AuthorizationBeforeAndParams = {
     cypher: string;
@@ -69,7 +69,7 @@ export function createAuthorizationBeforeAndParams({
     });
 
     if (predicateReturn) {
-        return compilePredicateReturn(predicateReturn, `${indexPrefix || "_"}before_`);
+        return compilePredicateReturn({ predicateReturn, indexPrefix: `${indexPrefix || "_"}before_`, context });
     }
 
     return undefined;
@@ -93,7 +93,7 @@ export function createAuthorizationBeforeAndParamsField({
     });
 
     if (predicateReturn) {
-        return compilePredicateReturn(predicateReturn, "_before_");
+        return compilePredicateReturn({ predicateReturn, indexPrefix: "_before_", context });
     }
 
     return undefined;

--- a/packages/graphql/src/translate/create-connect-and-params.ts
+++ b/packages/graphql/src/translate/create-connect-and-params.ts
@@ -36,6 +36,7 @@ import { createAuthorizationBeforeAndParams } from "./authorization/compatibilit
 import { createRelationshipValidationString } from "./create-relationship-validation-string";
 import { createSetRelationshipProperties } from "./create-set-relationship-properties";
 import { filterMetaVariable } from "./subscriptions/filter-meta-variable";
+import { buildClause } from "./utils/build-clause";
 import { createWhereNodePredicate } from "./where/create-where-predicate";
 
 interface Res {
@@ -148,7 +149,7 @@ function createConnectAndParams({
             if (filters?.preComputedSubqueries?.length) {
                 const columns = [new Cypher.NamedVariable(nodeName)];
                 const caseWhereClause = caseWhere(new Cypher.Raw(predicate), columns);
-                const { cypher } = caseWhereClause.build({ prefix: "aggregateWhereFilter" });
+                const { cypher } = buildClause(caseWhereClause, { context, prefix: "aggregateWhereFilter" });
                 subquery.push(cypher);
             } else {
                 subquery.push(`\tWHERE ${predicate}`);
@@ -429,7 +430,7 @@ function getFilters({
         return [cypher, {}];
     });
 
-    const result = whereCypher.build({ prefix: `${nodeName}_` });
+    const result = buildClause(whereCypher, { context, prefix: `${nodeName}_` });
 
     if (result.cypher) {
         return {

--- a/packages/graphql/src/translate/create-connect-or-create-and-params.ts
+++ b/packages/graphql/src/translate/create-connect-or-create-and-params.ts
@@ -29,6 +29,7 @@ import { createAuthorizationAfterPredicate } from "./authorization/create-author
 import { createAuthorizationBeforePredicate } from "./authorization/create-authorization-before-predicate";
 import { parseWhereField } from "./queryAST/factory/parsers/parse-where-field";
 import { assertNonAmbiguousUpdate } from "./utils/assert-non-ambiguous-update";
+import { buildClause } from "./utils/build-clause";
 import { addCallbackAndSetParamCypher } from "./utils/callback-utils";
 
 type CreateOrConnectInput = {
@@ -99,7 +100,7 @@ export function createConnectOrCreateAndParams({
     });
 
     const query = Cypher.utils.concat(...wrappedQueries);
-    return query.build({ prefix: `${varName}_` });
+    return buildClause(query, { context, prefix: `${varName}_` });
 }
 
 function createConnectOrCreatePartialStatement({

--- a/packages/graphql/src/translate/create-delete-and-params.ts
+++ b/packages/graphql/src/translate/create-delete-and-params.ts
@@ -23,6 +23,7 @@ import type { Neo4jGraphQLTranslationContext } from "../types/neo4j-graphql-tran
 import { caseWhere } from "../utils/case-where";
 import { checkAuthentication } from "./authorization/check-authentication";
 import { createAuthorizationBeforeAndParams } from "./authorization/compatibility/create-authorization-before-and-params";
+import { buildClause } from "./utils/build-clause";
 import createConnectionWhereAndParams from "./where/create-connection-where-and-params";
 
 interface Res {
@@ -173,7 +174,10 @@ function createDeleteAndParams({
                                 new Cypher.NamedVariable(variableName),
                             ];
                             const caseWhereClause = caseWhere(new Cypher.Raw(predicate), columns);
-                            const { cypher } = caseWhereClause.build({ prefix: "aggregateWhereFilter" });
+                            const { cypher } = buildClause(caseWhereClause, {
+                                context,
+                                prefix: "aggregateWhereFilter",
+                            });
                             innerStrs.push(cypher);
                         } else {
                             innerStrs.push(`WHERE ${predicate}`);

--- a/packages/graphql/src/translate/create-disconnect-and-params.ts
+++ b/packages/graphql/src/translate/create-disconnect-and-params.ts
@@ -25,6 +25,7 @@ import { caseWhere } from "../utils/case-where";
 import { checkAuthentication } from "./authorization/check-authentication";
 import { createAuthorizationAfterAndParams } from "./authorization/compatibility/create-authorization-after-and-params";
 import { createAuthorizationBeforeAndParams } from "./authorization/compatibility/create-authorization-before-and-params";
+import { buildClause } from "./utils/build-clause";
 import createConnectionWhereAndParams from "./where/create-connection-where-and-params";
 
 interface Res {
@@ -142,7 +143,7 @@ function createDisconnectAndParams({
             if (aggregationWhere) {
                 const columns = [new Cypher.NamedVariable(relVarName), new Cypher.NamedVariable(variableName)];
                 const caseWhereClause = caseWhere(new Cypher.Raw(predicate), columns);
-                const { cypher } = caseWhereClause.build({ prefix: "aggregateWhereFilter" });
+                const { cypher } = buildClause(caseWhereClause, { context, prefix: "aggregateWhereFilter" });
                 subquery.push(cypher);
             } else {
                 subquery.push(`WHERE ${predicate}`);

--- a/packages/graphql/src/translate/create-update-and-params.ts
+++ b/packages/graphql/src/translate/create-update-and-params.ts
@@ -42,6 +42,7 @@ import createDisconnectAndParams from "./create-disconnect-and-params";
 import { createRelationshipValidationString } from "./create-relationship-validation-string";
 import { createSetRelationshipProperties } from "./create-set-relationship-properties";
 import { assertNonAmbiguousUpdate } from "./utils/assert-non-ambiguous-update";
+import { buildClause } from "./utils/build-clause";
 import { addCallbackAndSetParam } from "./utils/callback-utils";
 import { getAuthorizationStatements } from "./utils/get-authorization-statements";
 import { getMutationFieldStatements } from "./utils/get-mutation-field-statements";
@@ -252,7 +253,10 @@ export default function createUpdateAndParams({
                                     new Cypher.NamedVariable(variableName),
                                 ];
                                 const caseWhereClause = caseWhere(new Cypher.Raw(predicate), columns);
-                                const { cypher } = caseWhereClause.build({ prefix: "aggregateWhereFilter" });
+                                const { cypher } = buildClause(caseWhereClause, {
+                                    context,
+                                    prefix: "aggregateWhereFilter",
+                                });
                                 innerUpdate.push(cypher);
                             } else {
                                 innerUpdate.push(`WHERE ${predicate}`);

--- a/packages/graphql/src/translate/translate-aggregate.ts
+++ b/packages/graphql/src/translate/translate-aggregate.ts
@@ -23,6 +23,7 @@ import { DEBUG_TRANSLATE } from "../constants";
 import type { EntityAdapter } from "../schema-model/entity/EntityAdapter";
 import type { Neo4jGraphQLTranslationContext } from "../types/neo4j-graphql-translation-context";
 import { QueryASTFactory } from "./queryAST/factory/QueryASTFactory";
+import { buildClause } from "./utils/build-clause";
 
 const debug = Debug(DEBUG_TRANSLATE);
 
@@ -43,5 +44,5 @@ export function translateAggregate({
     const queryAST = queryASTFactory.createQueryAST({ resolveTree, entityAdapter, context });
     debug(queryAST.print());
     const clause = queryAST.buildNew(context);
-    return clause.build();
+    return buildClause(clause, { context });
 }

--- a/packages/graphql/src/translate/translate-create.ts
+++ b/packages/graphql/src/translate/translate-create.ts
@@ -30,6 +30,7 @@ import { QueryASTContext, QueryASTEnv } from "./queryAST/ast/QueryASTContext";
 import { QueryASTFactory } from "./queryAST/factory/QueryASTFactory";
 import { isUnwindCreateSupported } from "./queryAST/factory/parsers/is-unwind-create-supported";
 import unwindCreate from "./unwind-create";
+import { buildClause } from "./utils/build-clause";
 import { getAuthorizationStatements } from "./utils/get-authorization-statements";
 
 const debug = Debug(DEBUG_TRANSLATE);
@@ -152,7 +153,7 @@ export default async function translateCreate({
         ];
     });
 
-    const createQueryCypher = createQuery.build({ prefix: "create_" });
+    const createQueryCypher = buildClause(createQuery, { context, prefix: "create_" });
     const { cypher, params: resolvedCallbacks } = await callbackBucket.resolveCallbacksAndFilterCypher({
         cypher: createQueryCypher.cypher,
     });

--- a/packages/graphql/src/translate/translate-delete.ts
+++ b/packages/graphql/src/translate/translate-delete.ts
@@ -25,6 +25,7 @@ import type { Neo4jGraphQLTranslationContext } from "../types/neo4j-graphql-tran
 import { QueryASTFactory } from "./queryAST/factory/QueryASTFactory";
 
 import type { ResolveTree } from "graphql-parse-resolve-info";
+import { buildClause } from "./utils/build-clause";
 
 const debug = Debug(DEBUG_TRANSLATE);
 
@@ -52,7 +53,7 @@ function translateUsingQueryAST({
     });
     debug(operationsTree.print());
     const clause = operationsTree.build(context, varName);
-    return clause.build();
+    return buildClause(clause, { context });
 }
 export function translateDelete({
     context,

--- a/packages/graphql/src/translate/translate-read.ts
+++ b/packages/graphql/src/translate/translate-read.ts
@@ -23,6 +23,7 @@ import { DEBUG_TRANSLATE } from "../constants";
 import type { EntityAdapter } from "../schema-model/entity/EntityAdapter";
 import type { Neo4jGraphQLTranslationContext } from "../types/neo4j-graphql-translation-context";
 import { QueryASTFactory } from "./queryAST/factory/QueryASTFactory";
+import { buildClause } from "./utils/build-clause";
 
 const debug = Debug(DEBUG_TRANSLATE);
 
@@ -45,5 +46,5 @@ export function translateRead({
     });
     debug(operationsTree.print());
     const clause = operationsTree.build(context, varName);
-    return clause.build();
+    return buildClause(clause, { context });
 }

--- a/packages/graphql/src/translate/translate-resolve-reference.ts
+++ b/packages/graphql/src/translate/translate-resolve-reference.ts
@@ -23,6 +23,7 @@ import { DEBUG_TRANSLATE } from "../constants";
 import type { EntityAdapter } from "../schema-model/entity/EntityAdapter";
 import type { Neo4jGraphQLTranslationContext } from "../types/neo4j-graphql-translation-context";
 import { QueryASTFactory } from "./queryAST/factory/QueryASTFactory";
+import { buildClause } from "./utils/build-clause";
 
 const debug = Debug(DEBUG_TRANSLATE);
 
@@ -46,5 +47,5 @@ export function translateResolveReference({
     });
     debug(operationsTree.print());
     const clause = operationsTree.build(context, "this");
-    return clause.build();
+    return buildClause(clause, { context });
 }

--- a/packages/graphql/src/translate/translate-top-level-cypher.ts
+++ b/packages/graphql/src/translate/translate-top-level-cypher.ts
@@ -27,6 +27,7 @@ import type { Neo4jGraphQLTranslationContext } from "../types/neo4j-graphql-tran
 import { applyAuthentication } from "./authorization/utils/apply-authentication";
 import { QueryASTContext, QueryASTEnv } from "./queryAST/ast/QueryASTContext";
 import { QueryASTFactory } from "./queryAST/factory/QueryASTFactory";
+import { buildClause } from "./utils/build-clause";
 
 const debug = Debug(DEBUG_TRANSLATE);
 
@@ -84,5 +85,5 @@ export function translateTopLevelCypher({
     const projectionStatements = queryASTResult.clauses.length
         ? Cypher.utils.concat(...queryASTResult.clauses)
         : new Cypher.Return(new Cypher.Literal("Query cannot conclude with CALL"));
-    return projectionStatements.build();
+    return buildClause(projectionStatements, { context });
 }

--- a/packages/graphql/src/translate/translate-top-level-match.ts
+++ b/packages/graphql/src/translate/translate-top-level-match.ts
@@ -25,6 +25,7 @@ import type { GraphQLWhereArg } from "../types";
 import type { Neo4jGraphQLTranslationContext } from "../types/neo4j-graphql-translation-context";
 import { getEntityAdapterFromNode } from "../utils/get-entity-adapter-from-node";
 import { createAuthorizationBeforePredicate } from "./authorization/create-authorization-before-predicate";
+import { buildClause } from "./utils/build-clause";
 import { createWhereNodePredicate } from "./where/create-where-predicate";
 
 export function translateTopLevelMatch({
@@ -51,7 +52,7 @@ export function translateTopLevelMatch({
         where,
     });
 
-    return Cypher.utils.concat(matchClause, preComputedWhereFieldSubqueries, whereClause).build();
+    return buildClause(Cypher.utils.concat(matchClause, preComputedWhereFieldSubqueries, whereClause), { context });
 }
 
 type CreateMatchClauseReturn = {

--- a/packages/graphql/src/translate/translate-update.ts
+++ b/packages/graphql/src/translate/translate-update.ts
@@ -36,6 +36,7 @@ import createUpdateAndParams from "./create-update-and-params";
 import { QueryASTContext, QueryASTEnv } from "./queryAST/ast/QueryASTContext";
 import { QueryASTFactory } from "./queryAST/factory/QueryASTFactory";
 import { translateTopLevelMatch } from "./translate-top-level-match";
+import { buildClause } from "./utils/build-clause";
 import { getAuthorizationStatements } from "./utils/get-authorization-statements";
 
 const debug = Debug(DEBUG_TRANSLATE);
@@ -485,7 +486,7 @@ export default async function translateUpdate({
         ];
     });
 
-    const cypherResult = updateQuery.build({ prefix: "update_" });
+    const cypherResult = buildClause(updateQuery, { context, prefix: "update_" });
     const { cypher, params: resolvedCallbacks } = await callbackBucket.resolveCallbacksAndFilterCypher({
         cypher: cypherResult.cypher,
     });

--- a/packages/graphql/src/translate/unwind-create.ts
+++ b/packages/graphql/src/translate/unwind-create.ts
@@ -22,6 +22,7 @@ import { DEBUG_TRANSLATE } from "../constants";
 import type { EntityAdapter } from "../schema-model/entity/EntityAdapter";
 import type { Neo4jGraphQLTranslationContext } from "../types/neo4j-graphql-translation-context";
 import { QueryASTFactory } from "./queryAST/factory/QueryASTFactory";
+import { buildClause } from "./utils/build-clause";
 
 const debug = Debug(DEBUG_TRANSLATE);
 
@@ -44,5 +45,5 @@ export default function unwindCreate({
 
     const clauses = queryAST.build(context);
 
-    return clauses.build({ prefix: "create_" });
+    return buildClause(clauses, { context, prefix: "create_" });
 }

--- a/packages/graphql/src/translate/utils/build-clause.ts
+++ b/packages/graphql/src/translate/utils/build-clause.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type Cypher from "@neo4j/cypher-builder";
+import type { Neo4jGraphQLTranslationContext } from "../../types/neo4j-graphql-translation-context";
+
+export function buildClause(
+    clause: Cypher.Clause,
+    { context, prefix }: { context: Neo4jGraphQLTranslationContext; prefix?: string }
+): Cypher.CypherResult {
+    return clause.build({
+        prefix,
+        unsafeEscapeOptions: {
+            disableNodeLabelEscaping: Boolean(context.features.unsafeEscapeOptions?.disableNodeLabelEscaping),
+            disableRelationshipTypeEscaping: Boolean(
+                context.features.unsafeEscapeOptions?.disableRelationshipTypeEscaping
+            ),
+        },
+    });
+}

--- a/packages/graphql/src/translate/where/create-connection-where-and-params.ts
+++ b/packages/graphql/src/translate/where/create-connection-where-and-params.ts
@@ -22,6 +22,7 @@ import type { Node, Relationship } from "../../classes";
 import type { ConnectionWhereArg } from "../../types";
 import type { Neo4jGraphQLTranslationContext } from "../../types/neo4j-graphql-translation-context";
 import { compileCypher } from "../../utils/compile-cypher";
+import { buildClause } from "../utils/build-clause";
 import { createConnectionWherePropertyOperation } from "./property-operations/create-connection-operation";
 
 export default function createConnectionWhereAndParams({
@@ -63,7 +64,8 @@ export default function createConnectionWhereAndParams({
     });
 
     // NOTE: the following prefix is just to avoid collision until this is refactored into a single cypher ast
-    const result = whereCypher.build({
+    const result = buildClause(whereCypher, {
+        context,
         prefix: `${parameterPrefix.replace(/\./g, "_").replace(/\[|\]/g, "")}_${nodeVariable}`,
     });
     return { cypher: result.cypher, subquery, params: result.params };

--- a/packages/graphql/src/types/index.ts
+++ b/packages/graphql/src/types/index.ts
@@ -457,6 +457,23 @@ export type Neo4jFeaturesSettings = {
         idAggregations?: boolean;
         typename_IN?: boolean;
     };
+
+    /** Options for disabling automatic escaping of potentially unsafe strings.
+     *
+     * **WARNING**: Changing these options may lead to code injection and unsafe Cypher.
+     */
+    unsafeEscapeOptions?: {
+        /** Disables automatic escaping of node labels.
+         *
+         * **WARNING**: Disabling label escaping may lead to code injection and unsafe Cypher.
+         */
+        disableNodeLabelEscaping?: boolean;
+        /** Disables automatic escaping of relationship types.
+         *
+         * **WARNING**: Disabling type escaping may lead to code injection and unsafe Cypher.
+         */
+        disableRelationshipTypeEscaping?: boolean;
+    };
     vector?: Neo4jVectorSettings;
 };
 

--- a/packages/graphql/tests/integration/disable-escaping.int.test.ts
+++ b/packages/graphql/tests/integration/disable-escaping.int.test.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { UniqueType } from "../utils/graphql-types";
+import { TestHelper } from "../utils/tests-helper";
+
+describe("Disable escaping", () => {
+    const testHelper = new TestHelper();
+
+    let Movie: UniqueType;
+    let Actor: UniqueType;
+    let Production: UniqueType;
+
+    beforeAll(async () => {
+        Movie = testHelper.createUniqueType("Movie");
+        Actor = testHelper.createUniqueType("Actor");
+        Production = testHelper.createUniqueType("Production");
+
+        const typeDefs = /* GraphQL */ `
+            type ${Actor} {
+                name: String!
+            }
+
+            type ${Movie} {
+                title: String!
+                actors: [${Actor}!]! @relationship(type: "FROM_PRODUCTION]->(:${Production})-[:ACTED_IN", direction: OUT)
+            }
+        `;
+
+        await testHelper.executeCypher(
+            `
+        CREATE (:${Movie} {title: "Matrix"})-[:FROM_PRODUCTION]->(:${Production})-[:ACTED_IN]->(:${Actor} {name: "Keanu"})
+        `
+        );
+        await testHelper.initNeo4jGraphQL({
+            typeDefs,
+            features: {
+                unsafeEscapeOptions: {
+                    disableRelationshipTypeEscaping: true,
+                },
+            },
+        });
+    });
+
+    afterAll(async () => {
+        await testHelper.close();
+    });
+
+    test("should match with unescaped type in relationship", async () => {
+        const query = `
+            query {
+                ${Movie.plural} {
+                    title
+                    actors {
+                        name
+                    }
+                }
+            }
+        `;
+
+        const gqlResult = await testHelper.executeGraphQL(query);
+
+        expect(gqlResult.errors).toBeFalsy();
+        expect(gqlResult.data).toEqual({
+            [Movie.plural]: [
+                {
+                    title: "Matrix",
+                    actors: [
+                        {
+                            name: "Keanu",
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+});

--- a/packages/graphql/tests/tck/disable-escaping.test.ts
+++ b/packages/graphql/tests/tck/disable-escaping.test.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Neo4jGraphQL } from "../../src";
+import { formatCypher, formatParams, translateQuery } from "./utils/tck-test-utils";
+
+describe("Disable escaping", () => {
+    let typeDefs: string;
+    let neoSchema: Neo4jGraphQL;
+
+    beforeAll(() => {
+        typeDefs = /* GraphQL */ `
+            type Actor {
+                name: String!
+            }
+
+            type Movie @node(labels: ["Movie:Film"]) {
+                title: String!
+                actors: [Actor!]! @relationship(type: "ACTED_IN|PATICIPATED", direction: IN)
+            }
+        `;
+    });
+
+    test("disableRelationshipTypeEscaping", async () => {
+        neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            features: {
+                unsafeEscapeOptions: {
+                    disableRelationshipTypeEscaping: true,
+                },
+            },
+        });
+        const query = /* GraphQL */ `
+            {
+                movies {
+                    actors {
+                        name
+                    }
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`Movie:Film\`)
+            CALL {
+                WITH this
+                MATCH (this)<-[this0:ACTED_IN|PATICIPATED]-(this1:Actor)
+                WITH this1 { .name } AS this1
+                RETURN collect(this1) AS var2
+            }
+            RETURN this { actors: var2 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
+    });
+
+    test("disableNodeLabelEscaping", async () => {
+        neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            features: {
+                unsafeEscapeOptions: {
+                    disableNodeLabelEscaping: true,
+                },
+            },
+        });
+        const query = /* GraphQL */ `
+            {
+                movies {
+                    actors {
+                        name
+                    }
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:Movie:Film)
+            CALL {
+                WITH this
+                MATCH (this)<-[this0:\`ACTED_IN|PATICIPATED\`]-(this1:Actor)
+                WITH this1 { .name } AS this1
+                RETURN collect(this1) AS var2
+            }
+            RETURN this { actors: var2 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2138,10 +2138,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@neo4j/cypher-builder@npm:2.3.0":
-  version: 2.3.0
-  resolution: "@neo4j/cypher-builder@npm:2.3.0"
-  checksum: 10c0/bd7d98b8c3a84e9562ff88b9f2ad10a9258aabc2204dba247d4aa83944bce6f5100a3e14199a688dea62de2313910b90e03da7a9b1a423d0a279b022e5909fc3
+"@neo4j/cypher-builder@npm:^2.4.0":
+  version: 2.4.0
+  resolution: "@neo4j/cypher-builder@npm:2.4.0"
+  checksum: 10c0/c1745ee165596b7bd38db87bb3f4c9786e2ce8670f40e4ac8f10dd3ffe8d7a0c4eb4c76cf55a5695ed1e60744d5fdd74763506c6061f53419d966e0155ba5971
   languageName: node
   linkType: hard
 
@@ -2162,7 +2162,7 @@ __metadata:
     "@graphql-tools/resolvers-composition": "npm:^7.0.0"
     "@graphql-tools/schema": "npm:^10.0.0"
     "@graphql-tools/utils": "npm:10.6.1"
-    "@neo4j/cypher-builder": "npm:2.3.0"
+    "@neo4j/cypher-builder": "npm:^2.4.0"
     "@types/deep-equal": "npm:1.0.4"
     "@types/is-uuid": "npm:1.0.2"
     "@types/jest": "npm:29.5.14"


### PR DESCRIPTION
(cherry picked from commit 660861a11105fda3f94a796b99b42a5a0d5b1dfd)

# Description

Add `unsafeEscapeOptions` to `Neo4jGraphQL` features with the following flags:

- `disableRelationshipTypeEscaping` (default to `false`)
- `disableNodeLabelEscaping` (defaults to `false`)

These flags remove the automatic escaping of node labels and relationship types in the generated Cypher.

For example, given the following schema:

```graphql
type Actor {
    name: String!
}

type Movie {
    title: String!
    actors: [Actor!]! @relationship(type: "ACTED IN", direction: OUT)
}
```

A GraphQL query going through the `actors` relationship:

```graphql
query {
    movies {
        title
        actors {
            name
        }
    }
}
```

Will normally generate the following Cypher for the relationship:

```cypher
MATCH (this:Movie)-[this0:`ACTED IN`]->(this1:Actor)
```

The label `ACTED IN` is escaped by placing it inside backticks (`\``), as some characters in it are susceptible of code injection.

If the option `disableRelationshipTypeEscaping` is set in `Neo4jGraphQL`, this safety mechanism will be disabled:

```js
new Neo4jGraphQL({
    typeDefs,
    features: {
        unsafeEscapeOptions: {
            disableRelationshipTypeEscaping: true,
        },
    },
});
```

Generating the following (incorrect) Cypher instead:

```cypher
MATCH (this:Movie)-[this0:ACTED IN]->(this1:Actor)
```

This can be useful in very custom scenarios where the Cypher needs to be tweaked or if the labels and types have already been escaped.

> Warning: This is a safety mechanism to avoid Cypher injection. Changing these options may lead to code injection and an unsafe server.
