### PR TITLE
Improves handling of invalid identifier check from cdc

### DIFF
--- a/.changeset/small-weeks-ask.md
+++ b/.changeset/small-weeks-ask.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+Handles more errors for stale CDC cursors on subscriptions

--- a/packages/graphql/src/classes/subscription/cdc/cdc-api.ts
+++ b/packages/graphql/src/classes/subscription/cdc/cdc-api.ts
@@ -20,6 +20,7 @@
 import Cypher from "@neo4j/cypher-builder";
 import type { Driver, QueryConfig } from "neo4j-driver";
 import { Neo4jError } from "neo4j-driver";
+import { errorHasGQLStatus } from "../../../utils/error-has-gql-status";
 import type { CDCQueryResponse } from "./cdc-types";
 
 export class CDCApi {
@@ -57,7 +58,10 @@ export class CDCApi {
             if (err instanceof Neo4jError) {
                 // Cursor is stale, needs to be reset
                 // Events between this error and the next poll will be lost
-                if (err.gqlStatus === "52N29") {
+                if (
+                    errorHasGQLStatus(err, "52N29") ||
+                    err.code === "Neo.ClientError.ChangeDataCapture.InvalidIdentifier"
+                ) {
                     console.warn(err);
                     this.cursor = ""; // Resets cursor
                     return [];

--- a/packages/graphql/src/utils/error-has-gql-status.test.ts
+++ b/packages/graphql/src/utils/error-has-gql-status.test.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Neo4jError } from "neo4j-driver";
+import { errorHasGQLStatus } from "./error-has-gql-status";
+
+describe("errorHasGQLStatus", () => {
+    const changeIdentifierError = new Neo4jError(
+        "error: procedure exception",
+        "SERVICE_UNAVAILABLE",
+        "52N29",
+        "error: procedure exception - outdated change identifier. Given ChangeIdentifier describes a transaction that occurred before any enrichment records exist."
+    );
+    const wrappedChangeIdentifierError = new Neo4jError(
+        "error: procedure exception",
+        "SERVICE_UNAVAILABLE",
+        "52N16",
+        "error: procedure exception - outdated change identifier. Given ChangeIdentifier describes a transaction that occurred before any enrichment records exist.",
+        {} as any,
+        changeIdentifierError
+    );
+
+    test("checks an error with a gqlStatus", () => {
+        expect(errorHasGQLStatus(changeIdentifierError, "52N29")).toBeTrue();
+        expect(errorHasGQLStatus(changeIdentifierError, "52N30")).toBeFalse();
+    });
+
+    test("checks a wrapped error with a gqlStatus", () => {
+        expect(errorHasGQLStatus(wrappedChangeIdentifierError, "52N29")).toBeTrue();
+        expect(errorHasGQLStatus(wrappedChangeIdentifierError, "52N16")).toBeTrue();
+        expect(errorHasGQLStatus(wrappedChangeIdentifierError, "52N30")).toBeFalse();
+    });
+});

--- a/packages/graphql/src/utils/error-has-gql-status.ts
+++ b/packages/graphql/src/utils/error-has-gql-status.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Neo4jError } from "neo4j-driver";
+
+export function errorHasGQLStatus(error: Neo4jError, gqlStatus: string): boolean {
+    if (error.gqlStatus === gqlStatus) {
+        return true;
+    }
+
+    if (error.cause) {
+        if (!(error.cause instanceof Neo4jError)) {
+            return false;
+        }
+        return errorHasGQLStatus(error.cause, gqlStatus);
+    }
+
+    return false;
+}


### PR DESCRIPTION
# Description

Handles more errors for stale CDC cursors on subscriptions. This PR checks for the code `Neo.ClientError.ChangeDataCapture.InvalidIdentifier` and the `cause` chain

fix #6237 

This PR must be ported to 5.x and 6.x