### PR TITLE
Cypher optimized for connections only containing aggregate fields

### DIFF
--- a/.changeset/social-rice-like.md
+++ b/.changeset/social-rice-like.md
@@ -1,0 +1,50 @@
+---
+"@neo4j/graphql": patch
+---
+
+Cypher optimized for connections only containing aggregate fields. The following query:
+
+```graphql
+{
+    moviesConnection {
+        aggregate {
+            count {
+                nodes
+            }
+        }
+    }
+}
+```
+
+Will generate the new Cypher:
+
+```cypher
+CALL {
+    MATCH (this:Movie)
+    RETURN { nodes: count(DISTINCT this) } AS var0
+}
+RETURN { aggregate: { count: var0 } } AS this
+```
+
+Instead of the less performant previous Cypher:
+
+```cypher
+CALL {
+    MATCH (this:Movie)
+    RETURN { nodes: count(DISTINCT this) } AS var0
+}
+CALL {
+    WITH *
+    MATCH (this1:Movie)
+    WITH collect({ node: this1 }) AS edges
+    WITH edges, size(edges) AS totalCount
+    CALL {
+        WITH edges
+        UNWIND edges AS edge
+        WITH edge.node AS this1
+        RETURN collect({ node: { __id: id(this1), __resolveType: "Movie" } }) AS var2
+    }
+    RETURN var2, totalCount
+}
+RETURN { edges: var2, totalCount: totalCount, aggregate: { count: var0 } } AS this
+```

