### PR TITLE
Validate relationship targeting unions are implemented by node directive nodes

### DIFF
--- a/packages/graphql/src/schema/validation/custom-rules/directives/relationship-validation.test.ts
+++ b/packages/graphql/src/schema/validation/custom-rules/directives/relationship-validation.test.ts
@@ -116,7 +116,7 @@ describe("@relationship validation", () => {
         expect(errors[0]).not.toBeInstanceOf(NoErrorThrownError);
         expect(errors[0]).toHaveProperty(
             "message",
-            'Invalid directive usage: Directive @relationship should be a type with "@node".'
+            'Invalid directive usage: Directive @relationship should be an interface implemented by a type with "@node".'
         );
         expect(errors[0]).toHaveProperty("path", ["Movie", "someActors", "@relationship"]);
     });
@@ -132,6 +132,60 @@ describe("@relationship validation", () => {
             }
 
             type Actor implements Person @node {
+                name: String
+            }
+        `;
+
+        const executeValidate = () =>
+            validateDocument({
+                document: doc,
+                additionalDefinitions,
+                features: {},
+            });
+
+        const errors = getError(executeValidate);
+        expect(errors).toBeInstanceOf(NoErrorThrownError);
+    });
+
+    test("@relationship can't be used with a non-node union", () => {
+        const doc = gql`
+            type Movie @node {
+                someActors: [Person!]! @relationship(type: "ACTED_IN", direction: OUT)
+            }
+
+            union Person = Actor
+
+            type Actor {
+                name: String
+            }
+        `;
+
+        const executeValidate = () =>
+            validateDocument({
+                document: doc,
+                additionalDefinitions,
+                features: {},
+            });
+
+        const errors = getError(executeValidate);
+        expect(errors).toHaveLength(1);
+        expect(errors[0]).not.toBeInstanceOf(NoErrorThrownError);
+        expect(errors[0]).toHaveProperty(
+            "message",
+            'Invalid directive usage: Directive @relationship to an union should have all its types with "@node".'
+        );
+        expect(errors[0]).toHaveProperty("path", ["Movie", "someActors", "@relationship"]);
+    });
+
+    test("@relationship can be used with a node union", () => {
+        const doc = gql`
+            type Movie @node {
+                someActors: [Person!]! @relationship(type: "ACTED_IN", direction: OUT)
+            }
+
+            union Person = Actor
+
+            type Actor @node {
                 name: String
             }
         `;

--- a/packages/graphql/src/schema/validation/custom-rules/directives/relationship.ts
+++ b/packages/graphql/src/schema/validation/custom-rules/directives/relationship.ts
@@ -34,7 +34,7 @@ import type { Neo4jValidationContext } from "../../Neo4jValidationContext";
 import { assertValid, createGraphQLError, DocumentValidationError } from "../utils/document-validation-error";
 import { fieldIsInInterfaceType } from "../utils/location-helpers/is-in-interface-type";
 import { fieldIsInNodeType } from "../utils/location-helpers/is-in-node-type";
-import { interfaceIsNode, typeIsANodeType } from "../utils/location-helpers/is-node-type";
+import { interfaceIsNode, typeIsANodeType, unionIsNode } from "../utils/location-helpers/is-node-type";
 import { getPathToNode } from "../utils/path-parser";
 import { getInnerTypeName } from "../utils/utils";
 
@@ -189,7 +189,19 @@ function validateRelationshipTarget(fieldDefinitionNode: FieldDefinitionNode, co
             })
         ) {
             throw new DocumentValidationError(
-                `Invalid directive usage: Directive @${relationshipDirective.name} should be a type with "@node".`,
+                `Invalid directive usage: Directive @${relationshipDirective.name} should be an interface implemented by a type with "@node".`,
+                []
+            );
+        }
+    } else if (relatedType.kind === Kind.UNION_TYPE_DEFINITION) {
+        if (
+            !unionIsNode({
+                unionTypeDefinitionNode: relatedType,
+                typeMapWithExtensions,
+            })
+        ) {
+            throw new DocumentValidationError(
+                `Invalid directive usage: Directive @${relationshipDirective.name} to an union should have all its types with "@node".`,
                 []
             );
         }

--- a/packages/graphql/src/schema/validation/custom-rules/utils/location-helpers/is-node-type.ts
+++ b/packages/graphql/src/schema/validation/custom-rules/utils/location-helpers/is-node-type.ts
@@ -17,7 +17,12 @@
  * limitations under the License.
  */
 
-import type { InterfaceTypeDefinitionNode, ObjectTypeDefinitionNode } from "graphql";
+import {
+    Kind,
+    type InterfaceTypeDefinitionNode,
+    type ObjectTypeDefinitionNode,
+    type UnionTypeDefinitionNode,
+} from "graphql";
 import { nodeDirective } from "../../../../../graphql/directives";
 import { asArray } from "../../../../../utils/utils";
 import type { TypeMapWithExtensions } from "../../../Neo4jValidationContext";
@@ -62,5 +67,33 @@ export function interfaceIsNode({
             return false;
         }
     }
+    return true;
+}
+
+export function unionIsNode({
+    unionTypeDefinitionNode,
+    typeMapWithExtensions,
+}: {
+    unionTypeDefinitionNode: UnionTypeDefinitionNode;
+    typeMapWithExtensions: TypeMapWithExtensions;
+}): boolean {
+    for (const concreteType of unionTypeDefinitionNode.types ?? []) {
+        const concreteTypeFileName = concreteType.name.value;
+        const type = typeMapWithExtensions[concreteTypeFileName];
+        if (!type) {
+            throw new Error(`Type ${concreteTypeFileName} not found in validation`);
+        }
+
+        if (type.definition && type.definition.kind === Kind.OBJECT_TYPE_DEFINITION) {
+            const isConcreteTypeANode = typeIsANodeType({
+                objectTypeDefinitionNode: type.definition,
+                typeMapWithExtensions,
+            });
+            if (!isConcreteTypeANode) {
+                return false;
+            }
+        }
+    }
+
     return true;
 }


### PR DESCRIPTION

This makes schema such as this invalid:

```graphql
type Movie @node {
    someActors: [Person!]! @relationship(type: "ACTED_IN", direction: OUT)
}
union Person = Actor
type Actor {
    name: String
}
```