### PR TITLE
Use branch name as tag for backport and LTS releases

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -5,8 +5,8 @@ on:
     branches:
       - dev
       - lts
-      - '*.*.*'
-      - '*.x'
+      - "*.*.*"
+      - "*.x"
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -58,7 +58,7 @@ jobs:
         with:
           title: changesets for branch `${{ github.ref_name }}`
           version: yarn changeset-version
-          publish: yarn ${{ github.ref_name == 'lts' && 'release-lts' || 'release' }}
+          publish: yarn ${{ github.ref_name == 'dev' && 'release-dev' || 'release-tagged' }}
           setupGitUser: false
         env:
           GITHUB_TOKEN: ${{ secrets.NEO4J_TEAM_GRAPHQL_PERSONAL_ACCESS_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
         "test-docker": "docker-compose up --build --abort-on-container-exit",
         "prepare": "husky",
         "changeset-version": "changeset version --since $BRANCH && yarn",
-        "release": "yarn build && changeset publish",
-        "release-lts": "yarn build && changeset publish --tag lts"
+        "release-dev": "yarn build && changeset publish",
+        "release-tagged": "yarn build && changeset publish --tag $BRANCH"
     },
     "devDependencies": {
         "@tsconfig/node16": "1.0.4",


### PR DESCRIPTION
# Description

For releasing from `dev`, npm script `release-dev` is used which publishes with default `latest` tag. Otherwise, use `release-tagged` which uses branch name as tag. For example, `lts`, `3.x`, `4.x`, etc.