### PR TITLE
Fix populatedBy callback for relationship properties on nested create 

### DIFF
--- a/.changeset/great-pets-flash.md
+++ b/.changeset/great-pets-flash.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+Fix bug with `@populatedBy`. Callback wouldn't be triggered by nested create operations for relationship fields.

--- a/packages/graphql/src/translate/create-update-and-params.ts
+++ b/packages/graphql/src/translate/create-update-and-params.ts
@@ -433,32 +433,33 @@ export default function createUpdateAndParams({
                             });
                             subquery.push(nestedCreate);
                             res.params = { ...res.params, ...params };
-                            const relationVarName = create.edge ? propertiesName : "";
+
+                            const entity = context.schemaModel.getConcreteEntityAdapter(node.name);
+                            const relationshipAdapter = entity
+                                ? entity.findRelationship(relationField.fieldName)
+                                : undefined;
+
+                            const setA = createSetRelationshipProperties({
+                                properties: create.edge ?? {},
+                                varName: propertiesName,
+                                withVars,
+                                relationship,
+                                relationshipAdapter,
+                                callbackBucket,
+                                operation: "CREATE",
+                                parameterPrefix: `${parameterPrefix}.${key}${
+                                    relationField.union ? `.${refNode.name}` : ""
+                                }[${index}].create[${i}].edge`,
+                                parameterNotation: ".",
+                            });
+
+                            const relationVarName = setA ? propertiesName : "";
                             subquery.push(
                                 `MERGE (${parentVar})${inStr}[${relationVarName}:${relationField.type}]${outStr}(${nodeName})`
                             );
 
