### PR TITLE
Deprecate non-nested update where

### DIFF
--- a/.changeset/major-oranges-knock.md
+++ b/.changeset/major-oranges-knock.md
@@ -1,0 +1,40 @@
+---
+"@neo4j/graphql": minor
+---
+
+The `where` field for nested update operations has been deprecated to be moved within the `update` input field.
+The `where` in its deprecated location is a no-op for all nested operations apart from `update`.
+
+For example, the following mutation is using the deprecated syntax:
+
+```graphql
+mutation {
+    updateUsers(
+        where: { name: { eq: "Darrell" } }
+        update: {
+            posts: {
+                where: { node: { title: { eq: "Version 7 Release Notes" } } }
+                update: { node: { title: { set: "Version 7 Release Announcement" } } }
+            }
+        }
+    )
+}
+```
+
+It should be modified to move the `where` inside the `update` operation:
+
+```graphql
+mutation {
+    updateUsers(
+        where: { name: { eq: "Darrell" } }
+        update: {
+            posts: {
+                update: {
+                    where: { node: { title: { eq: "Version 7 Release Notes" } } }
+                    node: { title: { set: "Version 7 Release Announcement" } }
+                }
+            }
+        }
+    )
+}
+```

--- a/packages/graphql/src/schema/constants.ts
+++ b/packages/graphql/src/schema/constants.ts
@@ -96,3 +96,15 @@ export function DEPRECATE_NESTED_AGGREGATION(relationship: RelationshipAdapter |
         },
     };
 }
+
+export function DEPRECATE_UPDATE_WHERE(
+    relationship: RelationshipAdapter | RelationshipDeclarationAdapter,
+    ifUnionMemberEntity?: ConcreteEntityAdapter
+) {
+    return {
+        name: DEPRECATED,
+        args: {
+            reason: `Please use field "where" inside "${relationship.operations.getUpdateConnectionInputTypename(ifUnionMemberEntity)}" instead`,
+        },
+    };
+}

--- a/packages/graphql/src/schema/generation/update-input.ts
+++ b/packages/graphql/src/schema/generation/update-input.ts
@@ -41,6 +41,7 @@ import { withDeleteFieldInputType } from "./delete-input";
 import { withDisconnectFieldInputType } from "./disconnect-input";
 import { withCreateFieldInputType } from "./relation-input";
 import { shouldAddDeprecatedFields } from "./utils";
