### PR TITLE
Optimize total count

### DIFF
--- a/.changeset/chatty-cobras-guess.md
+++ b/.changeset/chatty-cobras-guess.md
@@ -1,0 +1,19 @@
+---
+"@neo4j/graphql": patch
+---
+
+Optimize connection queries without `totalCount` or `pageInfo` such as:
+
+```graphql
+query {
+    moviesConnection(first: 20, sort: [{ title: ASC }]) {
+        edges {
+            node {
+                title
+            }
+        }
+    }
+}
+```
+
+Will no longer calculate `totalCount` in the generated Cypher

--- a/packages/graphql/src/translate/queryAST/ast/operations/ConnectionReadOperation.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/ConnectionReadOperation.ts
@@ -54,6 +54,8 @@ export class ConnectionReadOperation extends Operation {
 
     protected selection: EntitySelection;
 
+    private hasTotalCount = false;
+
     constructor({
         relationship,
         target,
@@ -67,6 +69,10 @@ export class ConnectionReadOperation extends Operation {
         this.relationship = relationship;
         this.target = target;
         this.selection = selection;
+    }
+
+    public setHasTotalCount(value: boolean): void {
+        this.hasTotalCount = value;
     }
 
     public setNodeFields(fields: Field[]) {
@@ -131,11 +137,12 @@ export class ConnectionReadOperation extends Operation {
 
         const extraColumnsVariables = extraColumns.map((c) => c[1]);
 
-        return new Cypher.With([Cypher.collect(nodeAndRelationshipMap), edgesVar], ...extraColumns).with(
-            edgesVar,
-            [Cypher.size(edgesVar), totalCount],
-            ...extraColumnsVariables
-        );
+        const withClause = new Cypher.With([Cypher.collect(nodeAndRelationshipMap), edgesVar], ...extraColumns);
+
+        if (this.hasTotalCount) {
+            return withClause.with(edgesVar, [Cypher.size(edgesVar), totalCount], ...extraColumnsVariables);
+        }
+        return withClause;
     }
 
     public transpile(context: QueryASTContext): OperationTranspileResult {
@@ -228,8 +235,11 @@ export class ConnectionReadOperation extends Operation {
             projectionMap.set("edges", edgesProjectionVar);
         }
 
+        if (this.hasTotalCount) {
+            projectionMap.set("totalCount", totalCount);
+        }
+
         projectionMap.set({
-            totalCount: totalCount,
             ...aggregationProjection,
         });
 
@@ -246,10 +256,12 @@ export class ConnectionReadOperation extends Operation {
         );
 
         if (aggregationSubqueries.length > 0) {
-            connectionClauses = new Cypher.Call( // NOTE: this call is only needed when aggregate is used
-                Cypher.utils.concat(connectionClauses, new Cypher.Return(edgesProjectionVar, totalCount)),
-                "*"
-            );
+            const returnClause = new Cypher.Return(edgesProjectionVar);
+            if (this.hasTotalCount) {
+                returnClause.addColumns(totalCount);
+            }
+
+            connectionClauses = new Cypher.Call(Cypher.utils.concat(connectionClauses, returnClause), "*"); // NOTE: this call is only needed when aggregate is used
         }
 
         return {

--- a/packages/graphql/src/translate/queryAST/factory/Operations/ConnectionFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/Operations/ConnectionFactory.ts
@@ -219,7 +219,11 @@ export class ConnectionFactory {
             totalCountEdgeField = totalCount;
             pageInfoEdgeField = pageInfo;
         }
-        const operation = new ConnectionReadOperation({ relationship, target, selection });
+        const operation = new ConnectionReadOperation({
+            relationship,
+            target,
+            selection,
+        });
 
         if (Object.keys(resolveTreeEdgeFields).length === 0 && !totalCountEdgeField && !pageInfoEdgeField) {
             operation.skipConnection = true;
@@ -452,6 +456,15 @@ export class ConnectionFactory {
 
         const nodeFieldsRaw = findFieldsByNameInFieldsByTypeNameField(resolveTreeEdgeFields, "node");
         const propertiesFieldsRaw = findFieldsByNameInFieldsByTypeNameField(resolveTreeEdgeFields, "properties");
+
+        const { totalCount, pageInfo } = this.parseConnectionFields({
+            entityOrRel,
+            target,
+            resolveTree,
+        });
+
+        operation.setHasTotalCount(Boolean(totalCount || pageInfo));
+
         this.hydrateConnectionOperationsASTWithSort({
             entityOrRel,
             resolveTree,

--- a/packages/graphql/tests/tck/aggregations/where/authorization-with-aggregation-filter.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/authorization-with-aggregation-filter.test.ts
@@ -103,13 +103,12 @@ describe("Authorization with aggregation filter rule", () => {
             WITH *
             WHERE ($isAuthenticated = true AND var3 = true)
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
                 RETURN collect({ node: { content: this0.content, __resolveType: \\"Post\\" } }) AS var4
             }
-            RETURN { edges: var4, totalCount: totalCount } AS this"
+            RETURN { edges: var4 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/array-methods.test.ts
+++ b/packages/graphql/tests/tck/array-methods.test.ts
@@ -514,13 +514,12 @@ describe("Arrays Methods", () => {
             CALL (this) {
                 MATCH (this)-[update_this3:ACTED_IN]->(update_this4:Movie)
                 WITH collect({ node: update_this4, relationship: update_this3 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS update_this4, edge.relationship AS update_this3
                     RETURN collect({ properties: { pay: update_this3.pay, __resolveType: \\"ActedIn\\" }, node: { __id: id(update_this4), __resolveType: \\"Movie\\" } }) AS update_var5
                 }
-                RETURN { edges: update_var5, totalCount: totalCount } AS update_var6
+                RETURN { edges: update_var5 } AS update_var6
             }
             RETURN collect(DISTINCT this { .name, actedIn: update_var2, actedInConnection: update_var6 }) AS data"
         `);
@@ -615,13 +614,12 @@ describe("Arrays Methods", () => {
             CALL (this) {
                 MATCH (this)-[update_this3:ACTED_IN]->(update_this4:Movie)
                 WITH collect({ node: update_this4, relationship: update_this3 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS update_this4, edge.relationship AS update_this3
                     RETURN collect({ properties: { pay: update_this3.pay, __resolveType: \\"ActedIn\\" }, node: { __id: id(update_this4), __resolveType: \\"Movie\\" } }) AS update_var5
                 }
-                RETURN { edges: update_var5, totalCount: totalCount } AS update_var6
+                RETURN { edges: update_var5 } AS update_var6
             }
             RETURN collect(DISTINCT this { .name, actedIn: update_var2, actedInConnection: update_var6 }) AS data"
         `);

--- a/packages/graphql/tests/tck/connections/alias.test.ts
+++ b/packages/graphql/tests/tck/connections/alias.test.ts
@@ -113,25 +113,23 @@ describe("Connections Alias", () => {
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WHERE this1.name = $param1
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             CALL (this) {
                 MATCH (this)<-[this4:ACTED_IN]-(this5:Actor)
                 WHERE this5.name = $param2
                 WITH collect({ node: this5, relationship: this4 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this5, edge.relationship AS this4
                     RETURN collect({ properties: { screenTime: this4.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this5.name, __resolveType: \\"Actor\\" } }) AS var6
                 }
-                RETURN { edges: var6, totalCount: totalCount } AS var7
+                RETURN { edges: var6 } AS var7
             }
             RETURN this { .title, hanks: var3, jenny: var7 } AS this"
         `);

--- a/packages/graphql/tests/tck/connections/filtering/composite.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/composite.test.ts
@@ -82,13 +82,12 @@ describe("Cypher -> Connections -> Filtering -> Composite", () => {
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WHERE ((this1.firstName = $param1 AND this1.lastName = $param2) AND (this0.screenTime > $param3 AND this0.screenTime < $param4))
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { firstName: this1.firstName, lastName: this1.lastName, __resolveType: \\"Actor\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -145,13 +144,12 @@ describe("Cypher -> Connections -> Filtering -> Composite", () => {
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WHERE (NOT (this1.firstName = $param1 AND this1.lastName = $param2) AND NOT (this0.screenTime > $param3 AND this0.screenTime < $param4))
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { firstName: this1.firstName, lastName: this1.lastName, __resolveType: \\"Actor\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -210,13 +208,12 @@ describe("Cypher -> Connections -> Filtering -> Composite", () => {
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WHERE ((this1.firstName = $param1 AND this1.lastName = $param2) OR (this0.screenTime > $param3 AND this0.screenTime < $param4))
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { firstName: this1.firstName, lastName: this1.lastName, __resolveType: \\"Actor\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -277,13 +274,12 @@ describe("Cypher -> Connections -> Filtering -> Composite", () => {
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WHERE NOT ((this1.firstName = $param1 AND this1.lastName = $param2) OR (this0.screenTime > $param3 AND this0.screenTime < $param4))
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { firstName: this1.firstName, lastName: this1.lastName, __resolveType: \\"Actor\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -353,13 +349,12 @@ describe("Cypher -> Connections -> Filtering -> Composite", () => {
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WHERE NOT (((this1.firstName = $param1 AND this1.lastName = $param2) OR (this0.screenTime > $param3 AND this0.screenTime < $param4)) AND (this1.firstName = $param5 AND this1.lastName = $param6))
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { firstName: this1.firstName, lastName: this1.lastName, __resolveType: \\"Actor\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/connections/filtering/node/and.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/node/and.test.ts
@@ -78,13 +78,12 @@ describe("Cypher -> Connections -> Filtering -> Node -> AND", () => {
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WHERE (this1.firstName = $param0 AND this1.lastName = $param1)
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { firstName: this1.firstName, lastName: this1.lastName, __resolveType: \\"Actor\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -126,13 +125,12 @@ describe("Cypher -> Connections -> Filtering -> Node -> AND", () => {
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WHERE NOT (this1.firstName = $param0)
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { firstName: this1.firstName, lastName: this1.lastName, __resolveType: \\"Actor\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/connections/filtering/node/arrays.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/node/arrays.test.ts
@@ -75,13 +75,12 @@ describe("Cypher -> Connections -> Filtering -> Node -> Arrays", () => {
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WHERE this1.name IN $param0
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -125,13 +124,12 @@ describe("Cypher -> Connections -> Filtering -> Node -> Arrays", () => {
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WHERE $param0 IN this1.favouriteColours
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, favouriteColours: this1.favouriteColours, __resolveType: \\"Actor\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/connections/filtering/node/equality.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/node/equality.test.ts
@@ -74,13 +74,12 @@ describe("Cypher -> Connections -> Filtering -> Node -> Equality", () => {
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WHERE this1.name = $param0
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -120,13 +119,12 @@ describe("Cypher -> Connections -> Filtering -> Node -> Equality", () => {
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WHERE NOT (this1.name = $param0)
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/connections/filtering/node/numerical.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/node/numerical.test.ts
@@ -76,13 +76,12 @@ describe("Cypher -> Connections -> Filtering -> Node -> Numerical", () => {
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WHERE this1.age < $param0
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, age: this1.age, __resolveType: \\"Actor\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -126,13 +125,12 @@ describe("Cypher -> Connections -> Filtering -> Node -> Numerical", () => {
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WHERE this1.age <= $param0
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, age: this1.age, __resolveType: \\"Actor\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -176,13 +174,12 @@ describe("Cypher -> Connections -> Filtering -> Node -> Numerical", () => {
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WHERE this1.age > $param0
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, age: this1.age, __resolveType: \\"Actor\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -226,13 +223,12 @@ describe("Cypher -> Connections -> Filtering -> Node -> Numerical", () => {
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WHERE this1.age >= $param0
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, age: this1.age, __resolveType: \\"Actor\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/connections/filtering/node/or.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/node/or.test.ts
@@ -78,13 +78,12 @@ describe("Cypher -> Connections -> Filtering -> Node -> OR", () => {
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WHERE (this1.firstName = $param0 OR this1.lastName = $param1)
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { firstName: this1.firstName, lastName: this1.lastName, __resolveType: \\"Actor\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/connections/filtering/node/points.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/node/points.test.ts
@@ -92,13 +92,12 @@ describe("Cypher -> Connections -> Filtering -> Node -> Points", () => {
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WHERE point.distance(this1.currentLocation, point($param0.point)) = $param0.distance
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, currentLocation: this1.currentLocation, __resolveType: \\"Actor\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/connections/filtering/node/relationship.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/node/relationship.test.ts
@@ -70,13 +70,12 @@ describe("Cypher -> Connections -> Filtering -> Node -> Relationship", () => {
                     WHERE this2.title = $param0
                 }
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var3
                 }
-                RETURN { edges: var3, totalCount: totalCount } AS var4
+                RETURN { edges: var3 } AS var4
             }
             RETURN this { .title, actorsConnection: var4 } AS this"
         `);

--- a/packages/graphql/tests/tck/connections/filtering/node/string.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/node/string.test.ts
@@ -82,13 +82,12 @@ describe("Cypher -> Connections -> Filtering -> Node -> String", () => {
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WHERE this1.name CONTAINS $param0
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -128,13 +127,12 @@ describe("Cypher -> Connections -> Filtering -> Node -> String", () => {
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WHERE this1.name STARTS WITH $param0
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -174,13 +172,12 @@ describe("Cypher -> Connections -> Filtering -> Node -> String", () => {
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WHERE this1.name ENDS WITH $param0
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -220,13 +217,12 @@ describe("Cypher -> Connections -> Filtering -> Node -> String", () => {
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WHERE this1.name =~ $param0
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -266,13 +262,12 @@ describe("Cypher -> Connections -> Filtering -> Node -> String", () => {
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WHERE toLower(this1.name) CONTAINS toLower($param0)
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/connections/filtering/relationship/and.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/relationship/and.test.ts
@@ -78,13 +78,12 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> AND", () => {
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WHERE (this0.role ENDS WITH $param0 AND this0.screenTime < $param1)
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ properties: { role: this0.role, screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -129,13 +128,12 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> AND", () => {
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WHERE NOT (this0.role ENDS WITH $param0)
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ properties: { role: this0.role, screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/connections/filtering/relationship/arrays.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/relationship/arrays.test.ts
@@ -75,13 +75,12 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Arrays", () => {
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WHERE this0.screenTime IN $param0
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -130,13 +129,12 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Arrays", () => {
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WHERE $param0 IN this0.quotes
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/connections/filtering/relationship/equality.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/relationship/equality.test.ts
@@ -74,13 +74,12 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Equality", () =>
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WHERE this0.screenTime = $param0
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -123,13 +122,12 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Equality", () =>
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WHERE NOT (this0.screenTime = $param0)
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/connections/filtering/relationship/numerical.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/relationship/numerical.test.ts
@@ -74,13 +74,12 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Numerical", () =
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WHERE this0.screenTime < $param0
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -123,13 +122,12 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Numerical", () =
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WHERE this0.screenTime <= $param0
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -172,13 +170,12 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Numerical", () =
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WHERE this0.screenTime > $param0
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -221,13 +218,12 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Numerical", () =
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WHERE this0.screenTime >= $param0
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/connections/filtering/relationship/or.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/relationship/or.test.ts
@@ -78,13 +78,12 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> OR", () => {
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WHERE (this0.role ENDS WITH $param0 OR this0.screenTime < $param1)
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ properties: { role: this0.role, screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/connections/filtering/relationship/points.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/relationship/points.test.ts
@@ -90,13 +90,12 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Points", () => {
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WHERE point.distance(this0.location, point($param0.point)) = $param0.distance
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ properties: { screenTime: this0.screenTime, location: this0.location, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/connections/filtering/relationship/string.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/relationship/string.test.ts
@@ -82,13 +82,12 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> String", () => {
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WHERE this0.role CONTAINS $param0
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ properties: { role: this0.role, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -128,13 +127,12 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> String", () => {
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WHERE this0.role STARTS WITH $param0
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ properties: { role: this0.role, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -174,13 +172,12 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> String", () => {
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WHERE this0.role ENDS WITH $param0
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ properties: { role: this0.role, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -220,13 +217,12 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> String", () => {
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WHERE this0.role =~ $param0
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ properties: { role: this0.role, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/connections/filtering/relationship/temporal.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/relationship/temporal.test.ts
@@ -80,13 +80,12 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Temporal", () =>
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WHERE (this0.startDate > $param0 AND this0.endDateTime < datetime($param1))
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ properties: { startDate: this0.startDate, endDateTime: apoc.date.convertFormat(toString(this0.endDateTime), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\"), __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/connections/mixed-nesting.test.ts
+++ b/packages/graphql/tests/tck/connections/mixed-nesting.test.ts
@@ -78,7 +78,6 @@ describe("Mixed nesting", () => {
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WHERE this1.name = $param1
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
@@ -91,7 +90,7 @@ describe("Mixed nesting", () => {
                     }
                     RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, movies: var4, __resolveType: \\"Actor\\" } }) AS var5
                 }
-                RETURN { edges: var5, totalCount: totalCount } AS var6
+                RETURN { edges: var5 } AS var6
             }
             RETURN this { .title, actorsConnection: var6 } AS this"
         `);
@@ -144,7 +143,6 @@ describe("Mixed nesting", () => {
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WHERE this1.name = $param1
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
@@ -152,7 +150,6 @@ describe("Mixed nesting", () => {
                         MATCH (this1)-[this2:ACTED_IN]->(this3:Movie)
                         WHERE NOT (this3.title = $param2)
                         WITH collect({ node: this3, relationship: this2 }) AS edges
-                        WITH edges, size(edges) AS totalCount
                         CALL (edges) {
                             UNWIND edges AS edge
                             WITH edge.node AS this3, edge.relationship AS this2
@@ -165,11 +162,11 @@ describe("Mixed nesting", () => {
                             }
                             RETURN collect({ node: { title: this3.title, actors: var6, __resolveType: \\"Movie\\" } }) AS var7
                         }
-                        RETURN { edges: var7, totalCount: totalCount } AS var8
+                        RETURN { edges: var7 } AS var8
                     }
                     RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, moviesConnection: var8, __resolveType: \\"Actor\\" } }) AS var9
                 }
-                RETURN { edges: var9, totalCount: totalCount } AS var10
+                RETURN { edges: var9 } AS var10
             }
             RETURN this { .title, actorsConnection: var10 } AS this"
         `);
@@ -220,13 +217,12 @@ describe("Mixed nesting", () => {
                     MATCH (this1)-[this2:ACTED_IN]->(this3:Movie)
                     WHERE NOT (this3.title = $param2)
                     WITH collect({ node: this3, relationship: this2 }) AS edges
-                    WITH edges, size(edges) AS totalCount
                     CALL (edges) {
                         UNWIND edges AS edge
                         WITH edge.node AS this3, edge.relationship AS this2
                         RETURN collect({ properties: { screenTime: this2.screenTime, __resolveType: \\"ActedIn\\" }, node: { title: this3.title, __resolveType: \\"Movie\\" } }) AS var4
                     }
-                    RETURN { edges: var4, totalCount: totalCount } AS var5
+                    RETURN { edges: var4 } AS var5
                 }
                 WITH this1 { .name, moviesConnection: var5 } AS this1
                 RETURN collect(this1) AS var6

--- a/packages/graphql/tests/tck/connections/projections/create.test.ts
+++ b/packages/graphql/tests/tck/connections/projections/create.test.ts
@@ -81,13 +81,12 @@ describe("Cypher -> Connections -> Projections -> Create", () => {
             CALL (create_this1) {
                 MATCH (create_this1)<-[create_this2:ACTED_IN]-(create_this3:Actor)
                 WITH collect({ node: create_this3, relationship: create_this2 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS create_this3, edge.relationship AS create_this2
                     RETURN collect({ properties: { screenTime: create_this2.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: create_this3.name, __resolveType: \\"Actor\\" } }) AS create_var4
                 }
-                RETURN { edges: create_var4, totalCount: totalCount } AS create_var5
+                RETURN { edges: create_var4 } AS create_var5
             }
             RETURN collect(create_this1 { .title, actorsConnection: create_var5 }) AS data"
         `);
@@ -138,13 +137,12 @@ describe("Cypher -> Connections -> Projections -> Create", () => {
             CALL (create_this1) {
                 MATCH (create_this1)<-[create_this2:ACTED_IN]-(create_this3:Actor)
                 WITH collect({ node: create_this3, relationship: create_this2 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS create_this3, edge.relationship AS create_this2
                     RETURN collect({ properties: { screenTime: create_this2.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: create_this3.name, __resolveType: \\"Actor\\" } }) AS create_var4
                 }
-                RETURN { edges: create_var4, totalCount: totalCount } AS create_var5
+                RETURN { edges: create_var4 } AS create_var5
             }
             RETURN collect(create_this1 { .title, actorsConnection: create_var5 }) AS data"
         `);
@@ -199,13 +197,12 @@ describe("Cypher -> Connections -> Projections -> Create", () => {
                 MATCH (create_this1)<-[create_this2:ACTED_IN]-(create_this3:Actor)
                 WHERE create_this3.name = $create_param1
                 WITH collect({ node: create_this3, relationship: create_this2 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS create_this3, edge.relationship AS create_this2
                     RETURN collect({ properties: { screenTime: create_this2.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: create_this3.name, __resolveType: \\"Actor\\" } }) AS create_var4
                 }
-                RETURN { edges: create_var4, totalCount: totalCount } AS create_var5
+                RETURN { edges: create_var4 } AS create_var5
             }
             RETURN collect(create_this1 { .title, actorsConnection: create_var5 }) AS data"
         `);

--- a/packages/graphql/tests/tck/connections/projections/update.test.ts
+++ b/packages/graphql/tests/tck/connections/projections/update.test.ts
@@ -77,13 +77,12 @@ describe("Cypher -> Connections -> Projections -> Update", () => {
             CALL (this) {
                 MATCH (this)<-[update_this0:ACTED_IN]-(update_this1:Actor)
                 WITH collect({ node: update_this1, relationship: update_this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS update_this1, edge.relationship AS update_this0
                     RETURN collect({ properties: { screenTime: update_this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: update_this1.name, __resolveType: \\"Actor\\" } }) AS update_var2
                 }
-                RETURN { edges: update_var2, totalCount: totalCount } AS update_var3
+                RETURN { edges: update_var2 } AS update_var3
             }
             RETURN collect(DISTINCT this { .title, actorsConnection: update_var3 }) AS data"
         `);

--- a/packages/graphql/tests/tck/connections/relationship-properties.test.ts
+++ b/packages/graphql/tests/tck/connections/relationship-properties.test.ts
@@ -75,13 +75,12 @@ describe("Relationship Properties Cypher", () => {
             CALL (this) {
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -122,13 +121,12 @@ describe("Relationship Properties Cypher", () => {
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WHERE this1.name = $param1
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -169,7 +167,6 @@ describe("Relationship Properties Cypher", () => {
             CALL (this) {
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
@@ -177,7 +174,7 @@ describe("Relationship Properties Cypher", () => {
                     ORDER BY this0.screenTime DESC
                     RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -215,7 +212,6 @@ describe("Relationship Properties Cypher", () => {
             CALL (this) {
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
@@ -223,7 +219,7 @@ describe("Relationship Properties Cypher", () => {
                     ORDER BY this0.year DESC, this1.name ASC
                     RETURN collect({ properties: { year: this0.year, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { actorsConnection: var3 } AS this"
         `);
@@ -256,7 +252,6 @@ describe("Relationship Properties Cypher", () => {
             CALL (this) {
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
@@ -264,7 +259,7 @@ describe("Relationship Properties Cypher", () => {
                     ORDER BY this1.name ASC, this0.year DESC
                     RETURN collect({ properties: { year: this0.year, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { actorsConnection: var3 } AS this"
         `);
@@ -310,24 +305,22 @@ describe("Relationship Properties Cypher", () => {
             CALL (this) {
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     CALL (this1) {
                         MATCH (this1)-[this2:ACTED_IN]->(this3:Movie)
                         WITH collect({ node: this3, relationship: this2 }) AS edges
-                        WITH edges, size(edges) AS totalCount
                         CALL (edges) {
                             UNWIND edges AS edge
                             WITH edge.node AS this3, edge.relationship AS this2
                             RETURN collect({ properties: { screenTime: this2.screenTime, __resolveType: \\"ActedIn\\" }, node: { title: this3.title, __resolveType: \\"Movie\\" } }) AS var4
                         }
-                        RETURN { edges: var4, totalCount: totalCount } AS var5
+                        RETURN { edges: var4 } AS var5
                     }
                     RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, moviesConnection: var5, __resolveType: \\"Actor\\" } }) AS var6
                 }
-                RETURN { edges: var6, totalCount: totalCount } AS var7
+                RETURN { edges: var6 } AS var7
             }
             RETURN this { .title, actorsConnection: var7 } AS this"
         `);
@@ -387,35 +380,32 @@ describe("Relationship Properties Cypher", () => {
             CALL (this) {
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     CALL (this1) {
                         MATCH (this1)-[this2:ACTED_IN]->(this3:Movie)
                         WITH collect({ node: this3, relationship: this2 }) AS edges
-                        WITH edges, size(edges) AS totalCount
                         CALL (edges) {
                             UNWIND edges AS edge
                             WITH edge.node AS this3, edge.relationship AS this2
                             CALL (this3) {
                                 MATCH (this3)<-[this4:ACTED_IN]-(this5:Actor)
                                 WITH collect({ node: this5, relationship: this4 }) AS edges
-                                WITH edges, size(edges) AS totalCount
                                 CALL (edges) {
                                     UNWIND edges AS edge
                                     WITH edge.node AS this5, edge.relationship AS this4
                                     RETURN collect({ properties: { screenTime: this4.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this5.name, __resolveType: \\"Actor\\" } }) AS var6
                                 }
-                                RETURN { edges: var6, totalCount: totalCount } AS var7
+                                RETURN { edges: var6 } AS var7
                             }
                             RETURN collect({ properties: { screenTime: this2.screenTime, __resolveType: \\"ActedIn\\" }, node: { title: this3.title, actorsConnection: var7, __resolveType: \\"Movie\\" } }) AS var8
                         }
-                        RETURN { edges: var8, totalCount: totalCount } AS var9
+                        RETURN { edges: var8 } AS var9
                     }
                     RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, moviesConnection: var9, __resolveType: \\"Actor\\" } }) AS var10
                 }
-                RETURN { edges: var10, totalCount: totalCount } AS var11
+                RETURN { edges: var10 } AS var11
             }
             RETURN this { .title, actorsConnection: var11 } AS this"
         `);

--- a/packages/graphql/tests/tck/connections/relationship_properties/connect.test.ts
+++ b/packages/graphql/tests/tck/connections/relationship_properties/connect.test.ts
@@ -89,13 +89,12 @@ describe("Relationship Properties Connect Cypher", () => {
                 CALL (this) {
                     MATCH (this)<-[this3:ACTED_IN]-(this4:Actor)
                     WITH collect({ node: this4, relationship: this3 }) AS edges
-                    WITH edges, size(edges) AS totalCount
                     CALL (edges) {
                         UNWIND edges AS edge
                         WITH edge.node AS this4, edge.relationship AS this3
                         RETURN collect({ properties: { screenTime: this3.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this4.name, __resolveType: \\"Actor\\" } }) AS var5
                     }
-                    RETURN { edges: var5, totalCount: totalCount } AS var6
+                    RETURN { edges: var5 } AS var6
                 }
                 RETURN this { .title, actorsConnection: var6 } AS var7
             }
@@ -166,13 +165,12 @@ describe("Relationship Properties Connect Cypher", () => {
                 CALL (this) {
                     MATCH (this)<-[this3:ACTED_IN]-(this4:Actor)
                     WITH collect({ node: this4, relationship: this3 }) AS edges
-                    WITH edges, size(edges) AS totalCount
                     CALL (edges) {
                         UNWIND edges AS edge
                         WITH edge.node AS this4, edge.relationship AS this3
                         RETURN collect({ properties: { screenTime: this3.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this4.name, __resolveType: \\"Actor\\" } }) AS var5
                     }
-                    RETURN { edges: var5, totalCount: totalCount } AS var6
+                    RETURN { edges: var5 } AS var6
                 }
                 RETURN this { .title, actorsConnection: var6 } AS var7
             }
@@ -241,13 +239,12 @@ describe("Relationship Properties Connect Cypher", () => {
             CALL (this) {
                 MATCH (this)<-[update_this0:ACTED_IN]-(update_this1:Actor)
                 WITH collect({ node: update_this1, relationship: update_this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS update_this1, edge.relationship AS update_this0
                     RETURN collect({ properties: { screenTime: update_this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: update_this1.name, __resolveType: \\"Actor\\" } }) AS update_var2
                 }
-                RETURN { edges: update_var2, totalCount: totalCount } AS update_var3
+                RETURN { edges: update_var2 } AS update_var3
             }
             RETURN collect(DISTINCT this { .title, actorsConnection: update_var3 }) AS data"
         `);
@@ -319,13 +316,12 @@ describe("Relationship Properties Connect Cypher", () => {
             CALL (this) {
                 MATCH (this)<-[update_this0:ACTED_IN]-(update_this1:Actor)
                 WITH collect({ node: update_this1, relationship: update_this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS update_this1, edge.relationship AS update_this0
                     RETURN collect({ properties: { screenTime: update_this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: update_this1.name, __resolveType: \\"Actor\\" } }) AS update_var2
                 }
-                RETURN { edges: update_var2, totalCount: totalCount } AS update_var3
+                RETURN { edges: update_var2 } AS update_var3
             }
             RETURN collect(DISTINCT this { .title, actorsConnection: update_var3 }) AS data"
         `);

--- a/packages/graphql/tests/tck/connections/relationship_properties/create.test.ts
+++ b/packages/graphql/tests/tck/connections/relationship_properties/create.test.ts
@@ -99,13 +99,12 @@ describe("Relationship Properties Create Cypher", () => {
             CALL (create_this1) {
                 MATCH (create_this1)<-[create_this6:ACTED_IN]-(create_this7:Actor)
                 WITH collect({ node: create_this7, relationship: create_this6 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS create_this7, edge.relationship AS create_this6
                     RETURN collect({ properties: { screenTime: create_this6.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: create_this7.name, __resolveType: \\"Actor\\" } }) AS create_var8
                 }
-                RETURN { edges: create_var8, totalCount: totalCount } AS create_var9
+                RETURN { edges: create_var8 } AS create_var9
             }
             RETURN collect(create_this1 { .title, actorsConnection: create_var9 }) AS data"
         `);

--- a/packages/graphql/tests/tck/connections/sort.test.ts
+++ b/packages/graphql/tests/tck/connections/sort.test.ts
@@ -78,7 +78,6 @@ describe("Relationship Properties Cypher", () => {
             "CYPHER 5
             MATCH (this0:Movie)
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
@@ -88,17 +87,16 @@ describe("Relationship Properties Cypher", () => {
                 CALL (this0) {
                     MATCH (this0)<-[this1:ACTED_IN]-(this2:Actor)
                     WITH collect({ node: this2, relationship: this1 }) AS edges
-                    WITH edges, size(edges) AS totalCount
                     CALL (edges) {
                         UNWIND edges AS edge
                         WITH edge.node AS this2, edge.relationship AS this1
                         RETURN collect({ node: { name: this2.name, __resolveType: \\"Actor\\" } }) AS var3
                     }
-                    RETURN { edges: var3, totalCount: totalCount } AS var4
+                    RETURN { edges: var3 } AS var4
                 }
                 RETURN collect({ node: { title: this0.title, actorsConnection: var4, __resolveType: \\"Movie\\" } }) AS var5
             }
-            RETURN { edges: var5, totalCount: totalCount } AS this"
+            RETURN { edges: var5 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -137,7 +135,6 @@ describe("Relationship Properties Cypher", () => {
             "CYPHER 5
             MATCH (this0:Movie)
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
@@ -155,17 +152,16 @@ describe("Relationship Properties Cypher", () => {
                 CALL (this0) {
                     MATCH (this0)<-[this3:ACTED_IN]-(this4:Actor)
                     WITH collect({ node: this4, relationship: this3 }) AS edges
-                    WITH edges, size(edges) AS totalCount
                     CALL (edges) {
                         UNWIND edges AS edge
                         WITH edge.node AS this4, edge.relationship AS this3
                         RETURN collect({ node: { name: this4.name, __resolveType: \\"Actor\\" } }) AS var5
                     }
-                    RETURN { edges: var5, totalCount: totalCount } AS var6
+                    RETURN { edges: var5 } AS var6
                 }
                 RETURN collect({ node: { title: this0.title, actorsConnection: var6, __resolveType: \\"Movie\\" } }) AS var7
             }
-            RETURN { edges: var7, totalCount: totalCount } AS this"
+            RETURN { edges: var7 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/deprecated/cypher-sort-deprecated.test.ts
+++ b/packages/graphql/tests/tck/deprecated/cypher-sort-deprecated.test.ts
@@ -469,7 +469,6 @@ describe("Cypher sort deprecated", () => {
                 CALL (this0) {
                     MATCH (this0)<-[this3:ACTED_IN]-(this4:Actor)
                     WITH collect({ node: this4, relationship: this3 }) AS edges
-                    WITH edges, size(edges) AS totalCount
                     CALL (edges) {
                         UNWIND edges AS edge
                         WITH edge.node AS this4, edge.relationship AS this3
@@ -484,7 +483,7 @@ describe("Cypher sort deprecated", () => {
                         }
                         RETURN collect({ node: { name: this4.name, totalScreenTime: var6, __resolveType: \\"Actor\\" } }) AS var7
                     }
-                    RETURN { edges: var7, totalCount: totalCount } AS var8
+                    RETURN { edges: var7 } AS var8
                 }
                 RETURN collect({ node: { title: this0.title, actorsConnection: var8, __resolveType: \\"Movie\\" } }) AS var9
             }
@@ -555,7 +554,6 @@ describe("Cypher sort deprecated", () => {
                     CALL (this1) {
                         MATCH (this1)<-[this4:ACTED_IN]-(this5:Actor)
                         WITH collect({ node: this5, relationship: this4 }) AS edges
-                        WITH edges, size(edges) AS totalCount
                         CALL (edges) {
                             UNWIND edges AS edge
                             WITH edge.node AS this5, edge.relationship AS this4
@@ -570,7 +568,7 @@ describe("Cypher sort deprecated", () => {
                             }
                             RETURN collect({ node: { name: this5.name, totalScreenTime: var7, __resolveType: \\"Actor\\" } }) AS var8
                         }
-                        RETURN { edges: var8, totalCount: totalCount } AS var9
+                        RETURN { edges: var8 } AS var9
                     }
                     RETURN collect({ node: { title: this1.title, actorsConnection: var9, __resolveType: \\"Movie\\" } }) AS var10
                 }

--- a/packages/graphql/tests/tck/directives/alias.test.ts
+++ b/packages/graphql/tests/tck/directives/alias.test.ts
@@ -109,13 +109,12 @@ describe("Cypher alias directive", () => {
             CALL (this) {
                 MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ properties: { character: this0.characterPropInDb, screenTime: this0.screenTime, __resolveType: \\"ActorActedInProps\\" }, node: { title: this1.title, rating: this1.ratingPropInDb, __resolveType: \\"Movie\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { .name, city: this.cityPropInDb, actedInConnection: var3 } AS this"
         `);
@@ -198,13 +197,12 @@ describe("Cypher alias directive", () => {
             CALL (create_this1) {
                 MATCH (create_this1)-[create_this9:ACTED_IN]->(create_this10:Movie)
                 WITH collect({ node: create_this10, relationship: create_this9 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS create_this10, edge.relationship AS create_this9
                     RETURN collect({ properties: { character: create_this9.characterPropInDb, screenTime: create_this9.screenTime, __resolveType: \\"ActorActedInProps\\" }, node: { title: create_this10.title, rating: create_this10.ratingPropInDb, __resolveType: \\"Movie\\" } }) AS create_var11
                 }
-                RETURN { edges: create_var11, totalCount: totalCount } AS create_var12
+                RETURN { edges: create_var11 } AS create_var12
             }
             RETURN collect(create_this1 { .name, city: create_this1.cityPropInDb, actedIn: create_var8, actedInConnection: create_var12 }) AS data"
         `);

--- a/packages/graphql/tests/tck/directives/authorization/arguments/roles-where.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/roles-where.test.ts
@@ -251,13 +251,12 @@ describe("Cypher Auth Where with Roles", () => {
                     WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
                 } AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ node: { content: this1.content, __resolveType: \\"Post\\" } }) AS var3
                 }
-                RETURN { edges: var3, totalCount: totalCount } AS var4
+                RETURN { edges: var3 } AS var4
             }
             RETURN this { .id, postsConnection: var4 } AS this"
         `);
@@ -313,13 +312,12 @@ describe("Cypher Auth Where with Roles", () => {
                     WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
                 } AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param6 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ node: { content: this1.content, __resolveType: \\"Post\\" } }) AS var3
                 }
-                RETURN { edges: var3, totalCount: totalCount } AS var4
+                RETURN { edges: var3 } AS var4
             }
             RETURN this { .id, postsConnection: var4 } AS this"
         `);

--- a/packages/graphql/tests/tck/directives/authorization/arguments/where/connection-auth-filter.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/where/connection-auth-filter.test.ts
@@ -99,13 +99,12 @@ describe("Connection auth filter", () => {
             MATCH (this0:User)
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub))
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
                 RETURN collect({ node: { id: this0.id, __resolveType: \\"User\\" } }) AS var1
             }
-            RETURN { edges: var1, totalCount: totalCount } AS this"
+            RETURN { edges: var1 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -144,13 +143,12 @@ describe("Connection auth filter", () => {
             MATCH (this0:User)
             WHERE (this0.name = $param0 AND ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)))
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
                 RETURN collect({ node: { id: this0.id, __resolveType: \\"User\\" } }) AS var1
             }
-            RETURN { edges: var1, totalCount: totalCount } AS this"
+            RETURN { edges: var1 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -193,7 +191,6 @@ describe("Connection auth filter", () => {
             MATCH (this0:User)
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub))
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
@@ -210,7 +207,7 @@ describe("Connection auth filter", () => {
                 }
                 RETURN collect({ node: { id: this0.id, posts: var4, __resolveType: \\"User\\" } }) AS var5
             }
-            RETURN { edges: var5, totalCount: totalCount } AS this"
+            RETURN { edges: var5 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -256,7 +253,6 @@ describe("Connection auth filter", () => {
             MATCH (this0:User)
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub))
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
@@ -267,17 +263,16 @@ describe("Connection auth filter", () => {
                         WHERE ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
                     })
                     WITH collect({ node: this2, relationship: this1 }) AS edges
-                    WITH edges, size(edges) AS totalCount
                     CALL (edges) {
                         UNWIND edges AS edge
                         WITH edge.node AS this2, edge.relationship AS this1
                         RETURN collect({ node: { content: this2.content, __resolveType: \\"Post\\" } }) AS var4
                     }
-                    RETURN { edges: var4, totalCount: totalCount } AS var5
+                    RETURN { edges: var4 } AS var5
                 }
                 RETURN collect({ node: { id: this0.id, postsConnection: var5, __resolveType: \\"User\\" } }) AS var6
             }
-            RETURN { edges: var6, totalCount: totalCount } AS this"
+            RETURN { edges: var6 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -323,7 +318,6 @@ describe("Connection auth filter", () => {
             MATCH (this0:User)
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub))
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
@@ -334,17 +328,16 @@ describe("Connection auth filter", () => {
                         WHERE ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
                     }))
                     WITH collect({ node: this2, relationship: this1 }) AS edges
-                    WITH edges, size(edges) AS totalCount
                     CALL (edges) {
                         UNWIND edges AS edge
                         WITH edge.node AS this2, edge.relationship AS this1
                         RETURN collect({ node: { content: this2.content, __resolveType: \\"Post\\" } }) AS var4
                     }
-                    RETURN { edges: var4, totalCount: totalCount } AS var5
+                    RETURN { edges: var4 } AS var5
                 }
                 RETURN collect({ node: { id: this0.id, postsConnection: var5, __resolveType: \\"User\\" } }) AS var6
             }
-            RETURN { edges: var6, totalCount: totalCount } AS this"
+            RETURN { edges: var6 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -387,7 +380,6 @@ describe("Connection auth filter", () => {
             MATCH (this0:User)
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub))
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
@@ -404,7 +396,7 @@ describe("Connection auth filter", () => {
                 }
                 RETURN collect({ node: { id: this0.id, posts: var4, __resolveType: \\"User\\" } }) AS var5
             }
-            RETURN { edges: var5, totalCount: totalCount } AS this"
+            RETURN { edges: var5 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -449,7 +441,6 @@ describe("Connection auth filter", () => {
             MATCH (this0:User)
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub))
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
@@ -469,7 +460,7 @@ describe("Connection auth filter", () => {
                 }
                 RETURN collect({ node: { id: this0.id, content: var4, __resolveType: \\"User\\" } }) AS var5
             }
-            RETURN { edges: var5, totalCount: totalCount } AS this"
+            RETURN { edges: var5 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -517,7 +508,6 @@ describe("Connection auth filter", () => {
             MATCH (this0:User)
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub))
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
@@ -541,7 +531,7 @@ describe("Connection auth filter", () => {
                 }
                 RETURN collect({ node: { id: this0.id, contentConnection: var4, __resolveType: \\"User\\" } }) AS var5
             }
-            RETURN { edges: var5, totalCount: totalCount } AS this"
+            RETURN { edges: var5 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -589,7 +579,6 @@ describe("Connection auth filter", () => {
             MATCH (this0:User)
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub))
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
@@ -613,7 +602,7 @@ describe("Connection auth filter", () => {
                 }
                 RETURN collect({ node: { id: this0.id, contentConnection: var4, __resolveType: \\"User\\" } }) AS var5
             }
-            RETURN { edges: var5, totalCount: totalCount } AS this"
+            RETURN { edges: var5 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/directives/authorization/arguments/where/where.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/where/where.test.ts
@@ -229,13 +229,12 @@ describe("Cypher Auth Where", () => {
                     WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
                 })
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ node: { content: this1.content, __resolveType: \\"Post\\" } }) AS var3
                 }
-                RETURN { edges: var3, totalCount: totalCount } AS var4
+                RETURN { edges: var3 } AS var4
             }
             RETURN this { .id, postsConnection: var4 } AS this"
         `);
@@ -286,13 +285,12 @@ describe("Cypher Auth Where", () => {
                     WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
                 }))
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ node: { content: this1.content, __resolveType: \\"Post\\" } }) AS var3
                 }
-                RETURN { edges: var3, totalCount: totalCount } AS var4
+                RETURN { edges: var3 } AS var4
             }
             RETURN this { .id, postsConnection: var4 } AS this"
         `);

--- a/packages/graphql/tests/tck/directives/authorization/projection-connection-union.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/projection-connection-union.test.ts
@@ -105,13 +105,12 @@ describe("Cypher Auth Projection On Connections On Unions", () => {
                             MATCH (this1)<-[this3:HAS_POST]-(this4:User)
                             CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this4.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                             WITH collect({ node: this4, relationship: this3 }) AS edges
-                            WITH edges, size(edges) AS totalCount
                             CALL (edges) {
                                 UNWIND edges AS edge
                                 WITH edge.node AS this4, edge.relationship AS this3
                                 RETURN collect({ node: { name: this4.name, __resolveType: \\"User\\" } }) AS var5
                             }
-                            RETURN { edges: var5, totalCount: totalCount } AS var6
+                            RETURN { edges: var5 } AS var6
                         }
                         WITH { node: { __resolveType: \\"Post\\", __id: id(this1), content: this1.content, creatorConnection: var6 } } AS edge
                         RETURN edge

--- a/packages/graphql/tests/tck/directives/authorization/projection-connection.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/projection-connection.test.ts
@@ -89,13 +89,12 @@ describe("Cypher Auth Projection On Connections", () => {
                     WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
                 }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ node: { content: this1.content, __resolveType: \\"Post\\" } }) AS var3
                 }
-                RETURN { edges: var3, totalCount: totalCount } AS var4
+                RETURN { edges: var3 } AS var4
             }
             RETURN this { .name, postsConnection: var4 } AS this"
         `);
@@ -151,7 +150,6 @@ describe("Cypher Auth Projection On Connections", () => {
                     WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
                 }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
@@ -159,17 +157,16 @@ describe("Cypher Auth Projection On Connections", () => {
                         MATCH (this1)<-[this3:HAS_POST]-(this4:User)
                         CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this4.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                         WITH collect({ node: this4, relationship: this3 }) AS edges
-                        WITH edges, size(edges) AS totalCount
                         CALL (edges) {
                             UNWIND edges AS edge
                             WITH edge.node AS this4, edge.relationship AS this3
                             RETURN collect({ node: { name: this4.name, __resolveType: \\"User\\" } }) AS var5
                         }
-                        RETURN { edges: var5, totalCount: totalCount } AS var6
+                        RETURN { edges: var5 } AS var6
                     }
                     RETURN collect({ node: { content: this1.content, creatorConnection: var6, __resolveType: \\"Post\\" } }) AS var7
                 }
-                RETURN { edges: var7, totalCount: totalCount } AS var8
+                RETURN { edges: var7 } AS var8
             }
             RETURN this { .name, postsConnection: var8 } AS this"
         `);
@@ -251,7 +248,6 @@ describe("Cypher Auth Projection On top-level connections", () => {
             MATCH (this0:User)
             CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
@@ -262,17 +258,16 @@ describe("Cypher Auth Projection On top-level connections", () => {
                         WHERE ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
                     }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                     WITH collect({ node: this2, relationship: this1 }) AS edges
-                    WITH edges, size(edges) AS totalCount
                     CALL (edges) {
                         UNWIND edges AS edge
                         WITH edge.node AS this2, edge.relationship AS this1
                         RETURN collect({ node: { content: this2.content, __resolveType: \\"Post\\" } }) AS var4
                     }
-                    RETURN { edges: var4, totalCount: totalCount } AS var5
+                    RETURN { edges: var4 } AS var5
                 }
                 RETURN collect({ node: { name: this0.name, postsConnection: var5, __resolveType: \\"User\\" } }) AS var6
             }
-            RETURN { edges: var6, totalCount: totalCount } AS this"
+            RETURN { edges: var6 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -323,7 +318,6 @@ describe("Cypher Auth Projection On top-level connections", () => {
             MATCH (this0:User)
             CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
@@ -334,7 +328,6 @@ describe("Cypher Auth Projection On top-level connections", () => {
                         WHERE ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
                     }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                     WITH collect({ node: this2, relationship: this1 }) AS edges
-                    WITH edges, size(edges) AS totalCount
                     CALL (edges) {
                         UNWIND edges AS edge
                         WITH edge.node AS this2, edge.relationship AS this1
@@ -342,21 +335,20 @@ describe("Cypher Auth Projection On top-level connections", () => {
                             MATCH (this2)<-[this4:HAS_POST]-(this5:User)
                             CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this5.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                             WITH collect({ node: this5, relationship: this4 }) AS edges
-                            WITH edges, size(edges) AS totalCount
                             CALL (edges) {
                                 UNWIND edges AS edge
                                 WITH edge.node AS this5, edge.relationship AS this4
                                 RETURN collect({ node: { name: this5.name, __resolveType: \\"User\\" } }) AS var6
                             }
-                            RETURN { edges: var6, totalCount: totalCount } AS var7
+                            RETURN { edges: var6 } AS var7
                         }
                         RETURN collect({ node: { content: this2.content, creatorConnection: var7, __resolveType: \\"Post\\" } }) AS var8
                     }
-                    RETURN { edges: var8, totalCount: totalCount } AS var9
+                    RETURN { edges: var8 } AS var9
                 }
                 RETURN collect({ node: { name: this0.name, postsConnection: var9, __resolveType: \\"User\\" } }) AS var10
             }
-            RETURN { edges: var10, totalCount: totalCount } AS this"
+            RETURN { edges: var10 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/directives/coalesce.test.ts
+++ b/packages/graphql/tests/tck/directives/coalesce.test.ts
@@ -210,13 +210,12 @@ describe("Cypher coalesce()", () => {
                 MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
                 WHERE coalesce(this1.status, \\"ACTIVE\\") = $param0
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ node: { id: this1.id, status: coalesce(this1.status, \\"ACTIVE\\"), __resolveType: \\"Movie\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { moviesConnection: var3 } AS this"
         `);
@@ -272,13 +271,12 @@ describe("Cypher coalesce()", () => {
                 MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
                 WHERE coalesce(this1.statuses, [\\"ACTIVE\\", \\"INACTIVE\\"]) = $param0
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ node: { id: this1.id, statuses: coalesce(this1.statuses, [\\"ACTIVE\\", \\"INACTIVE\\"]), __resolveType: \\"Movie\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { moviesConnection: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/directives/cypher/filtering/relationships/cypher-filtering-relationship-auth.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher/filtering/relationships/cypher-filtering-relationship-auth.test.ts
@@ -94,13 +94,12 @@ describe("cypher directive filtering - relationship auth filter", () => {
             WITH *
             WHERE (this0.rating < $param0 AND ($isAuthenticated = true AND any(this3 IN this2 WHERE ($jwt.custom_value IS NOT NULL AND this3.name = $jwt.custom_value))))
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
                 RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var4
             }
-            RETURN { edges: var4, totalCount: totalCount } AS this"
+            RETURN { edges: var4 } AS this"
         `);
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -186,13 +185,12 @@ describe("cypher directive filtering - relationship auth filter", () => {
             WITH *
             WHERE (this0.rating < $param0 AND ($isAuthenticated = true AND any(this3 IN this2 WHERE ($jwt.custom_value IS NOT NULL AND this3.name = $jwt.custom_value))))
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
                 RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var4
             }
-            RETURN { edges: var4, totalCount: totalCount } AS this"
+            RETURN { edges: var4 } AS this"
         `);
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -279,13 +277,12 @@ describe("cypher directive filtering - relationship auth filter", () => {
             WHERE this0.rating < $param0
             CALL apoc.util.validate(NOT ($isAuthenticated = true AND any(this3 IN this2 WHERE ($jwt.custom_value IS NOT NULL AND this3.name = $jwt.custom_value))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
                 RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var4
             }
-            RETURN { edges: var4, totalCount: totalCount } AS this"
+            RETURN { edges: var4 } AS this"
         `);
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -372,13 +369,12 @@ describe("cypher directive filtering - relationship auth filter", () => {
             WHERE this0.rating > $param0
             CALL apoc.util.validate(NOT ($isAuthenticated = true AND any(this3 IN this2 WHERE ($jwt.custom_value IS NOT NULL AND this3.name = $jwt.custom_value))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
                 RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var4
             }
-            RETURN { edges: var4, totalCount: totalCount } AS this"
+            RETURN { edges: var4 } AS this"
         `);
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/directives/cypher/filtering/relationships/cypher-filtering-relationship-connection.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher/filtering/relationships/cypher-filtering-relationship-connection.test.ts
@@ -81,13 +81,12 @@ describe("Connection API - cypher directive filtering - Relationship", () => {
             WITH *
             WHERE NOT (any(this3 IN this2 WHERE this3.name = $param0))
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
                 RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var4
             }
-            RETURN { edges: var4, totalCount: totalCount } AS this"
+            RETURN { edges: var4 } AS this"
         `);
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -156,13 +155,12 @@ describe("Connection API - cypher directive filtering - Relationship", () => {
             WITH *
             WHERE all(this3 IN this2 WHERE this3.name = $param0)
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
                 RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var4
             }
-            RETURN { edges: var4, totalCount: totalCount } AS this"
+            RETURN { edges: var4 } AS this"
         `);
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -231,13 +229,12 @@ describe("Connection API - cypher directive filtering - Relationship", () => {
             WITH *
             WHERE single(this3 IN this2 WHERE this3.name = $param0)
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
                 RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var4
             }
-            RETURN { edges: var4, totalCount: totalCount } AS this"
+            RETURN { edges: var4 } AS this"
         `);
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -306,13 +303,12 @@ describe("Connection API - cypher directive filtering - Relationship", () => {
             WITH *
             WHERE any(this3 IN this2 WHERE this3.name = $param0)
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
                 RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var4
             }
-            RETURN { edges: var4, totalCount: totalCount } AS this"
+            RETURN { edges: var4 } AS this"
         `);
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -381,7 +377,6 @@ describe("Connection API - cypher directive filtering - Relationship", () => {
             WITH *
             WHERE any(this3 IN this2 WHERE this3.name = $param0)
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
@@ -389,7 +384,7 @@ describe("Connection API - cypher directive filtering - Relationship", () => {
                 ORDER BY this0.title DESC
                 RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var4
             }
-            RETURN { edges: var4, totalCount: totalCount } AS this"
+            RETURN { edges: var4 } AS this"
         `);
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -458,13 +453,12 @@ describe("Connection API - cypher directive filtering - Relationship", () => {
             WITH *
             WHERE none(this3 IN this2 WHERE this3.name = $param0)
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
                 RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var4
             }
-            RETURN { edges: var4, totalCount: totalCount } AS this"
+            RETURN { edges: var4 } AS this"
         `);
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -569,13 +563,12 @@ describe("Connection API - cypher directive filtering - Relationship", () => {
             WITH *
             WHERE (any(this5 IN this2 WHERE this5.name = $param0) OR any(this6 IN this4 WHERE this6.name = $param1))
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
                 RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var7
             }
-            RETURN { edges: var7, totalCount: totalCount } AS this"
+            RETURN { edges: var7 } AS this"
         `);
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/directives/node/node-label.test.ts
+++ b/packages/graphql/tests/tck/directives/node/node-label.test.ts
@@ -116,13 +116,12 @@ describe("Label in Node directive", () => {
             CALL (this) {
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Person)
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/directives/node/node-with-auth-projection.test.ts
+++ b/packages/graphql/tests/tck/directives/node/node-with-auth-projection.test.ts
@@ -85,13 +85,12 @@ describe("Cypher Auth Projection On Connections", () => {
                     WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
                 }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ node: { content: this1.content, __resolveType: \\"Post\\" } }) AS var3
                 }
-                RETURN { edges: var3, totalCount: totalCount } AS var4
+                RETURN { edges: var3 } AS var4
             }
             RETURN this { .name, postsConnection: var4 } AS this"
         `);

--- a/packages/graphql/tests/tck/directives/vector/auth.test.ts
+++ b/packages/graphql/tests/tck/directives/vector/auth.test.ts
@@ -92,13 +92,12 @@ describe("Cypher -> vector -> Auth", () => {
                 WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
             }))
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
                 RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var3
             }
-            RETURN { edges: var3, totalCount: totalCount } AS this"
+            RETURN { edges: var3 } AS this"
         `);
 
         expect(result.params).toMatchInlineSnapshot(`
@@ -292,13 +291,12 @@ describe("Cypher -> vector -> Auth", () => {
                 WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
             }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
                 RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var3
             }
-            RETURN { edges: var3, totalCount: totalCount } AS this"
+            RETURN { edges: var3 } AS this"
         `);
 
         expect(result.params).toMatchInlineSnapshot(`
@@ -497,13 +495,12 @@ describe("Cypher -> vector -> Auth", () => {
                 WHERE NOT ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
             }))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
                 RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var3
             }
-            RETURN { edges: var3, totalCount: totalCount } AS this"
+            RETURN { edges: var3 } AS this"
         `);
 
         expect(result.params).toMatchInlineSnapshot(`
@@ -701,13 +698,12 @@ describe("Cypher -> vector -> Auth", () => {
                 WHERE ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
             }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
                 RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var4
             }
-            RETURN { edges: var4, totalCount: totalCount } AS this"
+            RETURN { edges: var4 } AS this"
         `);
 
         expect(result.params).toMatchInlineSnapshot(`
@@ -911,13 +907,12 @@ describe("Cypher -> vector -> Auth", () => {
                 WHERE NOT ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
             }))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
                 RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var4
             }
-            RETURN { edges: var4, totalCount: totalCount } AS this"
+            RETURN { edges: var4 } AS this"
         `);
 
         expect(result.params).toMatchInlineSnapshot(`
@@ -1119,13 +1114,12 @@ describe("Cypher -> vector -> Auth", () => {
                 WHERE ($param3 IS NOT NULL AND this2.year = $param3)
             }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
                 RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var4
             }
-            RETURN { edges: var4, totalCount: totalCount } AS this"
+            RETURN { edges: var4 } AS this"
         `);
 
         expect(result.params).toMatchInlineSnapshot(`
@@ -1327,13 +1321,12 @@ describe("Cypher -> vector -> Auth", () => {
                 WHERE NOT ($param3 IS NOT NULL AND this2.year = $param3)
             }))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
                 RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var4
             }
-            RETURN { edges: var4, totalCount: totalCount } AS this"
+            RETURN { edges: var4 } AS this"
         `);
 
         expect(result.params).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/directives/vector/match.test.ts
+++ b/packages/graphql/tests/tck/directives/vector/match.test.ts
@@ -85,7 +85,7 @@ describe("Vector index match", () => {
                 WITH edge.node AS this0, edge.score AS var1
                 RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" }, score: var1 }) AS var2
             }
-            RETURN { edges: var2, totalCount: totalCount } AS this"
+            RETURN { edges: var2 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -258,7 +258,7 @@ describe("Vector index match", () => {
                 WITH edge.node AS this0, edge.score AS var1
                 RETURN collect({ node: { title: this0.title, released: this0.released, __resolveType: \\"Movie\\" }, score: var1 }) AS var2
             }
-            RETURN { edges: var2, totalCount: totalCount } AS this"
+            RETURN { edges: var2 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -435,7 +435,7 @@ describe("Vector index match", () => {
                 ORDER BY this0.title DESC
                 RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" }, score: var1 }) AS var2
             }
-            RETURN { edges: var2, totalCount: totalCount } AS this"
+            RETURN { edges: var2 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/directives/vector/phrase.test.ts
+++ b/packages/graphql/tests/tck/directives/vector/phrase.test.ts
@@ -96,7 +96,7 @@ describe("phrase input - genAI plugin", () => {
                 WITH edge.node AS this1, edge.score AS var2
                 RETURN collect({ node: { title: this1.title, __resolveType: \\"Movie\\" }, score: var2 }) AS var3
             }
-            RETURN { edges: var3, totalCount: totalCount } AS this"
+            RETURN { edges: var3 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/directives/vector/score.test.ts
+++ b/packages/graphql/tests/tck/directives/vector/score.test.ts
@@ -83,7 +83,7 @@ describe("Cypher -> vector -> Score", () => {
                 WITH edge.node AS this0, edge.score AS var1
                 RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" }, score: var1 }) AS var2
             }
-            RETURN { edges: var2, totalCount: totalCount } AS this"
+            RETURN { edges: var2 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -257,7 +257,7 @@ describe("Cypher -> vector -> Score", () => {
                 ORDER BY var1 ASC
                 RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" }, score: var1 }) AS var2
             }
-            RETURN { edges: var2, totalCount: totalCount } AS this"
+            RETURN { edges: var2 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -430,7 +430,7 @@ describe("Cypher -> vector -> Score", () => {
                 ORDER BY var1 ASC, this0.title DESC
                 RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" }, score: var1 }) AS var2
             }
-            RETURN { edges: var2, totalCount: totalCount } AS this"
+            RETURN { edges: var2 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/fulltext/auth.test.ts
+++ b/packages/graphql/tests/tck/fulltext/auth.test.ts
@@ -85,13 +85,12 @@ describe("Cypher -> fulltext -> Auth", () => {
                 WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
             }))
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
                 RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var3
             }
-            RETURN { edges: var3, totalCount: totalCount } AS this"
+            RETURN { edges: var3 } AS this"
         `);
 
         expect(result.params).toMatchInlineSnapshot(`
@@ -158,13 +157,12 @@ describe("Cypher -> fulltext -> Auth", () => {
                 WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
             }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
                 RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var3
             }
-            RETURN { edges: var3, totalCount: totalCount } AS this"
+            RETURN { edges: var3 } AS this"
         `);
 
         expect(result.params).toMatchInlineSnapshot(`
@@ -234,13 +232,12 @@ describe("Cypher -> fulltext -> Auth", () => {
                 WHERE NOT ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
             }))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
                 RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var3
             }
-            RETURN { edges: var3, totalCount: totalCount } AS this"
+            RETURN { edges: var3 } AS this"
         `);
 
         expect(result.params).toMatchInlineSnapshot(`
@@ -312,13 +309,12 @@ describe("Cypher -> fulltext -> Auth", () => {
                 WHERE ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
             }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
                 RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var4
             }
-            RETURN { edges: var4, totalCount: totalCount } AS this"
+            RETURN { edges: var4 } AS this"
         `);
 
         expect(result.params).toMatchInlineSnapshot(`
@@ -393,13 +389,12 @@ describe("Cypher -> fulltext -> Auth", () => {
                 WHERE NOT ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
             }))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
                 RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var4
             }
-            RETURN { edges: var4, totalCount: totalCount } AS this"
+            RETURN { edges: var4 } AS this"
         `);
 
         expect(result.params).toMatchInlineSnapshot(`
@@ -475,13 +470,12 @@ describe("Cypher -> fulltext -> Auth", () => {
                 WHERE ($param3 IS NOT NULL AND this2.year = $param3)
             }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
                 RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var4
             }
-            RETURN { edges: var4, totalCount: totalCount } AS this"
+            RETURN { edges: var4 } AS this"
         `);
 
         expect(result.params).toMatchInlineSnapshot(`
@@ -557,13 +551,12 @@ describe("Cypher -> fulltext -> Auth", () => {
                 WHERE NOT ($param3 IS NOT NULL AND this2.year = $param3)
             }))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
                 RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var4
             }
-            RETURN { edges: var4, totalCount: totalCount } AS this"
+            RETURN { edges: var4 } AS this"
         `);
 
         expect(result.params).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/fulltext/match.test.ts
+++ b/packages/graphql/tests/tck/fulltext/match.test.ts
@@ -58,13 +58,12 @@ describe("Cypher -> fulltext -> Match", () => {
             CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
             WHERE $param1 IN labels(this0)
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
                 RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var2
             }
-            RETURN { edges: var2, totalCount: totalCount } AS this"
+            RETURN { edges: var2 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -95,13 +94,12 @@ describe("Cypher -> fulltext -> Match", () => {
             CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
             WHERE ($param1 IN labels(this0) AND this0.title = $param2)
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
                 RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var2
             }
-            RETURN { edges: var2, totalCount: totalCount } AS this"
+            RETURN { edges: var2 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/fulltext/node-labels.test.ts
+++ b/packages/graphql/tests/tck/fulltext/node-labels.test.ts
@@ -54,13 +54,12 @@ describe("Cypher -> fulltext -> Additional Labels", () => {
             CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
             WHERE ($param1 IN labels(this0) AND $param2 IN labels(this0))
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
                 RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var2
             }
-            RETURN { edges: var2, totalCount: totalCount } AS this"
+            RETURN { edges: var2 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -112,13 +111,12 @@ describe("Cypher -> fulltext -> Additional Labels", () => {
             CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
             WHERE ($param1 IN labels(this0) AND $param2 IN labels(this0))
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
                 RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var2
             }
-            RETURN { edges: var2, totalCount: totalCount } AS this"
+            RETURN { edges: var2 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/fulltext/score.test.ts
+++ b/packages/graphql/tests/tck/fulltext/score.test.ts
@@ -67,7 +67,7 @@ describe("Cypher -> fulltext -> Score", () => {
                 WITH edge.node AS this0, edge.score AS var1
                 RETURN collect({ node: { title: this0.title, released: this0.released, __resolveType: \\"Movie\\" }, score: var1 }) AS var2
             }
-            RETURN { edges: var2, totalCount: totalCount } AS this"
+            RETURN { edges: var2 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -106,7 +106,7 @@ describe("Cypher -> fulltext -> Score", () => {
                 WITH edge.node AS this0, edge.score AS var1
                 RETURN collect({ node: { title: this0.title, released: this0.released, __resolveType: \\"Movie\\" }, score: var1 }) AS var2
             }
-            RETURN { edges: var2, totalCount: totalCount } AS this"
+            RETURN { edges: var2 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -148,7 +148,7 @@ describe("Cypher -> fulltext -> Score", () => {
                 WITH edge.node AS this0, edge.score AS var1
                 RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" }, score: var1 }) AS var2
             }
-            RETURN { edges: var2, totalCount: totalCount } AS this"
+            RETURN { edges: var2 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -189,7 +189,7 @@ describe("Cypher -> fulltext -> Score", () => {
                 ORDER BY this0.title DESC
                 RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" }, score: var1 }) AS var2
             }
-            RETURN { edges: var2, totalCount: totalCount } AS this"
+            RETURN { edges: var2 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -229,7 +229,7 @@ describe("Cypher -> fulltext -> Score", () => {
                 ORDER BY var1 ASC
                 RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" }, score: var1 }) AS var2
             }
-            RETURN { edges: var2, totalCount: totalCount } AS this"
+            RETURN { edges: var2 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -269,7 +269,7 @@ describe("Cypher -> fulltext -> Score", () => {
                 ORDER BY var1 ASC, this0.title DESC
                 RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" }, score: var1 }) AS var2
             }
-            RETURN { edges: var2, totalCount: totalCount } AS this"
+            RETURN { edges: var2 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/issues/1150.test.ts
+++ b/packages/graphql/tests/tck/issues/1150.test.ts
@@ -115,7 +115,6 @@ describe("https://github.com/neo4j/graphql/issues/1150", () => {
                 MATCH (this)-[this0:CONSISTS_OF]->(this1:DriveComposition)
                 WHERE this0.current = $param1
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
@@ -143,7 +142,7 @@ describe("https://github.com/neo4j/graphql/issues/1150", () => {
                     }
                     RETURN collect({ node: { driveComponentConnection: var6, __resolveType: \\"DriveComposition\\" } }) AS var7
                 }
-                RETURN { edges: var7, totalCount: totalCount } AS var8
+                RETURN { edges: var7 } AS var8
             }
             RETURN this { .current, driveCompositionsConnection: var8 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/1249.test.ts
+++ b/packages/graphql/tests/tck/issues/1249.test.ts
@@ -89,13 +89,12 @@ describe("https://github.com/neo4j/graphql/issues/1249", () => {
                 CALL (this1) {
                     MATCH (this1)-[this2:MATERIAL_SUPPLIER]->(this3:Supplier)
                     WITH collect({ node: this3, relationship: this2 }) AS edges
-                    WITH edges, size(edges) AS totalCount
                     CALL (edges) {
                         UNWIND edges AS edge
                         WITH edge.node AS this3, edge.relationship AS this2
                         RETURN collect({ properties: { supplierMaterialNumber: this2.supplierMaterialNumber, __resolveType: \\"RelationMaterialSupplier\\" }, node: { supplierId: this3.supplierId, __resolveType: \\"Supplier\\" } }) AS var4
                     }
-                    RETURN { edges: var4, totalCount: totalCount } AS var5
+                    RETURN { edges: var4 } AS var5
                 }
                 WITH this1 { .id, suppliersConnection: var5 } AS this1
                 RETURN collect(this1) AS var6

--- a/packages/graphql/tests/tck/issues/1364.test.ts
+++ b/packages/graphql/tests/tck/issues/1364.test.ts
@@ -94,7 +94,6 @@ describe("https://github.com/neo4j/graphql/issues/1364", () => {
             "CYPHER 5
             MATCH (this0:Movie)
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
@@ -111,7 +110,7 @@ describe("https://github.com/neo4j/graphql/issues/1364", () => {
                 }
                 RETURN collect({ node: { title: this0.title, totalGenres: var2, __resolveType: \\"Movie\\" } }) AS var3
             }
-            RETURN { edges: var3, totalCount: totalCount } AS this"
+            RETURN { edges: var3 } AS this"
         `);
     });
 
@@ -135,7 +134,6 @@ describe("https://github.com/neo4j/graphql/issues/1364", () => {
             "CYPHER 5
             MATCH (this0:Movie)
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
@@ -152,7 +150,7 @@ describe("https://github.com/neo4j/graphql/issues/1364", () => {
                 ORDER BY var2 ASC
                 RETURN collect({ node: { title: this0.title, totalGenres: var2, __resolveType: \\"Movie\\" } }) AS var3
             }
-            RETURN { edges: var3, totalCount: totalCount } AS this"
+            RETURN { edges: var3 } AS this"
         `);
     });
 
@@ -177,7 +175,6 @@ describe("https://github.com/neo4j/graphql/issues/1364", () => {
             "CYPHER 5
             MATCH (this0:Movie)
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
@@ -203,7 +200,7 @@ describe("https://github.com/neo4j/graphql/issues/1364", () => {
                 }
                 RETURN collect({ node: { title: this0.title, totalGenres: var2, totalActors: var4, __resolveType: \\"Movie\\" } }) AS var5
             }
-            RETURN { edges: var5, totalCount: totalCount } AS this"
+            RETURN { edges: var5 } AS this"
         `);
     });
 });

--- a/packages/graphql/tests/tck/issues/1528.test.ts
+++ b/packages/graphql/tests/tck/issues/1528.test.ts
@@ -74,7 +74,6 @@ describe("https://github.com/neo4j/graphql/issues/1528", () => {
             CALL (this) {
                 MATCH (this)<-[this0:IS_GENRE]-(this1:Movie)
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
@@ -91,7 +90,7 @@ describe("https://github.com/neo4j/graphql/issues/1528", () => {
                     ORDER BY var3 DESC
                     RETURN collect({ node: { title: this1.title, actorsCount: var3, __resolveType: \\"Movie\\" } }) AS var4
                 }
-                RETURN { edges: var4, totalCount: totalCount } AS var5
+                RETURN { edges: var4 } AS var5
             }
             RETURN this { moviesConnection: var5 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/1783.test.ts
+++ b/packages/graphql/tests/tck/issues/1783.test.ts
@@ -139,19 +139,17 @@ describe("https://github.com/neo4j/graphql/issues/1783", () => {
                 MATCH (this)-[this6:HAS_NAME]->(this7:NameDetails)
                 WHERE this6.current = $param6
                 WITH collect({ node: this7, relationship: this6 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this7, edge.relationship AS this6
                     RETURN collect({ node: { fullName: this7.fullName, __resolveType: \\"NameDetails\\" } }) AS var8
                 }
-                RETURN { edges: var8, totalCount: totalCount } AS var9
+                RETURN { edges: var8 } AS var9
             }
             CALL (this) {
                 MATCH (this)-[this10:ARCHITECTURE]->(this11:MasterData)
                 WHERE this10.current = $param7
                 WITH collect({ node: this11, relationship: this10 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this11, edge.relationship AS this10
@@ -159,17 +157,16 @@ describe("https://github.com/neo4j/graphql/issues/1783", () => {
                         MATCH (this11)-[this12:HAS_NAME]->(this13:NameDetails)
                         WHERE this12.current = $param8
                         WITH collect({ node: this13, relationship: this12 }) AS edges
-                        WITH edges, size(edges) AS totalCount
                         CALL (edges) {
                             UNWIND edges AS edge
                             WITH edge.node AS this13, edge.relationship AS this12
                             RETURN collect({ node: { fullName: this13.fullName, __resolveType: \\"NameDetails\\" } }) AS var14
                         }
-                        RETURN { edges: var14, totalCount: totalCount } AS var15
+                        RETURN { edges: var14 } AS var15
                     }
                     RETURN collect({ node: { nameDetailsConnection: var15, __resolveType: \\"MasterData\\" } }) AS var16
                 }
-                RETURN { edges: var16, totalCount: totalCount } AS var17
+                RETURN { edges: var16 } AS var17
             }
             RETURN this { .id, nameDetailsConnection: var9, architectureConnection: var17 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/2262.test.ts
+++ b/packages/graphql/tests/tck/issues/2262.test.ts
@@ -75,14 +75,12 @@ describe("https://github.com/neo4j/graphql/issues/2262", () => {
             CALL (this) {
                 MATCH (this)<-[this0:OUTPUT]-(this1:Process)
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     CALL (this1) {
                         MATCH (this1)<-[this2:INPUT]-(this3:Component)
                         WITH collect({ node: this3, relationship: this2 }) AS edges
-                        WITH edges, size(edges) AS totalCount
                         CALL (edges) {
                             UNWIND edges AS edge
                             WITH edge.node AS this3, edge.relationship AS this2
@@ -90,11 +88,11 @@ describe("https://github.com/neo4j/graphql/issues/2262", () => {
                             ORDER BY this3.uuid DESC
                             RETURN collect({ node: { uuid: this3.uuid, __resolveType: \\"Component\\" } }) AS var4
                         }
-                        RETURN { edges: var4, totalCount: totalCount } AS var5
+                        RETURN { edges: var4 } AS var5
                     }
                     RETURN collect({ node: { uuid: this1.uuid, componentInputsConnection: var5, __resolveType: \\"Process\\" } }) AS var6
                 }
-                RETURN { edges: var6, totalCount: totalCount } AS var7
+                RETURN { edges: var6 } AS var7
             }
             RETURN this { .uuid, upstreamProcessConnection: var7 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/3394.test.ts
+++ b/packages/graphql/tests/tck/issues/3394.test.ts
@@ -117,7 +117,6 @@ describe("https://github.com/neo4j/graphql/issues/3394", () => {
                 "CYPHER 5
                 MATCH (this0:Product)
                 WITH collect({ node: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this0
@@ -125,7 +124,7 @@ describe("https://github.com/neo4j/graphql/issues/3394", () => {
                     ORDER BY this0.fg_item DESC
                     RETURN collect({ node: { id: this0.fg_item_id, partNumber: this0.fg_item, description: this0.description, __resolveType: \\"Product\\" } }) AS var1
                 }
-                RETURN { edges: var1, totalCount: totalCount } AS this"
+                RETURN { edges: var1 } AS this"
             `);
 
             expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -156,7 +155,6 @@ describe("https://github.com/neo4j/graphql/issues/3394", () => {
                 CALL (this) {
                     MATCH (this)-[this0:CAN_ACCESS]->(this1:Product)
                     WITH collect({ node: this1, relationship: this0 }) AS edges
-                    WITH edges, size(edges) AS totalCount
                     CALL (edges) {
                         UNWIND edges AS edge
                         WITH edge.node AS this1, edge.relationship AS this0
@@ -164,7 +162,7 @@ describe("https://github.com/neo4j/graphql/issues/3394", () => {
                         ORDER BY this1.fg_item DESC
                         RETURN collect({ node: { id: this1.fg_item_id, partNumber: this1.fg_item, description: this1.description, __resolveType: \\"Product\\" } }) AS var2
                     }
-                    RETURN { edges: var2, totalCount: totalCount } AS var3
+                    RETURN { edges: var2 } AS var3
                 }
                 RETURN this { productsConnection: var3 } AS this"
             `);

--- a/packages/graphql/tests/tck/issues/4007.test.ts
+++ b/packages/graphql/tests/tck/issues/4007.test.ts
@@ -65,13 +65,12 @@ describe("https://github.com/neo4j/graphql/issues/4007", () => {
             CALL (this) {
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ node: { na: this1.name, __resolveType: \\"Actor\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { t: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/4015.test.ts
+++ b/packages/graphql/tests/tck/issues/4015.test.ts
@@ -69,13 +69,12 @@ describe("https://github.com/neo4j/graphql/issues/4015", () => {
             CALL (this) {
                 MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ node: { surname: this1.surname, name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { actorsConnection: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/4292.test.ts
+++ b/packages/graphql/tests/tck/issues/4292.test.ts
@@ -276,13 +276,12 @@ describe("https://github.com/neo4j/graphql/issues/4292", () => {
                         }
                     })), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                     WITH collect({ node: this12, relationship: this11 }) AS edges
-                    WITH edges, size(edges) AS totalCount
                     CALL (edges) {
                         UNWIND edges AS edge
                         WITH edge.node AS this12, edge.relationship AS this11
                         RETURN collect({ properties: { active: this11.active, firstDay: this11.firstDay, lastDay: this11.lastDay, __resolveType: \\"PartnerOf\\" }, node: { __id: id(this12), __resolveType: \\"Person\\" } }) AS var22
                     }
-                    RETURN { edges: var22, totalCount: totalCount } AS var23
+                    RETURN { edges: var22 } AS var23
                 }
                 WITH this1 { .id, .name, partnersConnection: var23 } AS this1
                 RETURN collect(this1) AS var24

--- a/packages/graphql/tests/tck/issues/433.test.ts
+++ b/packages/graphql/tests/tck/issues/433.test.ts
@@ -66,13 +66,12 @@ describe("#413", () => {
             CALL (this) {
                 MATCH (this)-[this0:ACTED_IN]->(this1:Person)
                 WITH collect({ node: this1, relationship: this0 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
                     RETURN collect({ node: { name: this1.name, __resolveType: \\"Person\\" } }) AS var2
                 }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+                RETURN { edges: var2 } AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/4741.test.ts
+++ b/packages/graphql/tests/tck/issues/4741.test.ts
@@ -70,7 +70,6 @@ describe("https://github.com/neo4j/graphql/issues/4741", () => {
             WITH *
             WHERE var3 = true
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
@@ -84,7 +83,7 @@ describe("https://github.com/neo4j/graphql/issues/4741", () => {
                 }
                 RETURN collect({ node: { country: this0.country, listsOlisConnection: var6, __resolveType: \\"Opportunity\\" } }) AS var7
             }
-            RETURN { edges: var7, totalCount: totalCount } AS this"
+            RETURN { edges: var7 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/issues/6005.test.ts
+++ b/packages/graphql/tests/tck/issues/6005.test.ts
@@ -147,13 +147,12 @@ describe("https://github.com/neo4j/graphql/issues/6005", () => {
             WITH *
             WHERE var3 = true
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
                 RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var4
             }
-            RETURN { edges: var4, totalCount: totalCount } AS this"
+            RETURN { edges: var4 } AS this"
         `);
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
                         "{
@@ -192,7 +191,6 @@ describe("https://github.com/neo4j/graphql/issues/6005", () => {
             "CYPHER 5
             MATCH (this0:Actor)
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
@@ -206,17 +204,16 @@ describe("https://github.com/neo4j/graphql/issues/6005", () => {
                     WITH *
                     WHERE var5 = true
                     WITH collect({ node: this2, relationship: this1 }) AS edges
-                    WITH edges, size(edges) AS totalCount
                     CALL (edges) {
                         UNWIND edges AS edge
                         WITH edge.node AS this2, edge.relationship AS this1
                         RETURN collect({ node: { title: this2.title, __resolveType: \\"Movie\\" } }) AS var6
                     }
-                    RETURN { edges: var6, totalCount: totalCount } AS var7
+                    RETURN { edges: var6 } AS var7
                 }
                 RETURN collect({ node: { moviesConnection: var7, __resolveType: \\"Actor\\" } }) AS var8
             }
-            RETURN { edges: var8, totalCount: totalCount } AS this"
+            RETURN { edges: var8 } AS this"
         `);
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
                 "{

--- a/packages/graphql/tests/tck/issues/6031.test.ts
+++ b/packages/graphql/tests/tck/issues/6031.test.ts
@@ -121,7 +121,6 @@ describe("https://github.com/neo4j/graphql/issues/6031", () => {
             "CYPHER 5
             MATCH (this0:Actor)
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
@@ -148,7 +147,7 @@ describe("https://github.com/neo4j/graphql/issues/6031", () => {
                 }
                 RETURN collect({ node: { name: this0.name, productionsConnection: var5, __resolveType: \\"Actor\\" } }) AS var6
             }
-            RETURN { edges: var6, totalCount: totalCount } AS this"
+            RETURN { edges: var6 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);

--- a/packages/graphql/tests/tck/issues/988.test.ts
+++ b/packages/graphql/tests/tck/issues/988.test.ts
@@ -154,24 +154,22 @@ describe("https://github.com/neo4j/graphql/issues/988", () => {
             CALL (this) {
                 MATCH (this)-[this6:MANUFACTURER]->(this7:Manufacturer)
                 WITH collect({ node: this7, relationship: this6 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this7, edge.relationship AS this6
                     RETURN collect({ properties: { current: this6.current, __resolveType: \\"RelationProps\\" }, node: { name: this7.name, __resolveType: \\"Manufacturer\\" } }) AS var8
                 }
-                RETURN { edges: var8, totalCount: totalCount } AS var9
+                RETURN { edges: var8 } AS var9
             }
             CALL (this) {
                 MATCH (this)-[this10:BRAND]->(this11:Brand)
                 WITH collect({ node: this11, relationship: this10 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS this11, edge.relationship AS this10
                     RETURN collect({ properties: { current: this10.current, __resolveType: \\"RelationProps\\" }, node: { name: this11.name, __resolveType: \\"Brand\\" } }) AS var12
                 }
-                RETURN { edges: var12, totalCount: totalCount } AS var13
+                RETURN { edges: var12 } AS var13
             }
             RETURN this { .name, .current, manufacturerConnection: var9, brandConnection: var13 } AS this"
         `);

--- a/packages/graphql/tests/tck/math.test.ts
+++ b/packages/graphql/tests/tck/math.test.ts
@@ -231,13 +231,12 @@ describe("Math operators", () => {
             CALL (this) {
                 MATCH (this)-[update_this3:ACTED_IN]->(update_this4:Movie)
                 WITH collect({ node: update_this4, relationship: update_this3 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS update_this4, edge.relationship AS update_this3
                     RETURN collect({ properties: { pay: update_this3.pay, __resolveType: \\"ActedIn\\" }, node: { __id: id(update_this4), __resolveType: \\"Movie\\" } }) AS update_var5
                 }
-                RETURN { edges: update_var5, totalCount: totalCount } AS update_var6
+                RETURN { edges: update_var5 } AS update_var6
             }
             RETURN collect(DISTINCT this { .name, actedIn: update_var2, actedInConnection: update_var6 }) AS data"
         `);

--- a/packages/graphql/tests/tck/pagination/cypher-connection-pagination.test.ts
+++ b/packages/graphql/tests/tck/pagination/cypher-connection-pagination.test.ts
@@ -108,7 +108,6 @@ describe("Cypher Connection pagination", () => {
             "CYPHER 5
             MATCH (this0:Movie)
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
@@ -125,7 +124,7 @@ describe("Cypher Connection pagination", () => {
                 ORDER BY var2 DESC
                 RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var3
             }
-            RETURN { edges: var3, totalCount: totalCount } AS this"
+            RETURN { edges: var3 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -150,7 +149,6 @@ describe("Cypher Connection pagination", () => {
             "CYPHER 5
             MATCH (this0:Movie)
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
@@ -167,7 +165,7 @@ describe("Cypher Connection pagination", () => {
                 ORDER BY var2 DESC
                 RETURN collect({ node: { totalGenres: var2, __resolveType: \\"Movie\\" } }) AS var3
             }
-            RETURN { edges: var3, totalCount: totalCount } AS this"
+            RETURN { edges: var3 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -193,7 +191,6 @@ describe("Cypher Connection pagination", () => {
             "CYPHER 5
             MATCH (this0:Movie)
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
@@ -218,7 +215,7 @@ describe("Cypher Connection pagination", () => {
                 ORDER BY var2 DESC, var4 ASC
                 RETURN collect({ node: { numberOfActors: var2, totalGenres: var4, __resolveType: \\"Movie\\" } }) AS var5
             }
-            RETURN { edges: var5, totalCount: totalCount } AS this"
+            RETURN { edges: var5 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -251,7 +248,6 @@ describe("Cypher Connection pagination", () => {
             MATCH (this0:Movie)
             WHERE this0.title = $param0
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
@@ -269,7 +265,7 @@ describe("Cypher Connection pagination", () => {
                 LIMIT $param2
                 RETURN collect({ node: { id: this0.id, title: this0.title, __resolveType: \\"Movie\\" } }) AS var3
             }
-            RETURN { edges: var3, totalCount: totalCount } AS this"
+            RETURN { edges: var3 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -312,14 +308,12 @@ describe("Cypher Connection pagination", () => {
             "CYPHER 5
             MATCH (this0:Movie)
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
                 CALL (this0) {
                     MATCH (this0)-[this1:HAS_GENRE]->(this2:Genre)
                     WITH collect({ node: this2, relationship: this1 }) AS edges
-                    WITH edges, size(edges) AS totalCount
                     CALL (edges) {
                         UNWIND edges AS edge
                         WITH edge.node AS this2, edge.relationship AS this1
@@ -336,11 +330,11 @@ describe("Cypher Connection pagination", () => {
                         ORDER BY var4 ASC
                         RETURN collect({ node: { name: this2.name, __resolveType: \\"Genre\\" } }) AS var5
                     }
-                    RETURN { edges: var5, totalCount: totalCount } AS var6
+                    RETURN { edges: var5 } AS var6
                 }
                 RETURN collect({ node: { genresConnection: var6, __resolveType: \\"Movie\\" } }) AS var7
             }
-            RETURN { edges: var7, totalCount: totalCount } AS this"
+            RETURN { edges: var7 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -376,14 +370,12 @@ describe("Cypher Connection pagination", () => {
             "CYPHER 5
             MATCH (this0:Movie)
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
                 CALL (this0) {
                     MATCH (this0)<-[this1:ACTED_IN]-(this2:Actor)
                     WITH collect({ node: this2, relationship: this1 }) AS edges
-                    WITH edges, size(edges) AS totalCount
                     CALL (edges) {
                         UNWIND edges AS edge
                         WITH edge.node AS this2, edge.relationship AS this1
@@ -400,11 +392,11 @@ describe("Cypher Connection pagination", () => {
                         ORDER BY this1.screenTime DESC, var4 ASC
                         RETURN collect({ properties: { screenTime: this1.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this2.name, __resolveType: \\"Actor\\" } }) AS var5
                     }
-                    RETURN { edges: var5, totalCount: totalCount } AS var6
+                    RETURN { edges: var5 } AS var6
                 }
                 RETURN collect({ node: { actorsConnection: var6, __resolveType: \\"Movie\\" } }) AS var7
             }
-            RETURN { edges: var7, totalCount: totalCount } AS this"
+            RETURN { edges: var7 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);

--- a/packages/graphql/tests/tck/rfcs/query-limits.test.ts
+++ b/packages/graphql/tests/tck/rfcs/query-limits.test.ts
@@ -209,7 +209,6 @@ describe("tck/rfcs/query-limits", () => {
                 CALL (this) {
                     MATCH (this)<-[this0:ACTED_IN]-(this1:Person)
                     WITH collect({ node: this1, relationship: this0 }) AS edges
-                    WITH edges, size(edges) AS totalCount
                     CALL (edges) {
                         UNWIND edges AS edge
                         WITH edge.node AS this1, edge.relationship AS this0
@@ -217,7 +216,7 @@ describe("tck/rfcs/query-limits", () => {
                         LIMIT $param1
                         RETURN collect({ node: { id: this1.id, __resolveType: \\"Person\\" } }) AS var2
                     }
-                    RETURN { edges: var2, totalCount: totalCount } AS var3
+                    RETURN { edges: var2 } AS var3
                 }
                 RETURN this { .id, actorsConnection: var3 } AS this"
             `);
@@ -262,7 +261,6 @@ describe("tck/rfcs/query-limits", () => {
                 CALL (this) {
                     MATCH (this)<-[this0:ACTED_IN]-(this1:Person)
                     WITH collect({ node: this1, relationship: this0 }) AS edges
-                    WITH edges, size(edges) AS totalCount
                     CALL (edges) {
                         UNWIND edges AS edge
                         WITH edge.node AS this1, edge.relationship AS this0
@@ -270,7 +268,7 @@ describe("tck/rfcs/query-limits", () => {
                         LIMIT $param1
                         RETURN collect({ node: { id: this1.id, __resolveType: \\"Person\\" } }) AS var2
                     }
-                    RETURN { edges: var2, totalCount: totalCount } AS var3
+                    RETURN { edges: var2 } AS var3
                 }
                 RETURN this { .id, actorsConnection: var3 } AS this"
             `);
@@ -313,7 +311,6 @@ describe("tck/rfcs/query-limits", () => {
                 CALL (this) {
                     MATCH (this)<-[this0:PART_OF]-(this1:Show)
                     WITH collect({ node: this1, relationship: this0 }) AS edges
-                    WITH edges, size(edges) AS totalCount
                     CALL (edges) {
                         UNWIND edges AS edge
                         WITH edge.node AS this1, edge.relationship AS this0
@@ -321,7 +318,7 @@ describe("tck/rfcs/query-limits", () => {
                         LIMIT $param0
                         RETURN collect({ node: { id: this1.id, __resolveType: \\"Show\\" } }) AS var2
                     }
-                    RETURN { edges: var2, totalCount: totalCount } AS var3
+                    RETURN { edges: var2 } AS var3
                 }
                 RETURN this { .name, showsConnection: var3 } AS this"
             `);

--- a/packages/graphql/tests/tck/root-connection.test.ts
+++ b/packages/graphql/tests/tck/root-connection.test.ts
@@ -99,7 +99,6 @@ describe("Root Connection Query tests", () => {
             "CYPHER 5
             MATCH (this0:Movie)
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
@@ -108,7 +107,7 @@ describe("Root Connection Query tests", () => {
                 LIMIT $param0
                 RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var1
             }
-            RETURN { edges: var1, totalCount: totalCount } AS this"
+            RETURN { edges: var1 } AS this"
         `);
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -138,7 +137,6 @@ describe("Root Connection Query tests", () => {
             MATCH (this0:Movie)
             WHERE this0.title CONTAINS $param0
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
@@ -147,7 +145,7 @@ describe("Root Connection Query tests", () => {
                 LIMIT $param1
                 RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var1
             }
-            RETURN { edges: var1, totalCount: totalCount } AS this"
+            RETURN { edges: var1 } AS this"
         `);
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -184,7 +182,6 @@ describe("Root Connection Query tests", () => {
             "CYPHER 5
             MATCH (this0:Movie)
             WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
             CALL (edges) {
                 UNWIND edges AS edge
                 WITH edge.node AS this0
@@ -204,7 +201,7 @@ describe("Root Connection Query tests", () => {
                 }
                 RETURN collect({ node: { title: this0.title, actorsConnection: var4, __resolveType: \\"Movie\\" } }) AS var5
             }
-            RETURN { edges: var5, totalCount: totalCount } AS this"
+            RETURN { edges: var5 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/subscriptions/create.test.ts
+++ b/packages/graphql/tests/tck/subscriptions/create.test.ts
@@ -123,13 +123,12 @@ describe("Subscriptions metadata on create", () => {
             CALL (create_this1) {
                 MATCH (create_this1)<-[create_this6:ACTED_IN]-(create_this7:Actor)
                 WITH collect({ node: create_this7, relationship: create_this6 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS create_this7, edge.relationship AS create_this6
                     RETURN collect({ properties: { screenTime: create_this6.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: create_this7.name, __resolveType: \\"Actor\\" } }) AS create_var8
                 }
-                RETURN { edges: create_var8, totalCount: totalCount } AS create_var9
+                RETURN { edges: create_var8 } AS create_var9
             }
             RETURN collect(create_this1 { .title, actorsConnection: create_var9 }) AS data"
         `);
@@ -222,13 +221,12 @@ describe("Subscriptions metadata on create", () => {
             CALL (create_this1) {
                 MATCH (create_this1)<-[create_this6:ACTED_IN]-(create_this7:Actor)
                 WITH collect({ node: create_this7, relationship: create_this6 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS create_this7, edge.relationship AS create_this6
                     RETURN collect({ node: { name: create_this7.name, __resolveType: \\"Actor\\" } }) AS create_var8
                 }
-                RETURN { edges: create_var8, totalCount: totalCount } AS create_var9
+                RETURN { edges: create_var8 } AS create_var9
             }
             RETURN collect(create_this1 { .title, actorsConnection: create_var9 }) AS data"
         `);
@@ -352,13 +350,12 @@ describe("Subscriptions metadata on create", () => {
             CALL (create_this1) {
                 MATCH (create_this1)<-[create_this10:ACTED_IN]-(create_this11:Actor)
                 WITH collect({ node: create_this11, relationship: create_this10 }) AS edges
-                WITH edges, size(edges) AS totalCount
                 CALL (edges) {
                     UNWIND edges AS edge
                     WITH edge.node AS create_this11, edge.relationship AS create_this10
                     RETURN collect({ properties: { screenTime: create_this10.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: create_this11.name, __resolveType: \\"Actor\\" } }) AS create_var12
                 }
-                RETURN { edges: create_var12, totalCount: totalCount } AS create_var13
+                RETURN { edges: create_var12 } AS create_var13
             }
             RETURN collect(create_this1 { .title, actorsConnection: create_var13 }) AS data"
         `);


### PR DESCRIPTION
# Description

Optimize connection queries without `totalCount` or `pageInfo` such as:

```graphql
query {
    moviesConnection(first: 20, sort: [{ title: ASC }]) {
        edges {
            node {
                title
            }
        }
    }
}
```

Will no longer calculate `totalCount` in the generated Cypher
