### PR TITLE
Add jsonwebtoken dependency explicitly in package.json

### DIFF
--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -59,6 +59,7 @@
         "is-uuid": "1.0.2",
         "jest": "29.7.0",
         "jest-extended": "4.0.2",
+        "jsonwebtoken": "9.0.2",
         "jwks-rsa": "3.2.0",
         "koa": "3.0.0",
         "koa-jwt": "4.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2341,6 +2341,7 @@ __metadata:
     jest: "npm:29.7.0"
     jest-extended: "npm:4.0.2"
     jose: "npm:^5.0.0"
+    jsonwebtoken: "npm:9.0.2"
     jwks-rsa: "npm:3.2.0"
     koa: "npm:3.0.0"
     koa-jwt: "npm:4.0.4"
@@ -10976,7 +10977,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonwebtoken@npm:^9.0.0":
+"jsonwebtoken@npm:9.0.2, jsonwebtoken@npm:^9.0.0":
   version: 9.0.2
   resolution: "jsonwebtoken@npm:9.0.2"
   dependencies:


### PR DESCRIPTION
# Description

The dependency "jsonwebtoken" is used in the tests, yet this dependency was not declared in package.json. We relied on it being a dependency of a different package