### PR TITLE
`@coalesce` now also applies to `RETURN` clauses

### DIFF
--- a/.changeset/cool-peas-chew.md
+++ b/.changeset/cool-peas-chew.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": major
+---
+
+Values specified within the `@coalesce` directive are now also returned when selecting those fields, and not just when those fields are used in a filter.

--- a/packages/graphql/src/translate/queryAST/ast/fields/attribute-fields/AttributeField.ts
+++ b/packages/graphql/src/translate/queryAST/ast/fields/attribute-fields/AttributeField.ts
@@ -17,10 +17,11 @@
  * limitations under the License.
  */
 
+import type Cypher from "@neo4j/cypher-builder";
 import type { AttributeAdapter } from "../../../../../schema-model/attribute/model-adapters/AttributeAdapter";
+import { coalesceValueIfNeeded } from "../../filters/utils/coalesce-if-needed";
 import type { QueryASTNode } from "../../QueryASTNode";
 import { Field } from "../Field";
-import type Cypher from "@neo4j/cypher-builder";
 
 export class AttributeField extends Field {
     protected attribute: AttributeAdapter;
@@ -48,8 +49,8 @@ export class AttributeField extends Field {
     }
 
     private createAttributeProperty(variableProperty: Cypher.Property): string | Record<string, Cypher.Expr> {
-        if (this.alias !== this.attribute.databaseName) {
-            return { [this.alias]: variableProperty };
+        if (this.alias !== this.attribute.databaseName || this.attribute.annotations.coalesce) {
+            return { [this.alias]: coalesceValueIfNeeded(this.attribute, variableProperty) };
         }
         return this.attribute.databaseName;
     }

--- a/packages/graphql/src/translate/queryAST/ast/fields/attribute-fields/DateTimeField.ts
+++ b/packages/graphql/src/translate/queryAST/ast/fields/attribute-fields/DateTimeField.ts
@@ -18,6 +18,7 @@
  */
 
 import Cypher from "@neo4j/cypher-builder";
+import { coalesceValueIfNeeded } from "../../filters/utils/coalesce-if-needed";
 import { AttributeField } from "./AttributeField";
 
 export class DateTimeField extends AttributeField {
@@ -30,7 +31,7 @@ export class DateTimeField extends AttributeField {
     public getProjectionField(variable: Cypher.Variable): Record<string, Cypher.Expr> {
         const targetProperty = variable.property(this.attribute.databaseName);
         const fieldExpr = this.createDateTimeProjection(targetProperty);
-        return { [this.alias]: fieldExpr };
+        return { [this.alias]: coalesceValueIfNeeded(this.attribute, fieldExpr) };
     }
 
     private createDateTimeProjection(targetProperty: Cypher.Property): Cypher.Expr {

--- a/packages/graphql/tests/integration/directives/coalesce.int.test.ts
+++ b/packages/graphql/tests/integration/directives/coalesce.int.test.ts
@@ -118,7 +118,7 @@ describe("@coalesce directive", () => {
 
         expect((gqlResult.data as any)[type.plural][0]).toEqual({
             id,
-            classification: null,
+            classification: "Unrated",
         });
     });
 
@@ -163,7 +163,7 @@ describe("@coalesce directive", () => {
 
         expect((gqlResult.data as any)[type.plural][0]).toEqual({
             id,
-            status: null,
+            status: "ACTIVE",
         });
     });
 
@@ -209,7 +209,50 @@ describe("@coalesce directive", () => {
 
         expect((gqlResult.data as any)[type.plural][0]).toEqual({
             id,
-            statuses: null,
+            statuses: ["ACTIVE", "INACTIVE"],
+        });
+    });
+
+    test("@cypher directive can be used for more complex coalesce scenarios", async () => {
+        const type = testHelper.createUniqueType("User");
+
+        const email = "notset@ohno.com";
+
+        const typeDefs = `
+            type ${type.name} @node {
+                id: ID!
+                email: String! @cypher(statement: "RETURN coalesce(this.email, this.backupEmail, this.backupBackupEmail) AS email", columnName: "email")
+            }
+        `;
+
+        await testHelper.initNeo4jGraphQL({
+            typeDefs,
+        });
+
+        const query = `
+            query {
+                ${type.plural}(where: { email: { eq: "${email}" } }) {
+                    id
+                    email
+                }
+            }
+        `;
+
+        const id = generate({
+            charset: "alphabetic",
+        });
+
+        await testHelper.executeCypher(`
+                CREATE (:${type.name} {id: "${id}", backupBackupEmail: "${email}"})
+            `);
+
+        const gqlResult = await testHelper.executeGraphQL(query);
+
+        expect(gqlResult.errors).toBeFalsy();
+
+        expect((gqlResult.data as any)[type.plural][0]).toEqual({
+            id,
+            email,
         });
     });
 });

--- a/packages/graphql/tests/tck/directives/coalesce.test.ts
+++ b/packages/graphql/tests/tck/directives/coalesce.test.ts
@@ -92,7 +92,7 @@ describe("Cypher coalesce()", () => {
             "CYPHER 5
             MATCH (this:User)
             WHERE (coalesce(this.id, \\"00000000-00000000-00000000-00000000\\") = $param0 AND coalesce(this.name, \\"Jane Smith\\") =~ $param1 AND coalesce(this.numberOfFriends, 0) > $param2 AND coalesce(this.rating, 2.5) < $param3 AND this.fromInterface = $param4 AND coalesce(this.toBeOverridden, \\"Overridden\\") = $param5 AND NOT (coalesce(this.verified, false) = $param6))
-            RETURN this { .name } AS this"
+            RETURN this { name: coalesce(this.name, \\"Jane Smith\\") } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -149,7 +149,7 @@ describe("Cypher coalesce()", () => {
             "CYPHER 5
             MATCH (this:Movie)
             WHERE coalesce(this.status, \\"ACTIVE\\") = $param0
-            RETURN this { .id, .status } AS this"
+            RETURN this { .id, status: coalesce(this.status, \\"ACTIVE\\") } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -216,7 +216,7 @@ describe("Cypher coalesce()", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ node: { id: this1.id, status: this1.status, __resolveType: \\"Movie\\" } }) AS var2
+                    RETURN collect({ node: { id: this1.id, status: coalesce(this1.status, \\"ACTIVE\\"), __resolveType: \\"Movie\\" } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }
@@ -280,7 +280,7 @@ describe("Cypher coalesce()", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ node: { id: this1.id, statuses: this1.statuses, __resolveType: \\"Movie\\" } }) AS var2
+                    RETURN collect({ node: { id: this1.id, statuses: coalesce(this1.statuses, [\\"ACTIVE\\", \\"INACTIVE\\"]), __resolveType: \\"Movie\\" } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }


### PR DESCRIPTION
# Description

Values specified within the `@coalesce` directive are now also returned when selecting those fields, and not just when those fields are used in a filter.

## Complexity

Complexity: Low

# Issue

Closes #2905
