### PR TITLE
Changelog entry for #6177

### DIFF
--- a/.changeset/twenty-islands-film.md
+++ b/.changeset/twenty-islands-film.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": minor
+---
+
+The Neo4j GraphQL Library is now bundled as a dual package containing both CommonJS and ESM builds. This is a changelog entry for #6177.


### PR DESCRIPTION
# Description

The Neo4j GraphQL Library is now bundled as a dual package containing both CommonJS and ESM builds. This is a changelog entry for #6177.