### PR TITLE
Update release pipeline to avoid semver tags

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - dev
       - lts
-      - "*.*.*"
       - "*.x"
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
@@ -59,7 +58,7 @@ jobs:
           title: changesets for branch `${{ github.ref_name }}`
           version: yarn changeset-version
           # Don't use a custom tag if either latest build or prerelease (error under changesets)
-          publish: yarn ${{ (github.ref_name == 'dev' || hashFiles('.changeset/pre.json') != '') && 'release-dev' || 'release-tagged' }}
+          publish: yarn ${{ ((github.ref_name == 'dev' || hashFiles('.changeset/pre.json') != '') && 'release-dev') || (github.ref_name == 'lts' && 'release-lts') || 'release-previous' }}
           setupGitUser: false
         env:
           GITHUB_TOKEN: ${{ secrets.NEO4J_TEAM_GRAPHQL_PERSONAL_ACCESS_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
         "prepare": "husky",
         "changeset-version": "changeset version --since $BRANCH && yarn",
         "release-dev": "yarn build && changeset publish",
-        "release-tagged": "yarn build && changeset publish --tag $BRANCH"
+        "release-lts": "yarn build && changeset publish --tag lts",
+        "release-previous": "yarn build && changeset publish --tag previous"
     },
     "devDependencies": {
         "@tsconfig/node22": "22.0.1",


### PR DESCRIPTION
# Description
SemVer tags are not allowed in NPM, blocking us from releasing branches other than `dev` and `lts`

This PR uses `previous` as a tag for all branches, except dev and lts


> NOTE: This needs to be cherrypicked and merged into lts and 6.x branches