### PR TITLE
Support for non node types on cypher directives

### DIFF
--- a/.changeset/plain-ants-build.md
+++ b/.changeset/plain-ants-build.md
@@ -1,0 +1,27 @@
+---
+"@neo4j/graphql": minor
+---
+
+Add support for `@cypher` directive of fields targeting types that do not use the `@node` directive. For example:
+
+```graphql
+type Movie @node {
+    title: String
+    id: String!
+    link: Link!
+        @cypher(
+            statement: """
+            MATCH(l:${Link})
+            WHERE l.movieId=this.id
+            RETURN l {.name, .url} as link
+            """
+            columnName: "link"
+        )
+}
+
+type Link {
+    movieId: String!
+    url: String!
+    name: String!
+}
+```

--- a/packages/graphql/src/schema-model/generate-model.ts
+++ b/packages/graphql/src/schema-model/generate-model.ts
@@ -135,14 +135,9 @@ function getCypherTarget(schema: Neo4jGraphQLSchemaModel, attributeType: Attribu
     if (attributeType instanceof ObjectType) {
         const foundConcreteEntity = schema.getConcreteEntity(attributeType.name);
         if (!foundConcreteEntity) {
-            throw new Neo4jGraphQLSchemaValidationError(
-                `@cypher field must target type annotated with the @node directive${attributeType.name}, `
-            );
+            return undefined;
         }
         return schema.getConcreteEntity(attributeType.name);
-    }
-    if (attributeType instanceof InterfaceEntity || attributeType instanceof UnionEntity) {
-        throw new Error("@cypher field target cannot be an interface or an union");
     }
 }
 

--- a/packages/graphql/src/schema-model/generate-model.ts
+++ b/packages/graphql/src/schema-model/generate-model.ts
@@ -36,7 +36,7 @@ import { Neo4jGraphQLSchemaModel } from "./Neo4jGraphQLSchemaModel";
 import { Operation } from "./Operation";
 import type { Attribute } from "./attribute/Attribute";
 import type { AttributeType } from "./attribute/AttributeType";
-import { ListType, ObjectType } from "./attribute/AttributeType";
+import { InterfaceType, ListType, ObjectType } from "./attribute/AttributeType";
 import type { CompositeEntity } from "./entity/CompositeEntity";
 import { ConcreteEntity } from "./entity/ConcreteEntity";
 import type { Entity } from "./entity/Entity";
@@ -128,9 +128,13 @@ function addCompositeEntitiesToConcreteEntity(compositeEntities: CompositeEntity
     });
 }
 
