### PR TITLE
Fix union predicates #5940

### DIFF
--- a/.changeset/free-socks-cover.md
+++ b/.changeset/free-socks-cover.md
@@ -1,0 +1,53 @@
+---
+"@neo4j/graphql": major
+---
+
+Fixed incorrect behavior of `single` and `some` filters on relationships to unions.
+
+Given the following union and relationship:
+
+```graphql
+union Production = Movie | Series
+```
+
+and a relationship to this union:
+
+```graphql
+type Actor @node {
+    name: String!
+    actedIn: [Production!]! @relationship(type: "ACTED_IN", direction: OUT)
+}
+```
+
+These queries previously returned incorrect results:
+
+```graphql
+query {
+    actors(
+        where: {
+            actedIn: { single: { Movie: { title_CONTAINS: "The Office" }, Series: { title_ENDS_WITH: "Office" } } }
+        }
+    ) {
+        name
+    }
+}
+```
+
+```graphql
+query {
+    actors(
+        where: { actedIn: { some: { Movie: { title_CONTAINS: "The Office" }, Series: { title_ENDS_WITH: "Office" } } } }
+    ) {
+        name
+    }
+}
+```
+
+Previously, conditions inside single and some were evaluated separately for each concrete type in the union, requiring all to match. This was incorrect.
+
+New behavior:
+
+- `single`: Now correctly returns actors with exactly one related node across the whole union, rather than per type.
+- `some`: Now correctly returns actors with at least one matching related node of any type in the union.
+
+This fix also applies to the deprecated filters `actedIn_SINGLE` and `actedIn_SOME`.