--- a/packages/graphql/src/translate/queryAST/ast/operations/ConnectionReadOperation.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/ConnectionReadOperation.ts
@@ -47,6 +47,7 @@ export class ConnectionReadOperation extends Operation {
     private aggregationField: ConnectionAggregationField | undefined;
 
     public filters: Filter[] = [];
+    public skipConnection: boolean = false; // If set to true, skips the connection (use for aggregation only queries optimisation)
     protected pagination: Pagination | undefined;
     protected sortFields: Array<{ node: Sort[]; edge: Sort[] }> = [];
     protected authFilters: AuthorizationFilters[] = [];
@@ -183,6 +184,20 @@ export class ConnectionReadOperation extends Operation {
         const totalCount = new Cypher.NamedVariable("totalCount");
         const edgesProjectionVar = new Cypher.Variable();
 
+        if (this.skipConnection) {
+            const returnClause = new Cypher.Return([
+                new Cypher.Map({
+                    ...aggregationProjection,
+                }),
+                context.returnVariable,
+            ]);
+
+            return {
+                clauses: [Cypher.utils.concat(...aggregationSubqueries, returnClause)],
+                projectionExpr: context.returnVariable,
+            };
+        }
+
         const unwindAndProjectionSubquery = this.createUnwindAndProjectionSubquery(
             nestedContext,
             edgesVar,
@@ -212,7 +227,9 @@ export class ConnectionReadOperation extends Operation {
             context.returnVariable,
         ]);
 
-        let connectionClauses: Cypher.Clause = Cypher.utils.concat(
+        let connectionClauses: Cypher.Clause;
+
+        connectionClauses = Cypher.utils.concat(
             ...extraMatches,
             selectionClause,
             ...filtersSubqueries,

--- a/packages/graphql/src/translate/queryAST/factory/Operations/ConnectionFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/Operations/ConnectionFactory.ts
@@ -97,7 +97,7 @@ export class ConnectionFactory {
                     entityOrRel: relationship,
                     target: concreteEntity,
                     resolveTree,
-                });
+                }).edges;
             } else {
                 selection = new NodeSelection({
                     target: concreteEntity,
@@ -106,7 +106,7 @@ export class ConnectionFactory {
                     entityOrRel: concreteEntity,
                     target: concreteEntity,
                     resolveTree,
-                });
+                }).edges;
             }
 
             const connectionPartial = new CompositeConnectionPartial({
@@ -190,16 +190,21 @@ export class ConnectionFactory {
 
         let selection: EntitySelection;
         let resolveTreeEdgeFields: Record<string, ResolveTree>;
+        let totalCountEdgeField: ResolveTree | undefined;
+        let pageInfoEdgeField: ResolveTree | undefined;
         if (relationship) {
             selection = new RelationshipSelection({
                 relationship,
                 directed: resolveTree.args.directed as boolean | undefined,
             });
-            resolveTreeEdgeFields = this.parseConnectionFields({
+            const { edges, totalCount, pageInfo } = this.parseConnectionFields({
                 entityOrRel: relationship,
                 target,
                 resolveTree,
             });
+            resolveTreeEdgeFields = edges;
+            totalCountEdgeField = totalCount;
+            pageInfoEdgeField = pageInfo;
         } else {
             if (context.resolveTree.args.fulltext || context.resolveTree.args.phrase) {
                 selection = this.fulltextFactory.getFulltextSelection(target, context);
@@ -208,13 +213,20 @@ export class ConnectionFactory {
                     target,
                 });
             }
-            resolveTreeEdgeFields = this.parseConnectionFields({
+            const { edges, totalCount, pageInfo } = this.parseConnectionFields({
                 entityOrRel: target,
                 target,
                 resolveTree,
             });
+            resolveTreeEdgeFields = edges;
+            totalCountEdgeField = totalCount;
+            pageInfoEdgeField = pageInfo;
         }
         const operation = new ConnectionReadOperation({ relationship, target, selection });
+
+        if (Object.keys(resolveTreeEdgeFields).length === 0 && !totalCountEdgeField && !pageInfoEdgeField) {
+            operation.skipConnection = true;
+        }
 
         this.hydrateConnectionOperationAST({
             relationship,
@@ -522,7 +534,7 @@ export class ConnectionFactory {
         entityOrRel: RelationshipAdapter | ConcreteEntityAdapter;
         target: ConcreteEntityAdapter;
         resolveTree: ResolveTree;
-    }): Record<string, ResolveTree> {
+    }): { edges: Record<string, ResolveTree>; totalCount?: ResolveTree; pageInfo?: ResolveTree } {
         const resolveTreeConnectionFields = this.parseConnectionResolveTree({
             entityOrRel,
             target,
@@ -531,13 +543,19 @@ export class ConnectionFactory {
 
         const entityInterfaces = getEntityInterfaces(target);
         const edgeFieldsRaw = findFieldsByNameInFieldsByTypeNameField(resolveTreeConnectionFields, "edges");
+        const totalCountFieldRaw = findFieldsByNameInFieldsByTypeNameField(resolveTreeConnectionFields, "totalCount");
+        const pageInfoFieldRaw = findFieldsByNameInFieldsByTypeNameField(resolveTreeConnectionFields, "pageInfo");
         const interfacesEdgeFields = entityInterfaces.map((interfaceAdapter) => {
             return getFieldsByTypeName(edgeFieldsRaw, `${interfaceAdapter.name}Edge`);
         });
 
         const concreteEdgeFields = getFieldsByTypeName(edgeFieldsRaw, entityOrRel.operations.relationshipFieldTypename);
 
-        return deepMerge([...interfacesEdgeFields, concreteEdgeFields]);
+        return {
+            edges: deepMerge([...interfacesEdgeFields, concreteEdgeFields]),
+            totalCount: totalCountFieldRaw[0],
+            pageInfo: pageInfoFieldRaw[0],
+        };
     }
 
     private parseConnectionResolveTree({

--- a/packages/graphql/tests/tck/aggregations/count.test.ts
+++ b/packages/graphql/tests/tck/aggregations/count.test.ts
@@ -39,8 +39,12 @@ describe("Cypher Aggregations Count", () => {
     test("Simple Count", async () => {
         const query = /* GraphQL */ `
             {
-                moviesAggregate {
-                    count
+                moviesConnection {
+                    aggregate {
+                        count {
+                            nodes
+                        }
+                    }
                 }
             }
         `;
@@ -50,9 +54,9 @@ describe("Cypher Aggregations Count", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CALL {
                 MATCH (this:Movie)
-                RETURN count(this) AS var0
+                RETURN { nodes: count(DISTINCT this) } AS var0
             }
-            RETURN { count: var0 }"
+            RETURN { aggregate: { count: var0 } } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);

--- a/packages/graphql/tests/tck/aggregations/field-level-aggregations/field-level-aggregations.test.ts
+++ b/packages/graphql/tests/tck/aggregations/field-level-aggregations/field-level-aggregations.test.ts
@@ -72,22 +72,9 @@ describe("Field Level Aggregations", () => {
                     MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                     RETURN { nodes: count(DISTINCT this1), edges: count(DISTINCT this0) } AS var2
                 }
-                CALL {
-                    WITH *
-                    MATCH (this)<-[this3:ACTED_IN]-(this4:Actor)
-                    WITH collect({ node: this4, relationship: this3 }) AS edges
-                    WITH edges, size(edges) AS totalCount
-                    CALL {
-                        WITH edges
-                        UNWIND edges AS edge
-                        WITH edge.node AS this4, edge.relationship AS this3
-                        RETURN collect({ node: { __id: id(this4), __resolveType: \\"Actor\\" } }) AS var5
-                    }
-                    RETURN var5, totalCount
-                }
-                RETURN { edges: var5, totalCount: totalCount, aggregate: { count: var2 } } AS var6
+                RETURN { aggregate: { count: var2 } } AS var3
             }
-            RETURN this { .title, actorsConnection: var6 } AS this"
+            RETURN this { .title, actorsConnection: var3 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);

--- a/packages/graphql/tests/tck/aggregations/where/connection-filters-with-aggregations.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/connection-filters-with-aggregations.test.ts
@@ -88,34 +88,15 @@ describe("Field Level Aggregations Edge Filters", () => {
                     WITH collect(this1.title) AS list
                     RETURN { longest: head(list) } AS var2
                 }
-                CALL {
-                    WITH *
-                    MATCH (this)-[this3:ACTED_IN]->(this4:Movie)
-                    WHERE (this4.title = $param2 AND this3.screentime = $param3)
-                    WITH collect({ node: this4, relationship: this3 }) AS edges
-                    WITH edges, size(edges) AS totalCount
-                    CALL {
-                        WITH edges
-                        UNWIND edges AS edge
-                        WITH edge.node AS this4, edge.relationship AS this3
-                        RETURN collect({ node: { __id: id(this4), __resolveType: \\"Movie\\" } }) AS var5
-                    }
-                    RETURN var5, totalCount
-                }
-                RETURN { edges: var5, totalCount: totalCount, aggregate: { node: { title: var2 } } } AS var6
+                RETURN { aggregate: { node: { title: var2 } } } AS var3
             }
-            RETURN this { moviesConnection: var6 } AS this"
+            RETURN this { moviesConnection: var3 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
                 \\"param0\\": \\"Tha Matrix\\",
                 \\"param1\\": {
-                    \\"low\\": 19,
-                    \\"high\\": 0
-                },
-                \\"param2\\": \\"Tha Matrix\\",
-                \\"param3\\": {
                     \\"low\\": 19,
                     \\"high\\": 0
                 }


### PR DESCRIPTION
# Description

Cypher optimized for connections only containing aggregate fields. The following query:

```graphql
{
    moviesConnection {
        aggregate {
            count {
                nodes
            }
        }
    }
}
```

Will generate the new Cypher:

```cypher
CALL {
    MATCH (this:Movie)
    RETURN { nodes: count(DISTINCT this) } AS var0
}
RETURN { aggregate: { count: var0 } } AS this
```

Instead of the less performant previous Cypher:

```cypher
CALL {
    MATCH (this:Movie)
    RETURN { nodes: count(DISTINCT this) } AS var0
}
CALL {
    WITH *
    MATCH (this1:Movie)
    WITH collect({ node: this1 }) AS edges
    WITH edges, size(edges) AS totalCount
    CALL {
        WITH edges
        UNWIND edges AS edge
        WITH edge.node AS this1
        RETURN collect({ node: { __id: id(this1), __resolveType: "Movie" } }) AS var2
    }
    RETURN var2, totalCount
}
RETURN { edges: var2, totalCount: totalCount, aggregate: { count: var0 } } AS this
```

This should improve performance with queries such as #6115 where only aggregations are requested. Note that this PR is not comprehensive, and cases where the edges re unnecessarily queried may still happen, for instance on interfaces
