### PR TITLE
6x: Typescript update 

### DIFF
--- a/.changeset/all-paws-agree.md
+++ b/.changeset/all-paws-agree.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+Typescript version has been updated to 5.8.2 slightly changing the emitted code. This change is not expected to have any impact on the generated code or the runtime behavior of the library.

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "release-tagged": "yarn build && changeset publish --tag $BRANCH"
     },
     "devDependencies": {
-        "@tsconfig/node16": "1.0.4",
+        "@tsconfig/node22": "22.0.0",
         "@typescript-eslint/eslint-plugin": "8.26.1",
         "@typescript-eslint/parser": "8.26.1",
         "concurrently": "9.1.2",
@@ -45,7 +45,7 @@
         "prettier-2": "npm:prettier@2.8.8",
         "set-tz": "0.2.0",
         "ts-jest": "29.2.6",
-        "typescript": "5.1.6"
+        "typescript": "5.8.2"
     },
     "packageManager": "yarn@4.7.0",
     "dependencies": {

--- a/packages/graphql/src/classes/Error.ts
+++ b/packages/graphql/src/classes/Error.ts
@@ -33,8 +33,6 @@ export class Neo4jGraphQLError extends GraphQLError {
 }
 
 export class Neo4jGraphQLForbiddenError extends Neo4jGraphQLError {
-    readonly name;
-
     constructor(message: string) {
         super(message);
 
@@ -43,8 +41,6 @@ export class Neo4jGraphQLForbiddenError extends Neo4jGraphQLError {
 }
 
 export class Neo4jGraphQLAuthenticationError extends Neo4jGraphQLError {
-    readonly name;
-
     constructor(message: string) {
         super(message);
 
@@ -53,8 +49,6 @@ export class Neo4jGraphQLAuthenticationError extends Neo4jGraphQLError {
 }
 
 export class Neo4jGraphQLConstraintValidationError extends Neo4jGraphQLError {
-    readonly name;
-
     constructor(message: string) {
         super(message);
 
@@ -63,8 +57,6 @@ export class Neo4jGraphQLConstraintValidationError extends Neo4jGraphQLError {
 }
 
 export class Neo4jGraphQLRelationshipValidationError extends Neo4jGraphQLError {
-    readonly name;
-
     constructor(message: string) {
         super(message);
 
@@ -73,8 +65,6 @@ export class Neo4jGraphQLRelationshipValidationError extends Neo4jGraphQLError {
 }
 
 export class Neo4jGraphQLSchemaValidationError extends Neo4jGraphQLError {
-    readonly name;
-
     constructor(message: string) {
         super(message);
 

--- a/packages/graphql/src/classes/Node.ts
+++ b/packages/graphql/src/classes/Node.ts
@@ -123,7 +123,6 @@ class Node extends GraphElement {
     public objectFields: ObjectField[];
     public nodeDirective?: NodeDirective;
     public fulltextDirective?: FullText;
-    public description?: string;
     public limit?: LimitDirective;
     public singular: string;
     public plural: string;

--- a/packages/graphql/src/schema-model/parser/parse-arguments.ts
+++ b/packages/graphql/src/schema-model/parser/parse-arguments.ts
@@ -18,7 +18,7 @@
  */
 
 import { inspect } from "@graphql-tools/utils";
-import type { Maybe } from "@graphql-tools/utils/typings/types";
+import type { Maybe } from "@graphql-tools/utils";
 import type { DirectiveNode, FieldNode, GraphQLDirective, GraphQLField } from "graphql";
 import { Kind, isNonNullType, print, valueFromAST } from "graphql";
 import type { ObjMap } from "graphql/jsutils/ObjMap";

--- a/packages/graphql/src/schema/validation/validate-sdl.ts
+++ b/packages/graphql/src/schema/validation/validate-sdl.ts
@@ -17,8 +17,8 @@
  * limitations under the License.
  */
 
-import type { Maybe } from "@graphql-tools/utils/typings/types";
-import type { DocumentNode, GraphQLSchema, GraphQLError } from "graphql";
+import type { Maybe } from "@graphql-tools/utils";
+import type { DocumentNode, GraphQLError, GraphQLSchema } from "graphql";
 import { visit, visitInParallel } from "graphql";
 import type { SDLValidationRule } from "graphql/validation/ValidationContext";
 import { SDLValidationContext } from "graphql/validation/ValidationContext";

--- a/packages/graphql/tsconfig.json
+++ b/packages/graphql/tsconfig.json
@@ -4,7 +4,8 @@
         "rootDir": ".",
         "baseUrl": ".",
         "outDir": "dist",
-        "noUncheckedIndexedAccess": true
+        "noUncheckedIndexedAccess": true,
+        "moduleResolution": "node10"
     },
     "include": ["global.d.ts", "package.json", "src/**/*", "tests/**/*"],
     "ts-node": {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,11 +1,14 @@
 {
-    "extends": "@tsconfig/node16/tsconfig.json",
+    "extends": "@tsconfig/node22/tsconfig.json",
     "compilerOptions": {
         "composite": true,
         "declarationMap": true,
         "sourceMap": true,
         "resolveJsonModule": true, // Required for package.json import in @neo4j/graphql
         "experimentalDecorators": true,
-        "noImplicitAny": false // TODO: Refactor so that this can be true for monorepo
+        "noImplicitAny": false, // TODO: Refactor so that this can be true for monorepo,
+        "module": "commonjs",
+        "target": "es2021",
+        "moduleResolution": "node10"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2749,10 +2749,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tsconfig/node16@npm:1.0.4, @tsconfig/node16@npm:^1.0.2":
+"@tsconfig/node16@npm:^1.0.2":
   version: 1.0.4
   resolution: "@tsconfig/node16@npm:1.0.4"
   checksum: 10c0/05f8f2734e266fb1839eb1d57290df1664fe2aa3b0fdd685a9035806daa635f7519bf6d5d9b33f6e69dd545b8c46bd6e2b5c79acb2b1f146e885f7f11a42a5bb
+  languageName: node
+  linkType: hard
+
+"@tsconfig/node22@npm:22.0.0":
+  version: 22.0.0
+  resolution: "@tsconfig/node22@npm:22.0.0"
+  checksum: 10c0/ccb736a008d33fb5ae0ac1254e83d7fa53cdbade02c645131eafcddd11f61982a4efe4c507487952202c240d2bd46c991561a4a0dfea52972947446d80de2081
   languageName: node
   linkType: hard
 
@@ -12669,7 +12676,7 @@ __metadata:
   dependencies:
     "@changesets/changelog-github": "npm:0.5.1"
     "@changesets/cli": "npm:2.28.1"
-    "@tsconfig/node16": "npm:1.0.4"
+    "@tsconfig/node22": "npm:22.0.0"
     "@typescript-eslint/eslint-plugin": "npm:8.26.1"
     "@typescript-eslint/parser": "npm:8.26.1"
     concurrently: "npm:9.1.2"
@@ -12690,7 +12697,7 @@ __metadata:
     prettier-2: "npm:prettier@2.8.8"
     set-tz: "npm:0.2.0"
     ts-jest: "npm:29.2.6"
-    typescript: "npm:5.1.6"
+    typescript: "npm:5.8.2"
   languageName: unknown
   linkType: soft
 
@@ -16933,6 +16940,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript@npm:5.8.2":
+  version: 5.8.2
+  resolution: "typescript@npm:5.8.2"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/5c4f6fbf1c6389b6928fe7b8fcd5dc73bb2d58cd4e3883f1d774ed5bd83b151cbac6b7ecf11723de56d4676daeba8713894b1e9af56174f2f9780ae7848ec3c6
+  languageName: node
+  linkType: hard
+
 "typescript@patch:typescript@npm%3A5.1.6#optional!builtin<compat/typescript>":
   version: 5.1.6
   resolution: "typescript@patch:typescript@npm%3A5.1.6#optional!builtin<compat/typescript>::version=5.1.6&hash=5da071"
@@ -16940,6 +16957,16 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10c0/c2bded58ab897a8341fdbb0c1d92ea2362f498cfffebdc8a529d03e15ea2454142dfbf122dabbd9a5cb79b7123790d27def16e11844887d20636226773ed329a
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@npm%3A5.8.2#optional!builtin<compat/typescript>":
+  version: 5.8.2
+  resolution: "typescript@patch:typescript@npm%3A5.8.2#optional!builtin<compat/typescript>::version=5.8.2&hash=5786d5"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/5448a08e595cc558ab321e49d4cac64fb43d1fa106584f6ff9a8d8e592111b373a995a1d5c7f3046211c8a37201eb6d0f1566f15cdb7a62a5e3be01d087848e2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

- Updates the old version of `@tsconfig/16` with an updated `@tsconfig/22` (matching the `engines` in `package.json` of `"node": ">=22.0.0"`)
- Updates tsconfig to retain the previous production build configuration which was essentially:
```json
        "module": "CommonJS",
        "target": "es2021",
        "moduleResolution": "node10"
```
- Updates Typescript to 5.8.2
- Addresses new errors raised during this update. Please see individual commits for errors raised.

## Complexity

Low
