### PR TITLE
Add ovewriteArgument feature flag

### DIFF
--- a/.changeset/slow-hoops-divide.md
+++ b/.changeset/slow-hoops-divide.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+Add `overwriteArgument` option to `excludeDeprecatedFields` to remove the argument `overwrite` from connect operations

--- a/packages/graphql/src/schema/create-relationship-fields/create-relationship-fields.ts
+++ b/packages/graphql/src/schema/create-relationship-fields/create-relationship-fields.ts
@@ -371,6 +371,7 @@ function createRelationshipFieldsForTarget({
         relationshipAdapter,
         composer,
         deprecatedDirectives,
+        features,
     });
 
     augmentDeleteInputTypeWithDeleteFieldInput({

--- a/packages/graphql/src/schema/generation/connect-input.ts
+++ b/packages/graphql/src/schema/generation/connect-input.ts
@@ -30,8 +30,9 @@ import { InterfaceEntityAdapter } from "../../schema-model/entity/model-adapters
 import { UnionEntityAdapter } from "../../schema-model/entity/model-adapters/UnionEntityAdapter";
 import type { RelationshipAdapter } from "../../schema-model/relationship/model-adapters/RelationshipAdapter";
 import type { RelationshipDeclarationAdapter } from "../../schema-model/relationship/model-adapters/RelationshipDeclarationAdapter";
+import type { Neo4jFeaturesSettings } from "../../types";
 import { overwrite } from "../create-relationship-fields/fields/overwrite";
-import { relationshipTargetHasRelationshipWithNestedOperation } from "./utils";
+import { relationshipTargetHasRelationshipWithNestedOperation, shouldAddDeprecatedFields } from "./utils";
 import { withConnectWhereFieldInputType } from "./where-input";
 
 export function withConnectInputType({
@@ -52,10 +53,12 @@ export function augmentConnectInputTypeWithConnectFieldInput({
     relationshipAdapter,
     composer,
     deprecatedDirectives,
+    features,
 }: {
     relationshipAdapter: RelationshipAdapter | RelationshipDeclarationAdapter;
     composer: SchemaComposer;
     deprecatedDirectives: Directive[];
+    features?: Neo4jFeaturesSettings;
 }) {
     if (relationshipAdapter.source instanceof UnionEntityAdapter) {
         throw new Error("Unexpected union source");
@@ -64,6 +67,7 @@ export function augmentConnectInputTypeWithConnectFieldInput({
         relationshipAdapter,
         composer,
         deprecatedDirectives,
+        features,
     });
     if (!connectFieldInput) {
         return;
@@ -87,15 +91,17 @@ function makeConnectInputType({
     relationshipAdapter,
     composer,
     deprecatedDirectives,
+    features,
 }: {
     relationshipAdapter: RelationshipAdapter | RelationshipDeclarationAdapter;
     composer: SchemaComposer;
     deprecatedDirectives: Directive[];
+    features: Neo4jFeaturesSettings | undefined;
 }): InputTypeComposer | undefined {
     if (relationshipAdapter.target instanceof UnionEntityAdapter) {
-        return withUnionConnectInputType({ relationshipAdapter, composer, deprecatedDirectives });
+        return withUnionConnectInputType({ relationshipAdapter, composer, deprecatedDirectives, features });
     }
-    return withConnectFieldInputType({ relationshipAdapter, composer });
+    return withConnectFieldInputType({ relationshipAdapter, composer, features });
 }
 function makeConnectInputTypeRelationshipField({
     relationshipAdapter,
@@ -126,10 +132,12 @@ function withUnionConnectInputType({
     relationshipAdapter,
     composer,
     deprecatedDirectives,
+    features,
 }: {
     relationshipAdapter: RelationshipAdapter | RelationshipDeclarationAdapter;
     composer: SchemaComposer;
     deprecatedDirectives: Directive[];
+    features: Neo4jFeaturesSettings | undefined;
 }): InputTypeComposer | undefined {
     const typeName = relationshipAdapter.operations.unionConnectInputTypeName;
     if (!relationshipAdapter.nestedOperations.has(RelationshipNestedOperationsOption.CONNECT)) {
@@ -138,7 +146,7 @@ function withUnionConnectInputType({
     if (composer.has(typeName)) {
         return composer.getITC(typeName);
     }
-    const fields = makeUnionConnectInputTypeFields({ relationshipAdapter, composer, deprecatedDirectives });
+    const fields = makeUnionConnectInputTypeFields({ relationshipAdapter, composer, deprecatedDirectives, features });
     if (!Object.keys(fields).length) {
         return;
     }
@@ -153,10 +161,12 @@ function makeUnionConnectInputTypeFields({
     relationshipAdapter,
     composer,
     deprecatedDirectives,
+    features,
 }: {
     relationshipAdapter: RelationshipAdapter | RelationshipDeclarationAdapter;
     composer: SchemaComposer;
     deprecatedDirectives: Directive[];
+    features: Neo4jFeaturesSettings | undefined;
 }): InputTypeComposerFieldConfigMapDefinition {
     const fields: InputTypeComposerFieldConfigMapDefinition = {};
     if (!(relationshipAdapter.target instanceof UnionEntityAdapter)) {
@@ -167,6 +177,7 @@ function makeUnionConnectInputTypeFields({
             relationshipAdapter,
             ifUnionMemberEntity: memberEntity,
             composer,
+            features,
         });
         if (fieldInput) {
             fields[memberEntity.name] = {
@@ -182,10 +193,12 @@ export function withConnectFieldInputType({
     relationshipAdapter,
     composer,
     ifUnionMemberEntity,
+    features,
 }: {
     relationshipAdapter: RelationshipAdapter | RelationshipDeclarationAdapter;
     composer: SchemaComposer;
     ifUnionMemberEntity?: ConcreteEntityAdapter;
+    features: Neo4jFeaturesSettings | undefined;
 }): InputTypeComposer | undefined {
     const typeName = relationshipAdapter.operations.getConnectFieldInputTypeName(ifUnionMemberEntity);
     if (!relationshipAdapter.nestedOperations.has(RelationshipNestedOperationsOption.CONNECT)) {
@@ -197,7 +210,7 @@ export function withConnectFieldInputType({
 
     const connectFieldInput = composer.createInputTC({
         name: typeName,
-        fields: makeConnectFieldInputTypeFields({ relationshipAdapter, composer, ifUnionMemberEntity }),
+        fields: makeConnectFieldInputTypeFields({ relationshipAdapter, composer, ifUnionMemberEntity, features }),
     });
     return connectFieldInput;
 }
@@ -205,10 +218,12 @@ function makeConnectFieldInputTypeFields({
     relationshipAdapter,
     composer,
     ifUnionMemberEntity,
+    features,
 }: {
     relationshipAdapter: RelationshipAdapter | RelationshipDeclarationAdapter;
     composer: SchemaComposer;
     ifUnionMemberEntity?: ConcreteEntityAdapter;
+    features: Neo4jFeaturesSettings | undefined;
 }): InputTypeComposerFieldConfigMapDefinition {
     const fields = {};
     if (relationshipAdapter.hasCreateInputFields) {
@@ -216,7 +231,9 @@ function makeConnectFieldInputTypeFields({
     }
     if (relationshipAdapter.target instanceof ConcreteEntityAdapter) {
         fields["where"] = withConnectWhereFieldInputType(relationshipAdapter.target, composer);
-        fields["overwrite"] = overwrite;
+        if (shouldAddDeprecatedFields(features, "overwriteArgument")) {
+            fields["overwrite"] = overwrite;
+        }
         if (
             relationshipTargetHasRelationshipWithNestedOperation(
                 relationshipAdapter.target,

--- a/packages/graphql/src/schema/generation/create-input.ts
+++ b/packages/graphql/src/schema/generation/create-input.ts
@@ -311,7 +311,12 @@ function makeFieldInputTypeFields({
         }
     }
 
-    const connectFieldInputType = withConnectFieldInputType({ relationshipAdapter, ifUnionMemberEntity, composer });
+    const connectFieldInputType = withConnectFieldInputType({
+        relationshipAdapter,
+        ifUnionMemberEntity,
+        composer,
+        features,
+    });
     if (connectFieldInputType) {
         fields["connect"] = {
             type: relationshipAdapter.isList ? connectFieldInputType.NonNull.List : connectFieldInputType,

--- a/packages/graphql/src/schema/generation/update-input.ts
+++ b/packages/graphql/src/schema/generation/update-input.ts
@@ -32,6 +32,7 @@ import { UnionEntityAdapter } from "../../schema-model/entity/model-adapters/Uni
 import { RelationshipAdapter } from "../../schema-model/relationship/model-adapters/RelationshipAdapter";
 import type { RelationshipDeclarationAdapter } from "../../schema-model/relationship/model-adapters/RelationshipDeclarationAdapter";
 import type { Neo4jFeaturesSettings } from "../../types";
+import { DEPRECATE_UPDATE_WHERE } from "../constants";
 import { ensureNonEmptyInput } from "../ensure-non-empty-input";
 import { concreteEntityToUpdateInputFields, withArrayOperators, withMathOperators } from "../to-compose";
 import { withConnectFieldInputType } from "./connect-input";
@@ -41,7 +42,6 @@ import { withDeleteFieldInputType } from "./delete-input";
 import { withDisconnectFieldInputType } from "./disconnect-input";
 import { withCreateFieldInputType } from "./relation-input";
 import { shouldAddDeprecatedFields } from "./utils";
-import { DEPRECATE_UPDATE_WHERE } from "../constants";
 
 export function withUpdateInputType({
     entityAdapter,
@@ -278,7 +278,12 @@ function makeUpdateFieldInputTypeFields({
             directives: [],
         };
     }
-    const connectFieldInputType = withConnectFieldInputType({ relationshipAdapter, ifUnionMemberEntity, composer });
+    const connectFieldInputType = withConnectFieldInputType({
+        relationshipAdapter,
+        ifUnionMemberEntity,
+        composer,
+        features,
+    });
     if (connectFieldInputType) {
         fields["connect"] = {
             type: relationshipAdapter.isList ? connectFieldInputType.NonNull.List : connectFieldInputType,

--- a/packages/graphql/src/types/index.ts
+++ b/packages/graphql/src/types/index.ts
@@ -458,6 +458,7 @@ export type Neo4jFeaturesSettings = {
         typename_IN?: boolean;
         deprecatedAggregateOperations?: boolean;
         nonNestedUpdateWhere?: boolean;
+        overwriteArgument?: boolean;
     };
 
     /** Options for disabling automatic escaping of potentially unsafe strings.

--- a/packages/graphql/tests/schema/remove-deprecated/overwrite-argument.test.ts
+++ b/packages/graphql/tests/schema/remove-deprecated/overwrite-argument.test.ts
@@ -1,0 +1,906 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { printSchemaWithDirectives } from "@graphql-tools/utils";
+import { gql } from "graphql-tag";
+import { lexicographicSortSchema } from "graphql/utilities";
+import { Neo4jGraphQL } from "../../../src";
+
+describe("Deprecated overwrite argument", () => {
+    test("should remove the overwrite argument", async () => {
+        const typeDefs = gql`
+            type Actor @node {
+                name: String!
+                movies: [Movie!]! @relationship(type: "ACTED_IN", direction: OUT, properties: "ActedIn")
+            }
+
+            type Movie @node {
+                title: String!
+                actors: [Actor!]! @relationship(type: "ACTED_IN", direction: IN, properties: "ActedIn")
+                favActor: Actor! @relationship(type: "ACTED_IN_FAV", direction: IN)
+            }
+
+            type ActedIn @relationshipProperties {
+                screenTime: Int!
+            }
+
+            type Genre @node {
+                id: ID
+            }
+        `;
+        const neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            features: {
+                excludeDeprecatedFields: {
+                    overwriteArgument: true,
+                },
+            },
+        });
+        const printedSchema = printSchemaWithDirectives(lexicographicSortSchema(await neoSchema.getSchema()));
+
+        expect(printedSchema).toMatchInlineSnapshot(`
+            "schema {
+              query: Query
+              mutation: Mutation
+            }
+
+            \\"\\"\\"
+            The edge properties for the following fields:
+            * Actor.movies
+            * Movie.actors
+            \\"\\"\\"
+            type ActedIn {
+              screenTime: Int!
+            }
+
+            input ActedInAggregationWhereInput {
+              AND: [ActedInAggregationWhereInput!]
+              NOT: ActedInAggregationWhereInput
+              OR: [ActedInAggregationWhereInput!]
+              screenTime_AVERAGE_EQUAL: Float
+              screenTime_AVERAGE_GT: Float
+              screenTime_AVERAGE_GTE: Float
+              screenTime_AVERAGE_LT: Float
+              screenTime_AVERAGE_LTE: Float
+              screenTime_MAX_EQUAL: Int
+              screenTime_MAX_GT: Int
+              screenTime_MAX_GTE: Int
+              screenTime_MAX_LT: Int
+              screenTime_MAX_LTE: Int
+              screenTime_MIN_EQUAL: Int
+              screenTime_MIN_GT: Int
+              screenTime_MIN_GTE: Int
+              screenTime_MIN_LT: Int
+              screenTime_MIN_LTE: Int
+              screenTime_SUM_EQUAL: Int
+              screenTime_SUM_GT: Int
+              screenTime_SUM_GTE: Int
+              screenTime_SUM_LT: Int
+              screenTime_SUM_LTE: Int
+            }
+
+            input ActedInCreateInput {
+              screenTime: Int!
+            }
+
+            input ActedInSort {
+              screenTime: SortDirection
+            }
+
+            input ActedInUpdateInput {
+              screenTime: Int @deprecated(reason: \\"Please use the explicit _SET field\\")
+              screenTime_DECREMENT: Int
+              screenTime_INCREMENT: Int
+              screenTime_SET: Int
+            }
+
+            input ActedInWhere {
+              AND: [ActedInWhere!]
+              NOT: ActedInWhere
+              OR: [ActedInWhere!]
+              screenTime: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              screenTime_EQ: Int
+              screenTime_GT: Int
+              screenTime_GTE: Int
+              screenTime_IN: [Int!]
+              screenTime_LT: Int
+              screenTime_LTE: Int
+            }
+
+            type Actor {
+              movies(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
+              moviesAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: MovieWhere): ActorMovieMoviesAggregationSelection @deprecated(reason: \\"Please use field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\" instead\\")
+              moviesConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [ActorMoviesConnectionSort!], where: ActorMoviesConnectionWhere): ActorMoviesConnection!
+              name: String!
+            }
+
+            type ActorAggregate {
+              count: Count!
+              node: ActorAggregateNode!
+            }
+
+            type ActorAggregateNode {
+              name: StringAggregateSelection!
+            }
+
+            type ActorAggregateSelection {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
+            input ActorConnectInput {
+              movies: [ActorMoviesConnectFieldInput!]
+            }
+
+            input ActorConnectWhere {
+              node: ActorWhere!
+            }
+
+            input ActorCreateInput {
+              movies: ActorMoviesFieldInput
+              name: String!
+            }
+
+            input ActorDeleteInput {
+              movies: [ActorMoviesDeleteFieldInput!]
+            }
+
+            input ActorDisconnectInput {
+              movies: [ActorMoviesDisconnectFieldInput!]
+            }
+
+            type ActorEdge {
+              cursor: String!
+              node: Actor!
+            }
+
+            type ActorMovieMoviesAggregateSelection {
+              count: CountConnection!
+              edge: ActorMovieMoviesEdgeAggregateSelection
+              node: ActorMovieMoviesNodeAggregateSelection
+            }
+
+            type ActorMovieMoviesAggregationSelection {
+              count: Int!
+              edge: ActorMovieMoviesEdgeAggregateSelection
+              node: ActorMovieMoviesNodeAggregateSelection
+            }
+
+            type ActorMovieMoviesEdgeAggregateSelection {
+              screenTime: IntAggregateSelection!
+            }
+
+            type ActorMovieMoviesNodeAggregateSelection {
+              title: StringAggregateSelection!
+            }
+
+            input ActorMoviesAggregateInput {
+              AND: [ActorMoviesAggregateInput!]
+              NOT: ActorMoviesAggregateInput
+              OR: [ActorMoviesAggregateInput!]
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
+              count_GT: Int
+              count_GTE: Int
+              count_LT: Int
+              count_LTE: Int
+              edge: ActedInAggregationWhereInput
+              node: ActorMoviesNodeAggregationWhereInput
+            }
+
+            input ActorMoviesConnectFieldInput {
+              connect: [MovieConnectInput!]
+              edge: ActedInCreateInput!
+              where: MovieConnectWhere
+            }
+
+            type ActorMoviesConnection {
+              aggregate: ActorMovieMoviesAggregateSelection!
+              edges: [ActorMoviesRelationship!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            input ActorMoviesConnectionSort {
+              edge: ActedInSort
+              node: MovieSort
+            }
+
+            input ActorMoviesConnectionWhere {
+              AND: [ActorMoviesConnectionWhere!]
+              NOT: ActorMoviesConnectionWhere
+              OR: [ActorMoviesConnectionWhere!]
+              edge: ActedInWhere
+              node: MovieWhere
+            }
+
+            input ActorMoviesCreateFieldInput {
+              edge: ActedInCreateInput!
+              node: MovieCreateInput!
+            }
+
+            input ActorMoviesDeleteFieldInput {
+              delete: MovieDeleteInput
+              where: ActorMoviesConnectionWhere
+            }
+
+            input ActorMoviesDisconnectFieldInput {
+              disconnect: MovieDisconnectInput
+              where: ActorMoviesConnectionWhere
+            }
+
+            input ActorMoviesFieldInput {
+              connect: [ActorMoviesConnectFieldInput!]
+              create: [ActorMoviesCreateFieldInput!]
+            }
+
+            input ActorMoviesNodeAggregationWhereInput {
+              AND: [ActorMoviesNodeAggregationWhereInput!]
+              NOT: ActorMoviesNodeAggregationWhereInput
+              OR: [ActorMoviesNodeAggregationWhereInput!]
+              title_AVERAGE_LENGTH_EQUAL: Float
+              title_AVERAGE_LENGTH_GT: Float
+              title_AVERAGE_LENGTH_GTE: Float
+              title_AVERAGE_LENGTH_LT: Float
+              title_AVERAGE_LENGTH_LTE: Float
+              title_LONGEST_LENGTH_EQUAL: Int
+              title_LONGEST_LENGTH_GT: Int
+              title_LONGEST_LENGTH_GTE: Int
+              title_LONGEST_LENGTH_LT: Int
+              title_LONGEST_LENGTH_LTE: Int
+              title_SHORTEST_LENGTH_EQUAL: Int
+              title_SHORTEST_LENGTH_GT: Int
+              title_SHORTEST_LENGTH_GTE: Int
+              title_SHORTEST_LENGTH_LT: Int
+              title_SHORTEST_LENGTH_LTE: Int
+            }
+
+            type ActorMoviesRelationship {
+              cursor: String!
+              node: Movie!
+              properties: ActedIn!
+            }
+
+            input ActorMoviesUpdateConnectionInput {
+              edge: ActedInUpdateInput
+              node: MovieUpdateInput
+              where: ActorMoviesConnectionWhere
+            }
+
+            input ActorMoviesUpdateFieldInput {
+              connect: [ActorMoviesConnectFieldInput!]
+              create: [ActorMoviesCreateFieldInput!]
+              delete: [ActorMoviesDeleteFieldInput!]
+              disconnect: [ActorMoviesDisconnectFieldInput!]
+              update: ActorMoviesUpdateConnectionInput
+              where: ActorMoviesConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"ActorMoviesUpdateConnectionInput\\\\\\" instead\\")
+            }
+
+            input ActorOptions {
+              limit: Int
+              offset: Int
+              \\"\\"\\"
+              Specify one or more ActorSort objects to sort Actors by. The sorts will be applied in the order in which they are arranged in the array.
+              \\"\\"\\"
+              sort: [ActorSort!]
+            }
+
+            \\"\\"\\"
+            Fields to sort Actors by. The order in which sorts are applied is not guaranteed when specifying many fields in one ActorSort object.
+            \\"\\"\\"
+            input ActorSort {
+              name: SortDirection
+            }
+
+            input ActorUpdateInput {
+              movies: [ActorMoviesUpdateFieldInput!]
+              name: String @deprecated(reason: \\"Please use the explicit _SET field\\")
+              name_SET: String
+            }
+
+            input ActorWhere {
+              AND: [ActorWhere!]
+              NOT: ActorWhere
+              OR: [ActorWhere!]
+              moviesAggregate: ActorMoviesAggregateInput
+              \\"\\"\\"
+              Return Actors where all of the related ActorMoviesConnections match this filter
+              \\"\\"\\"
+              moviesConnection_ALL: ActorMoviesConnectionWhere
+              \\"\\"\\"
+              Return Actors where none of the related ActorMoviesConnections match this filter
+              \\"\\"\\"
+              moviesConnection_NONE: ActorMoviesConnectionWhere
+              \\"\\"\\"
+              Return Actors where one of the related ActorMoviesConnections match this filter
+              \\"\\"\\"
+              moviesConnection_SINGLE: ActorMoviesConnectionWhere
+              \\"\\"\\"
+              Return Actors where some of the related ActorMoviesConnections match this filter
+              \\"\\"\\"
+              moviesConnection_SOME: ActorMoviesConnectionWhere
+              \\"\\"\\"Return Actors where all of the related Movies match this filter\\"\\"\\"
+              movies_ALL: MovieWhere
+              \\"\\"\\"Return Actors where none of the related Movies match this filter\\"\\"\\"
+              movies_NONE: MovieWhere
+              \\"\\"\\"Return Actors where one of the related Movies match this filter\\"\\"\\"
+              movies_SINGLE: MovieWhere
+              \\"\\"\\"Return Actors where some of the related Movies match this filter\\"\\"\\"
+              movies_SOME: MovieWhere
+              name: String @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              name_CONTAINS: String
+              name_ENDS_WITH: String
+              name_EQ: String
+              name_IN: [String!]
+              name_STARTS_WITH: String
+            }
+
+            type ActorsConnection {
+              aggregate: ActorAggregate!
+              edges: [ActorEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
+            type CreateActorsMutationResponse {
+              actors: [Actor!]!
+              info: CreateInfo!
+            }
+
+            type CreateGenresMutationResponse {
+              genres: [Genre!]!
+              info: CreateInfo!
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships created during a create mutation
+            \\"\\"\\"
+            type CreateInfo {
+              nodesCreated: Int!
+              relationshipsCreated: Int!
+            }
+
+            type CreateMoviesMutationResponse {
+              info: CreateInfo!
+              movies: [Movie!]!
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships deleted during a delete mutation
+            \\"\\"\\"
+            type DeleteInfo {
+              nodesDeleted: Int!
+              relationshipsDeleted: Int!
+            }
+
+            type Genre {
+              id: ID
+            }
+
+            type GenreAggregate {
+              count: Count!
+              node: GenreAggregateNode!
+            }
+
+            type GenreAggregateNode {
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+            }
+
+            type GenreAggregateSelection {
+              count: Int!
+              id: IDAggregateSelection! @deprecated(reason: \\"aggregation of ID fields are deprecated and will be removed\\")
+            }
+
+            input GenreCreateInput {
+              id: ID
+            }
+
+            type GenreEdge {
+              cursor: String!
+              node: Genre!
+            }
+
+            input GenreOptions {
+              limit: Int
+              offset: Int
+              \\"\\"\\"
+              Specify one or more GenreSort objects to sort Genres by. The sorts will be applied in the order in which they are arranged in the array.
+              \\"\\"\\"
+              sort: [GenreSort!]
+            }
+
+            \\"\\"\\"
+            Fields to sort Genres by. The order in which sorts are applied is not guaranteed when specifying many fields in one GenreSort object.
+            \\"\\"\\"
+            input GenreSort {
+              id: SortDirection
+            }
+
+            input GenreUpdateInput {
+              id: ID @deprecated(reason: \\"Please use the explicit _SET field\\")
+              id_SET: ID
+            }
+
+            input GenreWhere {
+              AND: [GenreWhere!]
+              NOT: GenreWhere
+              OR: [GenreWhere!]
+              id: ID @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              id_CONTAINS: ID
+              id_ENDS_WITH: ID
+              id_EQ: ID
+              id_IN: [ID]
+              id_STARTS_WITH: ID
+            }
+
+            type GenresConnection {
+              aggregate: GenreAggregate!
+              edges: [GenreEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type IDAggregateSelection {
+              longest: ID
+              shortest: ID
+            }
+
+            type IntAggregateSelection {
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
+            }
+
+            type Movie {
+              actors(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
+              actorsAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: ActorWhere): MovieActorActorsAggregationSelection @deprecated(reason: \\"Please use field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\" instead\\")
+              actorsConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [MovieActorsConnectionSort!], where: MovieActorsConnectionWhere): MovieActorsConnection!
+              favActor(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): Actor!
+              favActorAggregate(directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), where: ActorWhere): MovieActorFavActorAggregationSelection @deprecated(reason: \\"Please use field \\\\\\"aggregate\\\\\\" inside \\\\\\"favActorConnection\\\\\\" instead\\")
+              favActorConnection(after: String, directed: Boolean = true @deprecated(reason: \\"The directed argument is deprecated, and the direction of the field will be configured in the GraphQL server\\"), first: Int, sort: [MovieFavActorConnectionSort!], where: MovieFavActorConnectionWhere): MovieFavActorConnection!
+              title: String!
+            }
+
+            type MovieActorActorsAggregateSelection {
+              count: CountConnection!
+              edge: MovieActorActorsEdgeAggregateSelection
+              node: MovieActorActorsNodeAggregateSelection
+            }
+
+            type MovieActorActorsAggregationSelection {
+              count: Int!
+              edge: MovieActorActorsEdgeAggregateSelection
+              node: MovieActorActorsNodeAggregateSelection
+            }
+
+            type MovieActorActorsEdgeAggregateSelection {
+              screenTime: IntAggregateSelection!
+            }
+
+            type MovieActorActorsNodeAggregateSelection {
+              name: StringAggregateSelection!
+            }
+
+            type MovieActorFavActorAggregateSelection {
+              count: CountConnection!
+              node: MovieActorFavActorNodeAggregateSelection
+            }
+
+            type MovieActorFavActorAggregationSelection {
+              count: Int!
+              node: MovieActorFavActorNodeAggregateSelection
+            }
+
+            type MovieActorFavActorNodeAggregateSelection {
+              name: StringAggregateSelection!
+            }
+
+            input MovieActorsAggregateInput {
+              AND: [MovieActorsAggregateInput!]
+              NOT: MovieActorsAggregateInput
+              OR: [MovieActorsAggregateInput!]
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
+              count_GT: Int
+              count_GTE: Int
+              count_LT: Int
+              count_LTE: Int
+              edge: ActedInAggregationWhereInput
+              node: MovieActorsNodeAggregationWhereInput
+            }
+
+            input MovieActorsConnectFieldInput {
+              connect: [ActorConnectInput!]
+              edge: ActedInCreateInput!
+              where: ActorConnectWhere
+            }
+
+            type MovieActorsConnection {
+              aggregate: MovieActorActorsAggregateSelection!
+              edges: [MovieActorsRelationship!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            input MovieActorsConnectionSort {
+              edge: ActedInSort
+              node: ActorSort
+            }
+
+            input MovieActorsConnectionWhere {
+              AND: [MovieActorsConnectionWhere!]
+              NOT: MovieActorsConnectionWhere
+              OR: [MovieActorsConnectionWhere!]
+              edge: ActedInWhere
+              node: ActorWhere
+            }
+
+            input MovieActorsCreateFieldInput {
+              edge: ActedInCreateInput!
+              node: ActorCreateInput!
+            }
+
+            input MovieActorsDeleteFieldInput {
+              delete: ActorDeleteInput
+              where: MovieActorsConnectionWhere
+            }
+
+            input MovieActorsDisconnectFieldInput {
+              disconnect: ActorDisconnectInput
+              where: MovieActorsConnectionWhere
+            }
+
+            input MovieActorsFieldInput {
+              connect: [MovieActorsConnectFieldInput!]
+              create: [MovieActorsCreateFieldInput!]
+            }
+
+            input MovieActorsNodeAggregationWhereInput {
+              AND: [MovieActorsNodeAggregationWhereInput!]
+              NOT: MovieActorsNodeAggregationWhereInput
+              OR: [MovieActorsNodeAggregationWhereInput!]
+              name_AVERAGE_LENGTH_EQUAL: Float
+              name_AVERAGE_LENGTH_GT: Float
+              name_AVERAGE_LENGTH_GTE: Float
+              name_AVERAGE_LENGTH_LT: Float
+              name_AVERAGE_LENGTH_LTE: Float
+              name_LONGEST_LENGTH_EQUAL: Int
+              name_LONGEST_LENGTH_GT: Int
+              name_LONGEST_LENGTH_GTE: Int
+              name_LONGEST_LENGTH_LT: Int
+              name_LONGEST_LENGTH_LTE: Int
+              name_SHORTEST_LENGTH_EQUAL: Int
+              name_SHORTEST_LENGTH_GT: Int
+              name_SHORTEST_LENGTH_GTE: Int
+              name_SHORTEST_LENGTH_LT: Int
+              name_SHORTEST_LENGTH_LTE: Int
+            }
+
+            type MovieActorsRelationship {
+              cursor: String!
+              node: Actor!
+              properties: ActedIn!
+            }
+
+            input MovieActorsUpdateConnectionInput {
+              edge: ActedInUpdateInput
+              node: ActorUpdateInput
+              where: MovieActorsConnectionWhere
+            }
+
+            input MovieActorsUpdateFieldInput {
+              connect: [MovieActorsConnectFieldInput!]
+              create: [MovieActorsCreateFieldInput!]
+              delete: [MovieActorsDeleteFieldInput!]
+              disconnect: [MovieActorsDisconnectFieldInput!]
+              update: MovieActorsUpdateConnectionInput
+              where: MovieActorsConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieActorsUpdateConnectionInput\\\\\\" instead\\")
+            }
+
+            type MovieAggregate {
+              count: Count!
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              title: StringAggregateSelection!
+            }
+
+            type MovieAggregateSelection {
+              count: Int!
+              title: StringAggregateSelection!
+            }
+
+            input MovieConnectInput {
+              actors: [MovieActorsConnectFieldInput!]
+              favActor: MovieFavActorConnectFieldInput
+            }
+
+            input MovieConnectWhere {
+              node: MovieWhere!
+            }
+
+            input MovieCreateInput {
+              actors: MovieActorsFieldInput
+              favActor: MovieFavActorFieldInput
+              title: String!
+            }
+
+            input MovieDeleteInput {
+              actors: [MovieActorsDeleteFieldInput!]
+              favActor: MovieFavActorDeleteFieldInput
+            }
+
+            input MovieDisconnectInput {
+              actors: [MovieActorsDisconnectFieldInput!]
+              favActor: MovieFavActorDisconnectFieldInput
+            }
+
+            type MovieEdge {
+              cursor: String!
+              node: Movie!
+            }
+
+            input MovieFavActorAggregateInput {
+              AND: [MovieFavActorAggregateInput!]
+              NOT: MovieFavActorAggregateInput
+              OR: [MovieFavActorAggregateInput!]
+              count: Int @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              count_EQ: Int
+              count_GT: Int
+              count_GTE: Int
+              count_LT: Int
+              count_LTE: Int
+              node: MovieFavActorNodeAggregationWhereInput
+            }
+
+            input MovieFavActorConnectFieldInput {
+              connect: ActorConnectInput
+              where: ActorConnectWhere
+            }
+
+            type MovieFavActorConnection {
+              aggregate: MovieActorFavActorAggregateSelection!
+              edges: [MovieFavActorRelationship!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            input MovieFavActorConnectionSort {
+              node: ActorSort
+            }
+
+            input MovieFavActorConnectionWhere {
+              AND: [MovieFavActorConnectionWhere!]
+              NOT: MovieFavActorConnectionWhere
+              OR: [MovieFavActorConnectionWhere!]
+              node: ActorWhere
+            }
+
+            input MovieFavActorCreateFieldInput {
+              node: ActorCreateInput!
+            }
+
+            input MovieFavActorDeleteFieldInput {
+              delete: ActorDeleteInput
+              where: MovieFavActorConnectionWhere
+            }
+
+            input MovieFavActorDisconnectFieldInput {
+              disconnect: ActorDisconnectInput
+              where: MovieFavActorConnectionWhere
+            }
+
+            input MovieFavActorFieldInput {
+              connect: MovieFavActorConnectFieldInput
+              create: MovieFavActorCreateFieldInput
+            }
+
+            input MovieFavActorNodeAggregationWhereInput {
+              AND: [MovieFavActorNodeAggregationWhereInput!]
+              NOT: MovieFavActorNodeAggregationWhereInput
+              OR: [MovieFavActorNodeAggregationWhereInput!]
+              name_AVERAGE_LENGTH_EQUAL: Float
+              name_AVERAGE_LENGTH_GT: Float
+              name_AVERAGE_LENGTH_GTE: Float
+              name_AVERAGE_LENGTH_LT: Float
+              name_AVERAGE_LENGTH_LTE: Float
+              name_LONGEST_LENGTH_EQUAL: Int
+              name_LONGEST_LENGTH_GT: Int
+              name_LONGEST_LENGTH_GTE: Int
+              name_LONGEST_LENGTH_LT: Int
+              name_LONGEST_LENGTH_LTE: Int
+              name_SHORTEST_LENGTH_EQUAL: Int
+              name_SHORTEST_LENGTH_GT: Int
+              name_SHORTEST_LENGTH_GTE: Int
+              name_SHORTEST_LENGTH_LT: Int
+              name_SHORTEST_LENGTH_LTE: Int
+            }
+
+            type MovieFavActorRelationship {
+              cursor: String!
+              node: Actor!
+            }
+
+            input MovieFavActorUpdateConnectionInput {
+              node: ActorUpdateInput
+              where: MovieFavActorConnectionWhere
+            }
+
+            input MovieFavActorUpdateFieldInput {
+              connect: MovieFavActorConnectFieldInput
+              create: MovieFavActorCreateFieldInput
+              delete: MovieFavActorDeleteFieldInput
+              disconnect: MovieFavActorDisconnectFieldInput
+              update: MovieFavActorUpdateConnectionInput
+              where: MovieFavActorConnectionWhere @deprecated(reason: \\"Please use field \\\\\\"where\\\\\\" inside \\\\\\"MovieFavActorUpdateConnectionInput\\\\\\" instead\\")
+            }
+
+            input MovieOptions {
+              limit: Int
+              offset: Int
+              \\"\\"\\"
+              Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array.
+              \\"\\"\\"
+              sort: [MovieSort!]
+            }
+
+            \\"\\"\\"
+            Fields to sort Movies by. The order in which sorts are applied is not guaranteed when specifying many fields in one MovieSort object.
+            \\"\\"\\"
+            input MovieSort {
+              title: SortDirection
+            }
+
+            input MovieUpdateInput {
+              actors: [MovieActorsUpdateFieldInput!]
+              favActor: MovieFavActorUpdateFieldInput
+              title: String @deprecated(reason: \\"Please use the explicit _SET field\\")
+              title_SET: String
+            }
+
+            input MovieWhere {
+              AND: [MovieWhere!]
+              NOT: MovieWhere
+              OR: [MovieWhere!]
+              actorsAggregate: MovieActorsAggregateInput
+              \\"\\"\\"
+              Return Movies where all of the related MovieActorsConnections match this filter
+              \\"\\"\\"
+              actorsConnection_ALL: MovieActorsConnectionWhere
+              \\"\\"\\"
+              Return Movies where none of the related MovieActorsConnections match this filter
+              \\"\\"\\"
+              actorsConnection_NONE: MovieActorsConnectionWhere
+              \\"\\"\\"
+              Return Movies where one of the related MovieActorsConnections match this filter
+              \\"\\"\\"
+              actorsConnection_SINGLE: MovieActorsConnectionWhere
+              \\"\\"\\"
+              Return Movies where some of the related MovieActorsConnections match this filter
+              \\"\\"\\"
+              actorsConnection_SOME: MovieActorsConnectionWhere
+              \\"\\"\\"Return Movies where all of the related Actors match this filter\\"\\"\\"
+              actors_ALL: ActorWhere
+              \\"\\"\\"Return Movies where none of the related Actors match this filter\\"\\"\\"
+              actors_NONE: ActorWhere
+              \\"\\"\\"Return Movies where one of the related Actors match this filter\\"\\"\\"
+              actors_SINGLE: ActorWhere
+              \\"\\"\\"Return Movies where some of the related Actors match this filter\\"\\"\\"
+              actors_SOME: ActorWhere
+              favActor: ActorWhere
+              favActorAggregate: MovieFavActorAggregateInput
+              favActorConnection: MovieFavActorConnectionWhere
+              title: String @deprecated(reason: \\"Please use the explicit _EQ version\\")
+              title_CONTAINS: String
+              title_ENDS_WITH: String
+              title_EQ: String
+              title_IN: [String!]
+              title_STARTS_WITH: String
+            }
+
+            type MoviesConnection {
+              aggregate: MovieAggregate!
+              edges: [MovieEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type Mutation {
+              createActors(input: [ActorCreateInput!]!): CreateActorsMutationResponse!
+              createGenres(input: [GenreCreateInput!]!): CreateGenresMutationResponse!
+              createMovies(input: [MovieCreateInput!]!): CreateMoviesMutationResponse!
+              deleteActors(delete: ActorDeleteInput, where: ActorWhere): DeleteInfo!
+              deleteGenres(where: GenreWhere): DeleteInfo!
+              deleteMovies(delete: MovieDeleteInput, where: MovieWhere): DeleteInfo!
+              updateActors(update: ActorUpdateInput, where: ActorWhere): UpdateActorsMutationResponse!
+              updateGenres(update: GenreUpdateInput, where: GenreWhere): UpdateGenresMutationResponse!
+              updateMovies(update: MovieUpdateInput, where: MovieWhere): UpdateMoviesMutationResponse!
+            }
+
+            \\"\\"\\"Pagination information (Relay)\\"\\"\\"
+            type PageInfo {
+              endCursor: String
+              hasNextPage: Boolean!
+              hasPreviousPage: Boolean!
+              startCursor: String
+            }
+
+            type Query {
+              actors(limit: Int, offset: Int, options: ActorOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [ActorSort!], where: ActorWhere): [Actor!]!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection! @deprecated(reason: \\"Please use the explicit field \\\\\\"aggregate\\\\\\" inside \\\\\\"actorsConnection\\\\\\" instead\\")
+              actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
+              genres(limit: Int, offset: Int, options: GenreOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [GenreSort!], where: GenreWhere): [Genre!]!
+              genresAggregate(where: GenreWhere): GenreAggregateSelection! @deprecated(reason: \\"Please use the explicit field \\\\\\"aggregate\\\\\\" inside \\\\\\"genresConnection\\\\\\" instead\\")
+              genresConnection(after: String, first: Int, sort: [GenreSort!], where: GenreWhere): GenresConnection!
+              movies(limit: Int, offset: Int, options: MovieOptions @deprecated(reason: \\"Query options argument is deprecated, please use pagination arguments like limit, offset and sort instead.\\"), sort: [MovieSort!], where: MovieWhere): [Movie!]!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection! @deprecated(reason: \\"Please use the explicit field \\\\\\"aggregate\\\\\\" inside \\\\\\"moviesConnection\\\\\\" instead\\")
+              moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
+            }
+
+            \\"\\"\\"An enum for sorting in either ascending or descending order.\\"\\"\\"
+            enum SortDirection {
+              \\"\\"\\"Sort by field values in ascending order.\\"\\"\\"
+              ASC
+              \\"\\"\\"Sort by field values in descending order.\\"\\"\\"
+              DESC
+            }
+
+            type StringAggregateSelection {
+              longest: String
+              shortest: String
+            }
+
+            type UpdateActorsMutationResponse {
+              actors: [Actor!]!
+              info: UpdateInfo!
+            }
+
+            type UpdateGenresMutationResponse {
+              genres: [Genre!]!
+              info: UpdateInfo!
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships created and deleted during an update mutation
+            \\"\\"\\"
+            type UpdateInfo {
+              nodesCreated: Int!
+              nodesDeleted: Int!
+              relationshipsCreated: Int!
+              relationshipsDeleted: Int!
+            }
+
+            type UpdateMoviesMutationResponse {
+              info: UpdateInfo!
+              movies: [Movie!]!
+            }"
+        `);
+    });
+});


### PR DESCRIPTION
# Description

`overwrite` argument was deprecated in 6.x, but there is no flag to disable the deprecated feature. This PR adds the flag `overwriteArgument` in `excludeDeprecatedFields`