-function getCypherTarget(schema: Neo4jGraphQLSchemaModel, attributeType: AttributeType): ConcreteEntity | undefined {
+function getCypherTarget(
+    schema: Neo4jGraphQLSchemaModel,
+    attributeType: AttributeType,
+    attributeName: string
+): ConcreteEntity | undefined {
     if (attributeType instanceof ListType) {
-        return getCypherTarget(schema, attributeType.ofType);
+        return getCypherTarget(schema, attributeType.ofType, attributeName);
     }
     if (attributeType instanceof ObjectType) {
         const foundConcreteEntity = schema.getConcreteEntity(attributeType.name);
@@ -139,6 +143,15 @@ function getCypherTarget(schema: Neo4jGraphQLSchemaModel, attributeType: Attribu
         }
         return schema.getConcreteEntity(attributeType.name);
     }
+
+    if (attributeType instanceof InterfaceType) {
+        const compositeEntity = schema.compositeEntities.find((e) => e.name === attributeType.name);
+        if (!compositeEntity || compositeEntity.concreteEntities.length === 0) {
+            throw new Neo4jGraphQLSchemaValidationError(
+                `@cypher field ${attributeName} must target interface (${attributeType.name}) implemented by types annotated with the @node directive`
+            );
+        }
+    }
 }
 
 // TODO: currently the below is used only for Filtering purposes, and therefore the target is set only for ObjectTypes but in the future we might want to use it for other types as well
@@ -146,7 +159,7 @@ function hydrateCypherAnnotations(schema: Neo4jGraphQLSchemaModel, concreteEntit
     for (const concreteEntity of concreteEntities) {
         for (const attributeField of concreteEntity.attributes.values()) {
             if (attributeField.annotations.cypher) {
-                const target = getCypherTarget(schema, attributeField.type);
+                const target = getCypherTarget(schema, attributeField.type, attributeField.name);
                 attributeField.annotations.cypher.targetEntity = target;
             }
         }

--- a/packages/graphql/src/translate/queryAST/ast/operations/composite/CompositeCypherOperation.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/composite/CompositeCypherOperation.ts
@@ -55,6 +55,13 @@ export class CompositeCypherOperation extends Operation {
 
         const returnVariable = new Cypher.Variable();
         const partialContext = nestedContext.setReturn(returnVariable);
+
+        if (!this.partials.length) {
+            return {
+                clauses: [Cypher.utils.concat(matchClause, new Cypher.Return(nestedContext.returnVariable))],
+                projectionExpr: nestedContext.returnVariable,
+            };
+        }
         const partialClauses = this.partials.map((partial) => {
             const { clauses } = partial.transpile(partialContext);
             return Cypher.utils.concat(new Cypher.With("*"), ...clauses);

--- a/packages/graphql/tests/integration/directives/cypher/cypher-with-non-node-types.int.test.ts
+++ b/packages/graphql/tests/integration/directives/cypher/cypher-with-non-node-types.int.test.ts
@@ -269,8 +269,7 @@ describe("cypher directive targeting non node types", () => {
     });
 
     // Interfaces without `@node` are not supported yet because there is no way to access "__resolveTree", as the information of the concrete type returned by the cypher field is not available
-    // eslint-disable-next-line jest/no-disabled-tests
-    test.skip("interface field", async () => {
+    test("interface field", async () => {
         const Movie = testHelper.createUniqueType("Movie");
         const Link = testHelper.createUniqueType("Link");
 
@@ -298,35 +297,13 @@ describe("cypher directive targeting non node types", () => {
             }
         `;
 
-        await testHelper.initNeo4jGraphQL({ typeDefs });
+        const schema = await testHelper.initNeo4jGraphQL({ typeDefs });
 
-        await testHelper.executeCypher(`
-            CREATE (:${Movie} { id: "matrix", title: "The Matrix"})
-            CREATE (:${Link} {movieId: "matrix", url: "the-matrix.org", name: "Main Website"})
-        `);
-
-        const query = /* GraphQL */ `
-                {
-                    ${Movie.plural} {
-                        title
-                        link {
-                            url
-                            name
-                        }
-                    }
-                }
-            `;
-
-        const gqlResult = await testHelper.executeGraphQL(query);
-        expect(gqlResult.errors).toBeUndefined();
-        expect(gqlResult.data).toEqual({
-            [Movie.plural]: [
-                {
-                    title: "The Matrix",
-                    link: { name: "Main Website", url: "the-matrix.org" },
-                },
-            ],
-        });
+        await expect(() => {
+            return schema.getSchema();
+        }).rejects.toThrow(
+            `@cypher field link must target interface (Link) implemented by types annotated with the @node directive`
+        );
     });
 
     test("query", async () => {

--- a/packages/graphql/tests/integration/directives/cypher/cypher-with-non-node-types.int.test.ts
+++ b/packages/graphql/tests/integration/directives/cypher/cypher-with-non-node-types.int.test.ts
@@ -1,0 +1,375 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TestHelper } from "../../../utils/tests-helper";
+
+describe("cypher directive targeting non node types", () => {
+    const testHelper = new TestHelper();
+
+    afterEach(async () => {
+        await testHelper.close();
+    });
+
+    test("field", async () => {
+        const Movie = testHelper.createUniqueType("Movie");
+        const Link = testHelper.createUniqueType("Link");
+
+        const typeDefs = /* GraphQL */ `
+            type  ${Movie} @node {
+               title: String
+               id: String!
+               link: ${Link}! @cypher(statement: """
+               MATCH(l:${Link})
+               WHERE l.movieId=this.id
+               RETURN l {.name, .url} as link
+               """, columnName: "link")
+            }
+
+            type ${Link} {
+                movieId: String!
+                url: String!
+                name: String!
+            }
+        `;
+
+        await testHelper.initNeo4jGraphQL({ typeDefs });
+
+        await testHelper.executeCypher(`
+            CREATE (:${Movie} { id: "matrix", title: "The Matrix"})
+            CREATE (:${Link} {movieId: "matrix", url: "the-matrix.org", name: "Main Website"})
+        `);
+
+        const query = /* GraphQL */ `
+                {
+                    ${Movie.plural} {
+                        title
+                        link {
+                            url
+                            name
+                        }
+                    }
+                }
+            `;
+
+        const gqlResult = await testHelper.executeGraphQL(query);
+
+        expect(gqlResult.errors).toBeUndefined();
+        expect(gqlResult.data).toEqual({
+            [Movie.plural]: [
+                {
+                    title: "The Matrix",
+                    link: { name: "Main Website", url: "the-matrix.org" },
+                },
+            ],
+        });
+    });
+
+    test("field with nested object", async () => {
+        const Movie = testHelper.createUniqueType("Movie");
+        const Link = testHelper.createUniqueType("Link");
+
+        const typeDefs = /* GraphQL */ `
+            type  ${Movie} @node {
+               title: String
+               id: String!
+               link: ${Link}! @cypher(statement: """
+               MATCH(l:${Link})
+               WHERE l.movieId=this.id
+               RETURN l {.name, .url, somethingElse: {something: "Hello"}} as link
+               """, columnName: "link")
+            }
+
+            type ${Link} {
+                movieId: String!
+                url: String!
+                name: String!
+                somethingElse: SomethingElse!
+            }
+
+            type SomethingElse {
+               something: String!
+            }
+        `;
+
+        await testHelper.initNeo4jGraphQL({ typeDefs });
+
+        await testHelper.executeCypher(`
+            CREATE (:${Movie} { id: "matrix", title: "The Matrix"})
+            CREATE (:${Link} {movieId: "matrix", url: "the-matrix.org", name: "Main Website"})
+        `);
+
+        const query = /* GraphQL */ `
+                {
+                    ${Movie.plural} {
+                        title
+                        link {
+                            url
+                            name
+                            somethingElse {
+                                something
+                            }
+                        }
+                    }
+                }
+            `;
+
+        const gqlResult = await testHelper.executeGraphQL(query);
+
+        expect(gqlResult.errors).toBeUndefined();
+        expect(gqlResult.data).toEqual({
+            [Movie.plural]: [
+                {
+                    title: "The Matrix",
+                    link: { name: "Main Website", url: "the-matrix.org", somethingElse: { something: "Hello" } },
+                },
+            ],
+        });
+    });
+
+    test("array field", async () => {
+        const Movie = testHelper.createUniqueType("Movie");
+        const Link = testHelper.createUniqueType("Link");
+
+        const typeDefs = /* GraphQL */ `
+            type  ${Movie} @node {
+               title: String
+               id: String!
+               links: [${Link}!]! @cypher(statement: """
+               MATCH(l:${Link})
+               WHERE l.movieId=this.id
+               RETURN l {.name, .url} as links
+               """, columnName: "links")
+            }
+
+            type ${Link} {
+                movieId: String!
+                url: String!
+                name: String!
+            }
+        `;
+
+        await testHelper.initNeo4jGraphQL({ typeDefs });
+
+        await testHelper.executeCypher(`
+            CREATE (:${Movie} { id: "matrix", title: "The Matrix"})
+            CREATE (:${Link} {movieId: "matrix", url: "the-matrix.org", name: "Main Website"})
+            CREATE (:${Link} {movieId: "matrix", url: "not-imdb.com", name: "Public Database" })
+        `);
+
+        const query = /* GraphQL */ `
+                {
+                    ${Movie.plural} {
+                        title
+                        links {
+                            url
+                            name
+                        }
+                    }
+                }
+            `;
+
+        const gqlResult = await testHelper.executeGraphQL(query);
+
+        expect(gqlResult.errors).toBeUndefined();
+        expect(gqlResult.data).toEqual({
+            [Movie.plural]: [
+                {
+                    title: "The Matrix",
+                    links: expect.toIncludeSameMembers([
+                        { name: "Main Website", url: "the-matrix.org" },
+                        { name: "Public Database", url: "not-imdb.com" },
+                    ]),
+                },
+            ],
+        });
+    });
+
+    test("nested field", async () => {
+        const Movie = testHelper.createUniqueType("Movie");
+        const Actor = testHelper.createUniqueType("Actor");
+        const Link = testHelper.createUniqueType("Link");
+
+        const typeDefs = /* GraphQL */ `
+            type ${Actor} @node {
+                name: String
+                movies: [${Movie}!]!  @relationship(type: "ACTED_IN", direction: OUT)
+            }
+
+            type  ${Movie} @node {
+               title: String
+               id: String!
+               link: ${Link}! @cypher(statement: """
+               MATCH(l:${Link})
+               WHERE l.movieId=this.id
+               RETURN l {.name, .url} as link
+               """, columnName: "link")
+            }
+
+            type ${Link} {
+                movieId: String!
+                url: String!
+                name: String!
+            }
+        `;
+
+        await testHelper.initNeo4jGraphQL({ typeDefs });
+
+        await testHelper.executeCypher(`
+            CREATE (:${Actor} {name: "Keanu"})-[:ACTED_IN]->(:${Movie} { id: "matrix", title: "The Matrix"})
+            CREATE (:${Link} {movieId: "matrix", url: "the-matrix.org", name: "Main Website"})
+        `);
+
+        const query = /* GraphQL */ `
+                {
+                    ${Actor.plural} {
+                        name
+                        movies {
+                            title
+                            link {
+                                url
+                                name
+                            }
+                        }
+                    }
+                }
+            `;
+
+        const gqlResult = await testHelper.executeGraphQL(query);
+
+        expect(gqlResult.errors).toBeUndefined();
+        expect(gqlResult.data).toEqual({
+            [Actor.plural]: [
+                {
+                    name: "Keanu",
+                    movies: [
+                        {
+                            title: "The Matrix",
+                            link: { name: "Main Website", url: "the-matrix.org" },
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+
+    // Interfaces without `@node` are not supported yet because there is no way to access "__resolveTree", as the information of the concrete type returned by the cypher field is not available
+    // eslint-disable-next-line jest/no-disabled-tests
+    test.skip("interface field", async () => {
+        const Movie = testHelper.createUniqueType("Movie");
+        const Link = testHelper.createUniqueType("Link");
+
+        const typeDefs = /* GraphQL */ `
+            type ${Movie} @node {
+               title: String
+               id: String!
+               link: Link! @cypher(statement: """
+               MATCH(l:${Link})
+               WHERE l.movieId=this.id
+               RETURN l {.name, .url } as link
+               """, columnName: "link")
+            }
+
+            interface Link {
+                movieId: String!
+                url: String!
+                name: String!
+            }
+
+            type ${Link} implements Link {
+                movieId: String!
+                url: String!
+                name: String!
+            }
+        `;
+
+        await testHelper.initNeo4jGraphQL({ typeDefs });
+
+        await testHelper.executeCypher(`
+            CREATE (:${Movie} { id: "matrix", title: "The Matrix"})
+            CREATE (:${Link} {movieId: "matrix", url: "the-matrix.org", name: "Main Website"})
+        `);
+
+        const query = /* GraphQL */ `
+                {
+                    ${Movie.plural} {
+                        title
+                        link {
+                            url
+                            name
+                        }
+                    }
+                }
+            `;
+
+        const gqlResult = await testHelper.executeGraphQL(query);
+        expect(gqlResult.errors).toBeUndefined();
+        expect(gqlResult.data).toEqual({
+            [Movie.plural]: [
+                {
+                    title: "The Matrix",
+                    link: { name: "Main Website", url: "the-matrix.org" },
+                },
+            ],
+        });
+    });
+
+    test("query", async () => {
+        const Movie = testHelper.createUniqueType("Movie");
+
+        const typeDefs = /* GraphQL */ `
+            type Movie {
+                id: String
+            }
+
+            type Query {
+                movie: Movie
+                    @cypher(
+                        statement: """
+                        MATCH (m:${Movie})
+                        RETURN m { .id } as m
+                        """
+                        columnName: "m"
+                    )
+            }
+        `;
+
+        await testHelper.initNeo4jGraphQL({ typeDefs });
+
+        await testHelper.executeCypher(`
+            CREATE (:${Movie} { id: "matrix", title: "The Matrix"})
+        `);
+
+        const query = /* GraphQL */ `
+            {
+                movie {
+                    id
+                }
+            }
+        `;
+
+        const gqlResult = await testHelper.executeGraphQL(query);
+
+        expect(gqlResult.errors).toBeUndefined();
+        expect(gqlResult.data).toEqual({
+            movie: {
+                id: "matrix",
+            },
+        });
+    });
+});


### PR DESCRIPTION
# Description

Add support for `@cypher` directive of fields targeting types that do not use the `@node` directive. For example:

```graphql
type Movie @node {
    title: String
    id: String!
    link: Link!
        @cypher(
            statement: """
            MATCH(l:${Link})
            WHERE l.movieId=this.id
            RETURN l {.name, .url} as link
            """
            columnName: "link"
        )
}

type Link {
    movieId: String!
    url: String!
    name: String!
}
```


This approach has some limitations, particularly with non-node interfaces and unions
