### PR TITLE
Fixed mutation input type generation for enum and custom scalar list

### DIFF
--- a/.changeset/social-banks-greet.md
+++ b/.changeset/social-banks-greet.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+Fixed mutation input type generation for enum and custom scalar list operations. The `push`, `pop`, and `set` operations in list mutation inputs for enums and custom scalars are now correctly marked as optional instead of required.

--- a/packages/graphql/src/schema/make-augmented-schema.ts
+++ b/packages/graphql/src/schema/make-augmented-schema.ts
@@ -183,57 +183,57 @@ function makeAugmentedSchema({
             name: `${enumType.name.value}ListEnumScalarMutations`,
             description: `Mutations for a list for ${enumType.name.value}`,
             fields: {
-                set: { type: `[${enumType.name.value}!]!` },
-                push: { type: `[${enumType.name.value}!]!` },
+                set: { type: `[${enumType.name.value}!]` },
+                push: { type: `[${enumType.name.value}!]` },
                 pop: { type: enumType.name.value },
             },
         });
     });
 
     // Generates the filters for custom scalars
-    Array.from(scalarTypes.values()).forEach((enumType) => {
+    Array.from(scalarTypes.values()).forEach((scalarType) => {
         composer.createInputTC({
-            name: `${enumType.name.value}ScalarFilters`,
-            description: `${enumType.name.value} filters`,
+            name: `${scalarType.name.value}ScalarFilters`,
+            description: `${scalarType.name.value} filters`,
             fields: {
                 eq: {
-                    type: enumType.name.value,
+                    type: scalarType.name.value,
                 },
-                in: { type: `[${enumType.name.value}!]` },
+                in: { type: `[${scalarType.name.value}!]` },
             },
         });
 
         composer.createInputTC({
-            name: `${enumType.name.value}ListScalarFilters`,
-            description: `${enumType.name.value} filters`,
+            name: `${scalarType.name.value}ListScalarFilters`,
+            description: `${scalarType.name.value} filters`,
             fields: {
                 eq: {
-                    type: `[${enumType.name.value}!]`,
+                    type: `[${scalarType.name.value}!]`,
                 },
                 includes: {
-                    type: enumType.name.value,
+                    type: scalarType.name.value,
                 },
             },
         });
     });
 
     // Generates the mutations for custom scalars
-    Array.from(scalarTypes.values()).forEach((enumType) => {
+    Array.from(scalarTypes.values()).forEach((scalarType) => {
         composer.createInputTC({
-            name: `${enumType.name.value}ScalarMutations`,
-            description: `${enumType.name.value} filters`,
+            name: `${scalarType.name.value}ScalarMutations`,
+            description: `${scalarType.name.value} filters`,
             fields: {
-                set: { type: enumType.name.value },
+                set: { type: scalarType.name.value },
             },
         });
 
         composer.createInputTC({
-            name: `${enumType.name.value}ListScalarMutations`,
-            description: `Mutations for a list for ${enumType.name.value}`,
+            name: `${scalarType.name.value}ListScalarMutations`,
+            description: `Mutations for a list for ${scalarType.name.value}`,
             fields: {
-                set: { type: `[${enumType.name.value}!]!` },
-                push: { type: `[${enumType.name.value}!]!` },
-                pop: { type: enumType.name.value },
+                set: { type: `[${scalarType.name.value}!]` },
+                push: { type: `[${scalarType.name.value}!]` },
+                pop: { type: scalarType.name.value },
             },
         });
     });

--- a/packages/graphql/tests/integration/issues/6422.int.test.ts
+++ b/packages/graphql/tests/integration/issues/6422.int.test.ts
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { GraphQLScalarType, Kind } from "graphql";
+import type { UniqueType } from "../../utils/graphql-types";
+import { TestHelper } from "../../utils/tests-helper";
+
+describe("https://github.com/neo4j/graphql/issues/6422", () => {
+    const testHelper = new TestHelper();
+    let typeDefs: string;
+
+    let MutationTest: UniqueType;
+    const GraphQLUpperCaseString = new GraphQLScalarType({
+        name: "UpperCaseString",
+        description: "The `UpperCaseString` scalar type returns all strings in upper case",
+        serialize: (value) => {
+            if (typeof value === "string") {
+                return value.toUpperCase();
+            }
+
+            throw new Error("Unknown type");
+        },
+        parseValue: (value) => {
+            if (typeof value === "string") {
+                return value.toUpperCase();
+            }
+
+            throw new Error("Unknown type");
+        },
+        parseLiteral: (ast) => {
+            if (ast.kind === Kind.STRING) {
+                return ast.value.toUpperCase();
+            }
+
+            return undefined;
+        },
+    });
+
+    beforeEach(async () => {
+        MutationTest = testHelper.createUniqueType("MutationTest");
+
+        typeDefs = /* GraphQL */ `
+            scalar CustomScalar
+            type ${MutationTest} @mutation(operations: [CREATE, UPDATE, DELETE]) @node @subscription(events: []) {
+                enumValue: [EnumMutationTestEnumValue!]!
+                myScalar: [CustomScalar!]!
+                intValue: [Int!]!
+                stringValue: [String!]!
+            }
+
+            """
+            enum test
+            """
+            enum EnumMutationTestEnumValue {
+                ONE
+                TWO
+                THREE
+            }
+        `;
+
+        await testHelper.executeCypher(`
+            CREATE(:${MutationTest} { enumValue: ["ONE", "TWO"], myScalar: ["TEST", "TEST2"], intValue: [1, 2], stringValue: ["test", "test2"] })
+        `);
+
+        await testHelper.initNeo4jGraphQL({
+            typeDefs,
+            resolvers: { CustomScalar: GraphQLUpperCaseString },
+        });
+    });
+
+    afterEach(async () => {
+        await testHelper.close();
+    });
+
+    test("It should be possible to push an enum to an enum list", async () => {
+        const query = /* GraphQL */ `
+            mutation {
+            ${MutationTest.operations.update}(
+                update: {
+                enumValue: {
+                    push: [THREE]
+                }
+                }
+            ) {
+                ${MutationTest.plural} {
+                    enumValue   
+                }
+            }
+            }
+        `;
+
+        const queryResult = await testHelper.executeGraphQL(query);
+        expect(queryResult.errors).toBeUndefined();
+        expect(queryResult.data).toEqual({
+            [MutationTest.operations.update]: {
+                [MutationTest.plural]: [
+                    {
+                        enumValue: expect.toIncludeSameMembers(["ONE", "TWO", "THREE"]),
+                    },
+                ],
+            },
+        });
+    });
+
+    test("It should be possible to push a custom scalar to an custom scalar list", async () => {
+        const query = /* GraphQL */ `
+            mutation {
+            ${MutationTest.operations.update}(
+                update: {
+                    myScalar: {
+                        push: ["test3"]
+                    }
+                }
+            ) {
+                ${MutationTest.plural} {
+                    myScalar   
+                }
+            }
+            }
+        `;
+
+        const queryResult = await testHelper.executeGraphQL(query);
+        expect(queryResult.errors).toBeUndefined();
+        expect(queryResult.data).toEqual({
+            [MutationTest.operations.update]: {
+                [MutationTest.plural]: [
+                    {
+                        myScalar: expect.toIncludeSameMembers(["TEST", "TEST2", "TEST3"]),
+                    },
+                ],
+            },
+        });
+    });
+});

--- a/packages/graphql/tests/schema/issues/2377.test.ts
+++ b/packages/graphql/tests/schema/issues/2377.test.ts
@@ -224,8 +224,8 @@ describe("https://github.com/neo4j/graphql/issues/2377", () => {
             \\"\\"\\"Mutations for a list for Property\\"\\"\\"
             input PropertyListEnumScalarMutations {
               pop: Property
-              push: [Property!]!
-              set: [Property!]!
+              push: [Property!]
+              set: [Property!]
             }
 
             type Query {
@@ -712,8 +712,8 @@ describe("https://github.com/neo4j/graphql/issues/2377", () => {
             \\"\\"\\"Mutations for a list for Tag\\"\\"\\"
             input TagListEnumScalarMutations {
               pop: Tag
-              push: [Tag!]!
-              set: [Tag!]!
+              push: [Tag!]
+              set: [Tag!]
             }
 
             \\"\\"\\"

--- a/packages/graphql/tests/schema/issues/6422.test.ts
+++ b/packages/graphql/tests/schema/issues/6422.test.ts
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { printSchemaWithDirectives } from "@graphql-tools/utils";
+import { lexicographicSortSchema } from "graphql/utilities";
+import { Neo4jGraphQL } from "../../../src";
+
+describe("https://github.com/neo4j/graphql/issues/6422", () => {
+    test("Mutation operations should not be required for list of Enums or Custom scalar properties", async () => {
+        const typeDefs = /* GraphQL */ `
+            scalar CustomScalar
+            type EnumMutationTest @mutation(operations: [CREATE, UPDATE, DELETE]) @node @subscription(events: []) {
+                enumValue: [EnumMutationTestEnumValue!]!
+                intValue: [Int!]!
+                stringValue: [String!]!
+                myScalar: [CustomScalar!]!
+            }
+
+            """
+            enum test
+            """
+            enum EnumMutationTestEnumValue {
+                ONE
+                TWO
+                THREE
+            }
+        `;
+
+        const neoSchema = new Neo4jGraphQL({
+            typeDefs,
+        });
+
+        const printedSchema = printSchemaWithDirectives(lexicographicSortSchema(await neoSchema.getSchema()));
+
+        expect(printedSchema).toMatchInlineSnapshot(`
+            "schema {
+              query: Query
+              mutation: Mutation
+            }
+
+            type Count {
+              nodes: Int!
+            }
+
+            type CreateEnumMutationTestsMutationResponse {
+              enumMutationTests: [EnumMutationTest!]!
+              info: CreateInfo!
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships created during a create mutation
+            \\"\\"\\"
+            type CreateInfo {
+              nodesCreated: Int!
+              relationshipsCreated: Int!
+            }
+
+            scalar CustomScalar
+
+            \\"\\"\\"CustomScalar filters\\"\\"\\"
+            input CustomScalarListScalarFilters {
+              eq: [CustomScalar!]
+              includes: CustomScalar
+            }
+
+            \\"\\"\\"Mutations for a list for CustomScalar\\"\\"\\"
+            input CustomScalarListScalarMutations {
+              pop: CustomScalar
+              push: [CustomScalar!]
+              set: [CustomScalar!]
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships deleted during a delete mutation
+            \\"\\"\\"
+            type DeleteInfo {
+              nodesDeleted: Int!
+              relationshipsDeleted: Int!
+            }
+
+            type EnumMutationTest {
+              enumValue: [EnumMutationTestEnumValue!]!
+              intValue: [Int!]!
+              myScalar: [CustomScalar!]!
+              stringValue: [String!]!
+            }
+
+            type EnumMutationTestAggregate {
+              count: Count!
+            }
+
+            input EnumMutationTestCreateInput {
+              enumValue: [EnumMutationTestEnumValue!]!
+              intValue: [Int!]!
+              myScalar: [CustomScalar!]!
+              stringValue: [String!]!
+            }
+
+            type EnumMutationTestEdge {
+              cursor: String!
+              node: EnumMutationTest!
+            }
+
+            \\"\\"\\"enum test\\"\\"\\"
+            enum EnumMutationTestEnumValue {
+              ONE
+              THREE
+              TWO
+            }
+
+            \\"\\"\\"EnumMutationTestEnumValue filters\\"\\"\\"
+            input EnumMutationTestEnumValueListEnumScalarFilters {
+              eq: [EnumMutationTestEnumValue!]
+              includes: EnumMutationTestEnumValue
+            }
+
+            \\"\\"\\"Mutations for a list for EnumMutationTestEnumValue\\"\\"\\"
+            input EnumMutationTestEnumValueListEnumScalarMutations {
+              pop: EnumMutationTestEnumValue
+              push: [EnumMutationTestEnumValue!]
+              set: [EnumMutationTestEnumValue!]
+            }
+
+            input EnumMutationTestUpdateInput {
+              enumValue: EnumMutationTestEnumValueListEnumScalarMutations
+              enumValue_SET: [EnumMutationTestEnumValue!] @deprecated(reason: \\"Please use the generic mutation 'enumValue: { set: ... } }' instead.\\")
+              intValue: ListIntMutations
+              intValue_POP: Int @deprecated(reason: \\"Please use the generic mutation 'intValue: { pop: ... } }' instead.\\")
+              intValue_PUSH: [Int!] @deprecated(reason: \\"Please use the generic mutation 'intValue: { push: ... } }' instead.\\")
+              intValue_SET: [Int!] @deprecated(reason: \\"Please use the generic mutation 'intValue: { set: ... } }' instead.\\")
+              myScalar: CustomScalarListScalarMutations
+              myScalar_SET: [CustomScalar!] @deprecated(reason: \\"Please use the generic mutation 'myScalar: { set: ... } }' instead.\\")
+              stringValue: ListStringMutations
+              stringValue_POP: Int @deprecated(reason: \\"Please use the generic mutation 'stringValue: { pop: ... } }' instead.\\")
+              stringValue_PUSH: [String!] @deprecated(reason: \\"Please use the generic mutation 'stringValue: { push: ... } }' instead.\\")
+              stringValue_SET: [String!] @deprecated(reason: \\"Please use the generic mutation 'stringValue: { set: ... } }' instead.\\")
+            }
+
+            input EnumMutationTestWhere {
+              AND: [EnumMutationTestWhere!]
+              NOT: EnumMutationTestWhere
+              OR: [EnumMutationTestWhere!]
+              enumValue: EnumMutationTestEnumValueListEnumScalarFilters
+              enumValue_EQ: [EnumMutationTestEnumValue!] @deprecated(reason: \\"Please use the relevant generic filter enumValue: { eq: ... }\\")
+              enumValue_INCLUDES: EnumMutationTestEnumValue @deprecated(reason: \\"Please use the relevant generic filter enumValue: { includes: ... }\\")
+              intValue: IntListFilters
+              intValue_EQ: [Int!] @deprecated(reason: \\"Please use the relevant generic filter intValue: { eq: ... }\\")
+              intValue_INCLUDES: Int @deprecated(reason: \\"Please use the relevant generic filter intValue: { includes: ... }\\")
+              myScalar: CustomScalarListScalarFilters
+              myScalar_EQ: [CustomScalar!] @deprecated(reason: \\"Please use the relevant generic filter myScalar: { eq: ... }\\")
+              myScalar_INCLUDES: CustomScalar @deprecated(reason: \\"Please use the relevant generic filter myScalar: { includes: ... }\\")
+              stringValue: StringListFilters
+              stringValue_EQ: [String!] @deprecated(reason: \\"Please use the relevant generic filter stringValue: { eq: ... }\\")
+              stringValue_INCLUDES: String @deprecated(reason: \\"Please use the relevant generic filter stringValue: { includes: ... }\\")
+            }
+
+            type EnumMutationTestsConnection {
+              aggregate: EnumMutationTestAggregate!
+              edges: [EnumMutationTestEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            \\"\\"\\"Int list filters\\"\\"\\"
+            input IntListFilters {
+              eq: [Int!]
+              includes: Int
+            }
+
+            \\"\\"\\"Mutations for a list for Int\\"\\"\\"
+            input ListIntMutations {
+              pop: Int
+              push: [Int!]
+              set: [Int!]
+            }
+
+            \\"\\"\\"Mutations for a list for String\\"\\"\\"
+            input ListStringMutations {
+              pop: Int
+              push: [String!]
+              set: [String!]
+            }
+
+            type Mutation {
+              createEnumMutationTests(input: [EnumMutationTestCreateInput!]!): CreateEnumMutationTestsMutationResponse!
+              deleteEnumMutationTests(where: EnumMutationTestWhere): DeleteInfo!
+              updateEnumMutationTests(update: EnumMutationTestUpdateInput, where: EnumMutationTestWhere): UpdateEnumMutationTestsMutationResponse!
+            }
+
+            \\"\\"\\"Pagination information (Relay)\\"\\"\\"
+            type PageInfo {
+              endCursor: String
+              hasNextPage: Boolean!
+              hasPreviousPage: Boolean!
+              startCursor: String
+            }
+
+            type Query {
+              enumMutationTests(limit: Int, offset: Int, where: EnumMutationTestWhere): [EnumMutationTest!]!
+              enumMutationTestsConnection(after: String, first: Int, where: EnumMutationTestWhere): EnumMutationTestsConnection!
+            }
+
+            \\"\\"\\"String list filters\\"\\"\\"
+            input StringListFilters {
+              eq: [String!]
+              includes: String
+            }
+
+            type UpdateEnumMutationTestsMutationResponse {
+              enumMutationTests: [EnumMutationTest!]!
+              info: UpdateInfo!
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships created and deleted during an update mutation
+            \\"\\"\\"
+            type UpdateInfo {
+              nodesCreated: Int!
+              nodesDeleted: Int!
+              relationshipsCreated: Int!
+              relationshipsDeleted: Int!
+            }"
+        `);
+    });
+});

--- a/packages/graphql/tests/schema/scalar.test.ts
+++ b/packages/graphql/tests/schema/scalar.test.ts
@@ -71,8 +71,8 @@ describe("Scalar", () => {
             \\"\\"\\"Mutations for a list for CustomScalar\\"\\"\\"
             input CustomScalarListScalarMutations {
               pop: CustomScalar
-              push: [CustomScalar!]!
-              set: [CustomScalar!]!
+              push: [CustomScalar!]
+              set: [CustomScalar!]
             }
 
             \\"\\"\\"CustomScalar filters\\"\\"\\"


### PR DESCRIPTION
Fixed mutation input type generation for enum and custom scalar list operations. The `push`, `pop`, and `set` operations in list mutation inputs for enums and custom scalars are now correctly marked as optional instead of required.
