### PR TITLE
Add cypher version prefix option on tests

### DIFF
--- a/packages/graphql/tests/e2e/setup/apollo-server.ts
+++ b/packages/graphql/tests/e2e/setup/apollo-server.ts
@@ -24,15 +24,16 @@ import { ApolloServerPluginDrainHttpServer } from "@apollo/server/plugin/drainHt
 import bodyParser from "body-parser";
 import cors from "cors";
 import express from "express";
+import { type DocumentNode } from "graphql";
+import { getComplexity } from "graphql-query-complexity";
 import { useServer } from "graphql-ws/lib/use/ws";
 import type { Server } from "http";
 import { createServer } from "http";
 import type { AddressInfo } from "ws";
 import { WebSocketServer } from "ws";
 import type { Neo4jGraphQL } from "../../../src";
-import { getComplexity } from "graphql-query-complexity";
-import { type DocumentNode } from "graphql";
 import { DefaultComplexityEstimators } from "../../../src/classes";
+import { ADD_CYPHER_VERSION_PREFIX } from "../../utils/constants";
 
 export interface TestGraphQLServer {
     path: string;
@@ -148,10 +149,24 @@ export class ApolloTestServer implements TestGraphQLServer {
             bodyParser.json(),
             expressMiddleware(server, {
                 context: this.customContext
-                    ? this.customContext
+                    ? async (ctx) => {
+                          const customContext = await this.customContext!(ctx);
+                          return {
+                              cypherQueryOptions: {
+                                  addVersionPrefix: ADD_CYPHER_VERSION_PREFIX,
+                              },
+                              ...customContext,
+                          };
+                      }
                     : // eslint-disable-next-line @typescript-eslint/require-await
                       async ({ req }) => {
-                          return { req, token: req.headers.authorization };
+                          return {
+                              req,
+                              token: req.headers.authorization,
+                              cypherQueryOptions: {
+                                  addVersionPrefix: ADD_CYPHER_VERSION_PREFIX,
+                              },
+                          };
                       },
             })
         );

--- a/packages/graphql/tests/utils/constants.ts
+++ b/packages/graphql/tests/utils/constants.ts
@@ -1,0 +1,2 @@
+/** Explicitly define if the Cypher version prefix should be added in the tests */
+export const ADD_CYPHER_VERSION_PREFIX = true;

--- a/packages/graphql/tests/utils/tests-helper.ts
+++ b/packages/graphql/tests/utils/tests-helper.ts
@@ -26,6 +26,7 @@ import { Neo4jGraphQL, Neo4jGraphQLSubscriptionsCDCEngine } from "../../src";
 import { Neo4jDatabaseInfo } from "../../src/classes";
 import type { Neo4jGraphQLSessionConfig } from "../../src/classes/Executor";
 import type { Neo4jEdition } from "../../src/classes/Neo4jDatabaseInfo";
+import { ADD_CYPHER_VERSION_PREFIX } from "./constants";
 import { createBearerToken } from "./create-bearer-token";
 import { UniqueType } from "./graphql-types";
 
@@ -199,14 +200,16 @@ export class TestHelper {
         const sessionConfig: Neo4jGraphQLSessionConfig = {
             database: this.database,
         };
-       
+
         if (useRestrictedUser) {
             sessionConfig.impersonatedUser = readWriteUser;
         }
-
         return {
             executionContext: driver,
             sessionConfig,
+            cypherQueryOptions: {
+                addVersionPrefix: ADD_CYPHER_VERSION_PREFIX,
+            },
             ...(options || {}),
         };
     }


### PR DESCRIPTION
# Description

Adds the constant `ADD_CYPHER_VERSION_PREFIX` on tests so they can be run with and without the Cypher Prefix (i.e. Cypher Version 5 and 25)