--- a/packages/graphql/src/translate/queryAST/factory/FilterFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/FilterFactory.ts
@@ -736,7 +736,7 @@ export class FilterFactory {
         target: EntityAdapter,
         operator: "SOME" | "ALL" | "SINGLE" | "NONE" = "SOME"
     ): "AND" | "OR" | "XOR" {
-        if (isInterfaceEntity(target)) {
+        if (isInterfaceEntity(target) || isUnionEntity(target)) {
             if (operator === "SOME") {
                 return "OR";
             }

--- a/packages/graphql/tests/integration/issues/5940.int.test.ts
+++ b/packages/graphql/tests/integration/issues/5940.int.test.ts
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { UniqueType } from "../../utils/graphql-types";
+import { TestHelper } from "../../utils/tests-helper";
+
+describe("https://github.com/neo4j/graphql/issues/5940", () => {
+    let Movie: UniqueType;
+    let Series: UniqueType;
+    let Actor: UniqueType;
+
+    const testHelper = new TestHelper();
+
+    beforeEach(async () => {
+        Movie = testHelper.createUniqueType("Movie");
+        Series = testHelper.createUniqueType("Series");
+        Actor = testHelper.createUniqueType("Actor");
+
+        const typeDefs = /* GraphQL */ `
+            union Production = ${Movie} | ${Series}
+
+            type ${Movie} @node {
+                title: String!
+                actors: [${Actor}!]! @relationship(type: "ACTED_IN", direction: IN, properties: "ActedIn")
+            }
+
+            type ${Series} @node {
+                title: String!
+                episodes: Int
+                actors: [${Actor}!]! @relationship(type: "ACTED_IN", direction: IN, properties: "ActedIn")
+            }
+
+            type ${Actor} @node {
+                name: String!
+                actedIn: [Production!]! @relationship(type: "ACTED_IN", direction: OUT, properties: "ActedIn")
+            }
+
+            type ActedIn @relationshipProperties {
+                screenTime: Int
+            }
+        `;
+        await testHelper.initNeo4jGraphQL({
+            typeDefs,
+        });
+    });
+
+    afterEach(async () => {
+        await testHelper.close();
+    });
+
+    test("correct _single filters", async () => {
+        await testHelper.executeCypher(`
+            CREATE(m:${Movie} {title:"The Office"})
+            CREATE(s:${Series} {title:"The Office"})
+            CREATE(a1:${Actor} {name:"Arthur"})
+            CREATE(a2:${Actor} {name:"Marvin"})
+
+            CREATE(a1)-[:ACTED_IN]->(m)
+            CREATE(a1)-[:ACTED_IN]->(s)
+            CREATE(a2)-[:ACTED_IN]->(s)
+        `);
+
+        const query = /* GraphQL */ `
+            query {
+                ${Actor.plural}(
+                    where: {
+                        actedIn: { 
+                            single: {
+                                ${Movie}: { title_CONTAINS: "The Office" }
+                                ${Series}: { title_ENDS_WITH: "Office" }
+                            }
+                        }
+                    }
+                ) {
+                    name
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+        expect(result.errors).toBeUndefined();
+        expect(result.data).toEqual({
+            [Actor.plural]: [
+                {
+                    name: "Marvin",
+                },
+            ],
+        });
+    });
+
+    test("correct _some filters", async () => {
+        await testHelper.executeCypher(`
+            CREATE(m:${Movie} {title:"The Office"})
+            CREATE(s:${Series} {title:"The Office"})
+            CREATE(a1:${Actor} {name:"Arthur"})
+            CREATE(a2:${Actor} {name:"Marvin"})
+            CREATE(a3:${Actor} {name:"Zaphod"})
+
+            CREATE(a1)-[:ACTED_IN]->(m)
+            CREATE(a1)-[:ACTED_IN]->(s)
+            CREATE(a2)-[:ACTED_IN]->(s)
+        `);
+
+        const query = /* GraphQL */ `
+            query {
+                ${Actor.plural}(
+                    where: {
+                        actedIn: { some: { ${Movie}: { title_CONTAINS: "The Office" }, ${Series}: { title_ENDS_WITH: "Office" } } }
+                    }
+                ) {
+                    name
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+        expect(result.errors).toBeUndefined();
+        expect(result.data).toEqual({
+            [Actor.plural]: expect.toIncludeSameMembers([
+                {
+                    name: "Arthur",
+                },
+                {
+                    name: "Marvin",
+                },
+            ]),
+        });
+    });
+
+    test("correct _all filters", async () => {
+        await testHelper.executeCypher(`
+            CREATE(m:${Movie} {title:"The Office"})
+            CREATE(s:${Series} {title:"The Office"})
+            CREATE(s2:${Series} {title:"Another show"})
+            CREATE(a1:${Actor} {name:"Arthur"})
+            CREATE(a2:${Actor} {name:"Marvin"})
+            CREATE(a3:${Actor} {name:"Zaphod"})
+
+            CREATE(a1)-[:ACTED_IN]->(m)
+            CREATE(a1)-[:ACTED_IN]->(s)
+            CREATE(a1)-[:ACTED_IN]->(s2)
+            CREATE(a2)-[:ACTED_IN]->(s)
+            CREATE(a2)-[:ACTED_IN]->(m)
+        `);
+
+        const query = /* GraphQL */ `
+            query {
+                ${Actor.plural}(
+                    where: {
+                        actedIn: { all: { ${Movie}: { title_CONTAINS: "The Office" }, ${Series}: { title_ENDS_WITH: "Office" } } }
+                    }
+                ) {
+                    name
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+        expect(result.errors).toBeUndefined();
+        expect(result.data).toEqual({
+            [Actor.plural]: expect.toIncludeSameMembers([
+                {
+                    name: "Marvin",
+                },
+            ]),
+        });
+    });
+
+    test("correct _none filters", async () => {
+        await testHelper.executeCypher(`
+            CREATE(m:${Movie} {title:"The Office"})
+            CREATE(s:${Series} {title:"The Office"})
+            CREATE(s2:${Series} {title:"Another show"})
+            CREATE(a1:${Actor} {name:"Arthur"})
+            CREATE(a2:${Actor} {name:"Marvin"})
+            CREATE(a3:${Actor} {name:"Zaphod"})
+
+            CREATE(a1)-[:ACTED_IN]->(m)
+            CREATE(a1)-[:ACTED_IN]->(s)
+            CREATE(a2)-[:ACTED_IN]->(s2)
+        `);
+
+        const query = /* GraphQL */ `
+            query {
+                ${Actor.plural}(
+                    where: {
+                        actedIn: { none: { ${Movie}: { title_CONTAINS: "The Office" }, ${Series}: { title_ENDS_WITH: "Office" } } }
+                    }
+                ) {
+                    name
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+        expect(result.errors).toBeUndefined();
+        expect(result.data).toEqual({
+            [Actor.plural]: expect.toIncludeSameMembers([
+                {
+                    name: "Zaphod",
+                },
+                {
+                    name: "Marvin",
+                },
+            ]),
+        });
+    });
+});


### PR DESCRIPTION
# Description


Fixed incorrect behavior of `single` and `some` filters on relationships to unions.

Given the following union and relationship:

```graphql
union Production = Movie | Series
```

and a relationship to this union:

```graphql
type Actor @node {
    name: String!
    actedIn: [Production!]! @relationship(type: "ACTED_IN", direction: OUT)
}
```

These queries previously returned incorrect results:

```graphql
query {
    actors(
        where: {
            actedIn: { single: { Movie: { title_CONTAINS: "The Office" }, Series: { title_ENDS_WITH: "Office" } } }
        }
    ) {
        name
    }
}
```

```graphql
query {
    actors(
        where: { actedIn: { some: { Movie: { title_CONTAINS: "The Office" }, Series: { title_ENDS_WITH: "Office" } } } }
    ) {
        name
    }
}
```

Previously, conditions inside single and some were evaluated separately for each concrete type in the union, requiring all to match. This was incorrect.

New behavior:

- `single`: Now correctly returns actors with exactly one related node across the whole union, rather than per type.

- `some`: Now correctly returns actors with at least one matching related node of any type in the union.

This fix also applies to the deprecated filters `actedIn_SINGLE` and `actedIn_SOME`.