### PR TITLE
Add cypher version prefix option on tests - LTS

### DIFF
--- a/packages/graphql/tests/e2e/setup/apollo-server.ts
+++ b/packages/graphql/tests/e2e/setup/apollo-server.ts
@@ -30,6 +30,7 @@ import { createServer } from "http";
 import type { AddressInfo } from "ws";
 import { WebSocketServer } from "ws";
 import type { Neo4jGraphQL } from "../../../src";
+import { ADD_CYPHER_VERSION_PREFIX } from "../../utils/constants";
 
 export interface TestGraphQLServer {
     path: string;
@@ -106,10 +107,24 @@ export class ApolloTestServer implements TestGraphQLServer {
             bodyParser.json(),
             expressMiddleware(server, {
                 context: this.customContext
-                    ? this.customContext
+                    ? async (ctx) => {
+                          const customContext = await this.customContext!(ctx);
+                          return {
+                              cypherQueryOptions: {
+                                  addVersionPrefix: ADD_CYPHER_VERSION_PREFIX,
+                              },
+                              ...customContext,
+                          };
+                      }
                     : // eslint-disable-next-line @typescript-eslint/require-await
                       async ({ req }) => {
-                          return { req, token: req.headers.authorization };
+                          return {
+                              req,
+                              token: req.headers.authorization,
+                              cypherQueryOptions: {
+                                  addVersionPrefix: ADD_CYPHER_VERSION_PREFIX,
+                              },
+                          };
                       },
             })
         );

--- a/packages/graphql/tests/utils/constants.ts
+++ b/packages/graphql/tests/utils/constants.ts
@@ -1,0 +1,2 @@
+/** Explicitly define if the Cypher version prefix should be added in the tests */
+export const ADD_CYPHER_VERSION_PREFIX = false;

--- a/packages/graphql/tests/utils/tests-helper.ts
+++ b/packages/graphql/tests/utils/tests-helper.ts
@@ -25,6 +25,7 @@ import type { Neo4jGraphQLConstructor, Neo4jGraphQLContext } from "../../src";
 import { Neo4jGraphQL } from "../../src";
 import { Neo4jDatabaseInfo } from "../../src/classes";
 import type { Neo4jEdition } from "../../src/classes/Neo4jDatabaseInfo";
+import { ADD_CYPHER_VERSION_PREFIX } from "./constants";
 import { createBearerToken } from "./create-bearer-token";
 import { UniqueType } from "./graphql-types";
 
@@ -141,6 +142,9 @@ export class TestHelper {
         return {
             executionContext: driver,
             sessionConfig: { database: this.database },
+            cypherQueryOptions: {
+                addVersionPrefix: ADD_CYPHER_VERSION_PREFIX,
+            },
             ...(options || {}),
         };
     }


### PR DESCRIPTION
(cherry picked from commit a4deb48269eb5f905c1dc2e9a5a75bc7ac6438fe)

# Description

Add option `ADD_CYPHER_VERSION_PREFIX` to explicitly set the Cypher prefix on the tests