### PR TITLE
Skip flaky tests on authorization

### DIFF
--- a/packages/graphql/tests/integration/aggregations/where/authorization-with-aggregation-filter.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/authorization-with-aggregation-filter.int.test.ts
@@ -211,7 +211,10 @@ describe("Authorization with aggregation filter rule", () => {
         ]);
     });
 
-    test("should authorize update operations on post with exactly two likes", async () => {
+    // Test disabled due to flakyness. Enable once `validatePredicate` has been removed from update operations.
+    // The flakyness is caused by the `AND` operation, that doesn't guarantee shortcircuit of each predicate
+    // eslint-disable-next-line jest/no-disabled-tests
+    test.skip("should authorize update operations on post with exactly two likes", async () => {
         const typeDefs = /* GraphQL */ `
             type ${User} @node {
                 id: ID!


### PR DESCRIPTION
Skips a flaky test: https://github.com/neo4j/graphql/actions/runs/16721196542/job/47325827297