-                            if (create.edge) {
-                                const entity = context.schemaModel.getConcreteEntityAdapter(node.name);
-                                const relationshipAdapter = entity
-                                    ? entity.findRelationship(relationField.fieldName)
-                                    : undefined;
-                                const setA = createSetRelationshipProperties({
-                                    properties: create.edge,
-                                    varName: propertiesName,
-                                    withVars,
-                                    relationship,
-                                    relationshipAdapter,
-                                    callbackBucket,
-                                    operation: "CREATE",
-                                    parameterPrefix: `${parameterPrefix}.${key}${
-                                        relationField.union ? `.${refNode.name}` : ""
-                                    }[${index}].create[${i}].edge`,
-                                    parameterNotation: ".",
-                                });
-                                if (setA) {
-                                    subquery.push(setA[0]);
-                                }
+                            if (setA) {
+                                subquery.push(setA[0]);
                             }
 
                             subquery.push(

--- a/packages/graphql/tests/integration/issues/6218.int.test.ts
+++ b/packages/graphql/tests/integration/issues/6218.int.test.ts
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { UniqueType } from "../../utils/graphql-types";
+import { TestHelper } from "../../utils/tests-helper";
+
+describe("https://github.com/neo4j/graphql/issues/6219", () => {
+    const testHelper = new TestHelper();
+    let typeDefs: string;
+
+    let Continent: UniqueType;
+    let Country: UniqueType;
+
+    beforeAll(async () => {
+        Continent = testHelper.createUniqueType("Continent");
+        Country = testHelper.createUniqueType("Country");
+
+        typeDefs = /* GraphQL */ `
+            type ${Continent} @mutation(operations: [CREATE, UPDATE, DELETE]) @node {
+                countries: [${Country}!]!
+                    @relationship(
+                        type: "CONTINENT_HAS_COUNTRY"
+                        properties: "ContinentHasCountryProperties"
+                        direction: OUT
+                    )
+                id: Int!
+            }
+
+            type ${Country} @mutation(operations: [CREATE, UPDATE, DELETE]) @node {
+                code: String!
+                continent: [${Continent}!]!
+                    @relationship(
+                        type: "CONTINENT_HAS_COUNTRY"
+                        properties: "ContinentHasCountryProperties"
+                        direction: IN
+                    )
+            }
+
+            type ContinentHasCountryProperties @relationshipProperties {
+                _pk: String! @populatedBy(callback: "myCallback", operations: [CREATE, UPDATE])
+            }
+        `;
+
+        await testHelper.executeCypher(`
+            CREATE(:${Continent} { id: 112312312 })
+            CREATE(:${Country} { code: "ESS1" })
+        `);
+
+        await testHelper.initNeo4jGraphQL({
+            typeDefs,
+            features: {
+                populatedBy: {
+                    callbacks: {
+                        myCallback() {
+                            return "Test";
+                        },
+                    },
+                },
+            },
+        });
+    });
+
+    afterAll(async () => {
+        await testHelper.close();
+    });
+
+    test("trigger callbacks for relationship properties on create and connect", async () => {
+        const query = /* GraphQL */ `
+            mutation {
+                ${Continent.operations.update}(
+                    where: { id: { eq: 112312312 } }
+                    update: {
+                        countries: [
+                            {
+                                create: [{ node: { code: "FRS2" } }]
+                                connect: [{ where: { node: { code: { eq: "ESS1" } } } }]
+                            }
+                        ]
+                    }
+                ) {
+                    ${Continent.plural} {
+                        id
+                        countriesConnection {
+                            edges {
+                                properties {
+                                    _pk
+                                }
+                                node {
+                                    code
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        `;
+
+        const queryResult = await testHelper.executeGraphQL(query);
+        expect(queryResult.errors).toBeUndefined();
+        expect(queryResult.data).toEqual({
+            [Continent.operations.update]: {
+                [Continent.plural]: [
+                    {
+                        id: 112312312,
+                        countriesConnection: {
+                            edges: expect.toIncludeSameMembers([
+                                {
+                                    properties: {
+                                        _pk: "Test",
+                                    },
+                                    node: {
+                                        code: "FRS2",
+                                    },
+                                },
+                                {
+                                    properties: {
+                                        _pk: "Test",
+                                    },
+                                    node: {
+                                        code: "ESS1",
+                                    },
+                                },
+                            ]),
+                        },
+                    },
+                ],
+            },
+        });
+    });
+});

--- a/packages/graphql/tests/tck/operations/update.test.ts
+++ b/packages/graphql/tests/tck/operations/update.test.ts
@@ -574,7 +574,7 @@ describe("Cypher Update", () => {
             CREATE (this_movies0_create0_node:Movie)
             SET this_movies0_create0_node.id = $this_movies0_create0_node_id
             SET this_movies0_create0_node.title = $this_movies0_create0_node_title
-            MERGE (this)-[:ACTED_IN]->(this_movies0_create0_node)
+            MERGE (this)-[this_movies0_create0_relationship:ACTED_IN]->(this_movies0_create0_node)
             WITH *
             CALL {
                 WITH this
@@ -624,7 +624,7 @@ describe("Cypher Update", () => {
             CREATE (this_movies0_create0_node:Movie)
             SET this_movies0_create0_node.id = $this_movies0_create0_node_id
             SET this_movies0_create0_node.title = $this_movies0_create0_node_title
-            MERGE (this)-[:ACTED_IN]->(this_movies0_create0_node)
+            MERGE (this)-[this_movies0_create0_relationship:ACTED_IN]->(this_movies0_create0_node)
             WITH *
             CALL {
                 WITH this
@@ -681,11 +681,11 @@ describe("Cypher Update", () => {
             CREATE (this_movies0_create0_node:Movie)
             SET this_movies0_create0_node.id = $this_movies0_create0_node_id
             SET this_movies0_create0_node.title = $this_movies0_create0_node_title
-            MERGE (this)-[:ACTED_IN]->(this_movies0_create0_node)
+            MERGE (this)-[this_movies0_create0_relationship:ACTED_IN]->(this_movies0_create0_node)
             CREATE (this_movies0_create1_node:Movie)
             SET this_movies0_create1_node.id = $this_movies0_create1_node_id
             SET this_movies0_create1_node.title = $this_movies0_create1_node_title
-            MERGE (this)-[:ACTED_IN]->(this_movies0_create1_node)
+            MERGE (this)-[this_movies0_create1_relationship:ACTED_IN]->(this_movies0_create1_node)
             WITH *
             CALL {
                 WITH this

--- a/packages/graphql/tests/tck/union.test.ts
+++ b/packages/graphql/tests/tck/union.test.ts
@@ -294,7 +294,7 @@ describe("Cypher Union", () => {
             WITH this
             CREATE (this_search_Genre0_create0_node:Genre)
             SET this_search_Genre0_create0_node.name = $this_search_Genre0_create0_node_name
-            MERGE (this)-[:SEARCH]->(this_search_Genre0_create0_node)
+            MERGE (this)-[this_search_Genre0_create0_relationship:SEARCH]->(this_search_Genre0_create0_node)
             RETURN collect(DISTINCT this { .title }) AS data"
         `);
 


### PR DESCRIPTION
# Description

Fix bug with `@populatedBy`. Callback wouldn't be triggered by nested create operations for relationship fields.
