### PR TITLE
Change minimum nodejs version for 7.x to 20

### DIFF
--- a/.changeset/ten-starfishes-attend.md
+++ b/.changeset/ten-starfishes-attend.md
@@ -1,6 +1,0 @@
----
-"@neo4j/introspector": major
-"@neo4j/graphql": major
----
-
-The Neo4j GraphQL Library and Introspector now required Node.js 22 or greater.

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -22,7 +22,7 @@
         "dist/**/*.js.map"
     ],
     "engines": {
-        "node": ">=22.0.0"
+        "node": ">=20.0.0"
     },
     "scripts": {
         "build": "tsc --build src/tsconfig.production.json",

--- a/packages/introspector/package.json
+++ b/packages/introspector/package.json
@@ -22,7 +22,7 @@
         "dist/**/*.js.map"
     ],
     "engines": {
-        "node": ">=22.0.0"
+        "node": ">=20.0.0"
     },
     "scripts": {
         "build:clean": "yarn clean && yarn build",


### PR DESCRIPTION
# Description

22 should not be the minimum for Neo4j GraphQL, as it is still under maintenance until April 2026

This major change for 7.x has been reverted