+import { DEPRECATE_UPDATE_WHERE } from "../constants";
 
 export function withUpdateInputType({
     entityAdapter,
@@ -261,11 +262,13 @@ function makeUpdateFieldInputTypeFields({
             ifUnionMemberEntity,
         });
     }
-    if (connectionWhereInputType) {
-        fields["where"] = {
-            type: connectionWhereInputType,
-            directives: [],
-        };
+    if (shouldAddDeprecatedFields(features, "nonNestedUpdateWhere")) {
+        if (connectionWhereInputType) {
+            fields["where"] = {
+                type: connectionWhereInputType,
+                directives: [DEPRECATE_UPDATE_WHERE(relationshipAdapter, ifUnionMemberEntity)],
+            };
+        }
     }
     if (connectOrCreateFieldInputType && shouldAddDeprecatedFields(features, "connectOrCreate")) {
         fields["connectOrCreate"] = {
@@ -450,6 +453,11 @@ function makeUpdateConnectionFieldInputTypeFields({
             composer,
         });
         fields["node"] = updateInputType;
+        fields["where"] = withConnectionWhereInputType({
+            relationshipAdapter,
+            memberEntity: ifUnionMemberEntity,
+            composer,
+        });
     } else {
         // TODO: we need to fix deprecatedDirectives before we can use the reference
         // const updateInputType = withUpdateInputType({
@@ -459,6 +467,7 @@ function makeUpdateConnectionFieldInputTypeFields({
         // });
         // fields["node"] = updateInputType;
         fields["node"] = relationshipAdapter.target.operations.updateInputTypeName;
+        fields["where"] = relationshipAdapter.operations.getConnectionWhereTypename();
     }
     if (relationshipAdapter.hasUpdateInputFields) {
         fields["edge"] = relationshipAdapter.operations.edgeUpdateInputTypeName;

--- a/packages/graphql/src/translate/create-update-and-params.ts
+++ b/packages/graphql/src/translate/create-update-and-params.ts
@@ -185,14 +185,14 @@ export default function createUpdateAndParams({
                         const delayedSubquery: string[] = [];
                         let aggregationWhere = false;
 
-                        if (update.where) {
+                        if (update.update.where || update.where) {
                             try {
                                 const {
                                     cypher: whereClause,
                                     subquery: preComputedSubqueries,
                                     params: whereParams,
                                 } = createConnectionWhereAndParams({
-                                    whereInput: update.where,
+                                    whereInput: update.update.where || update.where,
                                     node: refNode,
                                     nodeVariable: variableName,
                                     relationship,

--- a/packages/graphql/src/types/index.ts
+++ b/packages/graphql/src/types/index.ts
@@ -457,6 +457,7 @@ export type Neo4jFeaturesSettings = {
         idAggregations?: boolean;
         typename_IN?: boolean;
         deprecatedAggregateOperations?: boolean;
+        nonNestedUpdateWhere?: boolean;
     };
 
     /** Options for disabling automatic escaping of potentially unsafe strings.

--- a/packages/graphql/tests/integration/deprecations/update.int.test.ts
+++ b/packages/graphql/tests/integration/deprecations/update.int.test.ts
@@ -18,8 +18,8 @@
  */
 
 import { generate } from "randomstring";
-import type { UniqueType } from "../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import type { UniqueType } from "../../utils/graphql-types";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("update (deprecate implicit _SET)", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/deprecations/update.int.test.ts
+++ b/packages/graphql/tests/integration/deprecations/update.int.test.ts
@@ -379,7 +379,8 @@ describe("update (deprecate implicit _SET)", () => {
               where: { id_EQ: $movieId },
               update: {
                 actors: [{
-                  update: { where: { node: { name_EQ: $initialName } }, node: { name_SET: $updatedName } }
+                  where: { node: { name_EQ: $initialName } },
+                  update: { node: { name_SET: $updatedName } }
                 }]
               }
           ) {
@@ -740,12 +741,13 @@ describe("update (deprecate implicit _SET)", () => {
               where: { id_EQ: "${movieId}" }
               update: {
                 actors: [{
+                  where: { node: { name_EQ: "old actor name" } }
                   update: {
-                    where: { node: { name_EQ: "old actor name" } }
                     node: {
                         name_SET: "new actor name"
                         movies: [{
-                            update: { where: { node: { title_EQ: "old movie title" } }, node: { title_SET: "new movie title" } }
+                            where: { node: { title_EQ: "old movie title" } }
+                            update: { node: { title_SET: "new movie title" } }
                         }]
                     }
                   }
@@ -1009,8 +1011,8 @@ describe("update (deprecate implicit _SET)", () => {
               where: { id_EQ: "${productId}" }
               update: {
                 photos: [{
+                  where: { node: { id_EQ: "${photoId}" } }
                   update: {
-                      where: { node: { id_EQ: "${photoId}" } }
                       node: {
                         color: { disconnect: { where: { node: { id_EQ: "${colorId}" } } } }
                       }
@@ -1113,8 +1115,8 @@ describe("update (deprecate implicit _SET)", () => {
                   update: {
                     photos: [
                       {
+                        where: { node: { name_EQ: "Green Photo", id_EQ: "${photo0Id}" } }
                         update: {
-                            where: { node: { name_EQ: "Green Photo", id_EQ: "${photo0Id}" } }
                             node: {
                                 name_SET: "Light Green Photo"
                                 color: {
@@ -1125,8 +1127,8 @@ describe("update (deprecate implicit _SET)", () => {
                         }
                       }
                       {
+                        where: { node: { name_EQ: "Yellow Photo", id_EQ: "${photo1Id}" } }
                         update: {
-                            where: { node: { name_EQ: "Yellow Photo", id_EQ: "${photo1Id}" } }
                             node: {
                                 name_SET: "Light Yellow Photo"
                                 color: {

--- a/packages/graphql/tests/schema/aggregations.test.ts
+++ b/packages/graphql/tests/schema/aggregations.test.ts
@@ -1117,6 +1117,7 @@ describe("Aggregations", () => {
             input PostLikesUpdateConnectionInput {
               edge: LikesUpdateInput
               node: UserUpdateInput
+              where: PostLikesConnectionWhere
             }
 
             input PostLikesUpdateFieldInput {
@@ -1125,7 +1126,7 @@ describe("Aggregations", () => {
               delete: [PostLikesDeleteFieldInput!]
               disconnect: [PostLikesDisconnectFieldInput!]
               update: PostLikesUpdateConnectionInput
-              where: PostLikesConnectionWhere
+              where: PostLikesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"PostLikesUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input PostOptions {

--- a/packages/graphql/tests/schema/array-methods.test.ts
+++ b/packages/graphql/tests/schema/array-methods.test.ts
@@ -198,6 +198,7 @@ describe("Arrays Methods", () => {
             input ActorActedInUpdateConnectionInput {
               edge: ActedInUpdateInput
               node: MovieUpdateInput
+              where: ActorActedInConnectionWhere
             }
 
             input ActorActedInUpdateFieldInput {
@@ -206,7 +207,7 @@ describe("Arrays Methods", () => {
               delete: [ActorActedInDeleteFieldInput!]
               disconnect: [ActorActedInDisconnectFieldInput!]
               update: ActorActedInUpdateConnectionInput
-              where: ActorActedInConnectionWhere
+              where: ActorActedInConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type ActorAggregate {
@@ -493,6 +494,7 @@ describe("Arrays Methods", () => {
             input MovieActorsUpdateConnectionInput {
               edge: ActedInUpdateInput
               node: ActorUpdateInput
+              where: MovieActorsConnectionWhere
             }
 
             input MovieActorsUpdateFieldInput {
@@ -501,7 +503,7 @@ describe("Arrays Methods", () => {
               delete: [MovieActorsDeleteFieldInput!]
               disconnect: [MovieActorsDisconnectFieldInput!]
               update: MovieActorsUpdateConnectionInput
-              where: MovieActorsConnectionWhere
+              where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type MovieAggregate {

--- a/packages/graphql/tests/schema/authorization.test.ts
+++ b/packages/graphql/tests/schema/authorization.test.ts
@@ -225,6 +225,7 @@ describe("Authorization", () => {
 
             input PostAuthorUpdateConnectionInput {
               node: UserUpdateInput
+              where: PostAuthorConnectionWhere
             }
 
             input PostAuthorUpdateFieldInput {
@@ -233,7 +234,7 @@ describe("Authorization", () => {
               delete: PostAuthorDeleteFieldInput
               disconnect: PostAuthorDisconnectFieldInput
               update: PostAuthorUpdateConnectionInput
-              where: PostAuthorConnectionWhere
+              where: PostAuthorConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"PostAuthorUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input PostCreateInput {
@@ -518,6 +519,7 @@ describe("Authorization", () => {
 
             input UserPostsUpdateConnectionInput {
               node: UserUpdateInput
+              where: UserPostsConnectionWhere
             }
 
             input UserPostsUpdateFieldInput {
@@ -526,7 +528,7 @@ describe("Authorization", () => {
               delete: [UserPostsDeleteFieldInput!]
               disconnect: [UserPostsDisconnectFieldInput!]
               update: UserPostsUpdateConnectionInput
-              where: UserPostsConnectionWhere
+              where: UserPostsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"UserPostsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             \\"\\"\\"

--- a/packages/graphql/tests/schema/comments.test.ts
+++ b/packages/graphql/tests/schema/comments.test.ts
@@ -1642,7 +1642,7 @@ describe("Comments", () => {
                   delete: [MovieSearchGenreDeleteFieldInput!]
                   disconnect: [MovieSearchGenreDisconnectFieldInput!]
                   update: MovieSearchGenreUpdateConnectionInput
-                  where: MovieSearchGenreConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieSearchUpdateConnectionInput\\\\\\" instead\\")
+                  where: MovieSearchGenreConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieSearchGenreUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 input MovieSearchMovieConnectFieldInput {
@@ -1687,7 +1687,7 @@ describe("Comments", () => {
                   delete: [MovieSearchMovieDeleteFieldInput!]
                   disconnect: [MovieSearchMovieDisconnectFieldInput!]
                   update: MovieSearchMovieUpdateConnectionInput
-                  where: MovieSearchMovieConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieSearchUpdateConnectionInput\\\\\\" instead\\")
+                  where: MovieSearchMovieConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieSearchMovieUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieSearchRelationship {

--- a/packages/graphql/tests/schema/comments.test.ts
+++ b/packages/graphql/tests/schema/comments.test.ts
@@ -535,6 +535,7 @@ describe("Comments", () => {
 
                 input MovieActorsUpdateConnectionInput {
                   node: ActorUpdateInput
+                  where: MovieActorsConnectionWhere
                 }
 
                 input MovieActorsUpdateFieldInput {
@@ -543,7 +544,7 @@ describe("Comments", () => {
                   delete: [MovieActorsDeleteFieldInput!]
                   disconnect: [MovieActorsDisconnectFieldInput!]
                   update: MovieActorsUpdateConnectionInput
-                  where: MovieActorsConnectionWhere
+                  where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieAggregate {
@@ -893,6 +894,7 @@ describe("Comments", () => {
                 input ActorActedInUpdateConnectionInput {
                   edge: ActedInUpdateInput
                   node: ProductionUpdateInput
+                  where: ActorActedInConnectionWhere
                 }
 
                 input ActorActedInUpdateFieldInput {
@@ -901,7 +903,7 @@ describe("Comments", () => {
                   delete: [ActorActedInDeleteFieldInput!]
                   disconnect: [ActorActedInDisconnectFieldInput!]
                   update: ActorActedInUpdateConnectionInput
-                  where: ActorActedInConnectionWhere
+                  where: ActorActedInConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type ActorAggregate {
@@ -1631,6 +1633,7 @@ describe("Comments", () => {
 
                 input MovieSearchGenreUpdateConnectionInput {
                   node: GenreUpdateInput
+                  where: MovieSearchGenreConnectionWhere
                 }
 
                 input MovieSearchGenreUpdateFieldInput {
@@ -1639,7 +1642,7 @@ describe("Comments", () => {
                   delete: [MovieSearchGenreDeleteFieldInput!]
                   disconnect: [MovieSearchGenreDisconnectFieldInput!]
                   update: MovieSearchGenreUpdateConnectionInput
-                  where: MovieSearchGenreConnectionWhere
+                  where: MovieSearchGenreConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieSearchUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 input MovieSearchMovieConnectFieldInput {
@@ -1675,6 +1678,7 @@ describe("Comments", () => {
 
                 input MovieSearchMovieUpdateConnectionInput {
                   node: MovieUpdateInput
+                  where: MovieSearchMovieConnectionWhere
                 }
 
                 input MovieSearchMovieUpdateFieldInput {
@@ -1683,7 +1687,7 @@ describe("Comments", () => {
                   delete: [MovieSearchMovieDeleteFieldInput!]
                   disconnect: [MovieSearchMovieDisconnectFieldInput!]
                   update: MovieSearchMovieUpdateConnectionInput
-                  where: MovieSearchMovieConnectionWhere
+                  where: MovieSearchMovieConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieSearchUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieSearchRelationship {

--- a/packages/graphql/tests/schema/connect-or-create-id.test.ts
+++ b/packages/graphql/tests/schema/connect-or-create-id.test.ts
@@ -198,6 +198,7 @@ describe("connect or create with id", () => {
 
             input ActorMoviesUpdateConnectionInput {
               node: MovieUpdateInput
+              where: ActorMoviesConnectionWhere
             }
 
             input ActorMoviesUpdateFieldInput {
@@ -207,7 +208,7 @@ describe("connect or create with id", () => {
               delete: [ActorMoviesDeleteFieldInput!]
               disconnect: [ActorMoviesDisconnectFieldInput!]
               update: ActorMoviesUpdateConnectionInput
-              where: ActorMoviesConnectionWhere
+              where: ActorMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorMoviesUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input ActorOptions {
@@ -713,6 +714,7 @@ describe("connect or create with id", () => {
 
             input PostCreatorUpdateConnectionInput {
               node: UserUpdateInput
+              where: PostCreatorConnectionWhere
             }
 
             input PostCreatorUpdateFieldInput {
@@ -722,7 +724,7 @@ describe("connect or create with id", () => {
               delete: PostCreatorDeleteFieldInput
               disconnect: PostCreatorDisconnectFieldInput
               update: PostCreatorUpdateConnectionInput
-              where: PostCreatorConnectionWhere
+              where: PostCreatorConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"PostCreatorUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input PostDeleteInput {
@@ -1069,6 +1071,7 @@ describe("connect or create with id", () => {
 
             input UserPostsUpdateConnectionInput {
               node: PostUpdateInput
+              where: UserPostsConnectionWhere
             }
 
             input UserPostsUpdateFieldInput {
@@ -1078,7 +1081,7 @@ describe("connect or create with id", () => {
               delete: [UserPostsDeleteFieldInput!]
               disconnect: [UserPostsDisconnectFieldInput!]
               update: UserPostsUpdateConnectionInput
-              where: UserPostsConnectionWhere
+              where: UserPostsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"UserPostsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             \\"\\"\\"

--- a/packages/graphql/tests/schema/connect-or-create-unions.test.ts
+++ b/packages/graphql/tests/schema/connect-or-create-unions.test.ts
@@ -177,7 +177,7 @@ describe("Connect Or Create", () => {
               delete: [ActorActedInMovieDeleteFieldInput!]
               disconnect: [ActorActedInMovieDisconnectFieldInput!]
               update: ActorActedInMovieUpdateConnectionInput
-              where: ActorActedInMovieConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInUpdateConnectionInput\\\\\\" instead\\")
+              where: ActorActedInMovieConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInMovieUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type ActorActedInRelationship {
@@ -241,7 +241,7 @@ describe("Connect Or Create", () => {
               delete: [ActorActedInSeriesDeleteFieldInput!]
               disconnect: [ActorActedInSeriesDisconnectFieldInput!]
               update: ActorActedInSeriesUpdateConnectionInput
-              where: ActorActedInSeriesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInUpdateConnectionInput\\\\\\" instead\\")
+              where: ActorActedInSeriesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInSeriesUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input ActorActedInUpdateInput {

--- a/packages/graphql/tests/schema/connect-or-create-unions.test.ts
+++ b/packages/graphql/tests/schema/connect-or-create-unions.test.ts
@@ -167,6 +167,7 @@ describe("Connect Or Create", () => {
             input ActorActedInMovieUpdateConnectionInput {
               edge: ActedInUpdateInput
               node: MovieUpdateInput
+              where: ActorActedInMovieConnectionWhere
             }
 
             input ActorActedInMovieUpdateFieldInput {
@@ -176,7 +177,7 @@ describe("Connect Or Create", () => {
               delete: [ActorActedInMovieDeleteFieldInput!]
               disconnect: [ActorActedInMovieDisconnectFieldInput!]
               update: ActorActedInMovieUpdateConnectionInput
-              where: ActorActedInMovieConnectionWhere
+              where: ActorActedInMovieConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type ActorActedInRelationship {
@@ -230,6 +231,7 @@ describe("Connect Or Create", () => {
             input ActorActedInSeriesUpdateConnectionInput {
               edge: ActedInUpdateInput
               node: SeriesUpdateInput
+              where: ActorActedInSeriesConnectionWhere
             }
 
             input ActorActedInSeriesUpdateFieldInput {
@@ -239,7 +241,7 @@ describe("Connect Or Create", () => {
               delete: [ActorActedInSeriesDeleteFieldInput!]
               disconnect: [ActorActedInSeriesDisconnectFieldInput!]
               update: ActorActedInSeriesUpdateConnectionInput
-              where: ActorActedInSeriesConnectionWhere
+              where: ActorActedInSeriesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input ActorActedInUpdateInput {

--- a/packages/graphql/tests/schema/connect-or-create.test.ts
+++ b/packages/graphql/tests/schema/connect-or-create.test.ts
@@ -203,6 +203,7 @@ describe("Connect Or Create", () => {
 
             input ActorMoviesUpdateConnectionInput {
               node: MovieUpdateInput
+              where: ActorMoviesConnectionWhere
             }
 
             input ActorMoviesUpdateFieldInput {
@@ -212,7 +213,7 @@ describe("Connect Or Create", () => {
               delete: [ActorMoviesDeleteFieldInput!]
               disconnect: [ActorMoviesDisconnectFieldInput!]
               update: ActorMoviesUpdateConnectionInput
-              where: ActorMoviesConnectionWhere
+              where: ActorMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorMoviesUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input ActorOptions {
@@ -763,6 +764,7 @@ describe("Connect Or Create", () => {
             input ActorMoviesUpdateConnectionInput {
               edge: ActedInUpdateInput
               node: MovieUpdateInput
+              where: ActorMoviesConnectionWhere
             }
 
             input ActorMoviesUpdateFieldInput {
@@ -772,7 +774,7 @@ describe("Connect Or Create", () => {
               delete: [ActorMoviesDeleteFieldInput!]
               disconnect: [ActorMoviesDisconnectFieldInput!]
               update: ActorMoviesUpdateConnectionInput
-              where: ActorMoviesConnectionWhere
+              where: ActorMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorMoviesUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input ActorOptions {

--- a/packages/graphql/tests/schema/connections/enums.test.ts
+++ b/packages/graphql/tests/schema/connections/enums.test.ts
@@ -238,6 +238,7 @@ describe("Enums", () => {
             input ActorMoviesUpdateConnectionInput {
               edge: ActedInUpdateInput
               node: MovieUpdateInput
+              where: ActorMoviesConnectionWhere
             }
 
             input ActorMoviesUpdateFieldInput {
@@ -246,7 +247,7 @@ describe("Enums", () => {
               delete: [ActorMoviesDeleteFieldInput!]
               disconnect: [ActorMoviesDisconnectFieldInput!]
               update: ActorMoviesUpdateConnectionInput
-              where: ActorMoviesConnectionWhere
+              where: ActorMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorMoviesUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input ActorOptions {
@@ -464,6 +465,7 @@ describe("Enums", () => {
             input MovieActorsUpdateConnectionInput {
               edge: ActedInUpdateInput
               node: ActorUpdateInput
+              where: MovieActorsConnectionWhere
             }
 
             input MovieActorsUpdateFieldInput {
@@ -472,7 +474,7 @@ describe("Enums", () => {
               delete: [MovieActorsDeleteFieldInput!]
               disconnect: [MovieActorsDisconnectFieldInput!]
               update: MovieActorsUpdateConnectionInput
-              where: MovieActorsConnectionWhere
+              where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type MovieAggregate {

--- a/packages/graphql/tests/schema/connections/interfaces.test.ts
+++ b/packages/graphql/tests/schema/connections/interfaces.test.ts
@@ -210,6 +210,7 @@ describe("Connection with interfaces", () => {
 
             input CreatureMoviesUpdateConnectionInput {
               node: ProductionUpdateInput
+              where: CreatureMoviesConnectionWhere
             }
 
             input CreatureMoviesUpdateFieldInput {
@@ -218,7 +219,7 @@ describe("Connection with interfaces", () => {
               delete: CreatureMoviesDeleteFieldInput
               disconnect: CreatureMoviesDisconnectFieldInput
               update: CreatureMoviesUpdateConnectionInput
-              where: CreatureMoviesConnectionWhere
+              where: CreatureMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"CreatureMoviesUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input CreatureOptions {
@@ -385,6 +386,7 @@ describe("Connection with interfaces", () => {
 
             input MovieDirectorUpdateConnectionInput {
               node: CreatureUpdateInput
+              where: ProductionDirectorConnectionWhere
             }
 
             input MovieDirectorUpdateFieldInput {
@@ -393,7 +395,7 @@ describe("Connection with interfaces", () => {
               delete: [MovieDirectorDeleteFieldInput!]
               disconnect: [MovieDirectorDisconnectFieldInput!]
               update: MovieDirectorUpdateConnectionInput
-              where: ProductionDirectorConnectionWhere
+              where: ProductionDirectorConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieDirectorUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type MovieEdge {
@@ -593,6 +595,7 @@ describe("Connection with interfaces", () => {
 
             input PersonMoviesUpdateConnectionInput {
               node: ProductionUpdateInput
+              where: CreatureMoviesConnectionWhere
             }
 
             input PersonMoviesUpdateFieldInput {
@@ -601,7 +604,7 @@ describe("Connection with interfaces", () => {
               delete: PersonMoviesDeleteFieldInput
               disconnect: PersonMoviesDisconnectFieldInput
               update: PersonMoviesUpdateConnectionInput
-              where: CreatureMoviesConnectionWhere
+              where: CreatureMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"PersonMoviesUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input PersonOptions {
@@ -759,6 +762,7 @@ describe("Connection with interfaces", () => {
 
             input ProductionDirectorUpdateConnectionInput {
               node: CreatureUpdateInput
+              where: ProductionDirectorConnectionWhere
             }
 
             input ProductionDirectorUpdateFieldInput {
@@ -767,7 +771,7 @@ describe("Connection with interfaces", () => {
               delete: [ProductionDirectorDeleteFieldInput!]
               disconnect: [ProductionDirectorDisconnectFieldInput!]
               update: ProductionDirectorUpdateConnectionInput
-              where: ProductionDirectorConnectionWhere
+              where: ProductionDirectorConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ProductionDirectorUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input ProductionDisconnectInput {
@@ -987,6 +991,7 @@ describe("Connection with interfaces", () => {
 
             input SeriesDirectorUpdateConnectionInput {
               node: CreatureUpdateInput
+              where: ProductionDirectorConnectionWhere
             }
 
             input SeriesDirectorUpdateFieldInput {
@@ -995,7 +1000,7 @@ describe("Connection with interfaces", () => {
               delete: [SeriesDirectorDeleteFieldInput!]
               disconnect: [SeriesDirectorDisconnectFieldInput!]
               update: SeriesDirectorUpdateConnectionInput
-              where: ProductionDirectorConnectionWhere
+              where: ProductionDirectorConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"SeriesDirectorUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type SeriesEdge {

--- a/packages/graphql/tests/schema/connections/sort.test.ts
+++ b/packages/graphql/tests/schema/connections/sort.test.ts
@@ -212,6 +212,7 @@ describe("Sort", () => {
 
             input Node1RelatedToUpdateConnectionInput {
               node: Node2UpdateInput
+              where: Node1RelatedToConnectionWhere
             }
 
             input Node1RelatedToUpdateFieldInput {
@@ -220,7 +221,7 @@ describe("Sort", () => {
               delete: [Node1RelatedToDeleteFieldInput!]
               disconnect: [Node1RelatedToDisconnectFieldInput!]
               update: Node1RelatedToUpdateConnectionInput
-              where: Node1RelatedToConnectionWhere
+              where: Node1RelatedToConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"Node1RelatedToUpdateConnectionInput\\\\\\" instead\\")
             }
 
             \\"\\"\\"
@@ -425,6 +426,7 @@ describe("Sort", () => {
 
             input Node2RelatedToUpdateConnectionInput {
               node: Node1UpdateInput
+              where: Node2RelatedToConnectionWhere
             }
 
             input Node2RelatedToUpdateFieldInput {
@@ -433,7 +435,7 @@ describe("Sort", () => {
               delete: [Node2RelatedToDeleteFieldInput!]
               disconnect: [Node2RelatedToDisconnectFieldInput!]
               update: Node2RelatedToUpdateConnectionInput
-              where: Node2RelatedToConnectionWhere
+              where: Node2RelatedToConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"Node2RelatedToUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input Node2UpdateInput {

--- a/packages/graphql/tests/schema/connections/unions.test.ts
+++ b/packages/graphql/tests/schema/connections/unions.test.ts
@@ -156,7 +156,7 @@ describe("Unions", () => {
               delete: [AuthorPublicationsBookDeleteFieldInput!]
               disconnect: [AuthorPublicationsBookDisconnectFieldInput!]
               update: AuthorPublicationsBookUpdateConnectionInput
-              where: AuthorPublicationsBookConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"AuthorPublicationsUpdateConnectionInput\\\\\\" instead\\")
+              where: AuthorPublicationsBookConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"AuthorPublicationsBookUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input AuthorPublicationsConnectInput {
@@ -240,7 +240,7 @@ describe("Unions", () => {
               delete: [AuthorPublicationsJournalDeleteFieldInput!]
               disconnect: [AuthorPublicationsJournalDisconnectFieldInput!]
               update: AuthorPublicationsJournalUpdateConnectionInput
-              where: AuthorPublicationsJournalConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"AuthorPublicationsUpdateConnectionInput\\\\\\" instead\\")
+              where: AuthorPublicationsJournalConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"AuthorPublicationsJournalUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type AuthorPublicationsRelationship {

--- a/packages/graphql/tests/schema/connections/unions.test.ts
+++ b/packages/graphql/tests/schema/connections/unions.test.ts
@@ -147,6 +147,7 @@ describe("Unions", () => {
             input AuthorPublicationsBookUpdateConnectionInput {
               edge: WroteUpdateInput
               node: BookUpdateInput
+              where: AuthorPublicationsBookConnectionWhere
             }
 
             input AuthorPublicationsBookUpdateFieldInput {
@@ -155,7 +156,7 @@ describe("Unions", () => {
               delete: [AuthorPublicationsBookDeleteFieldInput!]
               disconnect: [AuthorPublicationsBookDisconnectFieldInput!]
               update: AuthorPublicationsBookUpdateConnectionInput
-              where: AuthorPublicationsBookConnectionWhere
+              where: AuthorPublicationsBookConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"AuthorPublicationsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input AuthorPublicationsConnectInput {
@@ -230,6 +231,7 @@ describe("Unions", () => {
             input AuthorPublicationsJournalUpdateConnectionInput {
               edge: WroteUpdateInput
               node: JournalUpdateInput
+              where: AuthorPublicationsJournalConnectionWhere
             }
 
             input AuthorPublicationsJournalUpdateFieldInput {
@@ -238,7 +240,7 @@ describe("Unions", () => {
               delete: [AuthorPublicationsJournalDeleteFieldInput!]
               disconnect: [AuthorPublicationsJournalDisconnectFieldInput!]
               update: AuthorPublicationsJournalUpdateConnectionInput
-              where: AuthorPublicationsJournalConnectionWhere
+              where: AuthorPublicationsJournalConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"AuthorPublicationsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type AuthorPublicationsRelationship {
@@ -447,6 +449,7 @@ describe("Unions", () => {
             input BookAuthorUpdateConnectionInput {
               edge: WroteUpdateInput
               node: AuthorUpdateInput
+              where: BookAuthorConnectionWhere
             }
 
             input BookAuthorUpdateFieldInput {
@@ -455,7 +458,7 @@ describe("Unions", () => {
               delete: [BookAuthorDeleteFieldInput!]
               disconnect: [BookAuthorDisconnectFieldInput!]
               update: BookAuthorUpdateConnectionInput
-              where: BookAuthorConnectionWhere
+              where: BookAuthorConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"BookAuthorUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input BookConnectInput {
@@ -732,6 +735,7 @@ describe("Unions", () => {
             input JournalAuthorUpdateConnectionInput {
               edge: WroteUpdateInput
               node: AuthorUpdateInput
+              where: JournalAuthorConnectionWhere
             }
 
             input JournalAuthorUpdateFieldInput {
@@ -740,7 +744,7 @@ describe("Unions", () => {
               delete: [JournalAuthorDeleteFieldInput!]
               disconnect: [JournalAuthorDisconnectFieldInput!]
               update: JournalAuthorUpdateConnectionInput
-              where: JournalAuthorConnectionWhere
+              where: JournalAuthorConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"JournalAuthorUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input JournalConnectInput {

--- a/packages/graphql/tests/schema/deprecations/relationship-aggregate-deprecated.test.ts
+++ b/packages/graphql/tests/schema/deprecations/relationship-aggregate-deprecated.test.ts
@@ -445,6 +445,7 @@ describe("@relationship directive, aggregate argument, deprecated", () => {
 
                 input MovieActorsUpdateConnectionInput {
                   node: ActorUpdateInput
+                  where: MovieActorsConnectionWhere
                 }
 
                 input MovieActorsUpdateFieldInput {
@@ -453,7 +454,7 @@ describe("@relationship directive, aggregate argument, deprecated", () => {
                   delete: [MovieActorsDeleteFieldInput!]
                   disconnect: [MovieActorsDisconnectFieldInput!]
                   update: MovieActorsUpdateConnectionInput
-                  where: MovieActorsConnectionWhere
+                  where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieAggregate {
@@ -873,6 +874,7 @@ describe("@relationship directive, aggregate argument, deprecated", () => {
 
                 input MovieActorsUpdateConnectionInput {
                   node: ActorUpdateInput
+                  where: MovieActorsConnectionWhere
                 }
 
                 input MovieActorsUpdateFieldInput {
@@ -881,7 +883,7 @@ describe("@relationship directive, aggregate argument, deprecated", () => {
                   delete: [MovieActorsDeleteFieldInput!]
                   disconnect: [MovieActorsDisconnectFieldInput!]
                   update: MovieActorsUpdateConnectionInput
-                  where: MovieActorsConnectionWhere
+                  where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieAggregate {
@@ -1277,6 +1279,7 @@ describe("@relationship directive, aggregate argument, deprecated", () => {
 
                     input MovieActorsUpdateConnectionInput {
                       node: PersonUpdateInput
+                      where: MovieActorsConnectionWhere
                     }
 
                     input MovieActorsUpdateFieldInput {
@@ -1285,7 +1288,7 @@ describe("@relationship directive, aggregate argument, deprecated", () => {
                       delete: [MovieActorsDeleteFieldInput!]
                       disconnect: [MovieActorsDisconnectFieldInput!]
                       update: MovieActorsUpdateConnectionInput
-                      where: MovieActorsConnectionWhere
+                      where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     type MovieAggregate {
@@ -1778,6 +1781,7 @@ describe("@relationship directive, aggregate argument, deprecated", () => {
 
                     input MovieActorsUpdateConnectionInput {
                       node: PersonUpdateInput
+                      where: MovieActorsConnectionWhere
                     }
 
                     input MovieActorsUpdateFieldInput {
@@ -1786,7 +1790,7 @@ describe("@relationship directive, aggregate argument, deprecated", () => {
                       delete: [MovieActorsDeleteFieldInput!]
                       disconnect: [MovieActorsDisconnectFieldInput!]
                       update: MovieActorsUpdateConnectionInput
-                      where: MovieActorsConnectionWhere
+                      where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     type MovieAggregate {
@@ -2243,6 +2247,7 @@ describe("@relationship directive, aggregate argument, deprecated", () => {
 
                     input MovieActorsActorUpdateConnectionInput {
                       node: ActorUpdateInput
+                      where: MovieActorsActorConnectionWhere
                     }
 
                     input MovieActorsActorUpdateFieldInput {
@@ -2251,7 +2256,7 @@ describe("@relationship directive, aggregate argument, deprecated", () => {
                       delete: [MovieActorsActorDeleteFieldInput!]
                       disconnect: [MovieActorsActorDisconnectFieldInput!]
                       update: MovieActorsActorUpdateConnectionInput
-                      where: MovieActorsActorConnectionWhere
+                      where: MovieActorsActorConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     type MovieActorsConnection {
@@ -2305,6 +2310,7 @@ describe("@relationship directive, aggregate argument, deprecated", () => {
 
                     input MovieActorsPersonUpdateConnectionInput {
                       node: PersonUpdateInput
+                      where: MovieActorsPersonConnectionWhere
                     }
 
                     input MovieActorsPersonUpdateFieldInput {
@@ -2313,7 +2319,7 @@ describe("@relationship directive, aggregate argument, deprecated", () => {
                       delete: [MovieActorsPersonDeleteFieldInput!]
                       disconnect: [MovieActorsPersonDisconnectFieldInput!]
                       update: MovieActorsPersonUpdateConnectionInput
-                      where: MovieActorsPersonConnectionWhere
+                      where: MovieActorsPersonConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     type MovieActorsRelationship {
@@ -2758,6 +2764,7 @@ describe("@relationship directive, aggregate argument, deprecated", () => {
 
                     input MovieActorsActorUpdateConnectionInput {
                       node: ActorUpdateInput
+                      where: MovieActorsActorConnectionWhere
                     }
 
                     input MovieActorsActorUpdateFieldInput {
@@ -2766,7 +2773,7 @@ describe("@relationship directive, aggregate argument, deprecated", () => {
                       delete: [MovieActorsActorDeleteFieldInput!]
                       disconnect: [MovieActorsActorDisconnectFieldInput!]
                       update: MovieActorsActorUpdateConnectionInput
-                      where: MovieActorsActorConnectionWhere
+                      where: MovieActorsActorConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     type MovieActorsConnection {
@@ -2820,6 +2827,7 @@ describe("@relationship directive, aggregate argument, deprecated", () => {
 
                     input MovieActorsPersonUpdateConnectionInput {
                       node: PersonUpdateInput
+                      where: MovieActorsPersonConnectionWhere
                     }
 
                     input MovieActorsPersonUpdateFieldInput {
@@ -2828,7 +2836,7 @@ describe("@relationship directive, aggregate argument, deprecated", () => {
                       delete: [MovieActorsPersonDeleteFieldInput!]
                       disconnect: [MovieActorsPersonDisconnectFieldInput!]
                       update: MovieActorsPersonUpdateConnectionInput
-                      where: MovieActorsPersonConnectionWhere
+                      where: MovieActorsPersonConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     type MovieActorsRelationship {

--- a/packages/graphql/tests/schema/deprecations/relationship-aggregate-deprecated.test.ts
+++ b/packages/graphql/tests/schema/deprecations/relationship-aggregate-deprecated.test.ts
@@ -2256,7 +2256,7 @@ describe("@relationship directive, aggregate argument, deprecated", () => {
                       delete: [MovieActorsActorDeleteFieldInput!]
                       disconnect: [MovieActorsActorDisconnectFieldInput!]
                       update: MovieActorsActorUpdateConnectionInput
-                      where: MovieActorsActorConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
+                      where: MovieActorsActorConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsActorUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     type MovieActorsConnection {
@@ -2319,7 +2319,7 @@ describe("@relationship directive, aggregate argument, deprecated", () => {
                       delete: [MovieActorsPersonDeleteFieldInput!]
                       disconnect: [MovieActorsPersonDisconnectFieldInput!]
                       update: MovieActorsPersonUpdateConnectionInput
-                      where: MovieActorsPersonConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
+                      where: MovieActorsPersonConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsPersonUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     type MovieActorsRelationship {
@@ -2773,7 +2773,7 @@ describe("@relationship directive, aggregate argument, deprecated", () => {
                       delete: [MovieActorsActorDeleteFieldInput!]
                       disconnect: [MovieActorsActorDisconnectFieldInput!]
                       update: MovieActorsActorUpdateConnectionInput
-                      where: MovieActorsActorConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
+                      where: MovieActorsActorConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsActorUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     type MovieActorsConnection {
@@ -2836,7 +2836,7 @@ describe("@relationship directive, aggregate argument, deprecated", () => {
                       delete: [MovieActorsPersonDeleteFieldInput!]
                       disconnect: [MovieActorsPersonDisconnectFieldInput!]
                       update: MovieActorsPersonUpdateConnectionInput
-                      where: MovieActorsPersonConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
+                      where: MovieActorsPersonConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsPersonUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     type MovieActorsRelationship {

--- a/packages/graphql/tests/schema/directive-preserve.test.ts
+++ b/packages/graphql/tests/schema/directive-preserve.test.ts
@@ -443,6 +443,7 @@ describe("Directive-preserve", () => {
 
             input GenreMoviesUpdateConnectionInput {
               node: MovieUpdateInput
+              where: GenreMoviesConnectionWhere
             }
 
             input GenreMoviesUpdateFieldInput {
@@ -451,7 +452,7 @@ describe("Directive-preserve", () => {
               delete: [GenreMoviesDeleteFieldInput!]
               disconnect: [GenreMoviesDisconnectFieldInput!]
               update: GenreMoviesUpdateConnectionInput
-              where: GenreMoviesConnectionWhere
+              where: GenreMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"GenreMoviesUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input GenreOptions {
@@ -683,6 +684,7 @@ describe("Directive-preserve", () => {
 
             input MovieGenresUpdateConnectionInput {
               node: GenreUpdateInput
+              where: MovieGenresConnectionWhere
             }
 
             input MovieGenresUpdateFieldInput {
@@ -691,7 +693,7 @@ describe("Directive-preserve", () => {
               delete: [MovieGenresDeleteFieldInput!]
               disconnect: [MovieGenresDisconnectFieldInput!]
               update: MovieGenresUpdateConnectionInput
-              where: MovieGenresConnectionWhere
+              where: MovieGenresConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieGenresUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input MovieOptions {
@@ -1048,6 +1050,7 @@ describe("Directive-preserve", () => {
             input ActorActedInUpdateConnectionInput {
               edge: ActedInUpdateInput
               node: ProductionUpdateInput
+              where: ActorActedInConnectionWhere
             }
 
             input ActorActedInUpdateFieldInput {
@@ -1056,7 +1059,7 @@ describe("Directive-preserve", () => {
               delete: [ActorActedInDeleteFieldInput!]
               disconnect: [ActorActedInDisconnectFieldInput!]
               update: ActorActedInUpdateConnectionInput
-              where: ActorActedInConnectionWhere
+              where: ActorActedInConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type ActorAggregate {
@@ -1312,6 +1315,7 @@ describe("Directive-preserve", () => {
             input MovieActorsUpdateConnectionInput {
               edge: ActedInUpdateInput
               node: ActorUpdateInput
+              where: ProductionActorsConnectionWhere
             }
 
             input MovieActorsUpdateFieldInput {
@@ -1320,7 +1324,7 @@ describe("Directive-preserve", () => {
               delete: [ProductionActorsDeleteFieldInput!]
               disconnect: [ProductionActorsDisconnectFieldInput!]
               update: MovieActorsUpdateConnectionInput
-              where: ProductionActorsConnectionWhere
+              where: ProductionActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type MovieAggregate {
@@ -1593,6 +1597,7 @@ describe("Directive-preserve", () => {
             input ProductionActorsUpdateConnectionInput {
               edge: ProductionActorsEdgeUpdateInput
               node: ActorUpdateInput
+              where: ProductionActorsConnectionWhere
             }
 
             input ProductionActorsUpdateFieldInput {
@@ -1601,7 +1606,7 @@ describe("Directive-preserve", () => {
               delete: [ProductionActorsDeleteFieldInput!]
               disconnect: [ProductionActorsDisconnectFieldInput!]
               update: ProductionActorsUpdateConnectionInput
-              where: ProductionActorsConnectionWhere
+              where: ProductionActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ProductionActorsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type ProductionAggregate {
@@ -1812,6 +1817,7 @@ describe("Directive-preserve", () => {
             input SeriesActorsUpdateConnectionInput {
               edge: ActedInUpdateInput
               node: ActorUpdateInput
+              where: ProductionActorsConnectionWhere
             }
 
             input SeriesActorsUpdateFieldInput {
@@ -1820,7 +1826,7 @@ describe("Directive-preserve", () => {
               delete: [ProductionActorsDeleteFieldInput!]
               disconnect: [ProductionActorsDisconnectFieldInput!]
               update: SeriesActorsUpdateConnectionInput
-              where: ProductionActorsConnectionWhere
+              where: ProductionActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"SeriesActorsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type SeriesAggregate {
@@ -2171,6 +2177,7 @@ describe("Directive-preserve", () => {
             input ActorActedInUpdateConnectionInput {
               edge: ActedInUpdateInput
               node: ProductionUpdateInput
+              where: ActorActedInConnectionWhere
             }
 
             input ActorActedInUpdateFieldInput {
@@ -2179,7 +2186,7 @@ describe("Directive-preserve", () => {
               delete: [ActorActedInDeleteFieldInput!]
               disconnect: [ActorActedInDisconnectFieldInput!]
               update: ActorActedInUpdateConnectionInput
-              where: ActorActedInConnectionWhere
+              where: ActorActedInConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type ActorAggregate {
@@ -2477,6 +2484,7 @@ describe("Directive-preserve", () => {
             input MovieActorsUpdateConnectionInput {
               edge: ActedInUpdateInput
               node: ActorUpdateInput
+              where: MovieActorsConnectionWhere
             }
 
             input MovieActorsUpdateFieldInput {
@@ -2485,7 +2493,7 @@ describe("Directive-preserve", () => {
               delete: [MovieActorsDeleteFieldInput!]
               disconnect: [MovieActorsDisconnectFieldInput!]
               update: MovieActorsUpdateConnectionInput
-              where: MovieActorsConnectionWhere
+              where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type MovieAggregate {
@@ -2834,6 +2842,7 @@ describe("Directive-preserve", () => {
             input SeriesActorsUpdateConnectionInput {
               edge: ActedInUpdateInput
               node: ActorUpdateInput
+              where: SeriesActorsConnectionWhere
             }
 
             input SeriesActorsUpdateFieldInput {
@@ -2842,7 +2851,7 @@ describe("Directive-preserve", () => {
               delete: [SeriesActorsDeleteFieldInput!]
               disconnect: [SeriesActorsDisconnectFieldInput!]
               update: SeriesActorsUpdateConnectionInput
-              where: SeriesActorsConnectionWhere
+              where: SeriesActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"SeriesActorsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type SeriesAggregate {
@@ -3181,6 +3190,7 @@ describe("Directive-preserve", () => {
             input ActorActedInUpdateConnectionInput {
               edge: ActedInUpdateInput
               node: ProductionUpdateInput
+              where: ActorActedInConnectionWhere
             }
 
             input ActorActedInUpdateFieldInput {
@@ -3189,7 +3199,7 @@ describe("Directive-preserve", () => {
               delete: [ActorActedInDeleteFieldInput!]
               disconnect: [ActorActedInDisconnectFieldInput!]
               update: ActorActedInUpdateConnectionInput
-              where: ActorActedInConnectionWhere
+              where: ActorActedInConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type ActorAggregate {
@@ -3487,6 +3497,7 @@ describe("Directive-preserve", () => {
             input MovieActorsUpdateConnectionInput {
               edge: ActedInUpdateInput
               node: ActorUpdateInput
+              where: MovieActorsConnectionWhere
             }
 
             input MovieActorsUpdateFieldInput {
@@ -3495,7 +3506,7 @@ describe("Directive-preserve", () => {
               delete: [MovieActorsDeleteFieldInput!]
               disconnect: [MovieActorsDisconnectFieldInput!]
               update: MovieActorsUpdateConnectionInput
-              where: MovieActorsConnectionWhere
+              where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type MovieAggregate {
@@ -3844,6 +3855,7 @@ describe("Directive-preserve", () => {
             input SeriesActorsUpdateConnectionInput {
               edge: ActedInUpdateInput
               node: ActorUpdateInput
+              where: SeriesActorsConnectionWhere
             }
 
             input SeriesActorsUpdateFieldInput {
@@ -3852,7 +3864,7 @@ describe("Directive-preserve", () => {
               delete: [SeriesActorsDeleteFieldInput!]
               disconnect: [SeriesActorsDisconnectFieldInput!]
               update: SeriesActorsUpdateConnectionInput
-              where: SeriesActorsConnectionWhere
+              where: SeriesActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"SeriesActorsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type SeriesAggregate {
@@ -4188,6 +4200,7 @@ describe("Directive-preserve", () => {
 
             input BlogPostsUpdateConnectionInput {
               node: PostUpdateInput
+              where: BlogPostsConnectionWhere
             }
 
             input BlogPostsUpdateFieldInput {
@@ -4196,7 +4209,7 @@ describe("Directive-preserve", () => {
               delete: [BlogPostsDeleteFieldInput!]
               disconnect: [BlogPostsDisconnectFieldInput!]
               update: BlogPostsUpdateConnectionInput
-              where: BlogPostsConnectionWhere
+              where: BlogPostsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"BlogPostsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             \\"\\"\\"
@@ -4504,6 +4517,7 @@ describe("Directive-preserve", () => {
 
             input UserContentBlogUpdateConnectionInput {
               node: BlogUpdateInput
+              where: UserContentBlogConnectionWhere
             }
 
             input UserContentBlogUpdateFieldInput {
@@ -4512,7 +4526,7 @@ describe("Directive-preserve", () => {
               delete: [UserContentBlogDeleteFieldInput!]
               disconnect: [UserContentBlogDisconnectFieldInput!]
               update: UserContentBlogUpdateConnectionInput
-              where: UserContentBlogConnectionWhere
+              where: UserContentBlogConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"UserContentUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type UserContentConnection {
@@ -4566,6 +4580,7 @@ describe("Directive-preserve", () => {
 
             input UserContentPostUpdateConnectionInput {
               node: PostUpdateInput
+              where: UserContentPostConnectionWhere
             }
 
             input UserContentPostUpdateFieldInput {
@@ -4574,7 +4589,7 @@ describe("Directive-preserve", () => {
               delete: [UserContentPostDeleteFieldInput!]
               disconnect: [UserContentPostDisconnectFieldInput!]
               update: UserContentPostUpdateConnectionInput
-              where: UserContentPostConnectionWhere
+              where: UserContentPostConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"UserContentUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type UserContentRelationship {

--- a/packages/graphql/tests/schema/directive-preserve.test.ts
+++ b/packages/graphql/tests/schema/directive-preserve.test.ts
@@ -4526,7 +4526,7 @@ describe("Directive-preserve", () => {
               delete: [UserContentBlogDeleteFieldInput!]
               disconnect: [UserContentBlogDisconnectFieldInput!]
               update: UserContentBlogUpdateConnectionInput
-              where: UserContentBlogConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"UserContentUpdateConnectionInput\\\\\\" instead\\")
+              where: UserContentBlogConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"UserContentBlogUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type UserContentConnection {
@@ -4589,7 +4589,7 @@ describe("Directive-preserve", () => {
               delete: [UserContentPostDeleteFieldInput!]
               disconnect: [UserContentPostDisconnectFieldInput!]
               update: UserContentPostUpdateConnectionInput
-              where: UserContentPostConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"UserContentUpdateConnectionInput\\\\\\" instead\\")
+              where: UserContentPostConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"UserContentPostUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type UserContentRelationship {

--- a/packages/graphql/tests/schema/directives/alias.test.ts
+++ b/packages/graphql/tests/schema/directives/alias.test.ts
@@ -257,6 +257,7 @@ describe("Alias", () => {
             input ActorActedInUpdateConnectionInput {
               edge: ActorActedInPropsUpdateInput
               node: MovieUpdateInput
+              where: ActorActedInConnectionWhere
             }
 
             input ActorActedInUpdateFieldInput {
@@ -265,7 +266,7 @@ describe("Alias", () => {
               delete: [ActorActedInDeleteFieldInput!]
               disconnect: [ActorActedInDisconnectFieldInput!]
               update: ActorActedInUpdateConnectionInput
-              where: ActorActedInConnectionWhere
+              where: ActorActedInConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type ActorAggregate {

--- a/packages/graphql/tests/schema/directives/filterable.test.ts
+++ b/packages/graphql/tests/schema/directives/filterable.test.ts
@@ -8483,7 +8483,7 @@ describe("@filterable directive", () => {
                       delete: [MovieActorsActorDeleteFieldInput!]
                       disconnect: [MovieActorsActorDisconnectFieldInput!]
                       update: MovieActorsActorUpdateConnectionInput
-                      where: MovieActorsActorConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
+                      where: MovieActorsActorConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsActorUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     input MovieActorsAppearanceConnectFieldInput {
@@ -8528,7 +8528,7 @@ describe("@filterable directive", () => {
                       delete: [MovieActorsAppearanceDeleteFieldInput!]
                       disconnect: [MovieActorsAppearanceDisconnectFieldInput!]
                       update: MovieActorsAppearanceUpdateConnectionInput
-                      where: MovieActorsAppearanceConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
+                      where: MovieActorsAppearanceConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsAppearanceUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     input MovieActorsConnectInput {
@@ -9507,7 +9507,7 @@ describe("@filterable directive", () => {
                       delete: [MovieActorsActorDeleteFieldInput!]
                       disconnect: [MovieActorsActorDisconnectFieldInput!]
                       update: MovieActorsActorUpdateConnectionInput
-                      where: MovieActorsActorConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
+                      where: MovieActorsActorConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsActorUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     input MovieActorsAppearanceConnectFieldInput {
@@ -9552,7 +9552,7 @@ describe("@filterable directive", () => {
                       delete: [MovieActorsAppearanceDeleteFieldInput!]
                       disconnect: [MovieActorsAppearanceDisconnectFieldInput!]
                       update: MovieActorsAppearanceUpdateConnectionInput
-                      where: MovieActorsAppearanceConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
+                      where: MovieActorsAppearanceConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsAppearanceUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     input MovieActorsConnectInput {
@@ -10531,7 +10531,7 @@ describe("@filterable directive", () => {
                       delete: [MovieActorsActorDeleteFieldInput!]
                       disconnect: [MovieActorsActorDisconnectFieldInput!]
                       update: MovieActorsActorUpdateConnectionInput
-                      where: MovieActorsActorConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
+                      where: MovieActorsActorConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsActorUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     input MovieActorsAppearanceConnectFieldInput {
@@ -10576,7 +10576,7 @@ describe("@filterable directive", () => {
                       delete: [MovieActorsAppearanceDeleteFieldInput!]
                       disconnect: [MovieActorsAppearanceDisconnectFieldInput!]
                       update: MovieActorsAppearanceUpdateConnectionInput
-                      where: MovieActorsAppearanceConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
+                      where: MovieActorsAppearanceConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsAppearanceUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     input MovieActorsConnectInput {

--- a/packages/graphql/tests/schema/directives/filterable.test.ts
+++ b/packages/graphql/tests/schema/directives/filterable.test.ts
@@ -1040,6 +1040,7 @@ describe("@filterable directive", () => {
 
                     input ActorMoviesUpdateConnectionInput {
                       node: MovieUpdateInput
+                      where: ActorMoviesConnectionWhere
                     }
 
                     input ActorMoviesUpdateFieldInput {
@@ -1048,7 +1049,7 @@ describe("@filterable directive", () => {
                       delete: [ActorMoviesDeleteFieldInput!]
                       disconnect: [ActorMoviesDisconnectFieldInput!]
                       update: ActorMoviesUpdateConnectionInput
-                      where: ActorMoviesConnectionWhere
+                      where: ActorMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorMoviesUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     input ActorOptions {
@@ -1318,6 +1319,7 @@ describe("@filterable directive", () => {
 
                     input MovieActorsUpdateConnectionInput {
                       node: ActorUpdateInput
+                      where: MovieActorsConnectionWhere
                     }
 
                     input MovieActorsUpdateFieldInput {
@@ -1326,7 +1328,7 @@ describe("@filterable directive", () => {
                       delete: [MovieActorsDeleteFieldInput!]
                       disconnect: [MovieActorsDisconnectFieldInput!]
                       update: MovieActorsUpdateConnectionInput
-                      where: MovieActorsConnectionWhere
+                      where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     type MovieAggregate {
@@ -1737,6 +1739,7 @@ describe("@filterable directive", () => {
 
                     input ActorMoviesUpdateConnectionInput {
                       node: MovieUpdateInput
+                      where: ActorMoviesConnectionWhere
                     }
 
                     input ActorMoviesUpdateFieldInput {
@@ -1745,7 +1748,7 @@ describe("@filterable directive", () => {
                       delete: [ActorMoviesDeleteFieldInput!]
                       disconnect: [ActorMoviesDisconnectFieldInput!]
                       update: ActorMoviesUpdateConnectionInput
-                      where: ActorMoviesConnectionWhere
+                      where: ActorMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorMoviesUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     input ActorOptions {
@@ -2015,6 +2018,7 @@ describe("@filterable directive", () => {
 
                     input MovieActorsUpdateConnectionInput {
                       node: ActorUpdateInput
+                      where: MovieActorsConnectionWhere
                     }
 
                     input MovieActorsUpdateFieldInput {
@@ -2023,7 +2027,7 @@ describe("@filterable directive", () => {
                       delete: [MovieActorsDeleteFieldInput!]
                       disconnect: [MovieActorsDisconnectFieldInput!]
                       update: MovieActorsUpdateConnectionInput
-                      where: MovieActorsConnectionWhere
+                      where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     type MovieAggregate {
@@ -2434,6 +2438,7 @@ describe("@filterable directive", () => {
 
                     input ActorMoviesUpdateConnectionInput {
                       node: MovieUpdateInput
+                      where: ActorMoviesConnectionWhere
                     }
 
                     input ActorMoviesUpdateFieldInput {
@@ -2442,7 +2447,7 @@ describe("@filterable directive", () => {
                       delete: [ActorMoviesDeleteFieldInput!]
                       disconnect: [ActorMoviesDisconnectFieldInput!]
                       update: ActorMoviesUpdateConnectionInput
-                      where: ActorMoviesConnectionWhere
+                      where: ActorMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorMoviesUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     input ActorOptions {
@@ -2712,6 +2717,7 @@ describe("@filterable directive", () => {
 
                     input MovieActorsUpdateConnectionInput {
                       node: ActorUpdateInput
+                      where: MovieActorsConnectionWhere
                     }
 
                     input MovieActorsUpdateFieldInput {
@@ -2720,7 +2726,7 @@ describe("@filterable directive", () => {
                       delete: [MovieActorsDeleteFieldInput!]
                       disconnect: [MovieActorsDisconnectFieldInput!]
                       update: MovieActorsUpdateConnectionInput
-                      where: MovieActorsConnectionWhere
+                      where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     type MovieAggregate {
@@ -3116,6 +3122,7 @@ describe("@filterable directive", () => {
 
                     input ActorMoviesUpdateConnectionInput {
                       node: MovieUpdateInput
+                      where: ActorMoviesConnectionWhere
                     }
 
                     input ActorMoviesUpdateFieldInput {
@@ -3124,7 +3131,7 @@ describe("@filterable directive", () => {
                       delete: [ActorMoviesDeleteFieldInput!]
                       disconnect: [ActorMoviesDisconnectFieldInput!]
                       update: ActorMoviesUpdateConnectionInput
-                      where: ActorMoviesConnectionWhere
+                      where: ActorMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorMoviesUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     input ActorOptions {
@@ -3345,6 +3352,7 @@ describe("@filterable directive", () => {
 
                     input MovieActorsUpdateConnectionInput {
                       node: ActorUpdateInput
+                      where: MovieActorsConnectionWhere
                     }
 
                     input MovieActorsUpdateFieldInput {
@@ -3353,7 +3361,7 @@ describe("@filterable directive", () => {
                       delete: [MovieActorsDeleteFieldInput!]
                       disconnect: [MovieActorsDisconnectFieldInput!]
                       update: MovieActorsUpdateConnectionInput
-                      where: MovieActorsConnectionWhere
+                      where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     type MovieAggregate {
@@ -3765,6 +3773,7 @@ describe("@filterable directive", () => {
 
                     input ActorMoviesUpdateConnectionInput {
                       node: MovieUpdateInput
+                      where: ActorMoviesConnectionWhere
                     }
 
                     input ActorMoviesUpdateFieldInput {
@@ -3773,7 +3782,7 @@ describe("@filterable directive", () => {
                       delete: [ActorMoviesDeleteFieldInput!]
                       disconnect: [ActorMoviesDisconnectFieldInput!]
                       update: ActorMoviesUpdateConnectionInput
-                      where: ActorMoviesConnectionWhere
+                      where: ActorMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorMoviesUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     input ActorOptions {
@@ -4043,6 +4052,7 @@ describe("@filterable directive", () => {
 
                     input MovieActorsUpdateConnectionInput {
                       node: ActorUpdateInput
+                      where: MovieActorsConnectionWhere
                     }
 
                     input MovieActorsUpdateFieldInput {
@@ -4051,7 +4061,7 @@ describe("@filterable directive", () => {
                       delete: [MovieActorsDeleteFieldInput!]
                       disconnect: [MovieActorsDisconnectFieldInput!]
                       update: MovieActorsUpdateConnectionInput
-                      where: MovieActorsConnectionWhere
+                      where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     type MovieAggregate {
@@ -4464,6 +4474,7 @@ describe("@filterable directive", () => {
 
                     input ActorMoviesUpdateConnectionInput {
                       node: MovieUpdateInput
+                      where: ActorMoviesConnectionWhere
                     }
 
                     input ActorMoviesUpdateFieldInput {
@@ -4472,7 +4483,7 @@ describe("@filterable directive", () => {
                       delete: [ActorMoviesDeleteFieldInput!]
                       disconnect: [ActorMoviesDisconnectFieldInput!]
                       update: ActorMoviesUpdateConnectionInput
-                      where: ActorMoviesConnectionWhere
+                      where: ActorMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorMoviesUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     input ActorOptions {
@@ -4742,6 +4753,7 @@ describe("@filterable directive", () => {
 
                     input MovieActorsUpdateConnectionInput {
                       node: ActorUpdateInput
+                      where: MovieActorsConnectionWhere
                     }
 
                     input MovieActorsUpdateFieldInput {
@@ -4750,7 +4762,7 @@ describe("@filterable directive", () => {
                       delete: [MovieActorsDeleteFieldInput!]
                       disconnect: [MovieActorsDisconnectFieldInput!]
                       update: MovieActorsUpdateConnectionInput
-                      where: MovieActorsConnectionWhere
+                      where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     type MovieAggregate {
@@ -5139,6 +5151,7 @@ describe("@filterable directive", () => {
 
                     input ActorMoviesUpdateConnectionInput {
                       node: MovieUpdateInput
+                      where: ActorMoviesConnectionWhere
                     }
 
                     input ActorMoviesUpdateFieldInput {
@@ -5147,7 +5160,7 @@ describe("@filterable directive", () => {
                       delete: [ActorMoviesDeleteFieldInput!]
                       disconnect: [ActorMoviesDisconnectFieldInput!]
                       update: ActorMoviesUpdateConnectionInput
-                      where: ActorMoviesConnectionWhere
+                      where: ActorMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorMoviesUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     input ActorOptions {
@@ -5368,6 +5381,7 @@ describe("@filterable directive", () => {
 
                     input MovieActorsUpdateConnectionInput {
                       node: ActorUpdateInput
+                      where: MovieActorsConnectionWhere
                     }
 
                     input MovieActorsUpdateFieldInput {
@@ -5376,7 +5390,7 @@ describe("@filterable directive", () => {
                       delete: [MovieActorsDeleteFieldInput!]
                       disconnect: [MovieActorsDisconnectFieldInput!]
                       update: MovieActorsUpdateConnectionInput
-                      where: MovieActorsConnectionWhere
+                      where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     type MovieAggregate {
@@ -5781,6 +5795,7 @@ describe("@filterable directive", () => {
 
                     input ActorMoviesUpdateConnectionInput {
                       node: MovieUpdateInput
+                      where: ActorMoviesConnectionWhere
                     }
 
                     input ActorMoviesUpdateFieldInput {
@@ -5789,7 +5804,7 @@ describe("@filterable directive", () => {
                       delete: [ActorMoviesDeleteFieldInput!]
                       disconnect: [ActorMoviesDisconnectFieldInput!]
                       update: ActorMoviesUpdateConnectionInput
-                      where: ActorMoviesConnectionWhere
+                      where: ActorMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorMoviesUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     input ActorOptions {
@@ -5988,6 +6003,7 @@ describe("@filterable directive", () => {
 
                     input MovieActorsUpdateConnectionInput {
                       node: PersonUpdateInput
+                      where: MovieActorsConnectionWhere
                     }
 
                     input MovieActorsUpdateFieldInput {
@@ -5996,7 +6012,7 @@ describe("@filterable directive", () => {
                       delete: [MovieActorsDeleteFieldInput!]
                       disconnect: [MovieActorsDisconnectFieldInput!]
                       update: MovieActorsUpdateConnectionInput
-                      where: MovieActorsConnectionWhere
+                      where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     type MovieAggregate {
@@ -6495,6 +6511,7 @@ describe("@filterable directive", () => {
 
                     input ActorMoviesUpdateConnectionInput {
                       node: MovieUpdateInput
+                      where: ActorMoviesConnectionWhere
                     }
 
                     input ActorMoviesUpdateFieldInput {
@@ -6503,7 +6520,7 @@ describe("@filterable directive", () => {
                       delete: [ActorMoviesDeleteFieldInput!]
                       disconnect: [ActorMoviesDisconnectFieldInput!]
                       update: ActorMoviesUpdateConnectionInput
-                      where: ActorMoviesConnectionWhere
+                      where: ActorMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorMoviesUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     input ActorOptions {
@@ -6736,6 +6753,7 @@ describe("@filterable directive", () => {
 
                     input MovieActorsUpdateConnectionInput {
                       node: PersonUpdateInput
+                      where: MovieActorsConnectionWhere
                     }
 
                     input MovieActorsUpdateFieldInput {
@@ -6744,7 +6762,7 @@ describe("@filterable directive", () => {
                       delete: [MovieActorsDeleteFieldInput!]
                       disconnect: [MovieActorsDisconnectFieldInput!]
                       update: MovieActorsUpdateConnectionInput
-                      where: MovieActorsConnectionWhere
+                      where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     type MovieAggregate {
@@ -7244,6 +7262,7 @@ describe("@filterable directive", () => {
 
                     input ActorMoviesUpdateConnectionInput {
                       node: MovieUpdateInput
+                      where: ActorMoviesConnectionWhere
                     }
 
                     input ActorMoviesUpdateFieldInput {
@@ -7252,7 +7271,7 @@ describe("@filterable directive", () => {
                       delete: [ActorMoviesDeleteFieldInput!]
                       disconnect: [ActorMoviesDisconnectFieldInput!]
                       update: ActorMoviesUpdateConnectionInput
-                      where: ActorMoviesConnectionWhere
+                      where: ActorMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorMoviesUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     input ActorOptions {
@@ -7451,6 +7470,7 @@ describe("@filterable directive", () => {
 
                     input MovieActorsUpdateConnectionInput {
                       node: PersonUpdateInput
+                      where: MovieActorsConnectionWhere
                     }
 
                     input MovieActorsUpdateFieldInput {
@@ -7459,7 +7479,7 @@ describe("@filterable directive", () => {
                       delete: [MovieActorsDeleteFieldInput!]
                       disconnect: [MovieActorsDisconnectFieldInput!]
                       update: MovieActorsUpdateConnectionInput
-                      where: MovieActorsConnectionWhere
+                      where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     type MovieAggregate {
@@ -7974,6 +7994,7 @@ describe("@filterable directive", () => {
 
                     input ActorMoviesUpdateConnectionInput {
                       node: MovieUpdateInput
+                      where: ActorMoviesConnectionWhere
                     }
 
                     input ActorMoviesUpdateFieldInput {
@@ -7982,7 +8003,7 @@ describe("@filterable directive", () => {
                       delete: [ActorMoviesDeleteFieldInput!]
                       disconnect: [ActorMoviesDisconnectFieldInput!]
                       update: ActorMoviesUpdateConnectionInput
-                      where: ActorMoviesConnectionWhere
+                      where: ActorMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorMoviesUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     input ActorOptions {
@@ -8254,6 +8275,7 @@ describe("@filterable directive", () => {
 
                     input AppearanceMoviesUpdateConnectionInput {
                       node: MovieUpdateInput
+                      where: AppearanceMoviesConnectionWhere
                     }
 
                     input AppearanceMoviesUpdateFieldInput {
@@ -8262,7 +8284,7 @@ describe("@filterable directive", () => {
                       delete: [AppearanceMoviesDeleteFieldInput!]
                       disconnect: [AppearanceMoviesDisconnectFieldInput!]
                       update: AppearanceMoviesUpdateConnectionInput
-                      where: AppearanceMoviesConnectionWhere
+                      where: AppearanceMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"AppearanceMoviesUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     input AppearanceOptions {
@@ -8452,6 +8474,7 @@ describe("@filterable directive", () => {
 
                     input MovieActorsActorUpdateConnectionInput {
                       node: ActorUpdateInput
+                      where: MovieActorsActorConnectionWhere
                     }
 
                     input MovieActorsActorUpdateFieldInput {
@@ -8460,7 +8483,7 @@ describe("@filterable directive", () => {
                       delete: [MovieActorsActorDeleteFieldInput!]
                       disconnect: [MovieActorsActorDisconnectFieldInput!]
                       update: MovieActorsActorUpdateConnectionInput
-                      where: MovieActorsActorConnectionWhere
+                      where: MovieActorsActorConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     input MovieActorsAppearanceConnectFieldInput {
@@ -8496,6 +8519,7 @@ describe("@filterable directive", () => {
 
                     input MovieActorsAppearanceUpdateConnectionInput {
                       node: AppearanceUpdateInput
+                      where: MovieActorsAppearanceConnectionWhere
                     }
 
                     input MovieActorsAppearanceUpdateFieldInput {
@@ -8504,7 +8528,7 @@ describe("@filterable directive", () => {
                       delete: [MovieActorsAppearanceDeleteFieldInput!]
                       disconnect: [MovieActorsAppearanceDisconnectFieldInput!]
                       update: MovieActorsAppearanceUpdateConnectionInput
-                      where: MovieActorsAppearanceConnectionWhere
+                      where: MovieActorsAppearanceConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     input MovieActorsConnectInput {
@@ -8994,6 +9018,7 @@ describe("@filterable directive", () => {
 
                     input ActorMoviesUpdateConnectionInput {
                       node: MovieUpdateInput
+                      where: ActorMoviesConnectionWhere
                     }
 
                     input ActorMoviesUpdateFieldInput {
@@ -9002,7 +9027,7 @@ describe("@filterable directive", () => {
                       delete: [ActorMoviesDeleteFieldInput!]
                       disconnect: [ActorMoviesDisconnectFieldInput!]
                       update: ActorMoviesUpdateConnectionInput
-                      where: ActorMoviesConnectionWhere
+                      where: ActorMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorMoviesUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     input ActorOptions {
@@ -9274,6 +9299,7 @@ describe("@filterable directive", () => {
 
                     input AppearanceMoviesUpdateConnectionInput {
                       node: MovieUpdateInput
+                      where: AppearanceMoviesConnectionWhere
                     }
 
                     input AppearanceMoviesUpdateFieldInput {
@@ -9282,7 +9308,7 @@ describe("@filterable directive", () => {
                       delete: [AppearanceMoviesDeleteFieldInput!]
                       disconnect: [AppearanceMoviesDisconnectFieldInput!]
                       update: AppearanceMoviesUpdateConnectionInput
-                      where: AppearanceMoviesConnectionWhere
+                      where: AppearanceMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"AppearanceMoviesUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     input AppearanceOptions {
@@ -9472,6 +9498,7 @@ describe("@filterable directive", () => {
 
                     input MovieActorsActorUpdateConnectionInput {
                       node: ActorUpdateInput
+                      where: MovieActorsActorConnectionWhere
                     }
 
                     input MovieActorsActorUpdateFieldInput {
@@ -9480,7 +9507,7 @@ describe("@filterable directive", () => {
                       delete: [MovieActorsActorDeleteFieldInput!]
                       disconnect: [MovieActorsActorDisconnectFieldInput!]
                       update: MovieActorsActorUpdateConnectionInput
-                      where: MovieActorsActorConnectionWhere
+                      where: MovieActorsActorConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     input MovieActorsAppearanceConnectFieldInput {
@@ -9516,6 +9543,7 @@ describe("@filterable directive", () => {
 
                     input MovieActorsAppearanceUpdateConnectionInput {
                       node: AppearanceUpdateInput
+                      where: MovieActorsAppearanceConnectionWhere
                     }
 
                     input MovieActorsAppearanceUpdateFieldInput {
@@ -9524,7 +9552,7 @@ describe("@filterable directive", () => {
                       delete: [MovieActorsAppearanceDeleteFieldInput!]
                       disconnect: [MovieActorsAppearanceDisconnectFieldInput!]
                       update: MovieActorsAppearanceUpdateConnectionInput
-                      where: MovieActorsAppearanceConnectionWhere
+                      where: MovieActorsAppearanceConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     input MovieActorsConnectInput {
@@ -10014,6 +10042,7 @@ describe("@filterable directive", () => {
 
                     input ActorMoviesUpdateConnectionInput {
                       node: MovieUpdateInput
+                      where: ActorMoviesConnectionWhere
                     }
 
                     input ActorMoviesUpdateFieldInput {
@@ -10022,7 +10051,7 @@ describe("@filterable directive", () => {
                       delete: [ActorMoviesDeleteFieldInput!]
                       disconnect: [ActorMoviesDisconnectFieldInput!]
                       update: ActorMoviesUpdateConnectionInput
-                      where: ActorMoviesConnectionWhere
+                      where: ActorMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorMoviesUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     input ActorOptions {
@@ -10294,6 +10323,7 @@ describe("@filterable directive", () => {
 
                     input AppearanceMoviesUpdateConnectionInput {
                       node: MovieUpdateInput
+                      where: AppearanceMoviesConnectionWhere
                     }
 
                     input AppearanceMoviesUpdateFieldInput {
@@ -10302,7 +10332,7 @@ describe("@filterable directive", () => {
                       delete: [AppearanceMoviesDeleteFieldInput!]
                       disconnect: [AppearanceMoviesDisconnectFieldInput!]
                       update: AppearanceMoviesUpdateConnectionInput
-                      where: AppearanceMoviesConnectionWhere
+                      where: AppearanceMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"AppearanceMoviesUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     input AppearanceOptions {
@@ -10492,6 +10522,7 @@ describe("@filterable directive", () => {
 
                     input MovieActorsActorUpdateConnectionInput {
                       node: ActorUpdateInput
+                      where: MovieActorsActorConnectionWhere
                     }
 
                     input MovieActorsActorUpdateFieldInput {
@@ -10500,7 +10531,7 @@ describe("@filterable directive", () => {
                       delete: [MovieActorsActorDeleteFieldInput!]
                       disconnect: [MovieActorsActorDisconnectFieldInput!]
                       update: MovieActorsActorUpdateConnectionInput
-                      where: MovieActorsActorConnectionWhere
+                      where: MovieActorsActorConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     input MovieActorsAppearanceConnectFieldInput {
@@ -10536,6 +10567,7 @@ describe("@filterable directive", () => {
 
                     input MovieActorsAppearanceUpdateConnectionInput {
                       node: AppearanceUpdateInput
+                      where: MovieActorsAppearanceConnectionWhere
                     }
 
                     input MovieActorsAppearanceUpdateFieldInput {
@@ -10544,7 +10576,7 @@ describe("@filterable directive", () => {
                       delete: [MovieActorsAppearanceDeleteFieldInput!]
                       disconnect: [MovieActorsAppearanceDisconnectFieldInput!]
                       update: MovieActorsAppearanceUpdateConnectionInput
-                      where: MovieActorsAppearanceConnectionWhere
+                      where: MovieActorsAppearanceConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     input MovieActorsConnectInput {

--- a/packages/graphql/tests/schema/directives/populatedBy.test.ts
+++ b/packages/graphql/tests/schema/directives/populatedBy.test.ts
@@ -998,6 +998,7 @@ describe("@populatedBy tests", () => {
                 input MovieGenresUpdateConnectionInput {
                   edge: RelPropertiesUpdateInput
                   node: GenreUpdateInput
+                  where: MovieGenresConnectionWhere
                 }
 
                 input MovieGenresUpdateFieldInput {
@@ -1006,7 +1007,7 @@ describe("@populatedBy tests", () => {
                   delete: [MovieGenresDeleteFieldInput!]
                   disconnect: [MovieGenresDisconnectFieldInput!]
                   update: MovieGenresUpdateConnectionInput
-                  where: MovieGenresConnectionWhere
+                  where: MovieGenresConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieGenresUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 input MovieOptions {
@@ -1563,6 +1564,7 @@ describe("@populatedBy tests", () => {
                 input MovieGenresUpdateConnectionInput {
                   edge: RelPropertiesUpdateInput
                   node: GenreUpdateInput
+                  where: MovieGenresConnectionWhere
                 }
 
                 input MovieGenresUpdateFieldInput {
@@ -1571,7 +1573,7 @@ describe("@populatedBy tests", () => {
                   delete: [MovieGenresDeleteFieldInput!]
                   disconnect: [MovieGenresDisconnectFieldInput!]
                   update: MovieGenresUpdateConnectionInput
-                  where: MovieGenresConnectionWhere
+                  where: MovieGenresConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieGenresUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 input MovieOptions {

--- a/packages/graphql/tests/schema/directives/relationship-aggregate.test.ts
+++ b/packages/graphql/tests/schema/directives/relationship-aggregate.test.ts
@@ -436,6 +436,7 @@ describe("@relationship directive, aggregate argument", () => {
 
                 input MovieActorsUpdateConnectionInput {
                   node: ActorUpdateInput
+                  where: MovieActorsConnectionWhere
                 }
 
                 input MovieActorsUpdateFieldInput {
@@ -444,7 +445,7 @@ describe("@relationship directive, aggregate argument", () => {
                   delete: [MovieActorsDeleteFieldInput!]
                   disconnect: [MovieActorsDisconnectFieldInput!]
                   update: MovieActorsUpdateConnectionInput
-                  where: MovieActorsConnectionWhere
+                  where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieAggregate {
@@ -864,6 +865,7 @@ describe("@relationship directive, aggregate argument", () => {
 
                 input MovieActorsUpdateConnectionInput {
                   node: ActorUpdateInput
+                  where: MovieActorsConnectionWhere
                 }
 
                 input MovieActorsUpdateFieldInput {
@@ -872,7 +874,7 @@ describe("@relationship directive, aggregate argument", () => {
                   delete: [MovieActorsDeleteFieldInput!]
                   disconnect: [MovieActorsDisconnectFieldInput!]
                   update: MovieActorsUpdateConnectionInput
-                  where: MovieActorsConnectionWhere
+                  where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieAggregate {
@@ -1268,6 +1270,7 @@ describe("@relationship directive, aggregate argument", () => {
 
                     input MovieActorsUpdateConnectionInput {
                       node: PersonUpdateInput
+                      where: MovieActorsConnectionWhere
                     }
 
                     input MovieActorsUpdateFieldInput {
@@ -1276,7 +1279,7 @@ describe("@relationship directive, aggregate argument", () => {
                       delete: [MovieActorsDeleteFieldInput!]
                       disconnect: [MovieActorsDisconnectFieldInput!]
                       update: MovieActorsUpdateConnectionInput
-                      where: MovieActorsConnectionWhere
+                      where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     type MovieAggregate {
@@ -1769,6 +1772,7 @@ describe("@relationship directive, aggregate argument", () => {
 
                     input MovieActorsUpdateConnectionInput {
                       node: PersonUpdateInput
+                      where: MovieActorsConnectionWhere
                     }
 
                     input MovieActorsUpdateFieldInput {
@@ -1777,7 +1781,7 @@ describe("@relationship directive, aggregate argument", () => {
                       delete: [MovieActorsDeleteFieldInput!]
                       disconnect: [MovieActorsDisconnectFieldInput!]
                       update: MovieActorsUpdateConnectionInput
-                      where: MovieActorsConnectionWhere
+                      where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     type MovieAggregate {
@@ -2234,6 +2238,7 @@ describe("@relationship directive, aggregate argument", () => {
 
                     input MovieActorsActorUpdateConnectionInput {
                       node: ActorUpdateInput
+                      where: MovieActorsActorConnectionWhere
                     }
 
                     input MovieActorsActorUpdateFieldInput {
@@ -2242,7 +2247,7 @@ describe("@relationship directive, aggregate argument", () => {
                       delete: [MovieActorsActorDeleteFieldInput!]
                       disconnect: [MovieActorsActorDisconnectFieldInput!]
                       update: MovieActorsActorUpdateConnectionInput
-                      where: MovieActorsActorConnectionWhere
+                      where: MovieActorsActorConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     type MovieActorsConnection {
@@ -2296,6 +2301,7 @@ describe("@relationship directive, aggregate argument", () => {
 
                     input MovieActorsPersonUpdateConnectionInput {
                       node: PersonUpdateInput
+                      where: MovieActorsPersonConnectionWhere
                     }
 
                     input MovieActorsPersonUpdateFieldInput {
@@ -2304,7 +2310,7 @@ describe("@relationship directive, aggregate argument", () => {
                       delete: [MovieActorsPersonDeleteFieldInput!]
                       disconnect: [MovieActorsPersonDisconnectFieldInput!]
                       update: MovieActorsPersonUpdateConnectionInput
-                      where: MovieActorsPersonConnectionWhere
+                      where: MovieActorsPersonConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     type MovieActorsRelationship {
@@ -2749,6 +2755,7 @@ describe("@relationship directive, aggregate argument", () => {
 
                     input MovieActorsActorUpdateConnectionInput {
                       node: ActorUpdateInput
+                      where: MovieActorsActorConnectionWhere
                     }
 
                     input MovieActorsActorUpdateFieldInput {
@@ -2757,7 +2764,7 @@ describe("@relationship directive, aggregate argument", () => {
                       delete: [MovieActorsActorDeleteFieldInput!]
                       disconnect: [MovieActorsActorDisconnectFieldInput!]
                       update: MovieActorsActorUpdateConnectionInput
-                      where: MovieActorsActorConnectionWhere
+                      where: MovieActorsActorConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     type MovieActorsConnection {
@@ -2811,6 +2818,7 @@ describe("@relationship directive, aggregate argument", () => {
 
                     input MovieActorsPersonUpdateConnectionInput {
                       node: PersonUpdateInput
+                      where: MovieActorsPersonConnectionWhere
                     }
 
                     input MovieActorsPersonUpdateFieldInput {
@@ -2819,7 +2827,7 @@ describe("@relationship directive, aggregate argument", () => {
                       delete: [MovieActorsPersonDeleteFieldInput!]
                       disconnect: [MovieActorsPersonDisconnectFieldInput!]
                       update: MovieActorsPersonUpdateConnectionInput
-                      where: MovieActorsPersonConnectionWhere
+                      where: MovieActorsPersonConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     type MovieActorsRelationship {

--- a/packages/graphql/tests/schema/directives/relationship-aggregate.test.ts
+++ b/packages/graphql/tests/schema/directives/relationship-aggregate.test.ts
@@ -2247,7 +2247,7 @@ describe("@relationship directive, aggregate argument", () => {
                       delete: [MovieActorsActorDeleteFieldInput!]
                       disconnect: [MovieActorsActorDisconnectFieldInput!]
                       update: MovieActorsActorUpdateConnectionInput
-                      where: MovieActorsActorConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
+                      where: MovieActorsActorConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsActorUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     type MovieActorsConnection {
@@ -2310,7 +2310,7 @@ describe("@relationship directive, aggregate argument", () => {
                       delete: [MovieActorsPersonDeleteFieldInput!]
                       disconnect: [MovieActorsPersonDisconnectFieldInput!]
                       update: MovieActorsPersonUpdateConnectionInput
-                      where: MovieActorsPersonConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
+                      where: MovieActorsPersonConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsPersonUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     type MovieActorsRelationship {
@@ -2764,7 +2764,7 @@ describe("@relationship directive, aggregate argument", () => {
                       delete: [MovieActorsActorDeleteFieldInput!]
                       disconnect: [MovieActorsActorDisconnectFieldInput!]
                       update: MovieActorsActorUpdateConnectionInput
-                      where: MovieActorsActorConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
+                      where: MovieActorsActorConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsActorUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     type MovieActorsConnection {
@@ -2827,7 +2827,7 @@ describe("@relationship directive, aggregate argument", () => {
                       delete: [MovieActorsPersonDeleteFieldInput!]
                       disconnect: [MovieActorsPersonDisconnectFieldInput!]
                       update: MovieActorsPersonUpdateConnectionInput
-                      where: MovieActorsPersonConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
+                      where: MovieActorsPersonConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsPersonUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     type MovieActorsRelationship {

--- a/packages/graphql/tests/schema/directives/relationship-nested-operations.test.ts
+++ b/packages/graphql/tests/schema/directives/relationship-nested-operations.test.ts
@@ -4505,7 +4505,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieActorsPersonOneUpdateFieldInput {
                   create: [MovieActorsPersonOneCreateFieldInput!]
-                  where: MovieActorsPersonOneConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
+                  where: MovieActorsPersonOneConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsPersonOneUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 input MovieActorsPersonTwoConnectionWhere {
@@ -4525,7 +4525,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieActorsPersonTwoUpdateFieldInput {
                   create: [MovieActorsPersonTwoCreateFieldInput!]
-                  where: MovieActorsPersonTwoConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
+                  where: MovieActorsPersonTwoConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsPersonTwoUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieActorsRelationship {
@@ -4952,7 +4952,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieActorsPersonOneUpdateFieldInput {
                   connect: [MovieActorsPersonOneConnectFieldInput!]
-                  where: MovieActorsPersonOneConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
+                  where: MovieActorsPersonOneConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsPersonOneUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 input MovieActorsPersonTwoConnectFieldInput {
@@ -4972,7 +4972,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieActorsPersonTwoUpdateFieldInput {
                   connect: [MovieActorsPersonTwoConnectFieldInput!]
-                  where: MovieActorsPersonTwoConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
+                  where: MovieActorsPersonTwoConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsPersonTwoUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieActorsRelationship {
@@ -5399,7 +5399,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieActorsPersonOneUpdateFieldInput {
                   update: MovieActorsPersonOneUpdateConnectionInput
-                  where: MovieActorsPersonOneConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
+                  where: MovieActorsPersonOneConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsPersonOneUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 input MovieActorsPersonTwoConnectionWhere {
@@ -5416,7 +5416,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieActorsPersonTwoUpdateFieldInput {
                   update: MovieActorsPersonTwoUpdateConnectionInput
-                  where: MovieActorsPersonTwoConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
+                  where: MovieActorsPersonTwoConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsPersonTwoUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieActorsRelationship {
@@ -5838,7 +5838,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieActorsPersonOneUpdateFieldInput {
                   delete: [MovieActorsPersonOneDeleteFieldInput!]
-                  where: MovieActorsPersonOneConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
+                  where: MovieActorsPersonOneConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsPersonOneUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 input MovieActorsPersonTwoConnectionWhere {
@@ -5854,7 +5854,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieActorsPersonTwoUpdateFieldInput {
                   delete: [MovieActorsPersonTwoDeleteFieldInput!]
-                  where: MovieActorsPersonTwoConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
+                  where: MovieActorsPersonTwoConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsPersonTwoUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieActorsRelationship {
@@ -6275,7 +6275,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieActorsPersonOneUpdateFieldInput {
                   disconnect: [MovieActorsPersonOneDisconnectFieldInput!]
-                  where: MovieActorsPersonOneConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
+                  where: MovieActorsPersonOneConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsPersonOneUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 input MovieActorsPersonTwoConnectionWhere {
@@ -6291,7 +6291,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieActorsPersonTwoUpdateFieldInput {
                   disconnect: [MovieActorsPersonTwoDisconnectFieldInput!]
-                  where: MovieActorsPersonTwoConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
+                  where: MovieActorsPersonTwoConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsPersonTwoUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieActorsRelationship {
@@ -7135,7 +7135,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieActorsPersonOneUpdateFieldInput {
                   connectOrCreate: [MovieActorsPersonOneConnectOrCreateFieldInput!]
-                  where: MovieActorsPersonOneConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
+                  where: MovieActorsPersonOneConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsPersonOneUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 input MovieActorsPersonTwoConnectOrCreateFieldInput {
@@ -7160,7 +7160,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieActorsPersonTwoUpdateFieldInput {
                   connectOrCreate: [MovieActorsPersonTwoConnectOrCreateFieldInput!]
-                  where: MovieActorsPersonTwoConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
+                  where: MovieActorsPersonTwoConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsPersonTwoUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieActorsRelationship {
@@ -7663,7 +7663,7 @@ describe("Relationship nested operations", () => {
                   delete: [MovieActorsPersonOneDeleteFieldInput!]
                   disconnect: [MovieActorsPersonOneDisconnectFieldInput!]
                   update: MovieActorsPersonOneUpdateConnectionInput
-                  where: MovieActorsPersonOneConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
+                  where: MovieActorsPersonOneConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsPersonOneUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 input MovieActorsPersonTwoConnectFieldInput {
@@ -7705,7 +7705,7 @@ describe("Relationship nested operations", () => {
                   delete: [MovieActorsPersonTwoDeleteFieldInput!]
                   disconnect: [MovieActorsPersonTwoDisconnectFieldInput!]
                   update: MovieActorsPersonTwoUpdateConnectionInput
-                  where: MovieActorsPersonTwoConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
+                  where: MovieActorsPersonTwoConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsPersonTwoUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieActorsRelationship {
@@ -7779,7 +7779,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieProducersPersonOneUpdateFieldInput {
                   disconnect: [MovieProducersPersonOneDisconnectFieldInput!]
-                  where: MovieProducersPersonOneConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieProducersUpdateConnectionInput\\\\\\" instead\\")
+                  where: MovieProducersPersonOneConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieProducersPersonOneUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 input MovieProducersPersonTwoConnectionWhere {
@@ -7795,7 +7795,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieProducersPersonTwoUpdateFieldInput {
                   disconnect: [MovieProducersPersonTwoDisconnectFieldInput!]
-                  where: MovieProducersPersonTwoConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieProducersUpdateConnectionInput\\\\\\" instead\\")
+                  where: MovieProducersPersonTwoConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieProducersPersonTwoUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieProducersRelationship {
@@ -8225,7 +8225,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieActorsPersonOneUpdateFieldInput {
                   create: [MovieActorsPersonOneCreateFieldInput!]
-                  where: MovieActorsPersonOneConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
+                  where: MovieActorsPersonOneConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsPersonOneUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 input MovieActorsPersonTwoConnectionWhere {
@@ -8245,7 +8245,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieActorsPersonTwoUpdateFieldInput {
                   create: [MovieActorsPersonTwoCreateFieldInput!]
-                  where: MovieActorsPersonTwoConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
+                  where: MovieActorsPersonTwoConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsPersonTwoUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieActorsRelationship {
@@ -8315,7 +8315,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieProducersPersonOneUpdateFieldInput {
                   disconnect: [MovieProducersPersonOneDisconnectFieldInput!]
-                  where: MovieProducersPersonOneConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieProducersUpdateConnectionInput\\\\\\" instead\\")
+                  where: MovieProducersPersonOneConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieProducersPersonOneUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 input MovieProducersPersonTwoConnectionWhere {
@@ -8331,7 +8331,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieProducersPersonTwoUpdateFieldInput {
                   disconnect: [MovieProducersPersonTwoDisconnectFieldInput!]
-                  where: MovieProducersPersonTwoConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieProducersUpdateConnectionInput\\\\\\" instead\\")
+                  where: MovieProducersPersonTwoConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieProducersPersonTwoUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieProducersRelationship {

--- a/packages/graphql/tests/schema/directives/relationship-nested-operations.test.ts
+++ b/packages/graphql/tests/schema/directives/relationship-nested-operations.test.ts
@@ -518,7 +518,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieActorsUpdateFieldInput {
                   create: [MovieActorsCreateFieldInput!]
-                  where: MovieActorsConnectionWhere
+                  where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieAggregate {
@@ -891,7 +891,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieActorsUpdateFieldInput {
                   connect: [MovieActorsConnectFieldInput!]
-                  where: MovieActorsConnectionWhere
+                  where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieAggregate {
@@ -1256,11 +1256,12 @@ describe("Relationship nested operations", () => {
 
                 input MovieActorsUpdateConnectionInput {
                   node: PersonUpdateInput
+                  where: MovieActorsConnectionWhere
                 }
 
                 input MovieActorsUpdateFieldInput {
                   update: MovieActorsUpdateConnectionInput
-                  where: MovieActorsConnectionWhere
+                  where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieAggregate {
@@ -1624,7 +1625,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieActorsUpdateFieldInput {
                   delete: [MovieActorsDeleteFieldInput!]
-                  where: MovieActorsConnectionWhere
+                  where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieAggregate {
@@ -1992,7 +1993,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieActorsUpdateFieldInput {
                   disconnect: [MovieActorsDisconnectFieldInput!]
-                  where: MovieActorsConnectionWhere
+                  where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieAggregate {
@@ -2732,7 +2733,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieActorsUpdateFieldInput {
                   connectOrCreate: [MovieActorsConnectOrCreateFieldInput!]
-                  where: MovieActorsConnectionWhere
+                  where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieAggregate {
@@ -3146,6 +3147,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieActorsUpdateConnectionInput {
                   node: PersonUpdateInput
+                  where: MovieActorsConnectionWhere
                 }
 
                 input MovieActorsUpdateFieldInput {
@@ -3154,7 +3156,7 @@ describe("Relationship nested operations", () => {
                   delete: [MovieActorsDeleteFieldInput!]
                   disconnect: [MovieActorsDisconnectFieldInput!]
                   update: MovieActorsUpdateConnectionInput
-                  where: MovieActorsConnectionWhere
+                  where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieAggregate {
@@ -3285,7 +3287,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieProducersUpdateFieldInput {
                   disconnect: [MovieProducersDisconnectFieldInput!]
-                  where: MovieProducersConnectionWhere
+                  where: MovieProducersConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieProducersUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 \\"\\"\\"
@@ -3641,7 +3643,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieActorsUpdateFieldInput {
                   create: [MovieActorsCreateFieldInput!]
-                  where: MovieActorsConnectionWhere
+                  where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieAggregate {
@@ -3768,7 +3770,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieProducersUpdateFieldInput {
                   disconnect: [MovieProducersDisconnectFieldInput!]
-                  where: MovieProducersConnectionWhere
+                  where: MovieProducersConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieProducersUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 \\"\\"\\"
@@ -4503,7 +4505,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieActorsPersonOneUpdateFieldInput {
                   create: [MovieActorsPersonOneCreateFieldInput!]
-                  where: MovieActorsPersonOneConnectionWhere
+                  where: MovieActorsPersonOneConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 input MovieActorsPersonTwoConnectionWhere {
@@ -4523,7 +4525,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieActorsPersonTwoUpdateFieldInput {
                   create: [MovieActorsPersonTwoCreateFieldInput!]
-                  where: MovieActorsPersonTwoConnectionWhere
+                  where: MovieActorsPersonTwoConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieActorsRelationship {
@@ -4950,7 +4952,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieActorsPersonOneUpdateFieldInput {
                   connect: [MovieActorsPersonOneConnectFieldInput!]
-                  where: MovieActorsPersonOneConnectionWhere
+                  where: MovieActorsPersonOneConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 input MovieActorsPersonTwoConnectFieldInput {
@@ -4970,7 +4972,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieActorsPersonTwoUpdateFieldInput {
                   connect: [MovieActorsPersonTwoConnectFieldInput!]
-                  where: MovieActorsPersonTwoConnectionWhere
+                  where: MovieActorsPersonTwoConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieActorsRelationship {
@@ -5392,11 +5394,12 @@ describe("Relationship nested operations", () => {
 
                 input MovieActorsPersonOneUpdateConnectionInput {
                   node: PersonOneUpdateInput
+                  where: MovieActorsPersonOneConnectionWhere
                 }
 
                 input MovieActorsPersonOneUpdateFieldInput {
                   update: MovieActorsPersonOneUpdateConnectionInput
-                  where: MovieActorsPersonOneConnectionWhere
+                  where: MovieActorsPersonOneConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 input MovieActorsPersonTwoConnectionWhere {
@@ -5408,11 +5411,12 @@ describe("Relationship nested operations", () => {
 
                 input MovieActorsPersonTwoUpdateConnectionInput {
                   node: PersonTwoUpdateInput
+                  where: MovieActorsPersonTwoConnectionWhere
                 }
 
                 input MovieActorsPersonTwoUpdateFieldInput {
                   update: MovieActorsPersonTwoUpdateConnectionInput
-                  where: MovieActorsPersonTwoConnectionWhere
+                  where: MovieActorsPersonTwoConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieActorsRelationship {
@@ -5834,7 +5838,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieActorsPersonOneUpdateFieldInput {
                   delete: [MovieActorsPersonOneDeleteFieldInput!]
-                  where: MovieActorsPersonOneConnectionWhere
+                  where: MovieActorsPersonOneConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 input MovieActorsPersonTwoConnectionWhere {
@@ -5850,7 +5854,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieActorsPersonTwoUpdateFieldInput {
                   delete: [MovieActorsPersonTwoDeleteFieldInput!]
-                  where: MovieActorsPersonTwoConnectionWhere
+                  where: MovieActorsPersonTwoConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieActorsRelationship {
@@ -6271,7 +6275,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieActorsPersonOneUpdateFieldInput {
                   disconnect: [MovieActorsPersonOneDisconnectFieldInput!]
-                  where: MovieActorsPersonOneConnectionWhere
+                  where: MovieActorsPersonOneConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 input MovieActorsPersonTwoConnectionWhere {
@@ -6287,7 +6291,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieActorsPersonTwoUpdateFieldInput {
                   disconnect: [MovieActorsPersonTwoDisconnectFieldInput!]
-                  where: MovieActorsPersonTwoConnectionWhere
+                  where: MovieActorsPersonTwoConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieActorsRelationship {
@@ -7131,7 +7135,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieActorsPersonOneUpdateFieldInput {
                   connectOrCreate: [MovieActorsPersonOneConnectOrCreateFieldInput!]
-                  where: MovieActorsPersonOneConnectionWhere
+                  where: MovieActorsPersonOneConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 input MovieActorsPersonTwoConnectOrCreateFieldInput {
@@ -7156,7 +7160,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieActorsPersonTwoUpdateFieldInput {
                   connectOrCreate: [MovieActorsPersonTwoConnectOrCreateFieldInput!]
-                  where: MovieActorsPersonTwoConnectionWhere
+                  where: MovieActorsPersonTwoConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieActorsRelationship {
@@ -7650,6 +7654,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieActorsPersonOneUpdateConnectionInput {
                   node: PersonOneUpdateInput
+                  where: MovieActorsPersonOneConnectionWhere
                 }
 
                 input MovieActorsPersonOneUpdateFieldInput {
@@ -7658,7 +7663,7 @@ describe("Relationship nested operations", () => {
                   delete: [MovieActorsPersonOneDeleteFieldInput!]
                   disconnect: [MovieActorsPersonOneDisconnectFieldInput!]
                   update: MovieActorsPersonOneUpdateConnectionInput
-                  where: MovieActorsPersonOneConnectionWhere
+                  where: MovieActorsPersonOneConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 input MovieActorsPersonTwoConnectFieldInput {
@@ -7691,6 +7696,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieActorsPersonTwoUpdateConnectionInput {
                   node: PersonTwoUpdateInput
+                  where: MovieActorsPersonTwoConnectionWhere
                 }
 
                 input MovieActorsPersonTwoUpdateFieldInput {
@@ -7699,7 +7705,7 @@ describe("Relationship nested operations", () => {
                   delete: [MovieActorsPersonTwoDeleteFieldInput!]
                   disconnect: [MovieActorsPersonTwoDisconnectFieldInput!]
                   update: MovieActorsPersonTwoUpdateConnectionInput
-                  where: MovieActorsPersonTwoConnectionWhere
+                  where: MovieActorsPersonTwoConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieActorsRelationship {
@@ -7773,7 +7779,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieProducersPersonOneUpdateFieldInput {
                   disconnect: [MovieProducersPersonOneDisconnectFieldInput!]
-                  where: MovieProducersPersonOneConnectionWhere
+                  where: MovieProducersPersonOneConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieProducersUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 input MovieProducersPersonTwoConnectionWhere {
@@ -7789,7 +7795,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieProducersPersonTwoUpdateFieldInput {
                   disconnect: [MovieProducersPersonTwoDisconnectFieldInput!]
-                  where: MovieProducersPersonTwoConnectionWhere
+                  where: MovieProducersPersonTwoConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieProducersUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieProducersRelationship {
@@ -8219,7 +8225,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieActorsPersonOneUpdateFieldInput {
                   create: [MovieActorsPersonOneCreateFieldInput!]
-                  where: MovieActorsPersonOneConnectionWhere
+                  where: MovieActorsPersonOneConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 input MovieActorsPersonTwoConnectionWhere {
@@ -8239,7 +8245,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieActorsPersonTwoUpdateFieldInput {
                   create: [MovieActorsPersonTwoCreateFieldInput!]
-                  where: MovieActorsPersonTwoConnectionWhere
+                  where: MovieActorsPersonTwoConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieActorsRelationship {
@@ -8309,7 +8315,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieProducersPersonOneUpdateFieldInput {
                   disconnect: [MovieProducersPersonOneDisconnectFieldInput!]
-                  where: MovieProducersPersonOneConnectionWhere
+                  where: MovieProducersPersonOneConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieProducersUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 input MovieProducersPersonTwoConnectionWhere {
@@ -8325,7 +8331,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieProducersPersonTwoUpdateFieldInput {
                   disconnect: [MovieProducersPersonTwoDisconnectFieldInput!]
-                  where: MovieProducersPersonTwoConnectionWhere
+                  where: MovieProducersPersonTwoConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieProducersUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieProducersRelationship {
@@ -9317,7 +9323,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieActorsUpdateFieldInput {
                   create: [MovieActorsCreateFieldInput!]
-                  where: MovieActorsConnectionWhere
+                  where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieAggregate {
@@ -9860,7 +9866,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieActorsUpdateFieldInput {
                   connect: [MovieActorsConnectFieldInput!]
-                  where: MovieActorsConnectionWhere
+                  where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieAggregate {
@@ -10394,11 +10400,12 @@ describe("Relationship nested operations", () => {
 
                 input MovieActorsUpdateConnectionInput {
                   node: PersonUpdateInput
+                  where: MovieActorsConnectionWhere
                 }
 
                 input MovieActorsUpdateFieldInput {
                   update: MovieActorsUpdateConnectionInput
-                  where: MovieActorsConnectionWhere
+                  where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieAggregate {
@@ -10936,7 +10943,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieActorsUpdateFieldInput {
                   delete: [MovieActorsDeleteFieldInput!]
-                  where: MovieActorsConnectionWhere
+                  where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieAggregate {
@@ -11473,7 +11480,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieActorsUpdateFieldInput {
                   disconnect: [MovieActorsDisconnectFieldInput!]
-                  where: MovieActorsConnectionWhere
+                  where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieAggregate {
@@ -12027,6 +12034,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieActorsUpdateConnectionInput {
                   node: PersonUpdateInput
+                  where: MovieActorsConnectionWhere
                 }
 
                 input MovieActorsUpdateFieldInput {
@@ -12035,7 +12043,7 @@ describe("Relationship nested operations", () => {
                   delete: [MovieActorsDeleteFieldInput!]
                   disconnect: [MovieActorsDisconnectFieldInput!]
                   update: MovieActorsUpdateConnectionInput
-                  where: MovieActorsConnectionWhere
+                  where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieAggregate {
@@ -12166,7 +12174,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieProducersUpdateFieldInput {
                   disconnect: [MovieProducersDisconnectFieldInput!]
-                  where: MovieProducersConnectionWhere
+                  where: MovieProducersConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieProducersUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 \\"\\"\\"
@@ -12707,7 +12715,7 @@ describe("Relationship nested operations", () => {
                 input MovieActorsUpdateFieldInput {
                   create: [MovieActorsCreateFieldInput!]
                   delete: [MovieActorsDeleteFieldInput!]
-                  where: MovieActorsConnectionWhere
+                  where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieAggregate {
@@ -12838,7 +12846,7 @@ describe("Relationship nested operations", () => {
 
                 input MovieProducersUpdateFieldInput {
                   disconnect: [MovieProducersDisconnectFieldInput!]
-                  where: MovieProducersConnectionWhere
+                  where: MovieProducersConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieProducersUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 \\"\\"\\"

--- a/packages/graphql/tests/schema/directives/relationship-properties.test.ts
+++ b/packages/graphql/tests/schema/directives/relationship-properties.test.ts
@@ -293,6 +293,7 @@ describe("Relationship-properties", () => {
             input ActorMoviesUpdateConnectionInput {
               edge: ActedInUpdateInput
               node: MovieUpdateInput
+              where: ActorMoviesConnectionWhere
             }
 
             input ActorMoviesUpdateFieldInput {
@@ -301,7 +302,7 @@ describe("Relationship-properties", () => {
               delete: [ActorMoviesDeleteFieldInput!]
               disconnect: [ActorMoviesDisconnectFieldInput!]
               update: ActorMoviesUpdateConnectionInput
-              where: ActorMoviesConnectionWhere
+              where: ActorMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorMoviesUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input ActorOptions {
@@ -536,6 +537,7 @@ describe("Relationship-properties", () => {
             input MovieActorsUpdateConnectionInput {
               edge: ActedInUpdateInput
               node: ActorUpdateInput
+              where: MovieActorsConnectionWhere
             }
 
             input MovieActorsUpdateFieldInput {
@@ -544,7 +546,7 @@ describe("Relationship-properties", () => {
               delete: [MovieActorsDeleteFieldInput!]
               disconnect: [MovieActorsDisconnectFieldInput!]
               update: MovieActorsUpdateConnectionInput
-              where: MovieActorsConnectionWhere
+              where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type MovieAggregate {
@@ -1004,6 +1006,7 @@ describe("Relationship-properties", () => {
             input ActorMoviesUpdateConnectionInput {
               edge: ActedInUpdateInput
               node: MovieUpdateInput
+              where: ActorMoviesConnectionWhere
             }
 
             input ActorMoviesUpdateFieldInput {
@@ -1012,7 +1015,7 @@ describe("Relationship-properties", () => {
               delete: [ActorMoviesDeleteFieldInput!]
               disconnect: [ActorMoviesDisconnectFieldInput!]
               update: ActorMoviesUpdateConnectionInput
-              where: ActorMoviesConnectionWhere
+              where: ActorMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorMoviesUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input ActorOptions {
@@ -1259,6 +1262,7 @@ describe("Relationship-properties", () => {
             input MovieActorsUpdateConnectionInput {
               edge: ActedInUpdateInput
               node: ActorUpdateInput
+              where: MovieActorsConnectionWhere
             }
 
             input MovieActorsUpdateFieldInput {
@@ -1267,7 +1271,7 @@ describe("Relationship-properties", () => {
               delete: [MovieActorsDeleteFieldInput!]
               disconnect: [MovieActorsDisconnectFieldInput!]
               update: MovieActorsUpdateConnectionInput
-              where: MovieActorsConnectionWhere
+              where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type MovieAggregate {
@@ -1682,6 +1686,7 @@ describe("Relationship-properties", () => {
 
             input ActorMoviesUpdateConnectionInput {
               node: MovieUpdateInput
+              where: ActorMoviesConnectionWhere
             }
 
             input ActorMoviesUpdateFieldInput {
@@ -1690,7 +1695,7 @@ describe("Relationship-properties", () => {
               delete: [ActorMoviesDeleteFieldInput!]
               disconnect: [ActorMoviesDisconnectFieldInput!]
               update: ActorMoviesUpdateConnectionInput
-              where: ActorMoviesConnectionWhere
+              where: ActorMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorMoviesUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input ActorOptions {
@@ -1926,6 +1931,7 @@ describe("Relationship-properties", () => {
 
             input MovieActorsUpdateConnectionInput {
               node: ActorUpdateInput
+              where: MovieActorsConnectionWhere
             }
 
             input MovieActorsUpdateFieldInput {
@@ -1934,7 +1940,7 @@ describe("Relationship-properties", () => {
               delete: [MovieActorsDeleteFieldInput!]
               disconnect: [MovieActorsDisconnectFieldInput!]
               update: MovieActorsUpdateConnectionInput
-              where: MovieActorsConnectionWhere
+              where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type MovieAggregate {

--- a/packages/graphql/tests/schema/directives/selectable.test.ts
+++ b/packages/graphql/tests/schema/directives/selectable.test.ts
@@ -872,6 +872,7 @@ describe("@selectable", () => {
 
                 input ActorActedInUpdateConnectionInput {
                   node: MovieUpdateInput
+                  where: ActorActedInConnectionWhere
                 }
 
                 input ActorActedInUpdateFieldInput {
@@ -880,7 +881,7 @@ describe("@selectable", () => {
                   delete: [ActorActedInDeleteFieldInput!]
                   disconnect: [ActorActedInDisconnectFieldInput!]
                   update: ActorActedInUpdateConnectionInput
-                  where: ActorActedInConnectionWhere
+                  where: ActorActedInConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type ActorAggregate {
@@ -1299,6 +1300,7 @@ describe("@selectable", () => {
 
                 input ActorActedInUpdateConnectionInput {
                   node: MovieUpdateInput
+                  where: ActorActedInConnectionWhere
                 }
 
                 input ActorActedInUpdateFieldInput {
@@ -1307,7 +1309,7 @@ describe("@selectable", () => {
                   delete: [ActorActedInDeleteFieldInput!]
                   disconnect: [ActorActedInDisconnectFieldInput!]
                   update: ActorActedInUpdateConnectionInput
-                  where: ActorActedInConnectionWhere
+                  where: ActorActedInConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type ActorAggregate {
@@ -1679,6 +1681,7 @@ describe("@selectable", () => {
 
                 input ActorActedInMovieUpdateConnectionInput {
                   node: MovieUpdateInput
+                  where: ActorActedInMovieConnectionWhere
                 }
 
                 input ActorActedInMovieUpdateFieldInput {
@@ -1687,7 +1690,7 @@ describe("@selectable", () => {
                   delete: [ActorActedInMovieDeleteFieldInput!]
                   disconnect: [ActorActedInMovieDisconnectFieldInput!]
                   update: ActorActedInMovieUpdateConnectionInput
-                  where: ActorActedInMovieConnectionWhere
+                  where: ActorActedInMovieConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 input ActorActedInSeriesConnectFieldInput {
@@ -1720,6 +1723,7 @@ describe("@selectable", () => {
 
                 input ActorActedInSeriesUpdateConnectionInput {
                   node: SeriesUpdateInput
+                  where: ActorActedInSeriesConnectionWhere
                 }
 
                 input ActorActedInSeriesUpdateFieldInput {
@@ -1728,7 +1732,7 @@ describe("@selectable", () => {
                   delete: [ActorActedInSeriesDeleteFieldInput!]
                   disconnect: [ActorActedInSeriesDisconnectFieldInput!]
                   update: ActorActedInSeriesUpdateConnectionInput
-                  where: ActorActedInSeriesConnectionWhere
+                  where: ActorActedInSeriesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 input ActorActedInUpdateInput {
@@ -2203,6 +2207,7 @@ describe("@selectable", () => {
 
                 input ActorActedInMovieUpdateConnectionInput {
                   node: MovieUpdateInput
+                  where: ActorActedInMovieConnectionWhere
                 }
 
                 input ActorActedInMovieUpdateFieldInput {
@@ -2211,7 +2216,7 @@ describe("@selectable", () => {
                   delete: [ActorActedInMovieDeleteFieldInput!]
                   disconnect: [ActorActedInMovieDisconnectFieldInput!]
                   update: ActorActedInMovieUpdateConnectionInput
-                  where: ActorActedInMovieConnectionWhere
+                  where: ActorActedInMovieConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type ActorActedInRelationship {
@@ -2249,6 +2254,7 @@ describe("@selectable", () => {
 
                 input ActorActedInSeriesUpdateConnectionInput {
                   node: SeriesUpdateInput
+                  where: ActorActedInSeriesConnectionWhere
                 }
 
                 input ActorActedInSeriesUpdateFieldInput {
@@ -2257,7 +2263,7 @@ describe("@selectable", () => {
                   delete: [ActorActedInSeriesDeleteFieldInput!]
                   disconnect: [ActorActedInSeriesDisconnectFieldInput!]
                   update: ActorActedInSeriesUpdateConnectionInput
-                  where: ActorActedInSeriesConnectionWhere
+                  where: ActorActedInSeriesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 input ActorActedInUpdateInput {
@@ -2774,6 +2780,7 @@ describe("@selectable", () => {
 
                 input ActorActedInUpdateConnectionInput {
                   node: ProductionUpdateInput
+                  where: ActorActedInConnectionWhere
                 }
 
                 input ActorActedInUpdateFieldInput {
@@ -2782,7 +2789,7 @@ describe("@selectable", () => {
                   delete: [ActorActedInDeleteFieldInput!]
                   disconnect: [ActorActedInDisconnectFieldInput!]
                   update: ActorActedInUpdateConnectionInput
-                  where: ActorActedInConnectionWhere
+                  where: ActorActedInConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type ActorAggregate {
@@ -3393,6 +3400,7 @@ describe("@selectable", () => {
 
                 input ActorActedInUpdateConnectionInput {
                   node: ProductionUpdateInput
+                  where: ActorActedInConnectionWhere
                 }
 
                 input ActorActedInUpdateFieldInput {
@@ -3401,7 +3409,7 @@ describe("@selectable", () => {
                   delete: [ActorActedInDeleteFieldInput!]
                   disconnect: [ActorActedInDisconnectFieldInput!]
                   update: ActorActedInUpdateConnectionInput
-                  where: ActorActedInConnectionWhere
+                  where: ActorActedInConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type ActorAggregate {

--- a/packages/graphql/tests/schema/directives/selectable.test.ts
+++ b/packages/graphql/tests/schema/directives/selectable.test.ts
@@ -1690,7 +1690,7 @@ describe("@selectable", () => {
                   delete: [ActorActedInMovieDeleteFieldInput!]
                   disconnect: [ActorActedInMovieDisconnectFieldInput!]
                   update: ActorActedInMovieUpdateConnectionInput
-                  where: ActorActedInMovieConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInUpdateConnectionInput\\\\\\" instead\\")
+                  where: ActorActedInMovieConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInMovieUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 input ActorActedInSeriesConnectFieldInput {
@@ -1732,7 +1732,7 @@ describe("@selectable", () => {
                   delete: [ActorActedInSeriesDeleteFieldInput!]
                   disconnect: [ActorActedInSeriesDisconnectFieldInput!]
                   update: ActorActedInSeriesUpdateConnectionInput
-                  where: ActorActedInSeriesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInUpdateConnectionInput\\\\\\" instead\\")
+                  where: ActorActedInSeriesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInSeriesUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 input ActorActedInUpdateInput {
@@ -2216,7 +2216,7 @@ describe("@selectable", () => {
                   delete: [ActorActedInMovieDeleteFieldInput!]
                   disconnect: [ActorActedInMovieDisconnectFieldInput!]
                   update: ActorActedInMovieUpdateConnectionInput
-                  where: ActorActedInMovieConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInUpdateConnectionInput\\\\\\" instead\\")
+                  where: ActorActedInMovieConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInMovieUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type ActorActedInRelationship {
@@ -2263,7 +2263,7 @@ describe("@selectable", () => {
                   delete: [ActorActedInSeriesDeleteFieldInput!]
                   disconnect: [ActorActedInSeriesDisconnectFieldInput!]
                   update: ActorActedInSeriesUpdateConnectionInput
-                  where: ActorActedInSeriesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInUpdateConnectionInput\\\\\\" instead\\")
+                  where: ActorActedInSeriesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInSeriesUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 input ActorActedInUpdateInput {

--- a/packages/graphql/tests/schema/directives/settable.test.ts
+++ b/packages/graphql/tests/schema/directives/settable.test.ts
@@ -2680,7 +2680,7 @@ describe("@settable", () => {
                   delete: [ActorActedInMovieDeleteFieldInput!]
                   disconnect: [ActorActedInMovieDisconnectFieldInput!]
                   update: ActorActedInMovieUpdateConnectionInput
-                  where: ActorActedInMovieConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInUpdateConnectionInput\\\\\\" instead\\")
+                  where: ActorActedInMovieConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInMovieUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type ActorActedInRelationship {
@@ -2722,7 +2722,7 @@ describe("@settable", () => {
                   delete: [ActorActedInSeriesDeleteFieldInput!]
                   disconnect: [ActorActedInSeriesDisconnectFieldInput!]
                   update: ActorActedInSeriesUpdateConnectionInput
-                  where: ActorActedInSeriesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInUpdateConnectionInput\\\\\\" instead\\")
+                  where: ActorActedInSeriesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInSeriesUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 input ActorActedInUpdateInput {
@@ -4380,7 +4380,7 @@ describe("@settable", () => {
                   delete: [ActorActedInMovieDeleteFieldInput!]
                   disconnect: [ActorActedInMovieDisconnectFieldInput!]
                   update: ActorActedInMovieUpdateConnectionInput
-                  where: ActorActedInMovieConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInUpdateConnectionInput\\\\\\" instead\\")
+                  where: ActorActedInMovieConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInMovieUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type ActorActedInRelationship {
@@ -4422,7 +4422,7 @@ describe("@settable", () => {
                   delete: [ActorActedInSeriesDeleteFieldInput!]
                   disconnect: [ActorActedInSeriesDisconnectFieldInput!]
                   update: ActorActedInSeriesUpdateConnectionInput
-                  where: ActorActedInSeriesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInUpdateConnectionInput\\\\\\" instead\\")
+                  where: ActorActedInSeriesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInSeriesUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 input ActorActedInUpdateInput {

--- a/packages/graphql/tests/schema/directives/settable.test.ts
+++ b/packages/graphql/tests/schema/directives/settable.test.ts
@@ -709,6 +709,7 @@ describe("@settable", () => {
 
                 input ActorActedInUpdateConnectionInput {
                   node: MovieUpdateInput
+                  where: ActorActedInConnectionWhere
                 }
 
                 input ActorActedInUpdateFieldInput {
@@ -717,7 +718,7 @@ describe("@settable", () => {
                   delete: [ActorActedInDeleteFieldInput!]
                   disconnect: [ActorActedInDisconnectFieldInput!]
                   update: ActorActedInUpdateConnectionInput
-                  where: ActorActedInConnectionWhere
+                  where: ActorActedInConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type ActorAggregate {
@@ -1810,6 +1811,7 @@ describe("@settable", () => {
 
                 input MovieActorsUpdateConnectionInput {
                   node: ActorUpdateInput
+                  where: MovieActorsConnectionWhere
                 }
 
                 input MovieActorsUpdateFieldInput {
@@ -1818,7 +1820,7 @@ describe("@settable", () => {
                   delete: [MovieActorsDeleteFieldInput!]
                   disconnect: [MovieActorsDisconnectFieldInput!]
                   update: MovieActorsUpdateConnectionInput
-                  where: MovieActorsConnectionWhere
+                  where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieAggregate {
@@ -2125,6 +2127,7 @@ describe("@settable", () => {
 
                 input ActorActedInUpdateConnectionInput {
                   node: MovieUpdateInput
+                  where: ActorActedInConnectionWhere
                 }
 
                 input ActorActedInUpdateFieldInput {
@@ -2133,7 +2136,7 @@ describe("@settable", () => {
                   delete: [ActorActedInDeleteFieldInput!]
                   disconnect: [ActorActedInDisconnectFieldInput!]
                   update: ActorActedInUpdateConnectionInput
-                  where: ActorActedInConnectionWhere
+                  where: ActorActedInConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type ActorAggregate {
@@ -2400,6 +2403,7 @@ describe("@settable", () => {
 
                 input MovieActorsUpdateConnectionInput {
                   node: ActorUpdateInput
+                  where: MovieActorsConnectionWhere
                 }
 
                 input MovieActorsUpdateFieldInput {
@@ -2408,7 +2412,7 @@ describe("@settable", () => {
                   delete: [MovieActorsDeleteFieldInput!]
                   disconnect: [MovieActorsDisconnectFieldInput!]
                   update: MovieActorsUpdateConnectionInput
-                  where: MovieActorsConnectionWhere
+                  where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieAggregate {
@@ -2667,6 +2671,7 @@ describe("@settable", () => {
 
                 input ActorActedInMovieUpdateConnectionInput {
                   node: MovieUpdateInput
+                  where: ActorActedInMovieConnectionWhere
                 }
 
                 input ActorActedInMovieUpdateFieldInput {
@@ -2675,7 +2680,7 @@ describe("@settable", () => {
                   delete: [ActorActedInMovieDeleteFieldInput!]
                   disconnect: [ActorActedInMovieDisconnectFieldInput!]
                   update: ActorActedInMovieUpdateConnectionInput
-                  where: ActorActedInMovieConnectionWhere
+                  where: ActorActedInMovieConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type ActorActedInRelationship {
@@ -2708,6 +2713,7 @@ describe("@settable", () => {
 
                 input ActorActedInSeriesUpdateConnectionInput {
                   node: SeriesUpdateInput
+                  where: ActorActedInSeriesConnectionWhere
                 }
 
                 input ActorActedInSeriesUpdateFieldInput {
@@ -2716,7 +2722,7 @@ describe("@settable", () => {
                   delete: [ActorActedInSeriesDeleteFieldInput!]
                   disconnect: [ActorActedInSeriesDisconnectFieldInput!]
                   update: ActorActedInSeriesUpdateConnectionInput
-                  where: ActorActedInSeriesConnectionWhere
+                  where: ActorActedInSeriesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 input ActorActedInUpdateInput {
@@ -3977,6 +3983,7 @@ describe("@settable", () => {
 
                 input MovieActorsUpdateConnectionInput {
                   node: ActorUpdateInput
+                  where: MovieActorsConnectionWhere
                 }
 
                 input MovieActorsUpdateFieldInput {
@@ -3985,7 +3992,7 @@ describe("@settable", () => {
                   delete: [MovieActorsDeleteFieldInput!]
                   disconnect: [MovieActorsDisconnectFieldInput!]
                   update: MovieActorsUpdateConnectionInput
-                  where: MovieActorsConnectionWhere
+                  where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieAggregate {
@@ -4364,6 +4371,7 @@ describe("@settable", () => {
 
                 input ActorActedInMovieUpdateConnectionInput {
                   node: MovieUpdateInput
+                  where: ActorActedInMovieConnectionWhere
                 }
 
                 input ActorActedInMovieUpdateFieldInput {
@@ -4372,7 +4380,7 @@ describe("@settable", () => {
                   delete: [ActorActedInMovieDeleteFieldInput!]
                   disconnect: [ActorActedInMovieDisconnectFieldInput!]
                   update: ActorActedInMovieUpdateConnectionInput
-                  where: ActorActedInMovieConnectionWhere
+                  where: ActorActedInMovieConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type ActorActedInRelationship {
@@ -4405,6 +4413,7 @@ describe("@settable", () => {
 
                 input ActorActedInSeriesUpdateConnectionInput {
                   node: SeriesUpdateInput
+                  where: ActorActedInSeriesConnectionWhere
                 }
 
                 input ActorActedInSeriesUpdateFieldInput {
@@ -4413,7 +4422,7 @@ describe("@settable", () => {
                   delete: [ActorActedInSeriesDeleteFieldInput!]
                   disconnect: [ActorActedInSeriesDisconnectFieldInput!]
                   update: ActorActedInSeriesUpdateConnectionInput
-                  where: ActorActedInSeriesConnectionWhere
+                  where: ActorActedInSeriesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 input ActorActedInUpdateInput {
@@ -4674,6 +4683,7 @@ describe("@settable", () => {
 
                 input MovieActorsUpdateConnectionInput {
                   node: ActorUpdateInput
+                  where: MovieActorsConnectionWhere
                 }
 
                 input MovieActorsUpdateFieldInput {
@@ -4682,7 +4692,7 @@ describe("@settable", () => {
                   delete: [MovieActorsDeleteFieldInput!]
                   disconnect: [MovieActorsDisconnectFieldInput!]
                   update: MovieActorsUpdateConnectionInput
-                  where: MovieActorsConnectionWhere
+                  where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieAggregate {
@@ -5104,6 +5114,7 @@ describe("@settable", () => {
 
                 input ActorActedInUpdateConnectionInput {
                   node: ProductionUpdateInput
+                  where: ActorActedInConnectionWhere
                 }
 
                 input ActorActedInUpdateFieldInput {
@@ -5112,7 +5123,7 @@ describe("@settable", () => {
                   delete: [ActorActedInDeleteFieldInput!]
                   disconnect: [ActorActedInDisconnectFieldInput!]
                   update: ActorActedInUpdateConnectionInput
-                  where: ActorActedInConnectionWhere
+                  where: ActorActedInConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type ActorAggregate {
@@ -6551,6 +6562,7 @@ describe("@settable", () => {
 
                 input MovieActorsUpdateConnectionInput {
                   node: ActorUpdateInput
+                  where: ProductionActorsConnectionWhere
                 }
 
                 input MovieActorsUpdateFieldInput {
@@ -6559,7 +6571,7 @@ describe("@settable", () => {
                   delete: [ProductionActorsDeleteFieldInput!]
                   disconnect: [ProductionActorsDisconnectFieldInput!]
                   update: MovieActorsUpdateConnectionInput
-                  where: ProductionActorsConnectionWhere
+                  where: ProductionActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieAggregate {
@@ -6972,6 +6984,7 @@ describe("@settable", () => {
 
                 input SeriesActorsUpdateConnectionInput {
                   node: ActorUpdateInput
+                  where: ProductionActorsConnectionWhere
                 }
 
                 input SeriesActorsUpdateFieldInput {
@@ -6980,7 +6993,7 @@ describe("@settable", () => {
                   delete: [ProductionActorsDeleteFieldInput!]
                   disconnect: [ProductionActorsDisconnectFieldInput!]
                   update: SeriesActorsUpdateConnectionInput
-                  where: ProductionActorsConnectionWhere
+                  where: ProductionActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"SeriesActorsUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type SeriesAggregate {
@@ -7262,6 +7275,7 @@ describe("@settable", () => {
 
                 input ActorActedInUpdateConnectionInput {
                   node: ProductionUpdateInput
+                  where: ActorActedInConnectionWhere
                 }
 
                 input ActorActedInUpdateFieldInput {
@@ -7270,7 +7284,7 @@ describe("@settable", () => {
                   delete: [ActorActedInDeleteFieldInput!]
                   disconnect: [ActorActedInDisconnectFieldInput!]
                   update: ActorActedInUpdateConnectionInput
-                  where: ActorActedInConnectionWhere
+                  where: ActorActedInConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type ActorAggregate {
@@ -7504,6 +7518,7 @@ describe("@settable", () => {
 
                 input MovieActorsUpdateConnectionInput {
                   node: ActorUpdateInput
+                  where: ProductionActorsConnectionWhere
                 }
 
                 input MovieActorsUpdateFieldInput {
@@ -7512,7 +7527,7 @@ describe("@settable", () => {
                   delete: [ProductionActorsDeleteFieldInput!]
                   disconnect: [ProductionActorsDisconnectFieldInput!]
                   update: MovieActorsUpdateConnectionInput
-                  where: ProductionActorsConnectionWhere
+                  where: ProductionActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieAggregate {
@@ -7729,6 +7744,7 @@ describe("@settable", () => {
 
                 input ProductionActorsUpdateConnectionInput {
                   node: ActorUpdateInput
+                  where: ProductionActorsConnectionWhere
                 }
 
                 input ProductionActorsUpdateFieldInput {
@@ -7737,7 +7753,7 @@ describe("@settable", () => {
                   delete: [ProductionActorsDeleteFieldInput!]
                   disconnect: [ProductionActorsDisconnectFieldInput!]
                   update: ProductionActorsUpdateConnectionInput
-                  where: ProductionActorsConnectionWhere
+                  where: ProductionActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ProductionActorsUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type ProductionAggregate {
@@ -7950,6 +7966,7 @@ describe("@settable", () => {
 
                 input SeriesActorsUpdateConnectionInput {
                   node: ActorUpdateInput
+                  where: ProductionActorsConnectionWhere
                 }
 
                 input SeriesActorsUpdateFieldInput {
@@ -7958,7 +7975,7 @@ describe("@settable", () => {
                   delete: [ProductionActorsDeleteFieldInput!]
                   disconnect: [ProductionActorsDisconnectFieldInput!]
                   update: SeriesActorsUpdateConnectionInput
-                  where: ProductionActorsConnectionWhere
+                  where: ProductionActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"SeriesActorsUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type SeriesAggregate {

--- a/packages/graphql/tests/schema/directives/sortable.test.ts
+++ b/packages/graphql/tests/schema/directives/sortable.test.ts
@@ -298,6 +298,7 @@ describe("@sortable directive", () => {
 
                     input ActorMoviesUpdateConnectionInput {
                       node: MovieUpdateInput
+                      where: ActorMoviesConnectionWhere
                     }
 
                     input ActorMoviesUpdateFieldInput {
@@ -306,7 +307,7 @@ describe("@sortable directive", () => {
                       delete: [ActorMoviesDeleteFieldInput!]
                       disconnect: [ActorMoviesDisconnectFieldInput!]
                       update: ActorMoviesUpdateConnectionInput
-                      where: ActorMoviesConnectionWhere
+                      where: ActorMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorMoviesUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     input ActorOptions {
@@ -576,6 +577,7 @@ describe("@sortable directive", () => {
 
                     input MovieActorsUpdateConnectionInput {
                       node: ActorUpdateInput
+                      where: MovieActorsConnectionWhere
                     }
 
                     input MovieActorsUpdateFieldInput {
@@ -584,7 +586,7 @@ describe("@sortable directive", () => {
                       delete: [MovieActorsDeleteFieldInput!]
                       disconnect: [MovieActorsDisconnectFieldInput!]
                       update: MovieActorsUpdateConnectionInput
-                      where: MovieActorsConnectionWhere
+                      where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     type MovieAggregate {
@@ -991,6 +993,7 @@ describe("@sortable directive", () => {
 
                     input ActorMoviesUpdateConnectionInput {
                       node: MovieUpdateInput
+                      where: ActorMoviesConnectionWhere
                     }
 
                     input ActorMoviesUpdateFieldInput {
@@ -999,7 +1002,7 @@ describe("@sortable directive", () => {
                       delete: [ActorMoviesDeleteFieldInput!]
                       disconnect: [ActorMoviesDisconnectFieldInput!]
                       update: ActorMoviesUpdateConnectionInput
-                      where: ActorMoviesConnectionWhere
+                      where: ActorMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorMoviesUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     input ActorOptions {
@@ -1269,6 +1272,7 @@ describe("@sortable directive", () => {
 
                     input MovieActorsUpdateConnectionInput {
                       node: ActorUpdateInput
+                      where: MovieActorsConnectionWhere
                     }
 
                     input MovieActorsUpdateFieldInput {
@@ -1277,7 +1281,7 @@ describe("@sortable directive", () => {
                       delete: [MovieActorsDeleteFieldInput!]
                       disconnect: [MovieActorsDisconnectFieldInput!]
                       update: MovieActorsUpdateConnectionInput
-                      where: MovieActorsConnectionWhere
+                      where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                     }
 
                     type MovieAggregate {

--- a/packages/graphql/tests/schema/federation.test.ts
+++ b/packages/graphql/tests/schema/federation.test.ts
@@ -229,6 +229,7 @@ describe("Apollo Federation", () => {
 
             input PostAuthorUpdateConnectionInput {
               node: UserUpdateInput
+              where: PostAuthorConnectionWhere
             }
 
             input PostAuthorUpdateFieldInput {
@@ -237,7 +238,7 @@ describe("Apollo Federation", () => {
               delete: PostAuthorDeleteFieldInput
               disconnect: PostAuthorDisconnectFieldInput
               update: PostAuthorUpdateConnectionInput
-              where: PostAuthorConnectionWhere
+              where: PostAuthorConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"PostAuthorUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input PostConnectInput {
@@ -524,6 +525,7 @@ describe("Apollo Federation", () => {
 
             input UserPostsUpdateConnectionInput {
               node: PostUpdateInput
+              where: UserPostsConnectionWhere
             }
 
             input UserPostsUpdateFieldInput {
@@ -532,7 +534,7 @@ describe("Apollo Federation", () => {
               delete: [UserPostsDeleteFieldInput!]
               disconnect: [UserPostsDisconnectFieldInput!]
               update: UserPostsUpdateConnectionInput
-              where: UserPostsConnectionWhere
+              where: UserPostsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"UserPostsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             \\"\\"\\"
@@ -817,6 +819,7 @@ describe("Apollo Federation", () => {
 
             input PostAuthorUpdateConnectionInput {
               node: UserUpdateInput
+              where: PostAuthorConnectionWhere
             }
 
             input PostAuthorUpdateFieldInput {
@@ -825,7 +828,7 @@ describe("Apollo Federation", () => {
               delete: PostAuthorDeleteFieldInput
               disconnect: PostAuthorDisconnectFieldInput
               update: PostAuthorUpdateConnectionInput
-              where: PostAuthorConnectionWhere
+              where: PostAuthorConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"PostAuthorUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input PostCreateInput {

--- a/packages/graphql/tests/schema/inheritance.test.ts
+++ b/packages/graphql/tests/schema/inheritance.test.ts
@@ -157,6 +157,7 @@ describe("inheritance", () => {
             input ActorFriendsUpdateConnectionInput {
               edge: FriendsWithUpdateInput
               node: PersonUpdateInput
+              where: PersonFriendsConnectionWhere
             }
 
             input ActorFriendsUpdateFieldInput {
@@ -165,7 +166,7 @@ describe("inheritance", () => {
               delete: [ActorFriendsDeleteFieldInput!]
               disconnect: [ActorFriendsDisconnectFieldInput!]
               update: ActorFriendsUpdateConnectionInput
-              where: PersonFriendsConnectionWhere
+              where: PersonFriendsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorFriendsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input ActorOptions {
@@ -534,6 +535,7 @@ describe("inheritance", () => {
             input PersonFriendsUpdateConnectionInput {
               edge: PersonFriendsEdgeUpdateInput
               node: PersonUpdateInput
+              where: PersonFriendsConnectionWhere
             }
 
             input PersonFriendsUpdateFieldInput {
@@ -542,7 +544,7 @@ describe("inheritance", () => {
               delete: [PersonFriendsDeleteFieldInput!]
               disconnect: [PersonFriendsDisconnectFieldInput!]
               update: PersonFriendsUpdateConnectionInput
-              where: PersonFriendsConnectionWhere
+              where: PersonFriendsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"PersonFriendsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             enum PersonImplementation {

--- a/packages/graphql/tests/schema/interface-relationships.test.ts
+++ b/packages/graphql/tests/schema/interface-relationships.test.ts
@@ -213,6 +213,7 @@ describe("Interface Relationships", () => {
             input ActorActedInUpdateConnectionInput {
               edge: ActedInUpdateInput
               node: ProductionUpdateInput
+              where: ActorActedInConnectionWhere
             }
 
             input ActorActedInUpdateFieldInput {
@@ -221,7 +222,7 @@ describe("Interface Relationships", () => {
               delete: [ActorActedInDeleteFieldInput!]
               disconnect: [ActorActedInDisconnectFieldInput!]
               update: ActorActedInUpdateConnectionInput
-              where: ActorActedInConnectionWhere
+              where: ActorActedInConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type ActorAggregate {
@@ -909,6 +910,7 @@ describe("Interface Relationships", () => {
             input ActorActedInUpdateConnectionInput {
               edge: ActedInUpdateInput
               node: ProductionUpdateInput
+              where: ActorActedInConnectionWhere
             }
 
             input ActorActedInUpdateFieldInput {
@@ -917,7 +919,7 @@ describe("Interface Relationships", () => {
               delete: [ActorActedInDeleteFieldInput!]
               disconnect: [ActorActedInDisconnectFieldInput!]
               update: ActorActedInUpdateConnectionInput
-              where: ActorActedInConnectionWhere
+              where: ActorActedInConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type ActorAggregate {
@@ -1269,6 +1271,7 @@ describe("Interface Relationships", () => {
 
             input EpisodeSeriesUpdateConnectionInput {
               node: SeriesUpdateInput
+              where: EpisodeSeriesConnectionWhere
             }
 
             input EpisodeSeriesUpdateFieldInput {
@@ -1277,7 +1280,7 @@ describe("Interface Relationships", () => {
               delete: EpisodeSeriesDeleteFieldInput
               disconnect: EpisodeSeriesDisconnectFieldInput
               update: EpisodeSeriesUpdateConnectionInput
-              where: EpisodeSeriesConnectionWhere
+              where: EpisodeSeriesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"EpisodeSeriesUpdateConnectionInput\\\\\\" instead\\")
             }
 
             \\"\\"\\"
@@ -1405,6 +1408,7 @@ describe("Interface Relationships", () => {
             input MovieActorsUpdateConnectionInput {
               edge: ActedInUpdateInput
               node: ActorUpdateInput
+              where: ProductionActorsConnectionWhere
             }
 
             input MovieActorsUpdateFieldInput {
@@ -1413,7 +1417,7 @@ describe("Interface Relationships", () => {
               delete: [ProductionActorsDeleteFieldInput!]
               disconnect: [ProductionActorsDisconnectFieldInput!]
               update: MovieActorsUpdateConnectionInput
-              where: ProductionActorsConnectionWhere
+              where: ProductionActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type MovieAggregate {
@@ -1689,6 +1693,7 @@ describe("Interface Relationships", () => {
             input ProductionActorsUpdateConnectionInput {
               edge: ProductionActorsEdgeUpdateInput
               node: ActorUpdateInput
+              where: ProductionActorsConnectionWhere
             }
 
             input ProductionActorsUpdateFieldInput {
@@ -1697,7 +1702,7 @@ describe("Interface Relationships", () => {
               delete: [ProductionActorsDeleteFieldInput!]
               disconnect: [ProductionActorsDisconnectFieldInput!]
               update: ProductionActorsUpdateConnectionInput
-              where: ProductionActorsConnectionWhere
+              where: ProductionActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ProductionActorsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type ProductionAggregate {
@@ -1914,6 +1919,7 @@ describe("Interface Relationships", () => {
             input SeriesActorsUpdateConnectionInput {
               edge: ActedInUpdateInput
               node: ActorUpdateInput
+              where: ProductionActorsConnectionWhere
             }
 
             input SeriesActorsUpdateFieldInput {
@@ -1922,7 +1928,7 @@ describe("Interface Relationships", () => {
               delete: [ProductionActorsDeleteFieldInput!]
               disconnect: [ProductionActorsDisconnectFieldInput!]
               update: SeriesActorsUpdateConnectionInput
-              where: ProductionActorsConnectionWhere
+              where: ProductionActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"SeriesActorsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type SeriesAggregate {
@@ -2085,6 +2091,7 @@ describe("Interface Relationships", () => {
 
             input SeriesEpisodesUpdateConnectionInput {
               node: EpisodeUpdateInput
+              where: SeriesEpisodesConnectionWhere
             }
 
             input SeriesEpisodesUpdateFieldInput {
@@ -2093,7 +2100,7 @@ describe("Interface Relationships", () => {
               delete: [SeriesEpisodesDeleteFieldInput!]
               disconnect: [SeriesEpisodesDisconnectFieldInput!]
               update: SeriesEpisodesUpdateConnectionInput
-              where: SeriesEpisodesConnectionWhere
+              where: SeriesEpisodesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"SeriesEpisodesUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input SeriesOptions {
@@ -2445,6 +2452,7 @@ describe("Interface Relationships", () => {
             input ActorActedInUpdateConnectionInput {
               edge: ActedInUpdateInput
               node: ProductionUpdateInput
+              where: ActorActedInConnectionWhere
             }
 
             input ActorActedInUpdateFieldInput {
@@ -2453,7 +2461,7 @@ describe("Interface Relationships", () => {
               delete: [ActorActedInDeleteFieldInput!]
               disconnect: [ActorActedInDisconnectFieldInput!]
               update: ActorActedInUpdateConnectionInput
-              where: ActorActedInConnectionWhere
+              where: ActorActedInConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type ActorAggregate {
@@ -2805,6 +2813,7 @@ describe("Interface Relationships", () => {
 
             input EpisodeSeriesUpdateConnectionInput {
               node: SeriesUpdateInput
+              where: EpisodeSeriesConnectionWhere
             }
 
             input EpisodeSeriesUpdateFieldInput {
@@ -2813,7 +2822,7 @@ describe("Interface Relationships", () => {
               delete: EpisodeSeriesDeleteFieldInput
               disconnect: EpisodeSeriesDisconnectFieldInput
               update: EpisodeSeriesUpdateConnectionInput
-              where: EpisodeSeriesConnectionWhere
+              where: EpisodeSeriesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"EpisodeSeriesUpdateConnectionInput\\\\\\" instead\\")
             }
 
             \\"\\"\\"
@@ -2941,6 +2950,7 @@ describe("Interface Relationships", () => {
             input MovieActorsUpdateConnectionInput {
               edge: ActedInUpdateInput
               node: ActorUpdateInput
+              where: ProductionActorsConnectionWhere
             }
 
             input MovieActorsUpdateFieldInput {
@@ -2949,7 +2959,7 @@ describe("Interface Relationships", () => {
               delete: [ProductionActorsDeleteFieldInput!]
               disconnect: [ProductionActorsDisconnectFieldInput!]
               update: MovieActorsUpdateConnectionInput
-              where: ProductionActorsConnectionWhere
+              where: ProductionActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type MovieAggregate {
@@ -3245,6 +3255,7 @@ describe("Interface Relationships", () => {
             input ProductionActorsUpdateConnectionInput {
               edge: ProductionActorsEdgeUpdateInput
               node: ActorUpdateInput
+              where: ProductionActorsConnectionWhere
             }
 
             input ProductionActorsUpdateFieldInput {
@@ -3253,7 +3264,7 @@ describe("Interface Relationships", () => {
               delete: [ProductionActorsDeleteFieldInput!]
               disconnect: [ProductionActorsDisconnectFieldInput!]
               update: ProductionActorsUpdateConnectionInput
-              where: ProductionActorsConnectionWhere
+              where: ProductionActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ProductionActorsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type ProductionAggregate {
@@ -3470,6 +3481,7 @@ describe("Interface Relationships", () => {
             input SeriesActorsUpdateConnectionInput {
               edge: StarredInUpdateInput
               node: ActorUpdateInput
+              where: ProductionActorsConnectionWhere
             }
 
             input SeriesActorsUpdateFieldInput {
@@ -3478,7 +3490,7 @@ describe("Interface Relationships", () => {
               delete: [ProductionActorsDeleteFieldInput!]
               disconnect: [ProductionActorsDisconnectFieldInput!]
               update: SeriesActorsUpdateConnectionInput
-              where: ProductionActorsConnectionWhere
+              where: ProductionActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"SeriesActorsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type SeriesAggregate {
@@ -3641,6 +3653,7 @@ describe("Interface Relationships", () => {
 
             input SeriesEpisodesUpdateConnectionInput {
               node: EpisodeUpdateInput
+              where: SeriesEpisodesConnectionWhere
             }
 
             input SeriesEpisodesUpdateFieldInput {
@@ -3649,7 +3662,7 @@ describe("Interface Relationships", () => {
               delete: [SeriesEpisodesDeleteFieldInput!]
               disconnect: [SeriesEpisodesDisconnectFieldInput!]
               update: SeriesEpisodesUpdateConnectionInput
-              where: SeriesEpisodesConnectionWhere
+              where: SeriesEpisodesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"SeriesEpisodesUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input SeriesOptions {
@@ -4075,6 +4088,7 @@ describe("Interface Relationships", () => {
 
             input Interface1Interface2UpdateConnectionInput {
               node: Interface2UpdateInput
+              where: Interface1Interface2ConnectionWhere
             }
 
             input Interface1Interface2UpdateFieldInput {
@@ -4083,7 +4097,7 @@ describe("Interface Relationships", () => {
               delete: [Interface1Interface2DeleteFieldInput!]
               disconnect: [Interface1Interface2DisconnectFieldInput!]
               update: Interface1Interface2UpdateConnectionInput
-              where: Interface1Interface2ConnectionWhere
+              where: Interface1Interface2ConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"Interface1Interface2UpdateConnectionInput\\\\\\" instead\\")
             }
 
             input Interface1Options {
@@ -4509,6 +4523,7 @@ describe("Interface Relationships", () => {
 
             input Type1Interface1Interface2UpdateConnectionInput {
               node: Interface2UpdateInput
+              where: Interface1Interface2ConnectionWhere
             }
 
             input Type1Interface1Interface2UpdateFieldInput {
@@ -4517,7 +4532,7 @@ describe("Interface Relationships", () => {
               delete: [Type1Interface1Interface2DeleteFieldInput!]
               disconnect: [Type1Interface1Interface2DisconnectFieldInput!]
               update: Type1Interface1Interface2UpdateConnectionInput
-              where: Interface1Interface2ConnectionWhere
+              where: Interface1Interface2ConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"Type1Interface1Interface2UpdateConnectionInput\\\\\\" instead\\")
             }
 
             input Type1Interface1NodeAggregationWhereInput {
@@ -4564,6 +4579,7 @@ describe("Interface Relationships", () => {
 
             input Type1Interface1UpdateConnectionInput {
               node: Interface1UpdateInput
+              where: Type1Interface1ConnectionWhere
             }
 
             input Type1Interface1UpdateFieldInput {
@@ -4572,7 +4588,7 @@ describe("Interface Relationships", () => {
               delete: [Type1Interface1DeleteFieldInput!]
               disconnect: [Type1Interface1DisconnectFieldInput!]
               update: Type1Interface1UpdateConnectionInput
-              where: Type1Interface1ConnectionWhere
+              where: Type1Interface1ConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"Type1Interface1UpdateConnectionInput\\\\\\" instead\\")
             }
 
             input Type1Interface1UpdateInput {
@@ -4867,6 +4883,7 @@ describe("Interface Relationships", () => {
 
             input Type2Interface1Interface2UpdateConnectionInput {
               node: Interface2UpdateInput
+              where: Interface1Interface2ConnectionWhere
             }
 
             input Type2Interface1Interface2UpdateFieldInput {
@@ -4875,7 +4892,7 @@ describe("Interface Relationships", () => {
               delete: [Type2Interface1Interface2DeleteFieldInput!]
               disconnect: [Type2Interface1Interface2DisconnectFieldInput!]
               update: Type2Interface1Interface2UpdateConnectionInput
-              where: Interface1Interface2ConnectionWhere
+              where: Interface1Interface2ConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"Type2Interface1Interface2UpdateConnectionInput\\\\\\" instead\\")
             }
 
             input Type2Interface1Options {
@@ -5345,6 +5362,7 @@ describe("Interface Relationships", () => {
             input Interface1Interface2UpdateConnectionInput {
               edge: Interface1Interface2EdgeUpdateInput
               node: Interface2UpdateInput
+              where: Interface1Interface2ConnectionWhere
             }
 
             input Interface1Interface2UpdateFieldInput {
@@ -5353,7 +5371,7 @@ describe("Interface Relationships", () => {
               delete: [Interface1Interface2DeleteFieldInput!]
               disconnect: [Interface1Interface2DisconnectFieldInput!]
               update: Interface1Interface2UpdateConnectionInput
-              where: Interface1Interface2ConnectionWhere
+              where: Interface1Interface2ConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"Interface1Interface2UpdateConnectionInput\\\\\\" instead\\")
             }
 
             input Interface1Options {
@@ -5851,6 +5869,7 @@ describe("Interface Relationships", () => {
             input Type1Interface1Interface2UpdateConnectionInput {
               edge: PropsUpdateInput
               node: Interface2UpdateInput
+              where: Interface1Interface2ConnectionWhere
             }
 
             input Type1Interface1Interface2UpdateFieldInput {
@@ -5859,7 +5878,7 @@ describe("Interface Relationships", () => {
               delete: [Type1Interface1Interface2DeleteFieldInput!]
               disconnect: [Type1Interface1Interface2DisconnectFieldInput!]
               update: Type1Interface1Interface2UpdateConnectionInput
-              where: Interface1Interface2ConnectionWhere
+              where: Interface1Interface2ConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"Type1Interface1Interface2UpdateConnectionInput\\\\\\" instead\\")
             }
 
             input Type1Interface1NodeAggregationWhereInput {
@@ -5906,6 +5925,7 @@ describe("Interface Relationships", () => {
 
             input Type1Interface1UpdateConnectionInput {
               node: Interface1UpdateInput
+              where: Type1Interface1ConnectionWhere
             }
 
             input Type1Interface1UpdateFieldInput {
@@ -5914,7 +5934,7 @@ describe("Interface Relationships", () => {
               delete: [Type1Interface1DeleteFieldInput!]
               disconnect: [Type1Interface1DisconnectFieldInput!]
               update: Type1Interface1UpdateConnectionInput
-              where: Type1Interface1ConnectionWhere
+              where: Type1Interface1ConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"Type1Interface1UpdateConnectionInput\\\\\\" instead\\")
             }
 
             input Type1Interface1UpdateInput {
@@ -6218,6 +6238,7 @@ describe("Interface Relationships", () => {
             input Type2Interface1Interface2UpdateConnectionInput {
               edge: PropsUpdateInput
               node: Interface2UpdateInput
+              where: Interface1Interface2ConnectionWhere
             }
 
             input Type2Interface1Interface2UpdateFieldInput {
@@ -6226,7 +6247,7 @@ describe("Interface Relationships", () => {
               delete: [Type2Interface1Interface2DeleteFieldInput!]
               disconnect: [Type2Interface1Interface2DisconnectFieldInput!]
               update: Type2Interface1Interface2UpdateConnectionInput
-              where: Interface1Interface2ConnectionWhere
+              where: Interface1Interface2ConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"Type2Interface1Interface2UpdateConnectionInput\\\\\\" instead\\")
             }
 
             input Type2Interface1Options {
@@ -6722,6 +6743,7 @@ describe("Interface Relationships", () => {
             input Interface1Interface2UpdateConnectionInput {
               edge: Interface1Interface2EdgeUpdateInput
               node: Interface2UpdateInput
+              where: Interface1Interface2ConnectionWhere
             }
 
             input Interface1Interface2UpdateFieldInput {
@@ -6730,7 +6752,7 @@ describe("Interface Relationships", () => {
               delete: [Interface1Interface2DeleteFieldInput!]
               disconnect: [Interface1Interface2DisconnectFieldInput!]
               update: Interface1Interface2UpdateConnectionInput
-              where: Interface1Interface2ConnectionWhere
+              where: Interface1Interface2ConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"Interface1Interface2UpdateConnectionInput\\\\\\" instead\\")
             }
 
             input Interface1Options {
@@ -7165,6 +7187,7 @@ describe("Interface Relationships", () => {
             input Type1Interface1Interface2UpdateConnectionInput {
               edge: Type1PropsUpdateInput
               node: Interface2UpdateInput
+              where: Interface1Interface2ConnectionWhere
             }
 
             input Type1Interface1Interface2UpdateFieldInput {
@@ -7173,7 +7196,7 @@ describe("Interface Relationships", () => {
               delete: [Type1Interface1Interface2DeleteFieldInput!]
               disconnect: [Type1Interface1Interface2DisconnectFieldInput!]
               update: Type1Interface1Interface2UpdateConnectionInput
-              where: Interface1Interface2ConnectionWhere
+              where: Interface1Interface2ConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"Type1Interface1Interface2UpdateConnectionInput\\\\\\" instead\\")
             }
 
             input Type1Interface1NodeAggregationWhereInput {
@@ -7220,6 +7243,7 @@ describe("Interface Relationships", () => {
 
             input Type1Interface1UpdateConnectionInput {
               node: Interface1UpdateInput
+              where: Type1Interface1ConnectionWhere
             }
 
             input Type1Interface1UpdateFieldInput {
@@ -7228,7 +7252,7 @@ describe("Interface Relationships", () => {
               delete: [Type1Interface1DeleteFieldInput!]
               disconnect: [Type1Interface1DisconnectFieldInput!]
               update: Type1Interface1UpdateConnectionInput
-              where: Type1Interface1ConnectionWhere
+              where: Type1Interface1ConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"Type1Interface1UpdateConnectionInput\\\\\\" instead\\")
             }
 
             input Type1Interface1UpdateInput {
@@ -7594,6 +7618,7 @@ describe("Interface Relationships", () => {
             input Type2Interface1Interface2UpdateConnectionInput {
               edge: Type2PropsUpdateInput
               node: Interface2UpdateInput
+              where: Interface1Interface2ConnectionWhere
             }
 
             input Type2Interface1Interface2UpdateFieldInput {
@@ -7602,7 +7627,7 @@ describe("Interface Relationships", () => {
               delete: [Type2Interface1Interface2DeleteFieldInput!]
               disconnect: [Type2Interface1Interface2DisconnectFieldInput!]
               update: Type2Interface1Interface2UpdateConnectionInput
-              where: Interface1Interface2ConnectionWhere
+              where: Interface1Interface2ConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"Type2Interface1Interface2UpdateConnectionInput\\\\\\" instead\\")
             }
 
             input Type2Interface1Options {
@@ -7995,6 +8020,7 @@ describe("Interface Relationships", () => {
 
             input CommentCreatorUpdateConnectionInput {
               node: UserUpdateInput
+              where: ContentCreatorConnectionWhere
             }
 
             input CommentCreatorUpdateFieldInput {
@@ -8003,7 +8029,7 @@ describe("Interface Relationships", () => {
               delete: ContentCreatorDeleteFieldInput
               disconnect: ContentCreatorDisconnectFieldInput
               update: CommentCreatorUpdateConnectionInput
-              where: ContentCreatorConnectionWhere
+              where: ContentCreatorConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"CommentCreatorUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input CommentDeleteInput {
@@ -8142,6 +8168,7 @@ describe("Interface Relationships", () => {
 
             input CommentPostUpdateConnectionInput {
               node: PostUpdateInput
+              where: CommentPostConnectionWhere
             }
 
             input CommentPostUpdateFieldInput {
@@ -8150,7 +8177,7 @@ describe("Interface Relationships", () => {
               delete: CommentPostDeleteFieldInput
               disconnect: CommentPostDisconnectFieldInput
               update: CommentPostUpdateConnectionInput
-              where: CommentPostConnectionWhere
+              where: CommentPostConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"CommentPostUpdateConnectionInput\\\\\\" instead\\")
             }
 
             \\"\\"\\"
@@ -8338,6 +8365,7 @@ describe("Interface Relationships", () => {
 
             input ContentCreatorUpdateConnectionInput {
               node: UserUpdateInput
+              where: ContentCreatorConnectionWhere
             }
 
             input ContentCreatorUpdateFieldInput {
@@ -8346,7 +8374,7 @@ describe("Interface Relationships", () => {
               delete: ContentCreatorDeleteFieldInput
               disconnect: ContentCreatorDisconnectFieldInput
               update: ContentCreatorUpdateConnectionInput
-              where: ContentCreatorConnectionWhere
+              where: ContentCreatorConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ContentCreatorUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input ContentDeleteInput {
@@ -8626,6 +8654,7 @@ describe("Interface Relationships", () => {
 
             input PostCommentsUpdateConnectionInput {
               node: CommentUpdateInput
+              where: PostCommentsConnectionWhere
             }
 
             input PostCommentsUpdateFieldInput {
@@ -8634,7 +8663,7 @@ describe("Interface Relationships", () => {
               delete: [PostCommentsDeleteFieldInput!]
               disconnect: [PostCommentsDisconnectFieldInput!]
               update: PostCommentsUpdateConnectionInput
-              where: PostCommentsConnectionWhere
+              where: PostCommentsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"PostCommentsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input PostConnectInput {
@@ -8717,6 +8746,7 @@ describe("Interface Relationships", () => {
 
             input PostCreatorUpdateConnectionInput {
               node: UserUpdateInput
+              where: ContentCreatorConnectionWhere
             }
 
             input PostCreatorUpdateFieldInput {
@@ -8725,7 +8755,7 @@ describe("Interface Relationships", () => {
               delete: ContentCreatorDeleteFieldInput
               disconnect: ContentCreatorDisconnectFieldInput
               update: PostCreatorUpdateConnectionInput
-              where: ContentCreatorConnectionWhere
+              where: ContentCreatorConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"PostCreatorUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input PostDeleteInput {
@@ -9025,6 +9055,7 @@ describe("Interface Relationships", () => {
 
             input UserContentUpdateConnectionInput {
               node: ContentUpdateInput
+              where: UserContentConnectionWhere
             }
 
             input UserContentUpdateFieldInput {
@@ -9033,7 +9064,7 @@ describe("Interface Relationships", () => {
               delete: [UserContentDeleteFieldInput!]
               disconnect: [UserContentDisconnectFieldInput!]
               update: UserContentUpdateConnectionInput
-              where: UserContentConnectionWhere
+              where: UserContentConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"UserContentUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input UserCreateInput {
@@ -9339,6 +9370,7 @@ describe("Interface Relationships", () => {
             input ActorActedInUpdateConnectionInput {
               edge: ActedInUpdateInput
               node: ShowUpdateInput
+              where: ActorActedInConnectionWhere
             }
 
             input ActorActedInUpdateFieldInput {
@@ -9347,7 +9379,7 @@ describe("Interface Relationships", () => {
               delete: [ActorActedInDeleteFieldInput!]
               disconnect: [ActorActedInDisconnectFieldInput!]
               update: ActorActedInUpdateConnectionInput
-              where: ActorActedInConnectionWhere
+              where: ActorActedInConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type ActorAggregate {
@@ -9603,6 +9635,7 @@ describe("Interface Relationships", () => {
             input MovieActorsUpdateConnectionInput {
               edge: ActedInUpdateInput
               node: ActorUpdateInput
+              where: ShowActorsConnectionWhere
             }
 
             input MovieActorsUpdateFieldInput {
@@ -9611,7 +9644,7 @@ describe("Interface Relationships", () => {
               delete: [ShowActorsDeleteFieldInput!]
               disconnect: [ShowActorsDisconnectFieldInput!]
               update: MovieActorsUpdateConnectionInput
-              where: ShowActorsConnectionWhere
+              where: ShowActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type MovieAggregate {
@@ -9907,6 +9940,7 @@ describe("Interface Relationships", () => {
             input SeriesActorsUpdateConnectionInput {
               edge: StarredInUpdateInput
               node: ActorUpdateInput
+              where: ShowActorsConnectionWhere
             }
 
             input SeriesActorsUpdateFieldInput {
@@ -9915,7 +9949,7 @@ describe("Interface Relationships", () => {
               delete: [ShowActorsDeleteFieldInput!]
               disconnect: [ShowActorsDisconnectFieldInput!]
               update: SeriesActorsUpdateConnectionInput
-              where: ShowActorsConnectionWhere
+              where: ShowActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"SeriesActorsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type SeriesAggregate {
@@ -10188,6 +10222,7 @@ describe("Interface Relationships", () => {
             input ShowActorsUpdateConnectionInput {
               edge: ShowActorsEdgeUpdateInput
               node: ActorUpdateInput
+              where: ShowActorsConnectionWhere
             }
 
             input ShowActorsUpdateFieldInput {
@@ -10196,7 +10231,7 @@ describe("Interface Relationships", () => {
               delete: [ShowActorsDeleteFieldInput!]
               disconnect: [ShowActorsDisconnectFieldInput!]
               update: ShowActorsUpdateConnectionInput
-              where: ShowActorsConnectionWhere
+              where: ShowActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ShowActorsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type ShowAggregate {

--- a/packages/graphql/tests/schema/interfaces.test.ts
+++ b/packages/graphql/tests/schema/interfaces.test.ts
@@ -191,6 +191,7 @@ describe("Interfaces", () => {
 
             input MovieMoviesUpdateConnectionInput {
               node: MovieUpdateInput
+              where: MovieNodeMoviesConnectionWhere
             }
 
             input MovieMoviesUpdateFieldInput {
@@ -199,7 +200,7 @@ describe("Interfaces", () => {
               delete: [MovieNodeMoviesDeleteFieldInput!]
               disconnect: [MovieNodeMoviesDisconnectFieldInput!]
               update: MovieMoviesUpdateConnectionInput
-              where: MovieNodeMoviesConnectionWhere
+              where: MovieNodeMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieMoviesUpdateConnectionInput\\\\\\" instead\\")
             }
 
             interface MovieNode {
@@ -645,6 +646,7 @@ describe("Interfaces", () => {
 
             input MovieMoviesUpdateConnectionInput {
               node: MovieUpdateInput
+              where: MovieNodeMoviesConnectionWhere
             }
 
             input MovieMoviesUpdateFieldInput {
@@ -653,7 +655,7 @@ describe("Interfaces", () => {
               delete: [MovieNodeMoviesDeleteFieldInput!]
               disconnect: [MovieNodeMoviesDisconnectFieldInput!]
               update: MovieMoviesUpdateConnectionInput
-              where: MovieNodeMoviesConnectionWhere
+              where: MovieNodeMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieMoviesUpdateConnectionInput\\\\\\" instead\\")
             }
 
             interface MovieNode @something(something: \\"test\\") {

--- a/packages/graphql/tests/schema/issues/1182.test.ts
+++ b/packages/graphql/tests/schema/issues/1182.test.ts
@@ -356,6 +356,7 @@ describe("https://github.com/neo4j/graphql/issues/1182", () => {
 
             input MovieActorsUpdateConnectionInput {
               node: ActorUpdateInput
+              where: MovieActorsConnectionWhere
             }
 
             input MovieActorsUpdateFieldInput {
@@ -365,7 +366,7 @@ describe("https://github.com/neo4j/graphql/issues/1182", () => {
               delete: [MovieActorsDeleteFieldInput!]
               disconnect: [MovieActorsDisconnectFieldInput!]
               update: MovieActorsUpdateConnectionInput
-              where: MovieActorsConnectionWhere
+              where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type MovieAggregate {

--- a/packages/graphql/tests/schema/issues/1614.test.ts
+++ b/packages/graphql/tests/schema/issues/1614.test.ts
@@ -211,6 +211,7 @@ describe("https://github.com/neo4j/graphql/issues/1614", () => {
             input CrewMemberMoviesUpdateConnectionInput {
               edge: CrewPositionUpdateInput
               node: MovieUpdateInput
+              where: CrewMemberMoviesConnectionWhere
             }
 
             input CrewMemberMoviesUpdateFieldInput {
@@ -219,7 +220,7 @@ describe("https://github.com/neo4j/graphql/issues/1614", () => {
               delete: CrewMemberMoviesDeleteFieldInput
               disconnect: CrewMemberMoviesDisconnectFieldInput
               update: CrewMemberMoviesUpdateConnectionInput
-              where: CrewMemberMoviesConnectionWhere
+              where: CrewMemberMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"CrewMemberMoviesUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input CrewMemberOptions {

--- a/packages/graphql/tests/schema/issues/162.test.ts
+++ b/packages/graphql/tests/schema/issues/162.test.ts
@@ -461,6 +461,7 @@ describe("162", () => {
 
             input TigerJawLevel2Part1TigerUpdateConnectionInput {
               node: TigerUpdateInput
+              where: TigerJawLevel2Part1TigerConnectionWhere
             }
 
             input TigerJawLevel2Part1TigerUpdateFieldInput {
@@ -469,11 +470,12 @@ describe("162", () => {
               delete: TigerJawLevel2Part1TigerDeleteFieldInput
               disconnect: TigerJawLevel2Part1TigerDisconnectFieldInput
               update: TigerJawLevel2Part1TigerUpdateConnectionInput
-              where: TigerJawLevel2Part1TigerConnectionWhere
+              where: TigerJawLevel2Part1TigerConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"TigerJawLevel2Part1TigerUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input TigerJawLevel2Part1UpdateConnectionInput {
               node: TigerJawLevel2Part1UpdateInput
+              where: TigerJawLevel2Part1ConnectionWhere
             }
 
             input TigerJawLevel2Part1UpdateFieldInput {
@@ -482,7 +484,7 @@ describe("162", () => {
               delete: TigerJawLevel2Part1DeleteFieldInput
               disconnect: TigerJawLevel2Part1DisconnectFieldInput
               update: TigerJawLevel2Part1UpdateConnectionInput
-              where: TigerJawLevel2Part1ConnectionWhere
+              where: TigerJawLevel2Part1ConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"TigerJawLevel2Part1UpdateConnectionInput\\\\\\" instead\\")
             }
 
             input TigerJawLevel2Part1UpdateInput {

--- a/packages/graphql/tests/schema/issues/2187.test.ts
+++ b/packages/graphql/tests/schema/issues/2187.test.ts
@@ -280,6 +280,7 @@ describe("https://github.com/neo4j/graphql/issues/2187", () => {
 
             input GenreMoviesUpdateConnectionInput {
               node: MovieUpdateInput
+              where: GenreMoviesConnectionWhere
             }
 
             input GenreMoviesUpdateFieldInput {
@@ -288,7 +289,7 @@ describe("https://github.com/neo4j/graphql/issues/2187", () => {
               delete: [GenreMoviesDeleteFieldInput!]
               disconnect: [GenreMoviesDisconnectFieldInput!]
               update: GenreMoviesUpdateConnectionInput
-              where: GenreMoviesConnectionWhere
+              where: GenreMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"GenreMoviesUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input GenreOptions {
@@ -520,6 +521,7 @@ describe("https://github.com/neo4j/graphql/issues/2187", () => {
 
             input MovieGenresUpdateConnectionInput {
               node: GenreUpdateInput
+              where: MovieGenresConnectionWhere
             }
 
             input MovieGenresUpdateFieldInput {
@@ -528,7 +530,7 @@ describe("https://github.com/neo4j/graphql/issues/2187", () => {
               delete: [MovieGenresDeleteFieldInput!]
               disconnect: [MovieGenresDisconnectFieldInput!]
               update: MovieGenresUpdateConnectionInput
-              where: MovieGenresConnectionWhere
+              where: MovieGenresConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieGenresUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input MovieOptions {

--- a/packages/graphql/tests/schema/issues/2377.test.ts
+++ b/packages/graphql/tests/schema/issues/2377.test.ts
@@ -333,6 +333,7 @@ describe("https://github.com/neo4j/graphql/issues/2377", () => {
 
             input ResourceContainedByUpdateConnectionInput {
               node: ResourceUpdateInput
+              where: ResourceContainedByConnectionWhere
             }
 
             input ResourceContainedByUpdateFieldInput {
@@ -342,7 +343,7 @@ describe("https://github.com/neo4j/graphql/issues/2377", () => {
               delete: [ResourceContainedByDeleteFieldInput!]
               disconnect: [ResourceContainedByDisconnectFieldInput!]
               update: ResourceContainedByUpdateConnectionInput
-              where: ResourceContainedByConnectionWhere
+              where: ResourceContainedByConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ResourceContainedByUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input ResourceCreateInput {

--- a/packages/graphql/tests/schema/issues/2969.test.ts
+++ b/packages/graphql/tests/schema/issues/2969.test.ts
@@ -220,6 +220,7 @@ describe("https://github.com/neo4j/graphql/issues/2969", () => {
 
             input PostAuthorUpdateConnectionInput {
               node: UserUpdateInput
+              where: PostAuthorConnectionWhere
             }
 
             input PostAuthorUpdateFieldInput {
@@ -228,7 +229,7 @@ describe("https://github.com/neo4j/graphql/issues/2969", () => {
               delete: PostAuthorDeleteFieldInput
               disconnect: PostAuthorDisconnectFieldInput
               update: PostAuthorUpdateConnectionInput
-              where: PostAuthorConnectionWhere
+              where: PostAuthorConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"PostAuthorUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input PostConnectInput {
@@ -519,6 +520,7 @@ describe("https://github.com/neo4j/graphql/issues/2969", () => {
 
             input UserPostsUpdateConnectionInput {
               node: PostUpdateInput
+              where: UserPostsConnectionWhere
             }
 
             input UserPostsUpdateFieldInput {
@@ -527,7 +529,7 @@ describe("https://github.com/neo4j/graphql/issues/2969", () => {
               delete: [UserPostsDeleteFieldInput!]
               disconnect: [UserPostsDisconnectFieldInput!]
               update: UserPostsUpdateConnectionInput
-              where: UserPostsConnectionWhere
+              where: UserPostsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"UserPostsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             \\"\\"\\"

--- a/packages/graphql/tests/schema/issues/2981.test.ts
+++ b/packages/graphql/tests/schema/issues/2981.test.ts
@@ -278,6 +278,7 @@ describe("https://github.com/neo4j/graphql/issues/2981", () => {
 
             input BookTitle_ENBookUpdateConnectionInput {
               node: BookUpdateInput
+              where: BookTitle_ENBookConnectionWhere
             }
 
             input BookTitle_ENBookUpdateFieldInput {
@@ -286,7 +287,7 @@ describe("https://github.com/neo4j/graphql/issues/2981", () => {
               delete: BookTitle_ENBookDeleteFieldInput
               disconnect: BookTitle_ENBookDisconnectFieldInput
               update: BookTitle_ENBookUpdateConnectionInput
-              where: BookTitle_ENBookConnectionWhere
+              where: BookTitle_ENBookConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"BookTitle_ENBookUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input BookTitle_ENConnectInput {
@@ -490,6 +491,7 @@ describe("https://github.com/neo4j/graphql/issues/2981", () => {
 
             input BookTitle_SVBookUpdateConnectionInput {
               node: BookUpdateInput
+              where: BookTitle_SVBookConnectionWhere
             }
 
             input BookTitle_SVBookUpdateFieldInput {
@@ -498,7 +500,7 @@ describe("https://github.com/neo4j/graphql/issues/2981", () => {
               delete: BookTitle_SVBookDeleteFieldInput
               disconnect: BookTitle_SVBookDisconnectFieldInput
               update: BookTitle_SVBookUpdateConnectionInput
-              where: BookTitle_SVBookConnectionWhere
+              where: BookTitle_SVBookConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"BookTitle_SVBookUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input BookTitle_SVConnectInput {
@@ -597,6 +599,7 @@ describe("https://github.com/neo4j/graphql/issues/2981", () => {
 
             input BookTranslatedTitleBookTitle_ENUpdateConnectionInput {
               node: BookTitle_ENUpdateInput
+              where: BookTranslatedTitleBookTitle_ENConnectionWhere
             }
 
             input BookTranslatedTitleBookTitle_ENUpdateFieldInput {
@@ -605,7 +608,7 @@ describe("https://github.com/neo4j/graphql/issues/2981", () => {
               delete: BookTranslatedTitleBookTitle_ENDeleteFieldInput
               disconnect: BookTranslatedTitleBookTitle_ENDisconnectFieldInput
               update: BookTranslatedTitleBookTitle_ENUpdateConnectionInput
-              where: BookTranslatedTitleBookTitle_ENConnectionWhere
+              where: BookTranslatedTitleBookTitle_ENConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"BookTranslatedTitleUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input BookTranslatedTitleBookTitle_SVConnectFieldInput {
@@ -641,6 +644,7 @@ describe("https://github.com/neo4j/graphql/issues/2981", () => {
 
             input BookTranslatedTitleBookTitle_SVUpdateConnectionInput {
               node: BookTitle_SVUpdateInput
+              where: BookTranslatedTitleBookTitle_SVConnectionWhere
             }
 
             input BookTranslatedTitleBookTitle_SVUpdateFieldInput {
@@ -649,7 +653,7 @@ describe("https://github.com/neo4j/graphql/issues/2981", () => {
               delete: BookTranslatedTitleBookTitle_SVDeleteFieldInput
               disconnect: BookTranslatedTitleBookTitle_SVDisconnectFieldInput
               update: BookTranslatedTitleBookTitle_SVUpdateConnectionInput
-              where: BookTranslatedTitleBookTitle_SVConnectionWhere
+              where: BookTranslatedTitleBookTitle_SVConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"BookTranslatedTitleUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input BookTranslatedTitleConnectInput {

--- a/packages/graphql/tests/schema/issues/2981.test.ts
+++ b/packages/graphql/tests/schema/issues/2981.test.ts
@@ -608,7 +608,7 @@ describe("https://github.com/neo4j/graphql/issues/2981", () => {
               delete: BookTranslatedTitleBookTitle_ENDeleteFieldInput
               disconnect: BookTranslatedTitleBookTitle_ENDisconnectFieldInput
               update: BookTranslatedTitleBookTitle_ENUpdateConnectionInput
-              where: BookTranslatedTitleBookTitle_ENConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"BookTranslatedTitleUpdateConnectionInput\\\\\\" instead\\")
+              where: BookTranslatedTitleBookTitle_ENConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"BookTranslatedTitleBookTitle_ENUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input BookTranslatedTitleBookTitle_SVConnectFieldInput {
@@ -653,7 +653,7 @@ describe("https://github.com/neo4j/graphql/issues/2981", () => {
               delete: BookTranslatedTitleBookTitle_SVDeleteFieldInput
               disconnect: BookTranslatedTitleBookTitle_SVDisconnectFieldInput
               update: BookTranslatedTitleBookTitle_SVUpdateConnectionInput
-              where: BookTranslatedTitleBookTitle_SVConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"BookTranslatedTitleUpdateConnectionInput\\\\\\" instead\\")
+              where: BookTranslatedTitleBookTitle_SVConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"BookTranslatedTitleBookTitle_SVUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input BookTranslatedTitleConnectInput {

--- a/packages/graphql/tests/schema/issues/2993.test.ts
+++ b/packages/graphql/tests/schema/issues/2993.test.ts
@@ -412,6 +412,7 @@ describe("https://github.com/neo4j/graphql/issues/2993", () => {
             input UserFollowingUpdateConnectionInput {
               edge: FOLLOWSUpdateInput
               node: ProfileUpdateInput
+              where: UserFollowingConnectionWhere
             }
 
             input UserFollowingUpdateFieldInput {
@@ -420,7 +421,7 @@ describe("https://github.com/neo4j/graphql/issues/2993", () => {
               delete: [UserFollowingDeleteFieldInput!]
               disconnect: [UserFollowingDisconnectFieldInput!]
               update: UserFollowingUpdateConnectionInput
-              where: UserFollowingConnectionWhere
+              where: UserFollowingConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"UserFollowingUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input UserOptions {

--- a/packages/graphql/tests/schema/issues/3439.test.ts
+++ b/packages/graphql/tests/schema/issues/3439.test.ts
@@ -311,6 +311,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
 
             input GenreProductUpdateConnectionInput {
               node: IProductUpdateInput
+              where: GenreProductConnectionWhere
             }
 
             input GenreProductUpdateFieldInput {
@@ -319,7 +320,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               delete: [GenreProductDeleteFieldInput!]
               disconnect: [GenreProductDisconnectFieldInput!]
               update: GenreProductUpdateConnectionInput
-              where: GenreProductConnectionWhere
+              where: GenreProductConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"GenreProductUpdateConnectionInput\\\\\\" instead\\")
             }
 
             \\"\\"\\"
@@ -727,6 +728,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
 
             input MovieGenreUpdateConnectionInput {
               node: GenreUpdateInput
+              where: MovieGenreConnectionWhere
             }
 
             input MovieGenreUpdateFieldInput {
@@ -736,7 +738,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               delete: MovieGenreDeleteFieldInput
               disconnect: MovieGenreDisconnectFieldInput
               update: MovieGenreUpdateConnectionInput
-              where: MovieGenreConnectionWhere
+              where: MovieGenreConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieGenreUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input MovieOptions {
@@ -1029,6 +1031,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
 
             input SeriesGenreUpdateConnectionInput {
               node: GenreUpdateInput
+              where: SeriesGenreConnectionWhere
             }
 
             input SeriesGenreUpdateFieldInput {
@@ -1038,7 +1041,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               delete: SeriesGenreDeleteFieldInput
               disconnect: SeriesGenreDisconnectFieldInput
               update: SeriesGenreUpdateConnectionInput
-              where: SeriesGenreConnectionWhere
+              where: SeriesGenreConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"SeriesGenreUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input SeriesOptions {
@@ -1446,6 +1449,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
 
             input GenreProductUpdateConnectionInput {
               node: IProductUpdateInput
+              where: GenreProductConnectionWhere
             }
 
             input GenreProductUpdateFieldInput {
@@ -1454,7 +1458,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               delete: [GenreProductDeleteFieldInput!]
               disconnect: [GenreProductDisconnectFieldInput!]
               update: GenreProductUpdateConnectionInput
-              where: GenreProductConnectionWhere
+              where: GenreProductConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"GenreProductUpdateConnectionInput\\\\\\" instead\\")
             }
 
             \\"\\"\\"
@@ -1797,6 +1801,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
 
             input MovieGenreUpdateConnectionInput {
               node: GenreUpdateInput
+              where: MovieGenreConnectionWhere
             }
 
             input MovieGenreUpdateFieldInput {
@@ -1806,7 +1811,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               delete: MovieGenreDeleteFieldInput
               disconnect: MovieGenreDisconnectFieldInput
               update: MovieGenreUpdateConnectionInput
-              where: MovieGenreConnectionWhere
+              where: MovieGenreConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieGenreUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input MovieOptions {
@@ -2096,6 +2101,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
 
             input SeriesGenreUpdateConnectionInput {
               node: GenreUpdateInput
+              where: SeriesGenreConnectionWhere
             }
 
             input SeriesGenreUpdateFieldInput {
@@ -2105,7 +2111,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               delete: SeriesGenreDeleteFieldInput
               disconnect: SeriesGenreDisconnectFieldInput
               update: SeriesGenreUpdateConnectionInput
-              where: SeriesGenreConnectionWhere
+              where: SeriesGenreConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"SeriesGenreUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input SeriesOptions {
@@ -2524,6 +2530,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
 
             input GenreProductUpdateConnectionInput {
               node: IProductUpdateInput
+              where: GenreProductConnectionWhere
             }
 
             input GenreProductUpdateFieldInput {
@@ -2532,7 +2539,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               delete: [GenreProductDeleteFieldInput!]
               disconnect: [GenreProductDisconnectFieldInput!]
               update: GenreProductUpdateConnectionInput
-              where: GenreProductConnectionWhere
+              where: GenreProductConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"GenreProductUpdateConnectionInput\\\\\\" instead\\")
             }
 
             \\"\\"\\"
@@ -2830,6 +2837,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             input IProductGenreUpdateConnectionInput {
               edge: IProductGenreEdgeUpdateInput
               node: GenreUpdateInput
+              where: IProductGenreConnectionWhere
             }
 
             input IProductGenreUpdateFieldInput {
@@ -2839,7 +2847,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               delete: IProductGenreDeleteFieldInput
               disconnect: IProductGenreDisconnectFieldInput
               update: IProductGenreUpdateConnectionInput
-              where: IProductGenreConnectionWhere
+              where: IProductGenreConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"IProductGenreUpdateConnectionInput\\\\\\" instead\\")
             }
 
             enum IProductImplementation {
@@ -3048,6 +3056,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             input MovieGenreUpdateConnectionInput {
               edge: MoviePropsUpdateInput
               node: GenreUpdateInput
+              where: IProductGenreConnectionWhere
             }
 
             input MovieGenreUpdateFieldInput {
@@ -3057,7 +3066,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               delete: IProductGenreDeleteFieldInput
               disconnect: IProductGenreDisconnectFieldInput
               update: MovieGenreUpdateConnectionInput
-              where: IProductGenreConnectionWhere
+              where: IProductGenreConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieGenreUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input MovieOptions {
@@ -3381,6 +3390,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             input SeriesGenreUpdateConnectionInput {
               edge: SeriesPropsUpdateInput
               node: GenreUpdateInput
+              where: IProductGenreConnectionWhere
             }
 
             input SeriesGenreUpdateFieldInput {
@@ -3390,7 +3400,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               delete: IProductGenreDeleteFieldInput
               disconnect: IProductGenreDisconnectFieldInput
               update: SeriesGenreUpdateConnectionInput
-              where: IProductGenreConnectionWhere
+              where: IProductGenreConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"SeriesGenreUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input SeriesOptions {
@@ -3883,6 +3893,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
 
             input GenreProductUpdateConnectionInput {
               node: IProductUpdateInput
+              where: GenreProductConnectionWhere
             }
 
             input GenreProductUpdateFieldInput {
@@ -3891,7 +3902,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               delete: [GenreProductDeleteFieldInput!]
               disconnect: [GenreProductDisconnectFieldInput!]
               update: GenreProductUpdateConnectionInput
-              where: GenreProductConnectionWhere
+              where: GenreProductConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"GenreProductUpdateConnectionInput\\\\\\" instead\\")
             }
 
             \\"\\"\\"
@@ -4148,6 +4159,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             input IProductGenreGenreUpdateConnectionInput {
               edge: IProductGenreEdgeUpdateInput
               node: GenreUpdateInput
+              where: IProductGenreGenreConnectionWhere
             }
 
             input IProductGenreGenreUpdateFieldInput {
@@ -4157,7 +4169,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               delete: IProductGenreGenreDeleteFieldInput
               disconnect: IProductGenreGenreDisconnectFieldInput
               update: IProductGenreGenreUpdateConnectionInput
-              where: IProductGenreGenreConnectionWhere
+              where: IProductGenreGenreConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"IProductGenreUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input IProductGenreRatingConnectFieldInput {
@@ -4202,6 +4214,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             input IProductGenreRatingUpdateConnectionInput {
               edge: IProductGenreEdgeUpdateInput
               node: RatingUpdateInput
+              where: IProductGenreRatingConnectionWhere
             }
 
             input IProductGenreRatingUpdateFieldInput {
@@ -4211,7 +4224,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               delete: IProductGenreRatingDeleteFieldInput
               disconnect: IProductGenreRatingDisconnectFieldInput
               update: IProductGenreRatingUpdateConnectionInput
-              where: IProductGenreRatingConnectionWhere
+              where: IProductGenreRatingConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"IProductGenreUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type IProductGenreRelationship {
@@ -4388,6 +4401,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             input MovieGenreGenreUpdateConnectionInput {
               edge: MoviePropsUpdateInput
               node: GenreUpdateInput
+              where: IProductGenreGenreConnectionWhere
             }
 
             input MovieGenreGenreUpdateFieldInput {
@@ -4397,7 +4411,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               delete: IProductGenreGenreDeleteFieldInput
               disconnect: IProductGenreGenreDisconnectFieldInput
               update: MovieGenreGenreUpdateConnectionInput
-              where: IProductGenreGenreConnectionWhere
+              where: IProductGenreGenreConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieGenreUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input MovieGenreRatingConnectFieldInput {
@@ -4430,6 +4444,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             input MovieGenreRatingUpdateConnectionInput {
               edge: MoviePropsUpdateInput
               node: RatingUpdateInput
+              where: IProductGenreRatingConnectionWhere
             }
 
             input MovieGenreRatingUpdateFieldInput {
@@ -4439,7 +4454,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               delete: IProductGenreRatingDeleteFieldInput
               disconnect: IProductGenreRatingDisconnectFieldInput
               update: MovieGenreRatingUpdateConnectionInput
-              where: IProductGenreRatingConnectionWhere
+              where: IProductGenreRatingConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieGenreUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input MovieGenreUpdateInput {
@@ -4801,6 +4816,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
 
             input RatingProductUpdateConnectionInput {
               node: IProductUpdateInput
+              where: RatingProductConnectionWhere
             }
 
             input RatingProductUpdateFieldInput {
@@ -4809,7 +4825,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               delete: [RatingProductDeleteFieldInput!]
               disconnect: [RatingProductDisconnectFieldInput!]
               update: RatingProductUpdateConnectionInput
-              where: RatingProductConnectionWhere
+              where: RatingProductConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"RatingProductUpdateConnectionInput\\\\\\" instead\\")
             }
 
             \\"\\"\\"
@@ -4999,6 +5015,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             input SeriesGenreGenreUpdateConnectionInput {
               edge: SeriesPropsUpdateInput
               node: GenreUpdateInput
+              where: IProductGenreGenreConnectionWhere
             }
 
             input SeriesGenreGenreUpdateFieldInput {
@@ -5008,7 +5025,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               delete: IProductGenreGenreDeleteFieldInput
               disconnect: IProductGenreGenreDisconnectFieldInput
               update: SeriesGenreGenreUpdateConnectionInput
-              where: IProductGenreGenreConnectionWhere
+              where: IProductGenreGenreConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"SeriesGenreUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input SeriesGenreRatingConnectFieldInput {
@@ -5041,6 +5058,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             input SeriesGenreRatingUpdateConnectionInput {
               edge: SeriesPropsUpdateInput
               node: RatingUpdateInput
+              where: IProductGenreRatingConnectionWhere
             }
 
             input SeriesGenreRatingUpdateFieldInput {
@@ -5050,7 +5068,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               delete: IProductGenreRatingDeleteFieldInput
               disconnect: IProductGenreRatingDisconnectFieldInput
               update: SeriesGenreRatingUpdateConnectionInput
-              where: IProductGenreRatingConnectionWhere
+              where: IProductGenreRatingConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"SeriesGenreUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input SeriesGenreUpdateInput {

--- a/packages/graphql/tests/schema/issues/3439.test.ts
+++ b/packages/graphql/tests/schema/issues/3439.test.ts
@@ -4169,7 +4169,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               delete: IProductGenreGenreDeleteFieldInput
               disconnect: IProductGenreGenreDisconnectFieldInput
               update: IProductGenreGenreUpdateConnectionInput
-              where: IProductGenreGenreConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"IProductGenreUpdateConnectionInput\\\\\\" instead\\")
+              where: IProductGenreGenreConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"IProductGenreGenreUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input IProductGenreRatingConnectFieldInput {
@@ -4224,7 +4224,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               delete: IProductGenreRatingDeleteFieldInput
               disconnect: IProductGenreRatingDisconnectFieldInput
               update: IProductGenreRatingUpdateConnectionInput
-              where: IProductGenreRatingConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"IProductGenreUpdateConnectionInput\\\\\\" instead\\")
+              where: IProductGenreRatingConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"IProductGenreRatingUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type IProductGenreRelationship {
@@ -4411,7 +4411,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               delete: IProductGenreGenreDeleteFieldInput
               disconnect: IProductGenreGenreDisconnectFieldInput
               update: MovieGenreGenreUpdateConnectionInput
-              where: IProductGenreGenreConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieGenreUpdateConnectionInput\\\\\\" instead\\")
+              where: IProductGenreGenreConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieGenreGenreUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input MovieGenreRatingConnectFieldInput {
@@ -4454,7 +4454,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               delete: IProductGenreRatingDeleteFieldInput
               disconnect: IProductGenreRatingDisconnectFieldInput
               update: MovieGenreRatingUpdateConnectionInput
-              where: IProductGenreRatingConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieGenreUpdateConnectionInput\\\\\\" instead\\")
+              where: IProductGenreRatingConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieGenreRatingUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input MovieGenreUpdateInput {
@@ -5025,7 +5025,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               delete: IProductGenreGenreDeleteFieldInput
               disconnect: IProductGenreGenreDisconnectFieldInput
               update: SeriesGenreGenreUpdateConnectionInput
-              where: IProductGenreGenreConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"SeriesGenreUpdateConnectionInput\\\\\\" instead\\")
+              where: IProductGenreGenreConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"SeriesGenreGenreUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input SeriesGenreRatingConnectFieldInput {
@@ -5068,7 +5068,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               delete: IProductGenreRatingDeleteFieldInput
               disconnect: IProductGenreRatingDisconnectFieldInput
               update: SeriesGenreRatingUpdateConnectionInput
-              where: IProductGenreRatingConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"SeriesGenreUpdateConnectionInput\\\\\\" instead\\")
+              where: IProductGenreRatingConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"SeriesGenreRatingUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input SeriesGenreUpdateInput {

--- a/packages/graphql/tests/schema/issues/3541.test.ts
+++ b/packages/graphql/tests/schema/issues/3541.test.ts
@@ -602,6 +602,7 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
 
             input MovieActorsUpdateConnectionInput {
               node: ActorUpdateInput
+              where: MovieActorsConnectionWhere
             }
 
             input MovieActorsUpdateFieldInput {
@@ -610,7 +611,7 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
               delete: [MovieActorsDeleteFieldInput!]
               disconnect: [MovieActorsDisconnectFieldInput!]
               update: MovieActorsUpdateConnectionInput
-              where: MovieActorsConnectionWhere
+              where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input MovieCreateInput {

--- a/packages/graphql/tests/schema/issues/3698.test.ts
+++ b/packages/graphql/tests/schema/issues/3698.test.ts
@@ -320,6 +320,7 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
 
             input GenreProductUpdateConnectionInput {
               node: IProductUpdateInput
+              where: GenreProductConnectionWhere
             }
 
             input GenreProductUpdateFieldInput {
@@ -328,7 +329,7 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
               delete: [GenreProductDeleteFieldInput!]
               disconnect: [GenreProductDisconnectFieldInput!]
               update: GenreProductUpdateConnectionInput
-              where: GenreProductConnectionWhere
+              where: GenreProductConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"GenreProductUpdateConnectionInput\\\\\\" instead\\")
             }
 
             \\"\\"\\"
@@ -682,6 +683,7 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
 
             input MovieGenreUpdateConnectionInput {
               node: GenreUpdateInput
+              where: MovieGenreConnectionWhere
             }
 
             input MovieGenreUpdateFieldInput {
@@ -691,7 +693,7 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
               delete: MovieGenreDeleteFieldInput
               disconnect: MovieGenreDisconnectFieldInput
               update: MovieGenreUpdateConnectionInput
-              where: MovieGenreConnectionWhere
+              where: MovieGenreConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieGenreUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input MovieOptions {
@@ -1143,6 +1145,7 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
 
             input GenreProductUpdateConnectionInput {
               node: IProductUpdateInput
+              where: GenreProductConnectionWhere
             }
 
             input GenreProductUpdateFieldInput {
@@ -1151,7 +1154,7 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
               delete: [GenreProductDeleteFieldInput!]
               disconnect: [GenreProductDisconnectFieldInput!]
               update: GenreProductUpdateConnectionInput
-              where: GenreProductConnectionWhere
+              where: GenreProductConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"GenreProductUpdateConnectionInput\\\\\\" instead\\")
             }
 
             \\"\\"\\"
@@ -1376,6 +1379,7 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
 
             input IProductGenreUpdateConnectionInput {
               node: GenreUpdateInput
+              where: IProductGenreConnectionWhere
             }
 
             input IProductGenreUpdateFieldInput {
@@ -1385,7 +1389,7 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
               delete: IProductGenreDeleteFieldInput
               disconnect: IProductGenreDisconnectFieldInput
               update: IProductGenreUpdateConnectionInput
-              where: IProductGenreConnectionWhere
+              where: IProductGenreConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"IProductGenreUpdateConnectionInput\\\\\\" instead\\")
             }
 
             enum IProductImplementation {
@@ -1586,6 +1590,7 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
 
             input MovieGenreUpdateConnectionInput {
               node: GenreUpdateInput
+              where: IProductGenreConnectionWhere
             }
 
             input MovieGenreUpdateFieldInput {
@@ -1595,7 +1600,7 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
               delete: IProductGenreDeleteFieldInput
               disconnect: IProductGenreDisconnectFieldInput
               update: MovieGenreUpdateConnectionInput
-              where: IProductGenreConnectionWhere
+              where: IProductGenreConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieGenreUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input MovieOptions {
@@ -2060,6 +2065,7 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
 
             input GenreProductUpdateConnectionInput {
               node: IProductUpdateInput
+              where: GenreProductConnectionWhere
             }
 
             input GenreProductUpdateFieldInput {
@@ -2068,7 +2074,7 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
               delete: [GenreProductDeleteFieldInput!]
               disconnect: [GenreProductDisconnectFieldInput!]
               update: GenreProductUpdateConnectionInput
-              where: GenreProductConnectionWhere
+              where: GenreProductConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"GenreProductUpdateConnectionInput\\\\\\" instead\\")
             }
 
             \\"\\"\\"
@@ -2294,6 +2300,7 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
 
             input IProductGenreUpdateConnectionInput {
               node: GenreUpdateInput
+              where: IProductGenreConnectionWhere
             }
 
             input IProductGenreUpdateFieldInput {
@@ -2303,7 +2310,7 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
               delete: IProductGenreDeleteFieldInput
               disconnect: IProductGenreDisconnectFieldInput
               update: IProductGenreUpdateConnectionInput
-              where: IProductGenreConnectionWhere
+              where: IProductGenreConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"IProductGenreUpdateConnectionInput\\\\\\" instead\\")
             }
 
             enum IProductImplementation {
@@ -2505,6 +2512,7 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
 
             input MovieGenreUpdateConnectionInput {
               node: GenreUpdateInput
+              where: IProductGenreConnectionWhere
             }
 
             input MovieGenreUpdateFieldInput {
@@ -2514,7 +2522,7 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
               delete: IProductGenreDeleteFieldInput
               disconnect: IProductGenreDisconnectFieldInput
               update: MovieGenreUpdateConnectionInput
-              where: IProductGenreConnectionWhere
+              where: IProductGenreConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieGenreUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input MovieOptions {
@@ -2771,6 +2779,7 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
 
             input SeriesGenreUpdateConnectionInput {
               node: GenreUpdateInput
+              where: IProductGenreConnectionWhere
             }
 
             input SeriesGenreUpdateFieldInput {
@@ -2780,7 +2789,7 @@ describe("https://github.com/neo4j/graphql/issues/3698", () => {
               delete: IProductGenreDeleteFieldInput
               disconnect: IProductGenreDisconnectFieldInput
               update: SeriesGenreUpdateConnectionInput
-              where: IProductGenreConnectionWhere
+              where: IProductGenreConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"SeriesGenreUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input SeriesOptions {

--- a/packages/graphql/tests/schema/issues/3816.test.ts
+++ b/packages/graphql/tests/schema/issues/3816.test.ts
@@ -227,6 +227,7 @@ describe("https://github.com/neo4j/graphql/issues/3816", () => {
 
             input GenreMoviesUpdateConnectionInput {
               node: MovieUpdateInput
+              where: GenreMoviesConnectionWhere
             }
 
             input GenreMoviesUpdateFieldInput {
@@ -235,7 +236,7 @@ describe("https://github.com/neo4j/graphql/issues/3816", () => {
               delete: [GenreMoviesDeleteFieldInput!]
               disconnect: [GenreMoviesDisconnectFieldInput!]
               update: GenreMoviesUpdateConnectionInput
-              where: GenreMoviesConnectionWhere
+              where: GenreMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"GenreMoviesUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input GenreOptions {
@@ -439,7 +440,7 @@ describe("https://github.com/neo4j/graphql/issues/3816", () => {
             input MovieGenreUpdateFieldInput {
               connect: MovieGenreConnectFieldInput
               disconnect: MovieGenreDisconnectFieldInput
-              where: MovieGenreConnectionWhere
+              where: MovieGenreConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieGenreUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input MovieOptions {
@@ -737,6 +738,7 @@ describe("https://github.com/neo4j/graphql/issues/3816", () => {
 
             input GenreMoviesUpdateConnectionInput {
               node: MovieUpdateInput
+              where: GenreMoviesConnectionWhere
             }
 
             input GenreMoviesUpdateFieldInput {
@@ -745,7 +747,7 @@ describe("https://github.com/neo4j/graphql/issues/3816", () => {
               delete: [GenreMoviesDeleteFieldInput!]
               disconnect: [GenreMoviesDisconnectFieldInput!]
               update: GenreMoviesUpdateConnectionInput
-              where: GenreMoviesConnectionWhere
+              where: GenreMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"GenreMoviesUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input GenreOptions {

--- a/packages/graphql/tests/schema/issues/3817.test.ts
+++ b/packages/graphql/tests/schema/issues/3817.test.ts
@@ -319,6 +319,7 @@ describe("3817", () => {
             input PersonFriendsUpdateConnectionInput {
               edge: FriendOfUpdateInput
               node: PersonUpdateInput
+              where: PersonFriendsConnectionWhere
             }
 
             input PersonFriendsUpdateFieldInput {
@@ -328,7 +329,7 @@ describe("3817", () => {
               delete: [PersonFriendsDeleteFieldInput!]
               disconnect: [PersonFriendsDisconnectFieldInput!]
               update: PersonFriendsUpdateConnectionInput
-              where: PersonFriendsConnectionWhere
+              where: PersonFriendsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"PersonFriendsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input PersonOnCreateInput {

--- a/packages/graphql/tests/schema/issues/4511.test.ts
+++ b/packages/graphql/tests/schema/issues/4511.test.ts
@@ -205,6 +205,7 @@ describe("https://github.com/neo4j/graphql/issues/4511", () => {
 
             input CreatureMoviesUpdateConnectionInput {
               node: ProductionUpdateInput
+              where: CreatureMoviesConnectionWhere
             }
 
             input CreatureMoviesUpdateFieldInput {
@@ -213,7 +214,7 @@ describe("https://github.com/neo4j/graphql/issues/4511", () => {
               delete: CreatureMoviesDeleteFieldInput
               disconnect: CreatureMoviesDisconnectFieldInput
               update: CreatureMoviesUpdateConnectionInput
-              where: CreatureMoviesConnectionWhere
+              where: CreatureMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"CreatureMoviesUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input CreatureOptions {
@@ -347,6 +348,7 @@ describe("https://github.com/neo4j/graphql/issues/4511", () => {
 
             input MovieDirectorUpdateConnectionInput {
               node: CreatureUpdateInput
+              where: ProductionDirectorConnectionWhere
             }
 
             input MovieDirectorUpdateFieldInput {
@@ -355,7 +357,7 @@ describe("https://github.com/neo4j/graphql/issues/4511", () => {
               delete: MovieDirectorDeleteFieldInput
               disconnect: MovieDirectorDisconnectFieldInput
               update: MovieDirectorUpdateConnectionInput
-              where: ProductionDirectorConnectionWhere
+              where: ProductionDirectorConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieDirectorUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type MovieEdge {
@@ -535,6 +537,7 @@ describe("https://github.com/neo4j/graphql/issues/4511", () => {
 
             input PersonMoviesUpdateConnectionInput {
               node: ProductionUpdateInput
+              where: CreatureMoviesConnectionWhere
             }
 
             input PersonMoviesUpdateFieldInput {
@@ -543,7 +546,7 @@ describe("https://github.com/neo4j/graphql/issues/4511", () => {
               delete: PersonMoviesDeleteFieldInput
               disconnect: PersonMoviesDisconnectFieldInput
               update: PersonMoviesUpdateConnectionInput
-              where: CreatureMoviesConnectionWhere
+              where: CreatureMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"PersonMoviesUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input PersonOptions {
@@ -666,6 +669,7 @@ describe("https://github.com/neo4j/graphql/issues/4511", () => {
 
             input ProductionDirectorUpdateConnectionInput {
               node: CreatureUpdateInput
+              where: ProductionDirectorConnectionWhere
             }
 
             input ProductionDirectorUpdateFieldInput {
@@ -674,7 +678,7 @@ describe("https://github.com/neo4j/graphql/issues/4511", () => {
               delete: ProductionDirectorDeleteFieldInput
               disconnect: ProductionDirectorDisconnectFieldInput
               update: ProductionDirectorUpdateConnectionInput
-              where: ProductionDirectorConnectionWhere
+              where: ProductionDirectorConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ProductionDirectorUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input ProductionDisconnectInput {
@@ -854,6 +858,7 @@ describe("https://github.com/neo4j/graphql/issues/4511", () => {
 
             input SeriesDirectorUpdateConnectionInput {
               node: CreatureUpdateInput
+              where: ProductionDirectorConnectionWhere
             }
 
             input SeriesDirectorUpdateFieldInput {
@@ -862,7 +867,7 @@ describe("https://github.com/neo4j/graphql/issues/4511", () => {
               delete: SeriesDirectorDeleteFieldInput
               disconnect: SeriesDirectorDisconnectFieldInput
               update: SeriesDirectorUpdateConnectionInput
-              where: ProductionDirectorConnectionWhere
+              where: ProductionDirectorConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"SeriesDirectorUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type SeriesEdge {

--- a/packages/graphql/tests/schema/issues/4615.test.ts
+++ b/packages/graphql/tests/schema/issues/4615.test.ts
@@ -224,6 +224,7 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
             input ActorActedInUpdateConnectionInput {
               edge: ActedInUpdateInput
               node: ShowUpdateInput
+              where: ActorActedInConnectionWhere
             }
 
             input ActorActedInUpdateFieldInput {
@@ -232,7 +233,7 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
               delete: [ActorActedInDeleteFieldInput!]
               disconnect: [ActorActedInDisconnectFieldInput!]
               update: ActorActedInUpdateConnectionInput
-              where: ActorActedInConnectionWhere
+              where: ActorActedInConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type ActorAggregate {
@@ -497,6 +498,7 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
             input MovieActorsUpdateConnectionInput {
               edge: ActedInUpdateInput
               node: ActorUpdateInput
+              where: ShowActorsConnectionWhere
             }
 
             input MovieActorsUpdateFieldInput {
@@ -505,7 +507,7 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
               delete: [ShowActorsDeleteFieldInput!]
               disconnect: [ShowActorsDisconnectFieldInput!]
               update: MovieActorsUpdateConnectionInput
-              where: ShowActorsConnectionWhere
+              where: ShowActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type MovieAggregate {
@@ -745,6 +747,7 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
             input SeriesActorsUpdateConnectionInput {
               edge: ActedInUpdateInput
               node: ActorUpdateInput
+              where: ShowActorsConnectionWhere
             }
 
             input SeriesActorsUpdateFieldInput {
@@ -753,7 +756,7 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
               delete: [ShowActorsDeleteFieldInput!]
               disconnect: [ShowActorsDisconnectFieldInput!]
               update: SeriesActorsUpdateConnectionInput
-              where: ShowActorsConnectionWhere
+              where: ShowActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"SeriesActorsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type SeriesAggregate {
@@ -1006,6 +1009,7 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
             input ShowActorsUpdateConnectionInput {
               edge: ShowActorsEdgeUpdateInput
               node: ActorUpdateInput
+              where: ShowActorsConnectionWhere
             }
 
             input ShowActorsUpdateFieldInput {
@@ -1014,7 +1018,7 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
               delete: [ShowActorsDeleteFieldInput!]
               disconnect: [ShowActorsDisconnectFieldInput!]
               update: ShowActorsUpdateConnectionInput
-              where: ShowActorsConnectionWhere
+              where: ShowActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ShowActorsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type ShowAggregate {

--- a/packages/graphql/tests/schema/issues/872.test.ts
+++ b/packages/graphql/tests/schema/issues/872.test.ts
@@ -210,6 +210,7 @@ describe("https://github.com/neo4j/graphql/issues/872", () => {
 
             input Actor2MoviesUpdateConnectionInput {
               node: MovieUpdateInput
+              where: Actor2MoviesConnectionWhere
             }
 
             input Actor2MoviesUpdateFieldInput {
@@ -219,7 +220,7 @@ describe("https://github.com/neo4j/graphql/issues/872", () => {
               delete: [Actor2MoviesDeleteFieldInput!]
               disconnect: [Actor2MoviesDisconnectFieldInput!]
               update: Actor2MoviesUpdateConnectionInput
-              where: Actor2MoviesConnectionWhere
+              where: Actor2MoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"Actor2MoviesUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input Actor2Options {
@@ -435,6 +436,7 @@ describe("https://github.com/neo4j/graphql/issues/872", () => {
 
             input ActorMoviesUpdateConnectionInput {
               node: MovieUpdateInput
+              where: ActorMoviesConnectionWhere
             }
 
             input ActorMoviesUpdateFieldInput {
@@ -444,7 +446,7 @@ describe("https://github.com/neo4j/graphql/issues/872", () => {
               delete: [ActorMoviesDeleteFieldInput!]
               disconnect: [ActorMoviesDisconnectFieldInput!]
               update: ActorMoviesUpdateConnectionInput
-              where: ActorMoviesConnectionWhere
+              where: ActorMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorMoviesUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input ActorOptions {

--- a/packages/graphql/tests/schema/lowercase-type-names.test.ts
+++ b/packages/graphql/tests/schema/lowercase-type-names.test.ts
@@ -360,6 +360,7 @@ describe("lower case type names", () => {
 
             input actorMoviesUpdateConnectionInput {
               node: movieUpdateInput
+              where: actorMoviesConnectionWhere
             }
 
             input actorMoviesUpdateFieldInput {
@@ -368,7 +369,7 @@ describe("lower case type names", () => {
               delete: [actorMoviesDeleteFieldInput!]
               disconnect: [actorMoviesDisconnectFieldInput!]
               update: actorMoviesUpdateConnectionInput
-              where: actorMoviesConnectionWhere
+              where: actorMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"actorMoviesUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input actorOptions {
@@ -596,6 +597,7 @@ describe("lower case type names", () => {
 
             input movieActorsUpdateConnectionInput {
               node: actorUpdateInput
+              where: movieActorsConnectionWhere
             }
 
             input movieActorsUpdateFieldInput {
@@ -604,7 +606,7 @@ describe("lower case type names", () => {
               delete: [movieActorsDeleteFieldInput!]
               disconnect: [movieActorsDisconnectFieldInput!]
               update: movieActorsUpdateConnectionInput
-              where: movieActorsConnectionWhere
+              where: movieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"movieActorsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type movieAggregate {

--- a/packages/graphql/tests/schema/math.test.ts
+++ b/packages/graphql/tests/schema/math.test.ts
@@ -767,6 +767,7 @@ describe("Algebraic", () => {
 
             input DirectorDirectsUpdateConnectionInput {
               node: MovieUpdateInput
+              where: DirectorDirectsConnectionWhere
             }
 
             input DirectorDirectsUpdateFieldInput {
@@ -775,7 +776,7 @@ describe("Algebraic", () => {
               delete: [DirectorDirectsDeleteFieldInput!]
               disconnect: [DirectorDirectsDisconnectFieldInput!]
               update: DirectorDirectsUpdateConnectionInput
-              where: DirectorDirectsConnectionWhere
+              where: DirectorDirectsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"DirectorDirectsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input DirectorDisconnectInput {
@@ -1009,6 +1010,7 @@ describe("Algebraic", () => {
 
             input MovieDirectedByUpdateConnectionInput {
               node: DirectorUpdateInput
+              where: MovieDirectedByConnectionWhere
             }
 
             input MovieDirectedByUpdateFieldInput {
@@ -1017,7 +1019,7 @@ describe("Algebraic", () => {
               delete: MovieDirectedByDeleteFieldInput
               disconnect: MovieDirectedByDisconnectFieldInput
               update: MovieDirectedByUpdateConnectionInput
-              where: MovieDirectedByConnectionWhere
+              where: MovieDirectedByConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieDirectedByUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type MovieDirectorDirectedByAggregateSelection {
@@ -1443,6 +1445,7 @@ describe("Algebraic", () => {
 
             input MovieWorkersUpdateConnectionInput {
               node: PersonUpdateInput
+              where: MovieWorkersConnectionWhere
             }
 
             input MovieWorkersUpdateFieldInput {
@@ -1451,7 +1454,7 @@ describe("Algebraic", () => {
               delete: [MovieWorkersDeleteFieldInput!]
               disconnect: [MovieWorkersDisconnectFieldInput!]
               update: MovieWorkersUpdateConnectionInput
-              where: MovieWorkersConnectionWhere
+              where: MovieWorkersConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieWorkersUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type MoviesConnection {
@@ -1690,6 +1693,7 @@ describe("Algebraic", () => {
 
             input PersonWorksInProductionUpdateConnectionInput {
               node: ProductionUpdateInput
+              where: PersonWorksInProductionConnectionWhere
             }
 
             input PersonWorksInProductionUpdateFieldInput {
@@ -1698,7 +1702,7 @@ describe("Algebraic", () => {
               delete: [PersonWorksInProductionDeleteFieldInput!]
               disconnect: [PersonWorksInProductionDisconnectFieldInput!]
               update: PersonWorksInProductionUpdateConnectionInput
-              where: PersonWorksInProductionConnectionWhere
+              where: PersonWorksInProductionConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"PersonWorksInProductionUpdateConnectionInput\\\\\\" instead\\")
             }
 
             interface Production {
@@ -2072,6 +2076,7 @@ describe("Algebraic", () => {
             input MovieActorsUpdateConnectionInput {
               edge: ActedInUpdateInput
               node: PersonUpdateInput
+              where: MovieActorsConnectionWhere
             }
 
             input MovieActorsUpdateFieldInput {
@@ -2080,7 +2085,7 @@ describe("Algebraic", () => {
               delete: [MovieActorsDeleteFieldInput!]
               disconnect: [MovieActorsDisconnectFieldInput!]
               update: MovieActorsUpdateConnectionInput
-              where: MovieActorsConnectionWhere
+              where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type MovieAggregate {
@@ -2334,6 +2339,7 @@ describe("Algebraic", () => {
             input PersonActedInMoviesUpdateConnectionInput {
               edge: ActedInUpdateInput
               node: MovieUpdateInput
+              where: PersonActedInMoviesConnectionWhere
             }
 
             input PersonActedInMoviesUpdateFieldInput {
@@ -2342,7 +2348,7 @@ describe("Algebraic", () => {
               delete: [PersonActedInMoviesDeleteFieldInput!]
               disconnect: [PersonActedInMoviesDisconnectFieldInput!]
               update: PersonActedInMoviesUpdateConnectionInput
-              where: PersonActedInMoviesConnectionWhere
+              where: PersonActedInMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"PersonActedInMoviesUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type PersonAggregate {

--- a/packages/graphql/tests/schema/nested-aggregation-on-type.test.ts
+++ b/packages/graphql/tests/schema/nested-aggregation-on-type.test.ts
@@ -230,6 +230,7 @@ describe("nested aggregation on interface", () => {
             input ActorActedInUpdateConnectionInput {
               edge: ActedInUpdateInput
               node: MovieUpdateInput
+              where: ActorActedInConnectionWhere
             }
 
             input ActorActedInUpdateFieldInput {
@@ -238,7 +239,7 @@ describe("nested aggregation on interface", () => {
               delete: [ActorActedInDeleteFieldInput!]
               disconnect: [ActorActedInDisconnectFieldInput!]
               update: ActorActedInUpdateConnectionInput
-              where: ActorActedInConnectionWhere
+              where: ActorActedInConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type ActorAggregate {

--- a/packages/graphql/tests/schema/pluralize-consistency.test.ts
+++ b/packages/graphql/tests/schema/pluralize-consistency.test.ts
@@ -334,6 +334,7 @@ describe("Pluralize consistency", () => {
 
             input super_userMy_friendUpdateConnectionInput {
               node: super_friendUpdateInput
+              where: super_userMy_friendConnectionWhere
             }
 
             input super_userMy_friendUpdateFieldInput {
@@ -342,7 +343,7 @@ describe("Pluralize consistency", () => {
               delete: [super_userMy_friendDeleteFieldInput!]
               disconnect: [super_userMy_friendDisconnectFieldInput!]
               update: super_userMy_friendUpdateConnectionInput
-              where: super_userMy_friendConnectionWhere
+              where: super_userMy_friendConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"super_userMy_friendUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input super_userOptions {

--- a/packages/graphql/tests/schema/query-direction.test.ts
+++ b/packages/graphql/tests/schema/query-direction.test.ts
@@ -251,6 +251,7 @@ describe("Query Direction", () => {
 
             input UserFriendsUpdateConnectionInput {
               node: UserUpdateInput
+              where: UserFriendsConnectionWhere
             }
 
             input UserFriendsUpdateFieldInput {
@@ -259,7 +260,7 @@ describe("Query Direction", () => {
               delete: [UserFriendsDeleteFieldInput!]
               disconnect: [UserFriendsDisconnectFieldInput!]
               update: UserFriendsUpdateConnectionInput
-              where: UserFriendsConnectionWhere
+              where: UserFriendsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"UserFriendsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input UserOptions {
@@ -572,6 +573,7 @@ describe("Query Direction", () => {
 
             input UserFriendsUpdateConnectionInput {
               node: UserUpdateInput
+              where: UserFriendsConnectionWhere
             }
 
             input UserFriendsUpdateFieldInput {
@@ -580,7 +582,7 @@ describe("Query Direction", () => {
               delete: [UserFriendsDeleteFieldInput!]
               disconnect: [UserFriendsDisconnectFieldInput!]
               update: UserFriendsUpdateConnectionInput
-              where: UserFriendsConnectionWhere
+              where: UserFriendsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"UserFriendsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input UserOptions {

--- a/packages/graphql/tests/schema/remove-deprecated/aggregate-operations.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/aggregate-operations.test.ts
@@ -330,6 +330,7 @@ describe("Aggregate operations", () => {
             input PostLikesUpdateConnectionInput {
               edge: LikesUpdateInput
               node: UserUpdateInput
+              where: PostLikesConnectionWhere
             }
 
             input PostLikesUpdateFieldInput {
@@ -338,7 +339,7 @@ describe("Aggregate operations", () => {
               delete: [PostLikesDeleteFieldInput!]
               disconnect: [PostLikesDisconnectFieldInput!]
               update: PostLikesUpdateConnectionInput
-              where: PostLikesConnectionWhere
+              where: PostLikesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"PostLikesUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input PostOptions {

--- a/packages/graphql/tests/schema/remove-deprecated/array-methods.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/array-methods.test.ts
@@ -200,6 +200,7 @@ describe("Arrays Methods", () => {
             input ActorActedInUpdateConnectionInput {
               edge: ActedInUpdateInput
               node: MovieUpdateInput
+              where: ActorActedInConnectionWhere
             }
 
             input ActorActedInUpdateFieldInput {
@@ -208,7 +209,7 @@ describe("Arrays Methods", () => {
               delete: [ActorActedInDeleteFieldInput!]
               disconnect: [ActorActedInDisconnectFieldInput!]
               update: ActorActedInUpdateConnectionInput
-              where: ActorActedInConnectionWhere
+              where: ActorActedInConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type ActorAggregate {
@@ -495,6 +496,7 @@ describe("Arrays Methods", () => {
             input MovieActorsUpdateConnectionInput {
               edge: ActedInUpdateInput
               node: ActorUpdateInput
+              where: MovieActorsConnectionWhere
             }
 
             input MovieActorsUpdateFieldInput {
@@ -503,7 +505,7 @@ describe("Arrays Methods", () => {
               delete: [MovieActorsDeleteFieldInput!]
               disconnect: [MovieActorsDisconnectFieldInput!]
               update: MovieActorsUpdateConnectionInput
-              where: MovieActorsConnectionWhere
+              where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type MovieAggregate {

--- a/packages/graphql/tests/schema/remove-deprecated/comments.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/comments.test.ts
@@ -539,6 +539,7 @@ describe("Comments", () => {
 
                 input MovieActorsUpdateConnectionInput {
                   node: ActorUpdateInput
+                  where: MovieActorsConnectionWhere
                 }
 
                 input MovieActorsUpdateFieldInput {
@@ -547,7 +548,7 @@ describe("Comments", () => {
                   delete: [MovieActorsDeleteFieldInput!]
                   disconnect: [MovieActorsDisconnectFieldInput!]
                   update: MovieActorsUpdateConnectionInput
-                  where: MovieActorsConnectionWhere
+                  where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieAggregate {
@@ -899,6 +900,7 @@ describe("Comments", () => {
                 input ActorActedInUpdateConnectionInput {
                   edge: ActedInUpdateInput
                   node: ProductionUpdateInput
+                  where: ActorActedInConnectionWhere
                 }
 
                 input ActorActedInUpdateFieldInput {
@@ -907,7 +909,7 @@ describe("Comments", () => {
                   delete: [ActorActedInDeleteFieldInput!]
                   disconnect: [ActorActedInDisconnectFieldInput!]
                   update: ActorActedInUpdateConnectionInput
-                  where: ActorActedInConnectionWhere
+                  where: ActorActedInConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type ActorAggregate {
@@ -1639,6 +1641,7 @@ describe("Comments", () => {
 
                 input MovieSearchGenreUpdateConnectionInput {
                   node: GenreUpdateInput
+                  where: MovieSearchGenreConnectionWhere
                 }
 
                 input MovieSearchGenreUpdateFieldInput {
@@ -1647,7 +1650,7 @@ describe("Comments", () => {
                   delete: [MovieSearchGenreDeleteFieldInput!]
                   disconnect: [MovieSearchGenreDisconnectFieldInput!]
                   update: MovieSearchGenreUpdateConnectionInput
-                  where: MovieSearchGenreConnectionWhere
+                  where: MovieSearchGenreConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieSearchUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 input MovieSearchMovieConnectFieldInput {
@@ -1683,6 +1686,7 @@ describe("Comments", () => {
 
                 input MovieSearchMovieUpdateConnectionInput {
                   node: MovieUpdateInput
+                  where: MovieSearchMovieConnectionWhere
                 }
 
                 input MovieSearchMovieUpdateFieldInput {
@@ -1691,7 +1695,7 @@ describe("Comments", () => {
                   delete: [MovieSearchMovieDeleteFieldInput!]
                   disconnect: [MovieSearchMovieDisconnectFieldInput!]
                   update: MovieSearchMovieUpdateConnectionInput
-                  where: MovieSearchMovieConnectionWhere
+                  where: MovieSearchMovieConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieSearchUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieSearchRelationship {

--- a/packages/graphql/tests/schema/remove-deprecated/comments.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/comments.test.ts
@@ -1650,7 +1650,7 @@ describe("Comments", () => {
                   delete: [MovieSearchGenreDeleteFieldInput!]
                   disconnect: [MovieSearchGenreDisconnectFieldInput!]
                   update: MovieSearchGenreUpdateConnectionInput
-                  where: MovieSearchGenreConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieSearchUpdateConnectionInput\\\\\\" instead\\")
+                  where: MovieSearchGenreConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieSearchGenreUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 input MovieSearchMovieConnectFieldInput {
@@ -1695,7 +1695,7 @@ describe("Comments", () => {
                   delete: [MovieSearchMovieDeleteFieldInput!]
                   disconnect: [MovieSearchMovieDisconnectFieldInput!]
                   update: MovieSearchMovieUpdateConnectionInput
-                  where: MovieSearchMovieConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieSearchUpdateConnectionInput\\\\\\" instead\\")
+                  where: MovieSearchMovieConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieSearchMovieUpdateConnectionInput\\\\\\" instead\\")
                 }
 
                 type MovieSearchRelationship {

--- a/packages/graphql/tests/schema/remove-deprecated/connect-or-create.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/connect-or-create.test.ts
@@ -196,6 +196,7 @@ describe("Connect Or Create", () => {
 
             input ActorMoviesUpdateConnectionInput {
               node: MovieUpdateInput
+              where: ActorMoviesConnectionWhere
             }
 
             input ActorMoviesUpdateFieldInput {
@@ -204,7 +205,7 @@ describe("Connect Or Create", () => {
               delete: [ActorMoviesDeleteFieldInput!]
               disconnect: [ActorMoviesDisconnectFieldInput!]
               update: ActorMoviesUpdateConnectionInput
-              where: ActorMoviesConnectionWhere
+              where: ActorMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorMoviesUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input ActorOptions {

--- a/packages/graphql/tests/schema/remove-deprecated/directed-argument.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/directed-argument.test.ts
@@ -321,6 +321,7 @@ describe("Deprecated directed argument", () => {
             input ActorMoviesUpdateConnectionInput {
               edge: ActedInUpdateInput
               node: MovieUpdateInput
+              where: ActorMoviesConnectionWhere
             }
 
             input ActorMoviesUpdateFieldInput {
@@ -329,7 +330,7 @@ describe("Deprecated directed argument", () => {
               delete: [ActorMoviesDeleteFieldInput!]
               disconnect: [ActorMoviesDisconnectFieldInput!]
               update: ActorMoviesUpdateConnectionInput
-              where: ActorMoviesConnectionWhere
+              where: ActorMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorMoviesUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input ActorOptions {
@@ -641,6 +642,7 @@ describe("Deprecated directed argument", () => {
             input MovieActorsUpdateConnectionInput {
               edge: ActedInUpdateInput
               node: ActorUpdateInput
+              where: MovieActorsConnectionWhere
             }
 
             input MovieActorsUpdateFieldInput {
@@ -649,7 +651,7 @@ describe("Deprecated directed argument", () => {
               delete: [MovieActorsDeleteFieldInput!]
               disconnect: [MovieActorsDisconnectFieldInput!]
               update: MovieActorsUpdateConnectionInput
-              where: MovieActorsConnectionWhere
+              where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type MovieAggregate {

--- a/packages/graphql/tests/schema/remove-deprecated/id-aggregations.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/id-aggregations.test.ts
@@ -297,6 +297,7 @@ describe("Aggregations id", () => {
             input PostLikesUpdateConnectionInput {
               edge: LikesUpdateInput
               node: UserUpdateInput
+              where: PostLikesConnectionWhere
             }
 
             input PostLikesUpdateFieldInput {
@@ -305,7 +306,7 @@ describe("Aggregations id", () => {
               delete: [PostLikesDeleteFieldInput!]
               disconnect: [PostLikesDisconnectFieldInput!]
               update: PostLikesUpdateConnectionInput
-              where: PostLikesConnectionWhere
+              where: PostLikesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"PostLikesUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input PostOptions {

--- a/packages/graphql/tests/schema/remove-deprecated/implicit-equality.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/implicit-equality.test.ts
@@ -265,6 +265,7 @@ describe("Implicit Equality filters", () => {
             input ActorMoviesUpdateConnectionInput {
               edge: ActedInUpdateInput
               node: MovieUpdateInput
+              where: ActorMoviesConnectionWhere
             }
 
             input ActorMoviesUpdateFieldInput {
@@ -273,7 +274,7 @@ describe("Implicit Equality filters", () => {
               delete: [ActorMoviesDeleteFieldInput!]
               disconnect: [ActorMoviesDisconnectFieldInput!]
               update: ActorMoviesUpdateConnectionInput
-              where: ActorMoviesConnectionWhere
+              where: ActorMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorMoviesUpdateConnectionInput\\\\\\" instead\\")
             }
 
             \\"\\"\\"
@@ -494,6 +495,7 @@ describe("Implicit Equality filters", () => {
             input MovieActorsUpdateConnectionInput {
               edge: ActedInUpdateInput
               node: ActorUpdateInput
+              where: MovieActorsConnectionWhere
             }
 
             input MovieActorsUpdateFieldInput {
@@ -502,7 +504,7 @@ describe("Implicit Equality filters", () => {
               delete: [MovieActorsDeleteFieldInput!]
               disconnect: [MovieActorsDisconnectFieldInput!]
               update: MovieActorsUpdateConnectionInput
-              where: MovieActorsConnectionWhere
+              where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type MovieAggregate {

--- a/packages/graphql/tests/schema/remove-deprecated/implicit-set.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/implicit-set.test.ts
@@ -264,6 +264,7 @@ describe("Implicit SET field", () => {
             input ActorMoviesUpdateConnectionInput {
               edge: ActedInUpdateInput
               node: MovieUpdateInput
+              where: ActorMoviesConnectionWhere
             }
 
             input ActorMoviesUpdateFieldInput {
@@ -272,7 +273,7 @@ describe("Implicit SET field", () => {
               delete: [ActorMoviesDeleteFieldInput!]
               disconnect: [ActorMoviesDisconnectFieldInput!]
               update: ActorMoviesUpdateConnectionInput
-              where: ActorMoviesConnectionWhere
+              where: ActorMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorMoviesUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input ActorOptions {
@@ -501,6 +502,7 @@ describe("Implicit SET field", () => {
             input MovieActorsUpdateConnectionInput {
               edge: ActedInUpdateInput
               node: ActorUpdateInput
+              where: MovieActorsConnectionWhere
             }
 
             input MovieActorsUpdateFieldInput {
@@ -509,7 +511,7 @@ describe("Implicit SET field", () => {
               delete: [MovieActorsDeleteFieldInput!]
               disconnect: [MovieActorsDisconnectFieldInput!]
               update: MovieActorsUpdateConnectionInput
-              where: MovieActorsConnectionWhere
+              where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type MovieAggregate {

--- a/packages/graphql/tests/schema/remove-deprecated/non-nested-update-where.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/non-nested-update-where.test.ts
@@ -22,19 +22,42 @@ import { gql } from "graphql-tag";
 import { lexicographicSortSchema } from "graphql/utilities";
 import { Neo4jGraphQL } from "../../../src";
 
-describe("Relationship", () => {
-    test("Single Relationship", async () => {
+describe("Deprecated options argument", () => {
+    test("should remove the options argument", async () => {
         const typeDefs = gql`
             type Actor @node {
-                name: String
+                name: String!
+                movies: [Movie!]! @relationship(type: "ACTED_IN", direction: OUT, properties: "ActedIn")
             }
 
-            type Movie @node {
+            type Movie implements Production @node {
+                title: String!
+                actors: [Actor!]! @relationship(type: "ACTED_IN", direction: IN, properties: "ActedIn")
+            }
+
+            type ActedIn @relationshipProperties {
+                screenTime: Int!
+                startDate: Date!
+                leadRole: Boolean!
+            }
+            union Search = Movie | Genre
+
+            type Genre @node {
                 id: ID
-                actors: [Actor!]! @relationship(type: "ACTED_IN", direction: IN)
+            }
+
+            interface Production {
+                title: String!
             }
         `;
-        const neoSchema = new Neo4jGraphQL({ typeDefs });
+        const neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            features: {
+                excludeDeprecatedFields: {
+                    nonNestedUpdateWhere: true,
+                },
+            },
+        });
         const printedSchema = printSchemaWithDirectives(lexicographicSortSchema(await neoSchema.getSchema()));
 
         expect(printedSchema).toMatchInlineSnapshot(`
@@ -43,415 +66,93 @@ describe("Relationship", () => {
               mutation: Mutation
             }
 
-            type Actor {
-              name: String
-            }
-
-            type ActorAggregate {
-              count: Count!
-              node: ActorAggregateNode!
-            }
-
-            type ActorAggregateNode {
-              name: StringAggregateSelection!
-            }
-
-            type ActorAggregateSelection {
-              count: Int!
-              name: StringAggregateSelection!
-            }
-
-            input ActorConnectWhere {
-              node: ActorWhere!
-            }
-
-            input ActorCreateInput {
-              name: String
-            }
-
-            type ActorEdge {
-              cursor: String!
-              node: Actor!
-            }
-
-            input ActorOptions {
-              limit: Int
-              offset: Int
-              \\"\\"\\"
-              Specify one or more ActorSort objects to sort Actors by. The sorts will be applied in the order in which they are arranged in the array.
-              \\"\\"\\"
-              sort: [ActorSort!]
-            }
-
             \\"\\"\\"
-            Fields to sort Actors by. The order in which sorts are applied is not guaranteed when specifying many fields in one ActorSort object.
+            The edge properties for the following fields:
+            * Actor.movies
+            * Movie.actors
             \\"\\"\\"
-            input ActorSort {
-              name: SortDirection
+            type ActedIn {
+              leadRole: Boolean!
+              screenTime: Int!
+              startDate: Date!
             }
 
-            input ActorUpdateInput {
-              name: String @deprecated(reason: \\"Please use the explicit _SET field\\")
-              name_SET: String
+            input ActedInAggregationWhereInput {
+              AND: [ActedInAggregationWhereInput!]
+              NOT: ActedInAggregationWhereInput
+              OR: [ActedInAggregationWhereInput!]
+              screenTime_AVERAGE_EQUAL: Float
+              screenTime_AVERAGE_GT: Float
+              screenTime_AVERAGE_GTE: Float
+              screenTime_AVERAGE_LT: Float
+              screenTime_AVERAGE_LTE: Float
+              screenTime_MAX_EQUAL: Int
+              screenTime_MAX_GT: Int
+              screenTime_MAX_GTE: Int
+              screenTime_MAX_LT: Int
+              screenTime_MAX_LTE: Int
+              screenTime_MIN_EQUAL: Int
+              screenTime_MIN_GT: Int
+              screenTime_MIN_GTE: Int
+              screenTime_MIN_LT: Int
+              screenTime_MIN_LTE: Int
+              screenTime_SUM_EQUAL: Int
+              screenTime_SUM_GT: Int
+              screenTime_SUM_GTE: Int
+              screenTime_SUM_LT: Int
+              screenTime_SUM_LTE: Int
             }
 
-            input ActorWhere {
-              AND: [ActorWhere!]
-              NOT: ActorWhere
-              OR: [ActorWhere!]
-              name: String @deprecated(reason: \\"Please use the explicit _EQ version\\")
-              name_CONTAINS: String
-              name_ENDS_WITH: String
-              name_EQ: String
-              name_IN: [String]
-              name_STARTS_WITH: String
+            input ActedInCreateInput {
+              leadRole: Boolean!
+              screenTime: Int!
+              startDate: Date!
             }
 
-            type ActorsConnection {
-              aggregate: ActorAggregate!
-              edges: [ActorEdge!]!
-              pageInfo: PageInfo!
-              totalCount: Int!
+            input ActedInSort {
+              leadRole: SortDirection
+              screenTime: SortDirection
+              startDate: SortDirection
             }
 
-            type Count {
-              nodes: Int!
+            input ActedInUpdateInput {
+              leadRole: Boolean @deprecated(reason: \\"Please use the explicit _SET field\\")
+              leadRole_SET: Boolean
+              screenTime: Int @deprecated(reason: \\"Please use the explicit _SET field\\")
+              screenTime_DECREMENT: Int
+              screenTime_INCREMENT: Int
+              screenTime_SET: Int
+              startDate: Date @deprecated(reason: \\"Please use the explicit _SET field\\")
+              startDate_SET: Date
             }
 
-            type CountConnection {
-              edges: Int!
-              nodes: Int!
-            }
-
-            type CreateActorsMutationResponse {
-              actors: [Actor!]!
-              info: CreateInfo!
-            }
-
-            \\"\\"\\"
-            Information about the number of nodes and relationships created during a create mutation
-            \\"\\"\\"
-            type CreateInfo {
-              nodesCreated: Int!
-              relationshipsCreated: Int!
-            }
-
-            type CreateMoviesMutationResponse {
-              info: CreateInfo!
-              movies: [Movie!]!
-            }
-
-            \\"\\"\\"
-            Information about the number of nodes and relationships deleted during a delete mutation
-            \\"\\"\\"
-            type DeleteInfo {
-              nodesDeleted: Int!
-              relationshipsDeleted: Int!
-            }
-
-            type IDAggregateSelection {
-              longest: ID
-              shortest: ID
-            }
-
-            type Movie {
-              actors(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-              actorsAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: ActorWhere): MovieActorActorsAggregationSelection @deprecated(reason: \\"Please use field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\" instead\\")
-              actorsConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [MovieActorsConnectionSort!], where: MovieActorsConnectionWhere): MovieActorsConnection!
-              id: ID
-            }
-
-            type MovieActorActorsAggregateSelection {
-              count: CountConnection!
-              node: MovieActorActorsNodeAggregateSelection
-            }
-
-            type MovieActorActorsAggregationSelection {
-              count: Int!
-              node: MovieActorActorsNodeAggregateSelection
-            }
-
-            type MovieActorActorsNodeAggregateSelection {
-              name: StringAggregateSelection!
-            }
-
-            input MovieActorsAggregateInput {
-              AND: [MovieActorsAggregateInput!]
-              NOT: MovieActorsAggregateInput
-              OR: [MovieActorsAggregateInput!]
-              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
-              count_EQ: Int
-              count_GT: Int
-              count_GTE: Int
-              count_LT: Int
-              count_LTE: Int
-              node: MovieActorsNodeAggregationWhereInput
-            }
-
-            input MovieActorsConnectFieldInput {
-              \\"\\"\\"
-              Whether or not to overwrite any matching relationship with the new properties.
-              \\"\\"\\"
-              overwrite: Boolean! = true @deprecated(reason: \\"The overwrite argument is deprecated and will be removed\\")
-              where: ActorConnectWhere
-            }
-
-            type MovieActorsConnection {
-              aggregate: MovieActorActorsAggregateSelection!
-              edges: [MovieActorsRelationship!]!
-              pageInfo: PageInfo!
-              totalCount: Int!
-            }
-
-            input MovieActorsConnectionSort {
-              node: ActorSort
-            }
-
-            input MovieActorsConnectionWhere {
-              AND: [MovieActorsConnectionWhere!]
-              NOT: MovieActorsConnectionWhere
-              OR: [MovieActorsConnectionWhere!]
-              node: ActorWhere
-            }
-
-            input MovieActorsCreateFieldInput {
-              node: ActorCreateInput!
-            }
-
-            input MovieActorsDeleteFieldInput {
-              where: MovieActorsConnectionWhere
-            }
-
-            input MovieActorsDisconnectFieldInput {
-              where: MovieActorsConnectionWhere
-            }
-
-            input MovieActorsFieldInput {
-              connect: [MovieActorsConnectFieldInput!]
-              create: [MovieActorsCreateFieldInput!]
-            }
-
-            input MovieActorsNodeAggregationWhereInput {
-              AND: [MovieActorsNodeAggregationWhereInput!]
-              NOT: MovieActorsNodeAggregationWhereInput
-              OR: [MovieActorsNodeAggregationWhereInput!]
-              name_AVERAGE_LENGTH_EQUAL: Float
-              name_AVERAGE_LENGTH_GT: Float
-              name_AVERAGE_LENGTH_GTE: Float
-              name_AVERAGE_LENGTH_LT: Float
-              name_AVERAGE_LENGTH_LTE: Float
-              name_LONGEST_LENGTH_EQUAL: Int
-              name_LONGEST_LENGTH_GT: Int
-              name_LONGEST_LENGTH_GTE: Int
-              name_LONGEST_LENGTH_LT: Int
-              name_LONGEST_LENGTH_LTE: Int
-              name_SHORTEST_LENGTH_EQUAL: Int
-              name_SHORTEST_LENGTH_GT: Int
-              name_SHORTEST_LENGTH_GTE: Int
-              name_SHORTEST_LENGTH_LT: Int
-              name_SHORTEST_LENGTH_LTE: Int
-            }
-
-            type MovieActorsRelationship {
-              cursor: String!
-              node: Actor!
-            }
-
-            input MovieActorsUpdateConnectionInput {
-              node: ActorUpdateInput
-              where: MovieActorsConnectionWhere
-            }
-
-            input MovieActorsUpdateFieldInput {
-              connect: [MovieActorsConnectFieldInput!]
-              create: [MovieActorsCreateFieldInput!]
-              delete: [MovieActorsDeleteFieldInput!]
-              disconnect: [MovieActorsDisconnectFieldInput!]
-              update: MovieActorsUpdateConnectionInput
-              where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
-            }
-
-            type MovieAggregate {
-              count: Count!
-              node: MovieAggregateNode!
-            }
-
-            type MovieAggregateNode {
-              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
-            }
-
-            type MovieAggregateSelection {
-              count: Int!
-              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
-            }
-
-            input MovieCreateInput {
-              actors: MovieActorsFieldInput
-              id: ID
-            }
-
-            input MovieDeleteInput {
-              actors: [MovieActorsDeleteFieldInput!]
-            }
-
-            type MovieEdge {
-              cursor: String!
-              node: Movie!
-            }
-
-            input MovieOptions {
-              limit: Int
-              offset: Int
-              \\"\\"\\"
-              Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array.
-              \\"\\"\\"
-              sort: [MovieSort!]
-            }
-
-            \\"\\"\\"
-            Fields to sort Movies by. The order in which sorts are applied is not guaranteed when specifying many fields in one MovieSort object.
-            \\"\\"\\"
-            input MovieSort {
-              id: SortDirection
-            }
-
-            input MovieUpdateInput {
-              actors: [MovieActorsUpdateFieldInput!]
-              id: ID @deprecated(reason: \\"Please use the explicit _SET field\\")
-              id_SET: ID
-            }
-
-            input MovieWhere {
-              AND: [MovieWhere!]
-              NOT: MovieWhere
-              OR: [MovieWhere!]
-              actorsAggregate: MovieActorsAggregateInput
-              \\"\\"\\"
-              Return Movies where all of the related MovieActorsConnections match this filter
-              \\"\\"\\"
-              actorsConnection_ALL: MovieActorsConnectionWhere
-              \\"\\"\\"
-              Return Movies where none of the related MovieActorsConnections match this filter
-              \\"\\"\\"
-              actorsConnection_NONE: MovieActorsConnectionWhere
-              \\"\\"\\"
-              Return Movies where one of the related MovieActorsConnections match this filter
-              \\"\\"\\"
-              actorsConnection_SINGLE: MovieActorsConnectionWhere
-              \\"\\"\\"
-              Return Movies where some of the related MovieActorsConnections match this filter
-              \\"\\"\\"
-              actorsConnection_SOME: MovieActorsConnectionWhere
-              \\"\\"\\"Return Movies where all of the related Actors match this filter\\"\\"\\"
-              actors_ALL: ActorWhere
-              \\"\\"\\"Return Movies where none of the related Actors match this filter\\"\\"\\"
-              actors_NONE: ActorWhere
-              \\"\\"\\"Return Movies where one of the related Actors match this filter\\"\\"\\"
-              actors_SINGLE: ActorWhere
-              \\"\\"\\"Return Movies where some of the related Actors match this filter\\"\\"\\"
-              actors_SOME: ActorWhere
-              id: ID @deprecated(reason: \\"Please use the explicit _EQ version\\")
-              id_CONTAINS: ID
-              id_ENDS_WITH: ID
-              id_EQ: ID
-              id_IN: [ID]
-              id_STARTS_WITH: ID
-            }
-
-            type MoviesConnection {
-              aggregate: MovieAggregate!
-              edges: [MovieEdge!]!
-              pageInfo: PageInfo!
-              totalCount: Int!
-            }
-
-            type Mutation {
-              createActors(input: [ActorCreateInput!]!): CreateActorsMutationResponse!
-              createMovies(input: [MovieCreateInput!]!): CreateMoviesMutationResponse!
-              deleteActors(where: ActorWhere): DeleteInfo!
-              deleteMovies(delete: MovieDeleteInput, where: MovieWhere): DeleteInfo!
-              updateActors(update: ActorUpdateInput, where: ActorWhere): UpdateActorsMutationResponse!
-              updateMovies(update: MovieUpdateInput, where: MovieWhere): UpdateMoviesMutationResponse!
-            }
-
-            \\"\\"\\"Pagination information (Relay)\\"\\"\\"
-            type PageInfo {
-              endCursor: String
-              hasNextPage: Boolean!
-              hasPreviousPage: Boolean!
-              startCursor: String
-            }
-
-            type Query {
-              actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
-              actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\" instead\\")
-              actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
-              movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
-              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\" instead\\")
-              moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
-            }
-
-            \\"\\"\\"An enum for sorting in either ascending or descending order.\\"\\"\\"
-            enum SortDirection {
-              \\"\\"\\"Sort by field values in ascending order.\\"\\"\\"
-              ASC
-              \\"\\"\\"Sort by field values in descending order.\\"\\"\\"
-              DESC
-            }
-
-            type StringAggregateSelection {
-              longest: String
-              shortest: String
-            }
-
-            type UpdateActorsMutationResponse {
-              actors: [Actor!]!
-              info: UpdateInfo!
-            }
-
-            \\"\\"\\"
-            Information about the number of nodes and relationships created and deleted during an update mutation
-            \\"\\"\\"
-            type UpdateInfo {
-              nodesCreated: Int!
-              nodesDeleted: Int!
-              relationshipsCreated: Int!
-              relationshipsDeleted: Int!
-            }
-
-            type UpdateMoviesMutationResponse {
-              info: UpdateInfo!
-              movies: [Movie!]!
-            }"
-        `);
-    });
-
-    test("Multi Relationship", async () => {
-        const typeDefs = gql`
-            type Actor @node {
-                name: String
-                movies: [Movie!]! @relationship(type: "ACTED_IN", direction: OUT)
-            }
-
-            type Movie @node {
-                id: ID
-                actors: [Actor!]! @relationship(type: "ACTED_IN", direction: IN)
-            }
-        `;
-        const neoSchema = new Neo4jGraphQL({ typeDefs });
-        const printedSchema = printSchemaWithDirectives(lexicographicSortSchema(await neoSchema.getSchema()));
-
-        expect(printedSchema).toMatchInlineSnapshot(`
-            "schema {
-              query: Query
-              mutation: Mutation
+            input ActedInWhere {
+              AND: [ActedInWhere!]
+              NOT: ActedInWhere
+              OR: [ActedInWhere!]
+              leadRole: Boolean @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              leadRole_EQ: Boolean
+              screenTime: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              screenTime_EQ: Int
+              screenTime_GT: Int
+              screenTime_GTE: Int
+              screenTime_IN: [Int!]
+              screenTime_LT: Int
+              screenTime_LTE: Int
+              startDate: Date @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              startDate_EQ: Date
+              startDate_GT: Date
+              startDate_GTE: Date
+              startDate_IN: [Date!]
+              startDate_LT: Date
+              startDate_LTE: Date
             }
 
             type Actor {
               movies(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
               moviesAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: MovieWhere): ActorMovieMoviesAggregationSelection @deprecated(reason: \\"Please use field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\" instead\\")
               moviesConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [ActorMoviesConnectionSort!], where: ActorMoviesConnectionWhere): ActorMoviesConnection!
-              name: String
+              name: String!
             }
 
             type ActorAggregate {
@@ -478,7 +179,7 @@ describe("Relationship", () => {
 
             input ActorCreateInput {
               movies: ActorMoviesFieldInput
-              name: String
+              name: String!
             }
 
             input ActorDeleteInput {
@@ -496,16 +197,22 @@ describe("Relationship", () => {
 
             type ActorMovieMoviesAggregateSelection {
               count: CountConnection!
+              edge: ActorMovieMoviesEdgeAggregateSelection
               node: ActorMovieMoviesNodeAggregateSelection
             }
 
             type ActorMovieMoviesAggregationSelection {
               count: Int!
+              edge: ActorMovieMoviesEdgeAggregateSelection
               node: ActorMovieMoviesNodeAggregateSelection
             }
 
+            type ActorMovieMoviesEdgeAggregateSelection {
+              screenTime: IntAggregateSelection!
+            }
+
             type ActorMovieMoviesNodeAggregateSelection {
-              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              title: StringAggregateSelection!
             }
 
             input ActorMoviesAggregateInput {
@@ -518,11 +225,13 @@ describe("Relationship", () => {
               count_GTE: Int
               count_LT: Int
               count_LTE: Int
+              edge: ActedInAggregationWhereInput
               node: ActorMoviesNodeAggregationWhereInput
             }
 
             input ActorMoviesConnectFieldInput {
               connect: [MovieConnectInput!]
+              edge: ActedInCreateInput!
               \\"\\"\\"
               Whether or not to overwrite any matching relationship with the new properties.
               \\"\\"\\"
@@ -538,6 +247,7 @@ describe("Relationship", () => {
             }
 
             input ActorMoviesConnectionSort {
+              edge: ActedInSort
               node: MovieSort
             }
 
@@ -545,10 +255,12 @@ describe("Relationship", () => {
               AND: [ActorMoviesConnectionWhere!]
               NOT: ActorMoviesConnectionWhere
               OR: [ActorMoviesConnectionWhere!]
+              edge: ActedInWhere
               node: MovieWhere
             }
 
             input ActorMoviesCreateFieldInput {
+              edge: ActedInCreateInput!
               node: MovieCreateInput!
             }
 
@@ -571,24 +283,31 @@ describe("Relationship", () => {
               AND: [ActorMoviesNodeAggregationWhereInput!]
               NOT: ActorMoviesNodeAggregationWhereInput
               OR: [ActorMoviesNodeAggregationWhereInput!]
-              id_MAX_EQUAL: ID @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
-              id_MAX_GT: ID @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
-              id_MAX_GTE: ID @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
-              id_MAX_LT: ID @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
-              id_MAX_LTE: ID @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
-              id_MIN_EQUAL: ID @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
-              id_MIN_GT: ID @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
-              id_MIN_GTE: ID @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
-              id_MIN_LT: ID @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
-              id_MIN_LTE: ID @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              title_AVERAGE_LENGTH_EQUAL: Float
+              title_AVERAGE_LENGTH_GT: Float
+              title_AVERAGE_LENGTH_GTE: Float
+              title_AVERAGE_LENGTH_LT: Float
+              title_AVERAGE_LENGTH_LTE: Float
+              title_LONGEST_LENGTH_EQUAL: Int
+              title_LONGEST_LENGTH_GT: Int
+              title_LONGEST_LENGTH_GTE: Int
+              title_LONGEST_LENGTH_LT: Int
+              title_LONGEST_LENGTH_LTE: Int
+              title_SHORTEST_LENGTH_EQUAL: Int
+              title_SHORTEST_LENGTH_GT: Int
+              title_SHORTEST_LENGTH_GTE: Int
+              title_SHORTEST_LENGTH_LT: Int
+              title_SHORTEST_LENGTH_LTE: Int
             }
 
             type ActorMoviesRelationship {
               cursor: String!
               node: Movie!
+              properties: ActedIn!
             }
 
             input ActorMoviesUpdateConnectionInput {
+              edge: ActedInUpdateInput
               node: MovieUpdateInput
               where: ActorMoviesConnectionWhere
             }
@@ -599,7 +318,6 @@ describe("Relationship", () => {
               delete: [ActorMoviesDeleteFieldInput!]
               disconnect: [ActorMoviesDisconnectFieldInput!]
               update: ActorMoviesUpdateConnectionInput
-              where: ActorMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorMoviesUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input ActorOptions {
@@ -657,7 +375,7 @@ describe("Relationship", () => {
               name_CONTAINS: String
               name_ENDS_WITH: String
               name_EQ: String
-              name_IN: [String]
+              name_IN: [String!]
               name_STARTS_WITH: String
             }
 
@@ -682,6 +400,11 @@ describe("Relationship", () => {
               info: CreateInfo!
             }
 
+            type CreateGenresMutationResponse {
+              genres: [Genre!]!
+              info: CreateInfo!
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships created during a create mutation
             \\"\\"\\"
@@ -695,6 +418,9 @@ describe("Relationship", () => {
               movies: [Movie!]!
             }
 
+            \\"\\"\\"A date, represented as a 'yyyy-mm-dd' string\\"\\"\\"
+            scalar Date
+
             \\"\\"\\"
             Information about the number of nodes and relationships deleted during a delete mutation
             \\"\\"\\"
@@ -703,26 +429,106 @@ describe("Relationship", () => {
               relationshipsDeleted: Int!
             }
 
+            type Genre {
+              id: ID
+            }
+
+            type GenreAggregate {
+              count: Count!
+              node: GenreAggregateNode!
+            }
+
+            type GenreAggregateNode {
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+            }
+
+            type GenreAggregateSelection {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+            }
+
+            input GenreCreateInput {
+              id: ID
+            }
+
+            type GenreEdge {
+              cursor: String!
+              node: Genre!
+            }
+
+            input GenreOptions {
+              limit: Int
+              offset: Int
+              \\"\\"\\"
+              Specify one or more GenreSort objects to sort Genres by. The sorts will be applied in the order in which they are arranged in the array.
+              \\"\\"\\"
+              sort: [GenreSort!]
+            }
+
+            \\"\\"\\"
+            Fields to sort Genres by. The order in which sorts are applied is not guaranteed when specifying many fields in one GenreSort object.
+            \\"\\"\\"
+            input GenreSort {
+              id: SortDirection
+            }
+
+            input GenreUpdateInput {
+              id: ID @deprecated(reason: \\"Please use the explicit _SET field\\")
+              id_SET: ID
+            }
+
+            input GenreWhere {
+              AND: [GenreWhere!]
+              NOT: GenreWhere
+              OR: [GenreWhere!]
+              id: ID @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              id_CONTAINS: ID
+              id_ENDS_WITH: ID
+              id_EQ: ID
+              id_IN: [ID]
+              id_STARTS_WITH: ID
+            }
+
+            type GenresConnection {
+              aggregate: GenreAggregate!
+              edges: [GenreEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
             type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
 
-            type Movie {
+            type IntAggregateSelection {
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
+            }
+
+            type Movie implements Production {
               actors(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
               actorsAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: ActorWhere): MovieActorActorsAggregationSelection @deprecated(reason: \\"Please use field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\" instead\\")
               actorsConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [MovieActorsConnectionSort!], where: MovieActorsConnectionWhere): MovieActorsConnection!
-              id: ID
+              title: String!
             }
 
             type MovieActorActorsAggregateSelection {
               count: CountConnection!
+              edge: MovieActorActorsEdgeAggregateSelection
               node: MovieActorActorsNodeAggregateSelection
             }
 
             type MovieActorActorsAggregationSelection {
               count: Int!
+              edge: MovieActorActorsEdgeAggregateSelection
               node: MovieActorActorsNodeAggregateSelection
+            }
+
+            type MovieActorActorsEdgeAggregateSelection {
+              screenTime: IntAggregateSelection!
             }
 
             type MovieActorActorsNodeAggregateSelection {
@@ -739,11 +545,13 @@ describe("Relationship", () => {
               count_GTE: Int
               count_LT: Int
               count_LTE: Int
+              edge: ActedInAggregationWhereInput
               node: MovieActorsNodeAggregationWhereInput
             }
 
             input MovieActorsConnectFieldInput {
               connect: [ActorConnectInput!]
+              edge: ActedInCreateInput!
               \\"\\"\\"
               Whether or not to overwrite any matching relationship with the new properties.
               \\"\\"\\"
@@ -759,6 +567,7 @@ describe("Relationship", () => {
             }
 
             input MovieActorsConnectionSort {
+              edge: ActedInSort
               node: ActorSort
             }
 
@@ -766,10 +575,12 @@ describe("Relationship", () => {
               AND: [MovieActorsConnectionWhere!]
               NOT: MovieActorsConnectionWhere
               OR: [MovieActorsConnectionWhere!]
+              edge: ActedInWhere
               node: ActorWhere
             }
 
             input MovieActorsCreateFieldInput {
+              edge: ActedInCreateInput!
               node: ActorCreateInput!
             }
 
@@ -812,9 +623,11 @@ describe("Relationship", () => {
             type MovieActorsRelationship {
               cursor: String!
               node: Actor!
+              properties: ActedIn!
             }
 
             input MovieActorsUpdateConnectionInput {
+              edge: ActedInUpdateInput
               node: ActorUpdateInput
               where: MovieActorsConnectionWhere
             }
@@ -825,7 +638,6 @@ describe("Relationship", () => {
               delete: [MovieActorsDeleteFieldInput!]
               disconnect: [MovieActorsDisconnectFieldInput!]
               update: MovieActorsUpdateConnectionInput
-              where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type MovieAggregate {
@@ -834,12 +646,12 @@ describe("Relationship", () => {
             }
 
             type MovieAggregateNode {
-              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              title: StringAggregateSelection!
             }
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+              title: StringAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -852,7 +664,7 @@ describe("Relationship", () => {
 
             input MovieCreateInput {
               actors: MovieActorsFieldInput
-              id: ID
+              title: String!
             }
 
             input MovieDeleteInput {
@@ -881,13 +693,13 @@ describe("Relationship", () => {
             Fields to sort Movies by. The order in which sorts are applied is not guaranteed when specifying many fields in one MovieSort object.
             \\"\\"\\"
             input MovieSort {
-              id: SortDirection
+              title: SortDirection
             }
 
             input MovieUpdateInput {
               actors: [MovieActorsUpdateFieldInput!]
-              id: ID @deprecated(reason: \\"Please use the explicit _SET field\\")
-              id_SET: ID
+              title: String @deprecated(reason: \\"Please use the explicit _SET field\\")
+              title_SET: String
             }
 
             input MovieWhere {
@@ -919,12 +731,12 @@ describe("Relationship", () => {
               actors_SINGLE: ActorWhere
               \\"\\"\\"Return Movies where some of the related Actors match this filter\\"\\"\\"
               actors_SOME: ActorWhere
-              id: ID @deprecated(reason: \\"Please use the explicit _EQ version\\")
-              id_CONTAINS: ID
-              id_ENDS_WITH: ID
-              id_EQ: ID
-              id_IN: [ID]
-              id_STARTS_WITH: ID
+              title: String @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              title_CONTAINS: String
+              title_ENDS_WITH: String
+              title_EQ: String
+              title_IN: [String!]
+              title_STARTS_WITH: String
             }
 
             type MoviesConnection {
@@ -936,10 +748,13 @@ describe("Relationship", () => {
 
             type Mutation {
               createActors(input: [ActorCreateInput!]!): CreateActorsMutationResponse!
+              createGenres(input: [GenreCreateInput!]!): CreateGenresMutationResponse!
               createMovies(input: [MovieCreateInput!]!): CreateMoviesMutationResponse!
               deleteActors(delete: ActorDeleteInput, where: ActorWhere): DeleteInfo!
+              deleteGenres(where: GenreWhere): DeleteInfo!
               deleteMovies(delete: MovieDeleteInput, where: MovieWhere): DeleteInfo!
               updateActors(update: ActorUpdateInput, where: ActorWhere): UpdateActorsMutationResponse!
+              updateGenres(update: GenreUpdateInput, where: GenreWhere): UpdateGenresMutationResponse!
               updateMovies(update: MovieUpdateInput, where: MovieWhere): UpdateMoviesMutationResponse!
             }
 
@@ -951,13 +766,97 @@ describe("Relationship", () => {
               startCursor: String
             }
 
+            interface Production {
+              title: String!
+            }
+
+            type ProductionAggregate {
+              count: Count!
+              node: ProductionAggregateNode!
+            }
+
+            type ProductionAggregateNode {
+              title: StringAggregateSelection!
+            }
+
+            type ProductionAggregateSelection {
+              count: Int!
+              title: StringAggregateSelection!
+            }
+
+            type ProductionEdge {
+              cursor: String!
+              node: Production!
+            }
+
+            enum ProductionImplementation {
+              Movie
+            }
+
+            input ProductionOptions {
+              limit: Int
+              offset: Int
+              \\"\\"\\"
+              Specify one or more ProductionSort objects to sort Productions by. The sorts will be applied in the order in which they are arranged in the array.
+              \\"\\"\\"
+              sort: [ProductionSort!]
+            }
+
+            \\"\\"\\"
+            Fields to sort Productions by. The order in which sorts are applied is not guaranteed when specifying many fields in one ProductionSort object.
+            \\"\\"\\"
+            input ProductionSort {
+              title: SortDirection
+            }
+
+            input ProductionWhere {
+              AND: [ProductionWhere!]
+              NOT: ProductionWhere
+              OR: [ProductionWhere!]
+              title: String @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              title_CONTAINS: String
+              title_ENDS_WITH: String
+              title_EQ: String
+              title_IN: [String!]
+              title_STARTS_WITH: String
+              typename: [ProductionImplementation!]
+              typename_IN: [ProductionImplementation!] @deprecated(reason: \\"The typename_IN filter is deprecated, please use the typename filter instead\\")
+            }
+
+            type ProductionsConnection {
+              aggregate: ProductionAggregate!
+              edges: [ProductionEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
             type Query {
               actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
               actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\" instead\\")
               actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
+              genres(limit: Int, offset: Int, options: GenreOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [GenreSort!], where: GenreWhere): [Genre!]!
+              genresAggregate(where: GenreWhere): GenreAggregateSelection! @deprecated(reason: \\"Please use the explicit field \\\\\\"aggregate\\\\\\" inside \\\\\\"genresConnection\\\\\\" instead\\")
+              genresConnection(after: String, first: Int, sort: [GenreSort!], where: GenreWhere): GenresConnection!
               movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
               moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\" instead\\")
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
+              productions(limit: Int, offset: Int, options: ProductionOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ProductionSort!], where: ProductionWhere): [Production!]!
+              productionsAggregate(where: ProductionWhere): ProductionAggregateSelection! @deprecated(reason: \\"Please use the explicit field \\\\\\"aggregate\\\\\\" inside \\\\\\"productionsConnection\\\\\\" instead\\")
+              productionsConnection(after: String, first: Int, sort: [ProductionSort!], where: ProductionWhere): ProductionsConnection!
+              searches(limit: Int, offset: Int, options: QueryOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), where: SearchWhere): [Search!]!
+            }
+
+            \\"\\"\\"Input type for options that can be specified on a query operation.\\"\\"\\"
+            input QueryOptions {
+              limit: Int
+              offset: Int
+            }
+
+            union Search = Genre | Movie
+
+            input SearchWhere {
+              Genre: GenreWhere
+              Movie: MovieWhere
             }
 
             \\"\\"\\"An enum for sorting in either ascending or descending order.\\"\\"\\"
@@ -975,6 +874,11 @@ describe("Relationship", () => {
 
             type UpdateActorsMutationResponse {
               actors: [Actor!]!
+              info: UpdateInfo!
+            }
+
+            type UpdateGenresMutationResponse {
+              genres: [Genre!]!
               info: UpdateInfo!
             }
 

--- a/packages/graphql/tests/schema/remove-deprecated/options-argument.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/options-argument.test.ts
@@ -309,6 +309,7 @@ describe("Deprecated options argument", () => {
             input ActorMoviesUpdateConnectionInput {
               edge: ActedInUpdateInput
               node: MovieUpdateInput
+              where: ActorMoviesConnectionWhere
             }
 
             input ActorMoviesUpdateFieldInput {
@@ -317,7 +318,7 @@ describe("Deprecated options argument", () => {
               delete: [ActorMoviesDeleteFieldInput!]
               disconnect: [ActorMoviesDisconnectFieldInput!]
               update: ActorMoviesUpdateConnectionInput
-              where: ActorMoviesConnectionWhere
+              where: ActorMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorMoviesUpdateConnectionInput\\\\\\" instead\\")
             }
 
             \\"\\"\\"
@@ -611,6 +612,7 @@ describe("Deprecated options argument", () => {
             input MovieActorsUpdateConnectionInput {
               edge: ActedInUpdateInput
               node: ActorUpdateInput
+              where: MovieActorsConnectionWhere
             }
 
             input MovieActorsUpdateFieldInput {
@@ -619,7 +621,7 @@ describe("Deprecated options argument", () => {
               delete: [MovieActorsDeleteFieldInput!]
               disconnect: [MovieActorsDisconnectFieldInput!]
               update: MovieActorsUpdateConnectionInput
-              where: MovieActorsConnectionWhere
+              where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type MovieAggregate {

--- a/packages/graphql/tests/schema/remove-deprecated/query-direction.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/query-direction.test.ts
@@ -252,6 +252,7 @@ describe("Query Direction", () => {
 
             input UserFriendsUpdateConnectionInput {
               node: UserUpdateInput
+              where: UserFriendsConnectionWhere
             }
 
             input UserFriendsUpdateFieldInput {
@@ -260,7 +261,7 @@ describe("Query Direction", () => {
               delete: [UserFriendsDeleteFieldInput!]
               disconnect: [UserFriendsDisconnectFieldInput!]
               update: UserFriendsUpdateConnectionInput
-              where: UserFriendsConnectionWhere
+              where: UserFriendsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"UserFriendsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input UserOptions {
@@ -573,6 +574,7 @@ describe("Query Direction", () => {
 
             input UserFriendsUpdateConnectionInput {
               node: UserUpdateInput
+              where: UserFriendsConnectionWhere
             }
 
             input UserFriendsUpdateFieldInput {
@@ -581,7 +583,7 @@ describe("Query Direction", () => {
               delete: [UserFriendsDeleteFieldInput!]
               disconnect: [UserFriendsDisconnectFieldInput!]
               update: UserFriendsUpdateConnectionInput
-              where: UserFriendsConnectionWhere
+              where: UserFriendsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"UserFriendsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input UserOptions {
@@ -894,6 +896,7 @@ describe("Query Direction", () => {
 
             input UserFriendsUpdateConnectionInput {
               node: UserUpdateInput
+              where: UserFriendsConnectionWhere
             }
 
             input UserFriendsUpdateFieldInput {
@@ -902,7 +905,7 @@ describe("Query Direction", () => {
               delete: [UserFriendsDeleteFieldInput!]
               disconnect: [UserFriendsDisconnectFieldInput!]
               update: UserFriendsUpdateConnectionInput
-              where: UserFriendsConnectionWhere
+              where: UserFriendsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"UserFriendsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input UserOptions {

--- a/packages/graphql/tests/schema/string-comparators.test.ts
+++ b/packages/graphql/tests/schema/string-comparators.test.ts
@@ -723,6 +723,7 @@ describe("String Comparators", () => {
             input ActorActedInUpdateConnectionInput {
               edge: ActedInUpdateInput
               node: MovieUpdateInput
+              where: ActorActedInConnectionWhere
             }
 
             input ActorActedInUpdateFieldInput {
@@ -731,7 +732,7 @@ describe("String Comparators", () => {
               delete: [ActorActedInDeleteFieldInput!]
               disconnect: [ActorActedInDisconnectFieldInput!]
               update: ActorActedInUpdateConnectionInput
-              where: ActorActedInConnectionWhere
+              where: ActorActedInConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorActedInUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type ActorAggregate {
@@ -1020,6 +1021,7 @@ describe("String Comparators", () => {
             input MovieActorsUpdateConnectionInput {
               edge: ActedInUpdateInput
               node: ActorUpdateInput
+              where: MovieActorsConnectionWhere
             }
 
             input MovieActorsUpdateFieldInput {
@@ -1028,7 +1030,7 @@ describe("String Comparators", () => {
               delete: [MovieActorsDeleteFieldInput!]
               disconnect: [MovieActorsDisconnectFieldInput!]
               update: MovieActorsUpdateConnectionInput
-              where: MovieActorsConnectionWhere
+              where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type MovieAggregate {

--- a/packages/graphql/tests/schema/subscriptions.test.ts
+++ b/packages/graphql/tests/schema/subscriptions.test.ts
@@ -1487,7 +1487,7 @@ describe("Subscriptions", () => {
               delete: [MovieActorsPersonDeleteFieldInput!]
               disconnect: [MovieActorsPersonDisconnectFieldInput!]
               update: MovieActorsPersonUpdateConnectionInput
-              where: MovieActorsPersonConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
+              where: MovieActorsPersonConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsPersonUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type MovieActorsRelationship {
@@ -1537,7 +1537,7 @@ describe("Subscriptions", () => {
               delete: [MovieActorsStarDeleteFieldInput!]
               disconnect: [MovieActorsStarDisconnectFieldInput!]
               update: MovieActorsStarUpdateConnectionInput
-              where: MovieActorsStarConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
+              where: MovieActorsStarConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsStarUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input MovieActorsUpdateInput {
@@ -4297,7 +4297,7 @@ describe("Subscriptions", () => {
               delete: [MovieActorsPersonDeleteFieldInput!]
               disconnect: [MovieActorsPersonDisconnectFieldInput!]
               update: MovieActorsPersonUpdateConnectionInput
-              where: MovieActorsPersonConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
+              where: MovieActorsPersonConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsPersonUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type MovieActorsRelationship {
@@ -4347,7 +4347,7 @@ describe("Subscriptions", () => {
               delete: [MovieActorsStarDeleteFieldInput!]
               disconnect: [MovieActorsStarDisconnectFieldInput!]
               update: MovieActorsStarUpdateConnectionInput
-              where: MovieActorsStarConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
+              where: MovieActorsStarConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsStarUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input MovieActorsUpdateInput {

--- a/packages/graphql/tests/schema/subscriptions.test.ts
+++ b/packages/graphql/tests/schema/subscriptions.test.ts
@@ -329,6 +329,7 @@ describe("Subscriptions", () => {
 
             input MovieActorsUpdateConnectionInput {
               node: ActorUpdateInput
+              where: MovieActorsConnectionWhere
             }
 
             input MovieActorsUpdateFieldInput {
@@ -337,7 +338,7 @@ describe("Subscriptions", () => {
               delete: [MovieActorsDeleteFieldInput!]
               disconnect: [MovieActorsDisconnectFieldInput!]
               update: MovieActorsUpdateConnectionInput
-              where: MovieActorsConnectionWhere
+              where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type MovieAggregate {
@@ -814,6 +815,7 @@ describe("Subscriptions", () => {
 
             input ActorMoviesUpdateConnectionInput {
               node: MovieUpdateInput
+              where: ActorMoviesConnectionWhere
             }
 
             input ActorMoviesUpdateFieldInput {
@@ -822,7 +824,7 @@ describe("Subscriptions", () => {
               delete: [ActorMoviesDeleteFieldInput!]
               disconnect: [ActorMoviesDisconnectFieldInput!]
               update: ActorMoviesUpdateConnectionInput
-              where: ActorMoviesConnectionWhere
+              where: ActorMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorMoviesUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input ActorOptions {
@@ -1018,6 +1020,7 @@ describe("Subscriptions", () => {
 
             input MovieActorsUpdateConnectionInput {
               node: ActorUpdateInput
+              where: MovieActorsConnectionWhere
             }
 
             input MovieActorsUpdateFieldInput {
@@ -1026,7 +1029,7 @@ describe("Subscriptions", () => {
               delete: [MovieActorsDeleteFieldInput!]
               disconnect: [MovieActorsDisconnectFieldInput!]
               update: MovieActorsUpdateConnectionInput
-              where: MovieActorsConnectionWhere
+              where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type MovieAggregate {
@@ -1475,6 +1478,7 @@ describe("Subscriptions", () => {
 
             input MovieActorsPersonUpdateConnectionInput {
               node: PersonUpdateInput
+              where: MovieActorsPersonConnectionWhere
             }
 
             input MovieActorsPersonUpdateFieldInput {
@@ -1483,7 +1487,7 @@ describe("Subscriptions", () => {
               delete: [MovieActorsPersonDeleteFieldInput!]
               disconnect: [MovieActorsPersonDisconnectFieldInput!]
               update: MovieActorsPersonUpdateConnectionInput
-              where: MovieActorsPersonConnectionWhere
+              where: MovieActorsPersonConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type MovieActorsRelationship {
@@ -1524,6 +1528,7 @@ describe("Subscriptions", () => {
 
             input MovieActorsStarUpdateConnectionInput {
               node: StarUpdateInput
+              where: MovieActorsStarConnectionWhere
             }
 
             input MovieActorsStarUpdateFieldInput {
@@ -1532,7 +1537,7 @@ describe("Subscriptions", () => {
               delete: [MovieActorsStarDeleteFieldInput!]
               disconnect: [MovieActorsStarDisconnectFieldInput!]
               update: MovieActorsStarUpdateConnectionInput
-              where: MovieActorsStarConnectionWhere
+              where: MovieActorsStarConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input MovieActorsUpdateInput {
@@ -1951,6 +1956,7 @@ describe("Subscriptions", () => {
 
             input PersonMoviesUpdateConnectionInput {
               node: MovieUpdateInput
+              where: PersonMoviesConnectionWhere
             }
 
             input PersonMoviesUpdateFieldInput {
@@ -1959,7 +1965,7 @@ describe("Subscriptions", () => {
               delete: [PersonMoviesDeleteFieldInput!]
               disconnect: [PersonMoviesDisconnectFieldInput!]
               update: PersonMoviesUpdateConnectionInput
-              where: PersonMoviesConnectionWhere
+              where: PersonMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"PersonMoviesUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input PersonOptions {
@@ -2221,6 +2227,7 @@ describe("Subscriptions", () => {
 
             input StarMoviesUpdateConnectionInput {
               node: MovieUpdateInput
+              where: StarMoviesConnectionWhere
             }
 
             input StarMoviesUpdateFieldInput {
@@ -2229,7 +2236,7 @@ describe("Subscriptions", () => {
               delete: [StarMoviesDeleteFieldInput!]
               disconnect: [StarMoviesDisconnectFieldInput!]
               update: StarMoviesUpdateConnectionInput
-              where: StarMoviesConnectionWhere
+              where: StarMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"StarMoviesUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input StarOptions {
@@ -2607,6 +2614,7 @@ describe("Subscriptions", () => {
 
             input ActorMoviesUpdateConnectionInput {
               node: MovieUpdateInput
+              where: ActorMoviesConnectionWhere
             }
 
             input ActorMoviesUpdateFieldInput {
@@ -2615,7 +2623,7 @@ describe("Subscriptions", () => {
               delete: [ActorMoviesDeleteFieldInput!]
               disconnect: [ActorMoviesDisconnectFieldInput!]
               update: ActorMoviesUpdateConnectionInput
-              where: ActorMoviesConnectionWhere
+              where: ActorMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorMoviesUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input ActorOptions {
@@ -2827,6 +2835,7 @@ describe("Subscriptions", () => {
             input MovieActorsUpdateConnectionInput {
               edge: ActedInUpdateInput
               node: ActorUpdateInput
+              where: MovieActorsConnectionWhere
             }
 
             input MovieActorsUpdateFieldInput {
@@ -2835,7 +2844,7 @@ describe("Subscriptions", () => {
               delete: [MovieActorsDeleteFieldInput!]
               disconnect: [MovieActorsDisconnectFieldInput!]
               update: MovieActorsUpdateConnectionInput
-              where: MovieActorsConnectionWhere
+              where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type MovieAggregate {
@@ -3406,6 +3415,7 @@ describe("Subscriptions", () => {
 
             input MovieActorsUpdateConnectionInput {
               node: ActorUpdateInput
+              where: MovieActorsConnectionWhere
             }
 
             input MovieActorsUpdateFieldInput {
@@ -3414,7 +3424,7 @@ describe("Subscriptions", () => {
               delete: [MovieActorsDeleteFieldInput!]
               disconnect: [MovieActorsDisconnectFieldInput!]
               update: MovieActorsUpdateConnectionInput
-              where: MovieActorsConnectionWhere
+              where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type MovieAggregate {
@@ -3807,6 +3817,7 @@ describe("Subscriptions", () => {
 
             input AgreementOwnerUpdateConnectionInput {
               node: UserUpdateInput
+              where: AgreementOwnerConnectionWhere
             }
 
             input AgreementOwnerUpdateFieldInput {
@@ -3815,7 +3826,7 @@ describe("Subscriptions", () => {
               delete: AgreementOwnerDeleteFieldInput
               disconnect: AgreementOwnerDisconnectFieldInput
               update: AgreementOwnerUpdateConnectionInput
-              where: AgreementOwnerConnectionWhere
+              where: AgreementOwnerConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"AgreementOwnerUpdateConnectionInput\\\\\\" instead\\")
             }
 
             \\"\\"\\"
@@ -4277,6 +4288,7 @@ describe("Subscriptions", () => {
 
             input MovieActorsPersonUpdateConnectionInput {
               node: PersonUpdateInput
+              where: MovieActorsPersonConnectionWhere
             }
 
             input MovieActorsPersonUpdateFieldInput {
@@ -4285,7 +4297,7 @@ describe("Subscriptions", () => {
               delete: [MovieActorsPersonDeleteFieldInput!]
               disconnect: [MovieActorsPersonDisconnectFieldInput!]
               update: MovieActorsPersonUpdateConnectionInput
-              where: MovieActorsPersonConnectionWhere
+              where: MovieActorsPersonConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type MovieActorsRelationship {
@@ -4326,6 +4338,7 @@ describe("Subscriptions", () => {
 
             input MovieActorsStarUpdateConnectionInput {
               node: StarUpdateInput
+              where: MovieActorsStarConnectionWhere
             }
 
             input MovieActorsStarUpdateFieldInput {
@@ -4334,7 +4347,7 @@ describe("Subscriptions", () => {
               delete: [MovieActorsStarDeleteFieldInput!]
               disconnect: [MovieActorsStarDisconnectFieldInput!]
               update: MovieActorsStarUpdateConnectionInput
-              where: MovieActorsStarConnectionWhere
+              where: MovieActorsStarConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input MovieActorsUpdateInput {
@@ -4753,6 +4766,7 @@ describe("Subscriptions", () => {
 
             input PersonMoviesUpdateConnectionInput {
               node: MovieUpdateInput
+              where: PersonMoviesConnectionWhere
             }
 
             input PersonMoviesUpdateFieldInput {
@@ -4761,7 +4775,7 @@ describe("Subscriptions", () => {
               delete: [PersonMoviesDeleteFieldInput!]
               disconnect: [PersonMoviesDisconnectFieldInput!]
               update: PersonMoviesUpdateConnectionInput
-              where: PersonMoviesConnectionWhere
+              where: PersonMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"PersonMoviesUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input PersonOptions {
@@ -5013,6 +5027,7 @@ describe("Subscriptions", () => {
 
             input StarMoviesUpdateConnectionInput {
               node: MovieUpdateInput
+              where: StarMoviesConnectionWhere
             }
 
             input StarMoviesUpdateFieldInput {
@@ -5021,7 +5036,7 @@ describe("Subscriptions", () => {
               delete: [StarMoviesDeleteFieldInput!]
               disconnect: [StarMoviesDisconnectFieldInput!]
               update: StarMoviesUpdateConnectionInput
-              where: StarMoviesConnectionWhere
+              where: StarMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"StarMoviesUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input StarOptions {
@@ -5293,6 +5308,7 @@ describe("Subscriptions", () => {
 
             input CreatureMoviesUpdateConnectionInput {
               node: ProductionUpdateInput
+              where: CreatureMoviesConnectionWhere
             }
 
             input CreatureMoviesUpdateFieldInput {
@@ -5301,7 +5317,7 @@ describe("Subscriptions", () => {
               delete: CreatureMoviesDeleteFieldInput
               disconnect: CreatureMoviesDisconnectFieldInput
               update: CreatureMoviesUpdateConnectionInput
-              where: CreatureMoviesConnectionWhere
+              where: CreatureMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"CreatureMoviesUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input CreatureOptions {
@@ -5435,6 +5451,7 @@ describe("Subscriptions", () => {
 
             input MovieDirectorUpdateConnectionInput {
               node: CreatureUpdateInput
+              where: ProductionDirectorConnectionWhere
             }
 
             input MovieDirectorUpdateFieldInput {
@@ -5443,7 +5460,7 @@ describe("Subscriptions", () => {
               delete: MovieDirectorDeleteFieldInput
               disconnect: MovieDirectorDisconnectFieldInput
               update: MovieDirectorUpdateConnectionInput
-              where: ProductionDirectorConnectionWhere
+              where: ProductionDirectorConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieDirectorUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type MovieEdge {
@@ -5623,6 +5640,7 @@ describe("Subscriptions", () => {
 
             input PersonMoviesUpdateConnectionInput {
               node: ProductionUpdateInput
+              where: CreatureMoviesConnectionWhere
             }
 
             input PersonMoviesUpdateFieldInput {
@@ -5631,7 +5649,7 @@ describe("Subscriptions", () => {
               delete: PersonMoviesDeleteFieldInput
               disconnect: PersonMoviesDisconnectFieldInput
               update: PersonMoviesUpdateConnectionInput
-              where: CreatureMoviesConnectionWhere
+              where: CreatureMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"PersonMoviesUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input PersonOptions {
@@ -5754,6 +5772,7 @@ describe("Subscriptions", () => {
 
             input ProductionDirectorUpdateConnectionInput {
               node: CreatureUpdateInput
+              where: ProductionDirectorConnectionWhere
             }
 
             input ProductionDirectorUpdateFieldInput {
@@ -5762,7 +5781,7 @@ describe("Subscriptions", () => {
               delete: ProductionDirectorDeleteFieldInput
               disconnect: ProductionDirectorDisconnectFieldInput
               update: ProductionDirectorUpdateConnectionInput
-              where: ProductionDirectorConnectionWhere
+              where: ProductionDirectorConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ProductionDirectorUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input ProductionDisconnectInput {
@@ -5942,6 +5961,7 @@ describe("Subscriptions", () => {
 
             input SeriesDirectorUpdateConnectionInput {
               node: CreatureUpdateInput
+              where: ProductionDirectorConnectionWhere
             }
 
             input SeriesDirectorUpdateFieldInput {
@@ -5950,7 +5970,7 @@ describe("Subscriptions", () => {
               delete: SeriesDirectorDeleteFieldInput
               disconnect: SeriesDirectorDisconnectFieldInput
               update: SeriesDirectorUpdateConnectionInput
-              where: ProductionDirectorConnectionWhere
+              where: ProductionDirectorConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"SeriesDirectorUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type SeriesEdge {

--- a/packages/graphql/tests/schema/union-interface-relationship.test.ts
+++ b/packages/graphql/tests/schema/union-interface-relationship.test.ts
@@ -913,7 +913,7 @@ describe("Union Interface Relationships", () => {
               delete: [MovieDirectorsActorDeleteFieldInput!]
               disconnect: [MovieDirectorsActorDisconnectFieldInput!]
               update: MovieDirectorsActorUpdateConnectionInput
-              where: MovieDirectorsActorConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieDirectorsUpdateConnectionInput\\\\\\" instead\\")
+              where: MovieDirectorsActorConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieDirectorsActorUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input MovieDirectorsConnectInput {
@@ -1009,7 +1009,7 @@ describe("Union Interface Relationships", () => {
               delete: [MovieDirectorsPersonDeleteFieldInput!]
               disconnect: [MovieDirectorsPersonDisconnectFieldInput!]
               update: MovieDirectorsPersonUpdateConnectionInput
-              where: MovieDirectorsPersonConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieDirectorsUpdateConnectionInput\\\\\\" instead\\")
+              where: MovieDirectorsPersonConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieDirectorsPersonUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type MovieDirectorsRelationship {

--- a/packages/graphql/tests/schema/union-interface-relationship.test.ts
+++ b/packages/graphql/tests/schema/union-interface-relationship.test.ts
@@ -344,6 +344,7 @@ describe("Union Interface Relationships", () => {
             input ActorMoviesUpdateConnectionInput {
               edge: ActedInUpdateInput
               node: MovieUpdateInput
+              where: ActorMoviesConnectionWhere
             }
 
             input ActorMoviesUpdateFieldInput {
@@ -353,7 +354,7 @@ describe("Union Interface Relationships", () => {
               delete: [ActorMoviesDeleteFieldInput!]
               disconnect: [ActorMoviesDisconnectFieldInput!]
               update: ActorMoviesUpdateConnectionInput
-              where: ActorMoviesConnectionWhere
+              where: ActorMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorMoviesUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input ActorOnCreateInput {
@@ -797,6 +798,7 @@ describe("Union Interface Relationships", () => {
             input MovieActorsUpdateConnectionInput {
               edge: ActedInUpdateInput
               node: ActorUpdateInput
+              where: MovieActorsConnectionWhere
             }
 
             input MovieActorsUpdateFieldInput {
@@ -806,7 +808,7 @@ describe("Union Interface Relationships", () => {
               delete: [MovieActorsDeleteFieldInput!]
               disconnect: [MovieActorsDisconnectFieldInput!]
               update: MovieActorsUpdateConnectionInput
-              where: MovieActorsConnectionWhere
+              where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type MovieAggregate {
@@ -901,6 +903,7 @@ describe("Union Interface Relationships", () => {
             input MovieDirectorsActorUpdateConnectionInput {
               edge: DirectedUpdateInput
               node: ActorUpdateInput
+              where: MovieDirectorsActorConnectionWhere
             }
 
             input MovieDirectorsActorUpdateFieldInput {
@@ -910,7 +913,7 @@ describe("Union Interface Relationships", () => {
               delete: [MovieDirectorsActorDeleteFieldInput!]
               disconnect: [MovieDirectorsActorDisconnectFieldInput!]
               update: MovieDirectorsActorUpdateConnectionInput
-              where: MovieDirectorsActorConnectionWhere
+              where: MovieDirectorsActorConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieDirectorsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input MovieDirectorsConnectInput {
@@ -996,6 +999,7 @@ describe("Union Interface Relationships", () => {
             input MovieDirectorsPersonUpdateConnectionInput {
               edge: DirectedUpdateInput
               node: PersonUpdateInput
+              where: MovieDirectorsPersonConnectionWhere
             }
 
             input MovieDirectorsPersonUpdateFieldInput {
@@ -1005,7 +1009,7 @@ describe("Union Interface Relationships", () => {
               delete: [MovieDirectorsPersonDeleteFieldInput!]
               disconnect: [MovieDirectorsPersonDisconnectFieldInput!]
               update: MovieDirectorsPersonUpdateConnectionInput
-              where: MovieDirectorsPersonConnectionWhere
+              where: MovieDirectorsPersonConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieDirectorsUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type MovieDirectorsRelationship {
@@ -1177,6 +1181,7 @@ describe("Union Interface Relationships", () => {
             input MovieReviewersUpdateConnectionInput {
               edge: ReviewUpdateInput
               node: ReviewerUpdateInput
+              where: MovieReviewersConnectionWhere
             }
 
             input MovieReviewersUpdateFieldInput {
@@ -1185,7 +1190,7 @@ describe("Union Interface Relationships", () => {
               delete: [MovieReviewersDeleteFieldInput!]
               disconnect: [MovieReviewersDisconnectFieldInput!]
               update: MovieReviewersUpdateConnectionInput
-              where: MovieReviewersConnectionWhere
+              where: MovieReviewersConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieReviewersUpdateConnectionInput\\\\\\" instead\\")
             }
 
             \\"\\"\\"
@@ -1552,6 +1557,7 @@ describe("Union Interface Relationships", () => {
             input PersonMoviesUpdateConnectionInput {
               edge: ReviewUpdateInput
               node: MovieUpdateInput
+              where: PersonMoviesConnectionWhere
             }
 
             input PersonMoviesUpdateFieldInput {
@@ -1561,7 +1567,7 @@ describe("Union Interface Relationships", () => {
               delete: [PersonMoviesDeleteFieldInput!]
               disconnect: [PersonMoviesDisconnectFieldInput!]
               update: PersonMoviesUpdateConnectionInput
-              where: PersonMoviesConnectionWhere
+              where: PersonMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"PersonMoviesUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input PersonOnCreateInput {

--- a/packages/graphql/tests/schema/unions.test.ts
+++ b/packages/graphql/tests/schema/unions.test.ts
@@ -278,7 +278,7 @@ describe("Unions", () => {
               delete: [MovieSearchGenreDeleteFieldInput!]
               disconnect: [MovieSearchGenreDisconnectFieldInput!]
               update: MovieSearchGenreUpdateConnectionInput
-              where: MovieSearchGenreConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieSearchUpdateConnectionInput\\\\\\" instead\\")
+              where: MovieSearchGenreConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieSearchGenreUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input MovieSearchMovieConnectFieldInput {
@@ -323,7 +323,7 @@ describe("Unions", () => {
               delete: [MovieSearchMovieDeleteFieldInput!]
               disconnect: [MovieSearchMovieDisconnectFieldInput!]
               update: MovieSearchMovieUpdateConnectionInput
-              where: MovieSearchMovieConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieSearchUpdateConnectionInput\\\\\\" instead\\")
+              where: MovieSearchMovieConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieSearchMovieUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type MovieSearchRelationship {

--- a/packages/graphql/tests/schema/unions.test.ts
+++ b/packages/graphql/tests/schema/unions.test.ts
@@ -269,6 +269,7 @@ describe("Unions", () => {
 
             input MovieSearchGenreUpdateConnectionInput {
               node: GenreUpdateInput
+              where: MovieSearchGenreConnectionWhere
             }
 
             input MovieSearchGenreUpdateFieldInput {
@@ -277,7 +278,7 @@ describe("Unions", () => {
               delete: [MovieSearchGenreDeleteFieldInput!]
               disconnect: [MovieSearchGenreDisconnectFieldInput!]
               update: MovieSearchGenreUpdateConnectionInput
-              where: MovieSearchGenreConnectionWhere
+              where: MovieSearchGenreConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieSearchUpdateConnectionInput\\\\\\" instead\\")
             }
 
             input MovieSearchMovieConnectFieldInput {
@@ -313,6 +314,7 @@ describe("Unions", () => {
 
             input MovieSearchMovieUpdateConnectionInput {
               node: MovieUpdateInput
+              where: MovieSearchMovieConnectionWhere
             }
 
             input MovieSearchMovieUpdateFieldInput {
@@ -321,7 +323,7 @@ describe("Unions", () => {
               delete: [MovieSearchMovieDeleteFieldInput!]
               disconnect: [MovieSearchMovieDisconnectFieldInput!]
               update: MovieSearchMovieUpdateConnectionInput
-              where: MovieSearchMovieConnectionWhere
+              where: MovieSearchMovieConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieSearchUpdateConnectionInput\\\\\\" instead\\")
             }
 
             type MovieSearchRelationship {


### PR DESCRIPTION
# Description

A supplement to #6109, this deprecates the previous location to give a clean migration from Version 6. Requires some TCK/integration tests.

## Complexity

Complexity: Medium
