### PR TITLE
7: dual-package (CJS and ESM) configuration for release build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ jspm_packages/
 # Build directories
 dist/
 tmp/
+dist-esm/
+dist-cjs/
+dist-types/
 
 # Optional npm cache directory
 .npm

--- a/packages/apollo-federation-subgraph-compatibility/tsconfig.json
+++ b/packages/apollo-federation-subgraph-compatibility/tsconfig.json
@@ -9,5 +9,5 @@
         }
     },
     "include": ["src/**/*"],
-    "references": [{ "path": "../graphql/src/tsconfig.production.json" }]
+    "references": [{ "path": "../graphql/src/tsconfig.production.cjs.json" }]
 }

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -12,9 +12,9 @@
         "url": "https://github.com/neo4j/graphql/issues"
     },
     "homepage": "https://github.com/neo4j/graphql/tree/dev/packages/graphql",
-    "exports": "./dist/index.js",
-    "main": "./dist/index.js",
-    "types": "./dist/index.d.ts",
+    "exports": "./dist/esm/index.js",
+    "main": "./dist/cjs/index.js",
+    "types": "./dist/types/index.d.ts",
     "files": [
         "dist/**/*.ts",
         "dist/**/*.ts.map",
@@ -25,7 +25,7 @@
         "node": ">=20.0.0"
     },
     "scripts": {
-        "build": "tsc --build src/tsconfig.production.json",
+        "build": "tsc --build src/tsconfig.production.cjs.json",
         "clean": "cd src/ && tsc --build --clean",
         "cleanup:package-tests": "cd ../package-tests/ && yarn run cleanup && rimraf ./package/ && rimraf *.tgz",
         "performance": "ts-node tests/performance/performance.ts",

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -12,14 +12,21 @@
         "url": "https://github.com/neo4j/graphql/issues"
     },
     "homepage": "https://github.com/neo4j/graphql/tree/dev/packages/graphql",
-    "exports": "./dist/esm/index.js",
-    "main": "./dist/cjs/index.js",
-    "types": "./dist/types/index.d.ts",
+    "main": "./dist-cjs/index.js",
+    "types": "./dist-types/index.d.ts",
+    "exports": {
+        ".": {
+            "require": "./dist-cjs/index.js",
+            "import": "./dist-esm/index.js",
+            "default": "./dist-cjs/index.js",
+            "types": "./dist-types/index.d.ts"
+        }
+    },
     "files": [
-        "dist/**/*.ts",
-        "dist/**/*.ts.map",
-        "dist/**/*.js",
-        "dist/**/*.js.map"
+        "dist-*/**/*.ts",
+        "dist-*/**/*.ts.map",
+        "dist-*/**/*.js",
+        "dist-*/**/*.js.map"
     ],
     "engines": {
         "node": ">=20.0.0"

--- a/packages/graphql/src/tsconfig.production.cjs.json
+++ b/packages/graphql/src/tsconfig.production.cjs.json
@@ -2,11 +2,11 @@
     "extends": "../../../tsconfig.base.json",
     "compilerOptions": {
         "rootDir": ".",
-        "outDir": "../dist/cjs",
+        "outDir": "../dist-cjs",
         "module": "CommonJS",
         "target": "es2021",
         "moduleResolution": "node10",
-        "declarationDir": "../dist/types"
+        "declarationDir": "../dist-types"
     },
     "exclude": ["**/*.test.ts", "test-api.ts"],
     "references": [

--- a/packages/graphql/src/tsconfig.production.cjs.json
+++ b/packages/graphql/src/tsconfig.production.cjs.json
@@ -2,10 +2,11 @@
     "extends": "../../../tsconfig.base.json",
     "compilerOptions": {
         "rootDir": ".",
-        "outDir": "../dist",
-        "module": "commonjs",
+        "outDir": "../dist/cjs",
+        "module": "CommonJS",
         "target": "es2021",
-        "moduleResolution": "node10"
+        "moduleResolution": "node10",
+        "declarationDir": "../dist/types"
     },
     "exclude": ["**/*.test.ts", "test-api.ts"],
     "references": [

--- a/packages/graphql/src/tsconfig.production.esm.json
+++ b/packages/graphql/src/tsconfig.production.esm.json
@@ -2,11 +2,11 @@
     "extends": "../../../tsconfig.base.json",
     "compilerOptions": {
         "rootDir": ".",
-        "outDir": "../dist/esm",
+        "outDir": "../dist-esm",
         "module": "ES2022",
         "target": "es2021",
         "moduleResolution": "node10",
-        "declarationDir": "../dist/types"
+        "declarationDir": "../dist-types"
     },
     "exclude": ["**/*.test.ts", "test-api.ts"],
     "references": [

--- a/packages/graphql/src/tsconfig.production.esm.json
+++ b/packages/graphql/src/tsconfig.production.esm.json
@@ -1,0 +1,16 @@
+{
+    "extends": "../../../tsconfig.base.json",
+    "compilerOptions": {
+        "rootDir": ".",
+        "outDir": "../dist/esm",
+        "module": "ES2022",
+        "target": "es2021",
+        "moduleResolution": "node10",
+        "declarationDir": "../dist/types"
+    },
+    "exclude": ["**/*.test.ts", "test-api.ts"],
+    "references": [
+        // allows for the import of package.json without it being bundled into dist
+        { "path": "../tsconfig.package.json" }
+    ]
+}

--- a/tsconfig.production.json
+++ b/tsconfig.production.json
@@ -1,7 +1,8 @@
 {
     "files": [],
     "references": [
-        { "path": "./packages/graphql/src/tsconfig.production.json" },
+        { "path": "./packages/graphql/src/tsconfig.production.cjs.json" },
+        { "path": "./packages/graphql/src/tsconfig.production.esm.json" },
         { "path": "./packages/introspector/tsconfig.production.json" }
     ]
 }


### PR DESCRIPTION
# Description

This pull request includes changes to the build configuration and output structure for the `graphql` package to support both CommonJS and ES modules.

Build configuration updates:

* `packages/graphql/package.json`: Updated the `main`, `types`, and `exports` fields to support both CommonJS and ES modules. Adjusted the `files` array to include the new output directories.
* Replaces `tsconfig.production.json` with two new files, `packages/graphql/src/tsconfig.production.cjs.json` for building the package with CommonJS module format and `packages/graphql/src/tsconfig.production.esm.json` for building the package with ES module format.
* The `tsconfig.production.json` file which is used in the release build now refers to the two new tsconfig files.
* The output directories are prefixed with dist, like `dist-esm` due to our need to keep a single level of depth between the built `package.json` and the source files. This is due to how we load the package details from the package.json for use in runtime. See `packages/graphql/src/environment.ts` for more.

## Complexity

Medium