### PR TITLE
Does not generate operations for interfaces without implementing nodes

### DIFF
--- a/.changeset/nice-streets-rescue.md
+++ b/.changeset/nice-streets-rescue.md
@@ -1,0 +1,35 @@
+---
+"@neo4j/graphql": major
+---
+
+Does not generate queries for interfaces without an implementing type with the `@node` directive.
+
+For example. The following type definitions:
+
+```graphql
+interface Production {
+    title: String!
+}
+
+type Movie @node {
+    title: String!
+}
+
+type NotANode implements Production {
+    title: String!
+}
+```
+
+Will no longer generate the queries and types related to the interface `Production`:
+
+```graphql
+type Query {
+    productions(limit: Int, offset: Int, sort: [ProductionSort!], where: ProductionWhere): [Production!]!
+    productionsConnection(
+        after: String
+        first: Int
+        sort: [ProductionSort!]
+        where: ProductionWhere
+    ): ProductionsConnection!
+}
+```

--- a/packages/graphql/src/schema/make-augmented-schema.ts
+++ b/packages/graphql/src/schema/make-augmented-schema.ts
@@ -318,7 +318,9 @@ function makeAugmentedSchema({
             def.setDirectives(
                 graphqlDirectivesToCompose(userDefinedDirectivesForUnion.get(unionEntityAdapter.name) || [])
             );
-            if (unionEntityAdapter.isReadable) {
+            const hasImplementedEntities = unionEntityAdapter.concreteEntities.length > 0;
+
+            if (unionEntityAdapter.isReadable && hasImplementedEntities) {
                 complexityEstimatorHelper.registerField("Query", unionEntityAdapter.operations.rootTypeFieldNames.read);
                 composer.Query.addFields({
                     [unionEntityAdapter.operations.rootTypeFieldNames.read]: findResolver({

--- a/packages/graphql/src/schema/make-augmented-schema.ts
+++ b/packages/graphql/src/schema/make-augmented-schema.ts
@@ -801,59 +801,61 @@ function generateInterfaceObjectType({
         complexityEstimatorHelper,
     });
 
-    const propagatedDirectives = propagatedDirectivesForNode.get(interfaceEntityAdapter.name) || [];
-    if (interfaceEntityAdapter.isReadable || interfaceEntityAdapter.isAggregable) {
-        composer.Query.addFields({
-            [interfaceEntityAdapter.operations.rootTypeFieldNames.connection]: rootConnectionResolver({
-                composer,
+    const hasImplementedEntities = interfaceEntityAdapter.concreteEntities.length > 0;
+    if (hasImplementedEntities) {
+        const propagatedDirectives = propagatedDirectivesForNode.get(interfaceEntityAdapter.name) || [];
+        if (interfaceEntityAdapter.isReadable || interfaceEntityAdapter.isAggregable) {
+            composer.Query.addFields({
+                [interfaceEntityAdapter.operations.rootTypeFieldNames.connection]: rootConnectionResolver({
+                    composer,
+                    entityAdapter: interfaceEntityAdapter,
+                    propagatedDirectives,
+                    isLimitRequired: features?.limitRequired,
+                }),
+            });
+        }
+        if (interfaceEntityAdapter.isReadable) {
+            complexityEstimatorHelper.registerField("Query", interfaceEntityAdapter.operations.rootTypeFieldNames.read);
+            composer.Query.addFields({
+                [interfaceEntityAdapter.operations.rootTypeFieldNames.read]: findResolver({
+                    entityAdapter: interfaceEntityAdapter,
+                    composer,
+                    isLimitRequired: features?.limitRequired,
+                }),
+            });
+
+            composer.Query.setFieldDirectives(
+                interfaceEntityAdapter.operations.rootTypeFieldNames.read,
+                graphqlDirectivesToCompose(propagatedDirectives)
+            );
+
+            complexityEstimatorHelper.registerField(
+                "Query",
+                interfaceEntityAdapter.operations.rootTypeFieldNames.connection
+            );
+
+            composer.Query.addFields({
+                [interfaceEntityAdapter.operations.rootTypeFieldNames.connection]: rootConnectionResolver({
+                    composer,
+                    entityAdapter: interfaceEntityAdapter,
+                    propagatedDirectives,
+                    isLimitRequired: features?.limitRequired,
+                }),
+            });
+            composer.Query.setFieldDirectives(
+                interfaceEntityAdapter.operations.rootTypeFieldNames.connection,
+                graphqlDirectivesToCompose(propagatedDirectives)
+            );
+        }
+
+        if (interfaceEntityAdapter.isAggregable) {
+            withAggregateSelectionType({
                 entityAdapter: interfaceEntityAdapter,
+                aggregationTypesMapper,
                 propagatedDirectives,
-                isLimitRequired: features?.limitRequired,
-            }),
-        });
-    }
-    if (interfaceEntityAdapter.isReadable) {
-        complexityEstimatorHelper.registerField("Query", interfaceEntityAdapter.operations.rootTypeFieldNames.read);
-        composer.Query.addFields({
-            [interfaceEntityAdapter.operations.rootTypeFieldNames.read]: findResolver({
-                entityAdapter: interfaceEntityAdapter,
                 composer,
-                isLimitRequired: features?.limitRequired,
-            }),
-        });
-
-        composer.Query.setFieldDirectives(
-            interfaceEntityAdapter.operations.rootTypeFieldNames.read,
-            graphqlDirectivesToCompose(propagatedDirectives)
-        );
-
-        complexityEstimatorHelper.registerField(
-            "Query",
-            interfaceEntityAdapter.operations.rootTypeFieldNames.connection
-        );
-
-        // if (interfaceEntityAdapter.isAggregable) {
-        composer.Query.addFields({
-            [interfaceEntityAdapter.operations.rootTypeFieldNames.connection]: rootConnectionResolver({
-                composer,
-                entityAdapter: interfaceEntityAdapter,
-                propagatedDirectives,
-                isLimitRequired: features?.limitRequired,
-            }),
-        });
-        // }
-        composer.Query.setFieldDirectives(
-            interfaceEntityAdapter.operations.rootTypeFieldNames.connection,
-            graphqlDirectivesToCompose(propagatedDirectives)
-        );
-    }
-    if (interfaceEntityAdapter.isAggregable) {
-        withAggregateSelectionType({
-            entityAdapter: interfaceEntityAdapter,
-            aggregationTypesMapper,
-            propagatedDirectives,
-            composer,
-            features,
-        });
+                features,
+            });
+        }
     }
 }

--- a/packages/graphql/tests/schema/interface-without-implementation.test.ts
+++ b/packages/graphql/tests/schema/interface-without-implementation.test.ts
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { printSchemaWithDirectives } from "@graphql-tools/utils";
+import { gql } from "graphql-tag";
+import { lexicographicSortSchema } from "graphql/utilities";
+import { Neo4jGraphQL } from "../../src";
+
+describe("Interfaces without implementing types", () => {
+    test("Interfaces without implementing types", async () => {
+        const typeDefs = gql`
+            interface Production {
+                title: String!
+            }
+
+            type Movie @node {
+                title: String!
+            }
+
+            type NotANode implements Production {
+                title: String!
+            }
+        `;
+        const neoSchema = new Neo4jGraphQL({ typeDefs });
+        const printedSchema = printSchemaWithDirectives(lexicographicSortSchema(await neoSchema.getSchema()));
+
+        expect(printedSchema).toMatchInlineSnapshot(`
+            "schema {
+              query: Query
+              mutation: Mutation
+            }
+
+            type Count {
+              nodes: Int!
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships created during a create mutation
+            \\"\\"\\"
+            type CreateInfo {
+              nodesCreated: Int!
+              relationshipsCreated: Int!
+            }
+
+            type CreateMoviesMutationResponse {
+              info: CreateInfo!
+              movies: [Movie!]!
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships deleted during a delete mutation
+            \\"\\"\\"
+            type DeleteInfo {
+              nodesDeleted: Int!
+              relationshipsDeleted: Int!
+            }
+
+            type Movie {
+              title: String!
+            }
+
+            type MovieAggregate {
+              count: Count!
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              title: StringAggregateSelection!
+            }
+
+            input MovieCreateInput {
+              title: String!
+            }
+
+            type MovieEdge {
+              cursor: String!
+              node: Movie!
+            }
+
+            \\"\\"\\"
+            Fields to sort Movies by. The order in which sorts are applied is not guaranteed when specifying many fields in one MovieSort object.
+            \\"\\"\\"
+            input MovieSort {
+              title: SortDirection
+            }
+
+            input MovieUpdateInput {
+              title: StringScalarMutations
+              title_SET: String @deprecated(reason: \\"Please use the generic mutation 'title: { set: ... } }' instead.\\")
+            }
+
+            input MovieWhere {
+              AND: [MovieWhere!]
+              NOT: MovieWhere
+              OR: [MovieWhere!]
+              title: StringScalarFilters
+              title_CONTAINS: String @deprecated(reason: \\"Please use the relevant generic filter title: { contains: ... }\\")
+              title_ENDS_WITH: String @deprecated(reason: \\"Please use the relevant generic filter title: { endsWith: ... }\\")
+              title_EQ: String @deprecated(reason: \\"Please use the relevant generic filter title: { eq: ... }\\")
+              title_IN: [String!] @deprecated(reason: \\"Please use the relevant generic filter title: { in: ... }\\")
+              title_STARTS_WITH: String @deprecated(reason: \\"Please use the relevant generic filter title: { startsWith: ... }\\")
+            }
+
+            type MoviesConnection {
+              aggregate: MovieAggregate!
+              edges: [MovieEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type Mutation {
+              createMovies(input: [MovieCreateInput!]!): CreateMoviesMutationResponse!
+              deleteMovies(where: MovieWhere): DeleteInfo!
+              updateMovies(update: MovieUpdateInput, where: MovieWhere): UpdateMoviesMutationResponse!
+            }
+
+            \\"\\"\\"Pagination information (Relay)\\"\\"\\"
+            type PageInfo {
+              endCursor: String
+              hasNextPage: Boolean!
+              hasPreviousPage: Boolean!
+              startCursor: String
+            }
+
+            type Query {
+              movies(limit: Int, offset: Int, sort: [MovieSort!], where: MovieWhere): [Movie!]!
+              moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
+            }
+
+            \\"\\"\\"An enum for sorting in either ascending or descending order.\\"\\"\\"
+            enum SortDirection {
+              \\"\\"\\"Sort by field values in ascending order.\\"\\"\\"
+              ASC
+              \\"\\"\\"Sort by field values in descending order.\\"\\"\\"
+              DESC
+            }
+
+            type StringAggregateSelection {
+              longest: String
+              shortest: String
+            }
+
+            \\"\\"\\"String filters\\"\\"\\"
+            input StringScalarFilters {
+              contains: String
+              endsWith: String
+              eq: String
+              in: [String!]
+              startsWith: String
+            }
+
+            \\"\\"\\"String mutations\\"\\"\\"
+            input StringScalarMutations {
+              set: String
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships created and deleted during an update mutation
+            \\"\\"\\"
+            type UpdateInfo {
+              nodesCreated: Int!
+              nodesDeleted: Int!
+              relationshipsCreated: Int!
+              relationshipsDeleted: Int!
+            }
+
+            type UpdateMoviesMutationResponse {
+              info: UpdateInfo!
+              movies: [Movie!]!
+            }"
+        `);
+    });
+});

--- a/packages/graphql/tests/schema/union-without-implementing-types.test.ts
+++ b/packages/graphql/tests/schema/union-without-implementing-types.test.ts
@@ -18,22 +18,23 @@
  */
 
 import { printSchemaWithDirectives } from "@graphql-tools/utils";
-import { gql } from "graphql-tag";
-import { lexicographicSortSchema } from "graphql/utilities";
+import { lexicographicSortSchema } from "graphql";
+import gql from "graphql-tag";
 import { Neo4jGraphQL } from "../../src";
 
-describe("Interfaces without implementing types", () => {
-    test("Interfaces without implementing types", async () => {
+describe("Union Interface Relationships", () => {
+    test("Union Interface Relationships", async () => {
         const typeDefs = gql`
-            interface Production {
-                title: String!
-            }
+            union Production = NotANode | FakeNode
 
             type Movie @node {
                 title: String!
             }
 
-            type NotANode implements Production {
+            type NotANode {
+                title: String!
+            }
+            type FakeNode {
                 title: String!
             }
         `;


### PR DESCRIPTION
# Description

Does not generate queries for interfaces without an implementing type with the `@node` directive.

For example. The following type definitions:

```graphql
interface Production {
    title: String!
}

type Movie @node {
    title: String!
}

type NotANode implements Production {
    title: String!
}
```

Will no longer generate the queries and types related to the interface `Production`:

```graphql
type Query {
    productions(limit: Int, offset: Int, sort: [ProductionSort!], where: ProductionWhere): [Production!]!
    productionsConnection(
        after: String
        first: Int
        sort: [ProductionSort!]
        where: ProductionWhere
    ): ProductionsConnection!
}
```
