### PR TITLE
Cdc stale cursor fix

### DIFF
--- a/.changeset/quiet-symbols-tie.md
+++ b/.changeset/quiet-symbols-tie.md
@@ -1,0 +1,9 @@
+---
+"@neo4j/graphql": patch
+---
+
+Handle the following errors in CDC queries for subscription by resetting the cursor:
+
+- 52N27
+- 52N28
+- 52N30

--- a/.changeset/slimy-walls-flow.md
+++ b/.changeset/slimy-walls-flow.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+Update CDC changeID if no events are returned to prevent a stale cursor

--- a/packages/graphql/src/classes/subscription/Neo4jGraphQLSubscriptionsCDCEngine.ts
+++ b/packages/graphql/src/classes/subscription/Neo4jGraphQLSubscriptionsCDCEngine.ts
@@ -66,7 +66,7 @@ export class Neo4jGraphQLSubscriptionsCDCEngine implements Neo4jGraphQLSubscript
     }
 
     public async init({ schemaModel }: SubscriptionEngineContext): Promise<void> {
-        await this.cdcApi.updateCursor();
+        await this.cdcApi.refreshCursor();
         this._parser = new CDCEventParser(schemaModel);
         this.subscribeToLabels = this.getLabelsToFilter(schemaModel);
 

--- a/packages/graphql/src/classes/subscription/cdc/cdc-api.ts
+++ b/packages/graphql/src/classes/subscription/cdc/cdc-api.ts
@@ -18,7 +18,7 @@
  */
 
 import Cypher from "@neo4j/cypher-builder";
-import type { Driver, QueryConfig } from "neo4j-driver";
+import type { Driver, Integer, QueryConfig } from "neo4j-driver";
 import { Neo4jError } from "neo4j-driver";
 import { errorHasGQLStatus } from "../../../utils/error-has-gql-status";
 import type { CDCQueryResponse } from "./cdc-types";
@@ -36,22 +36,37 @@ export class CDCApi {
     /** Queries events since last call to queryEvents */
     public async queryEvents(labels?: string[], txFilter?: Cypher.Map): Promise<CDCQueryResponse[]> {
         if (!this.cursor) {
-            this.cursor = await this.fetchCurrentChangeId();
+            // Resets cursor if it doesn't exists
+            await this.refreshCursor();
         }
 
-        const cursorLiteral = new Cypher.Literal(this.cursor);
-
-        const selectors = this.createQuerySelectors(labels);
+        const cdcSelectors = this.createQuerySelectors(labels);
         if (txFilter) {
-            selectors.map((selector) => {
+            cdcSelectors.map((selector) => {
                 selector.set("txMetadata", txFilter);
             });
         }
 
-        const queryProcedure = Cypher.db.cdc.query(cursorLiteral, selectors);
+        const cdcQueryProcedure = this.createCDCQuery(this.cursor, cdcSelectors);
 
         try {
-            const events = await this.runProcedure<CDCQueryResponse>(queryProcedure);
+            const events = await this.runProcedure<CDCQueryResponse & { currentId: string; eventCount: Integer }>(
+                cdcQueryProcedure
+            );
+
+            const firstEventOrNull = events[0];
+            if (!firstEventOrNull) {
+                throw new Error(
+                    "No records found on CDC transaction, this is likely a problem with the GraphQL library, please reach support"
+                );
+            }
+
+            // If no events are returned, update the cursor id wit hthe current change ID to avoid a stale cursor
+            if (firstEventOrNull.eventCount.toInt() === 0) {
+                this.cursor = firstEventOrNull.currentId;
+                return [];
+            }
+
             this.updateChangeIdWithLastEvent(events);
             return events;
         } catch (err) {
@@ -66,7 +81,7 @@ export class CDCApi {
                     err.code === "Neo.ClientError.ChangeDataCapture.InvalidIdentifier"
                 ) {
                     console.warn(err);
-                    this.cursor = ""; // Resets cursor
+                    await this.refreshCursor();
                     return [];
                 }
             }
@@ -74,7 +89,7 @@ export class CDCApi {
         }
     }
 
-    public async updateCursor(): Promise<void> {
+    public async refreshCursor(): Promise<void> {
         this.cursor = await this.fetchCurrentChangeId();
     }
 
@@ -88,6 +103,28 @@ export class CDCApi {
         } else {
             throw new Error("id not available on cdc.current");
         }
+    }
+
+    private createCDCQuery(cursor: string, cdcSelectors: Cypher.Map[]): Cypher.Clause {
+        const cursorLiteral = new Cypher.Literal(cursor);
+
+        const currentId = new Cypher.NamedVariable("currentId");
+        const changeId = new Cypher.NamedVariable("id");
+        const event = new Cypher.NamedVariable("event");
+        const metadata = new Cypher.NamedVariable("metadata");
+        const txId = new Cypher.NamedVariable("txId");
+        const seq = new Cypher.NamedVariable("seq");
+
+        return Cypher.utils.concat(
+            Cypher.db.cdc.current().yield(["id", currentId]),
+            new Cypher.Raw("OPTIONAL "), // TODO: support for OPTIONAL CALL in procedures missing in Cypher Builder: https://github.com/neo4j/cypher-builder/issues/540
+            Cypher.db.cdc
+                .query(cursorLiteral, cdcSelectors)
+                .yield(["id", changeId], "txId", "seq", "event", "metadata"),
+            new Cypher.With("*")
+                .orderBy([txId, "ASC"], [seq, "ASC"])
+                .return(currentId, changeId, event, metadata, [Cypher.count(changeId), "eventCount"])
+        );
     }
 
     private updateChangeIdWithLastEvent(events: CDCQueryResponse[]): void {

--- a/packages/graphql/src/classes/subscription/cdc/cdc-api.ts
+++ b/packages/graphql/src/classes/subscription/cdc/cdc-api.ts
@@ -59,7 +59,10 @@ export class CDCApi {
                 // Cursor is stale, needs to be reset
                 // Events between this error and the next poll will be lost
                 if (
+                    errorHasGQLStatus(err, "52N27") ||
+                    errorHasGQLStatus(err, "52N28") ||
                     errorHasGQLStatus(err, "52N29") ||
+                    errorHasGQLStatus(err, "52N30") ||
                     err.code === "Neo.ClientError.ChangeDataCapture.InvalidIdentifier"
                 ) {
                     console.warn(err);

--- a/packages/graphql/src/classes/subscription/cdc/cdc-types.ts
+++ b/packages/graphql/src/classes/subscription/cdc/cdc-types.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import type { DateTime, Integer } from "neo4j-driver";
+import type { DateTime } from "neo4j-driver";
 
 type CDCEventState = {
     properties: Record<string, unknown>;
@@ -69,6 +69,4 @@ export type CDCQueryResponse = {
     id: string;
     event: CDCEvent;
     metadata: CDCMetadata;
-    txId: Integer;
-    seq: Integer;
 };


### PR DESCRIPTION
# Description

Update CDC changeID if no events are returned to prevent a stale cursor

Handle the following errors in CDC queries for subscription by resetting the cursor:

- 52N27
- 52N28
- 52N30

This would avoid the error discussed in #6237 
