### PR TITLE
Add tests for cypher filtering auth on top level queries

### DIFF
--- a/packages/graphql/tests/integration/directives/cypher/filtering/cypher-filtering-auth-top-level.int.test.ts
+++ b/packages/graphql/tests/integration/directives/cypher/filtering/cypher-filtering-auth-top-level.int.test.ts
@@ -20,7 +20,7 @@
 import { createBearerToken } from "../../../../utils/create-bearer-token";
 import { TestHelper } from "../../../../utils/tests-helper";
 
-describe("cypher directive filtering - Auth", () => {
+describe("cypher directive filtering top level - Auth", () => {
     const testHelper = new TestHelper();
 
     afterEach(async () => {
@@ -32,6 +32,10 @@ describe("cypher directive filtering - Auth", () => {
         const Actor = testHelper.createUniqueType("Actor");
 
         const typeDefs = /* GraphQL */ `
+            type Query {
+                getMovies: [${Movie}!]! @cypher(statement: "MATCH (m:${Movie}) RETURN m", columnName: "m")
+            }
+
             type ${Movie} @node @authorization(filter: [{ where: { node: { custom_field: { eq: "$jwt.custom_value" } } } }]) {
                 title: String
                 custom_field: String
@@ -75,7 +79,7 @@ describe("cypher directive filtering - Auth", () => {
 
         const query = /* GraphQL */ `
             query {
-                ${Movie.plural} {
+                getMovies {
                     title
                     custom_field
                 }
@@ -86,7 +90,7 @@ describe("cypher directive filtering - Auth", () => {
 
         expect(gqlResult.errors).toBeFalsy();
         expect(gqlResult?.data).toEqual({
-            [Movie.plural]: [
+            getMovies: [
                 {
                     title: "The Matrix",
                     custom_field: "hello",
@@ -100,6 +104,10 @@ describe("cypher directive filtering - Auth", () => {
         const Actor = testHelper.createUniqueType("Actor");
 
         const typeDefs = /* GraphQL */ `
+            type Query {
+                getMovies: [${Movie}!]! @cypher(statement: "MATCH (m:${Movie}) RETURN m", columnName: "m")
+            }
+
             type ${Movie} @node {
                 title: String
                 custom_field: String
@@ -144,7 +152,7 @@ describe("cypher directive filtering - Auth", () => {
 
         const query = /* GraphQL */ `
             query {
-                ${Movie.plural} {
+                getMovies {
                     custom_field
                 }
             }
@@ -154,7 +162,7 @@ describe("cypher directive filtering - Auth", () => {
 
         expect(gqlResult.errors).toBeFalsy();
         expect(gqlResult?.data).toEqual({
-            [Movie.plural]: [
+            getMovies: [
                 {
                     custom_field: "hello",
                 },
@@ -167,6 +175,10 @@ describe("cypher directive filtering - Auth", () => {
         const Actor = testHelper.createUniqueType("Actor");
 
         const typeDefs = /* GraphQL */ `
+            type Query {
+                getMovies: [${Movie}!]! @cypher(statement: "MATCH (m:${Movie}) RETURN m", columnName: "m")
+            }
+
             type ${Movie} @node {
                 title: String
                 custom_field: String
@@ -211,7 +223,7 @@ describe("cypher directive filtering - Auth", () => {
 
         const query = /* GraphQL */ `
             query {
-                ${Movie.plural} {
+                getMovies {
                     title
                 }
             }
@@ -221,7 +233,7 @@ describe("cypher directive filtering - Auth", () => {
 
         expect(gqlResult.errors).toBeFalsy();
         expect(gqlResult?.data).toEqual({
-            [Movie.plural]: expect.toIncludeSameMembers([
+            getMovies: expect.toIncludeSameMembers([
                 {
                     title: "The Matrix",
                 },
@@ -237,6 +249,10 @@ describe("cypher directive filtering - Auth", () => {
         const Actor = testHelper.createUniqueType("Actor");
 
         const typeDefs = /* GraphQL */ `
+            type Query {
+                getActors: [${Actor}!]! @cypher(statement: "MATCH (a:${Actor}) RETURN a", columnName: "a")
+            }
+
             type ${Movie} @node {
                 title: String
                 custom_field: String
@@ -282,7 +298,7 @@ describe("cypher directive filtering - Auth", () => {
 
         const query = /* GraphQL */ `
             query {
-                ${Actor.plural} {
+                getActors {
                     name
                 }
             }
@@ -292,7 +308,7 @@ describe("cypher directive filtering - Auth", () => {
 
         expect(gqlResult.errors).toBeFalsy();
         expect(gqlResult?.data).toEqual({
-            [Actor.plural]: [
+            getActors: [
                 {
                     name: "Keanu Reeves",
                 },
@@ -305,6 +321,10 @@ describe("cypher directive filtering - Auth", () => {
         const Actor = testHelper.createUniqueType("Actor");
 
         const typeDefs = /* GraphQL */ `
+            type Query {
+                getMovies: [${Movie}!]! @cypher(statement: "MATCH (m:${Movie}) RETURN m", columnName: "m")
+            }
+
             type ${Movie} @node {
                 title: String @authorization(filter: [{ where: { node: { custom_field: { eq: "$jwt.custom_value" } } } }])
                 custom_field: String
@@ -348,7 +368,7 @@ describe("cypher directive filtering - Auth", () => {
 
         const query = /* GraphQL */ `
             query {
-                ${Movie.plural} {
+                getMovies {
                     title
                 }
             }
@@ -358,7 +378,7 @@ describe("cypher directive filtering - Auth", () => {
 
         expect(gqlResult.errors).toBeFalsy();
         expect(gqlResult?.data).toEqual({
-            [Movie.plural]: expect.toIncludeSameMembers([
+            getMovies: expect.toIncludeSameMembers([
                 {
                     title: "The Matrix",
                 },
@@ -374,6 +394,10 @@ describe("cypher directive filtering - Auth", () => {
         const Actor = testHelper.createUniqueType("Actor");
 
         const typeDefs = /* GraphQL */ `
+            type Query {
+                getMovies: [${Movie}!]! @cypher(statement: "MATCH (m:${Movie}) RETURN m", columnName: "m")
+            }
+
             type ${Movie} @node @authorization(validate: [{ where: { node: { custom_field: { eq: "$jwt.custom_value" } } } }]) {
                 title: String
                 custom_field: String
@@ -417,7 +441,7 @@ describe("cypher directive filtering - Auth", () => {
 
         const query = /* GraphQL */ `
             query {
-                ${Movie.plural} {
+                getMovies {
                     title
                 }
             }
@@ -434,6 +458,10 @@ describe("cypher directive filtering - Auth", () => {
         const Actor = testHelper.createUniqueType("Actor");
 
         const typeDefs = /* GraphQL */ `
+            type Query {
+                getMovies: [${Movie}!]! @cypher(statement: "MATCH (m:${Movie}) RETURN m", columnName: "m")
+            }
+
             type ${Movie} @node @authorization(validate: [{ where: { node: { custom_field: { eq: "$jwt.custom_value" } } } }]) {
                 title: String
                 custom_field: String
@@ -477,7 +505,7 @@ describe("cypher directive filtering - Auth", () => {
 
         const query = /* GraphQL */ `
             query {
-                ${Movie.plural} {
+                getMovies {
                     title
                 }
             }
@@ -487,7 +515,7 @@ describe("cypher directive filtering - Auth", () => {
 
         expect(gqlResult.errors).toBeFalsy();
         expect(gqlResult?.data).toEqual({
-            [Movie.plural]: expect.toIncludeSameMembers([
+            getMovies: expect.toIncludeSameMembers([
                 {
                     title: "The Matrix",
                 },

--- a/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-auth-top-level.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-auth-top-level.test.ts
@@ -1,0 +1,485 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Neo4jGraphQL } from "../../../../../src";
+import { createBearerToken } from "../../../../utils/create-bearer-token";
+import { formatCypher, formatParams, translateQuery } from "../../../utils/tck-test-utils";
+
+describe("cypher directive filtering top level - Auth", () => {
+    test("With authorization on type using @cypher return value", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Query {
+                getMovies: [Movie!]! @cypher(statement: "MATCH (m:Movie) RETURN m", columnName: "m")
+            }
+
+            type Movie
+                @node
+                @authorization(filter: [{ where: { node: { custom_field: { eq: "$jwt.custom_value" } } } }]) {
+                title: String
+                custom_field: String
+                    @cypher(
+                        statement: """
+                        RETURN "hello" AS s
+                        """
+                        columnName: "s"
+                    )
+                actors: [Actor!]! @relationship(type: "ACTED_IN", direction: IN)
+            }
+
+            type Actor @node {
+                name: String
+                movies: [Movie!]! @relationship(type: "ACTED_IN", direction: OUT)
+            }
+        `;
+
+        const token = createBearerToken("secret", { custom_value: "hello" });
+
+        const query = /* GraphQL */ `
+            query {
+                getMovies {
+                    title
+                }
+            }
+        `;
+
+        const neoSchema: Neo4jGraphQL = new Neo4jGraphQL({
+            typeDefs,
+            features: {
+                authorization: {
+                    key: "secret",
+                },
+            },
+        });
+
+        const result = await translateQuery(neoSchema, query, { token });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "CYPHER 5
+            CALL {
+                MATCH (m:Movie) RETURN m
+            }
+            WITH m AS this0
+            CALL (this0) {
+                CALL (this0) {
+                    WITH this0 AS this
+                    RETURN \\"hello\\" AS s
+                }
+                WITH s AS this1
+                RETURN this1 AS var2
+            }
+            WITH *
+            WHERE ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND var2 IS NOT NULL AND var2 = $jwt.custom_value))
+            WITH this0 { .title } AS this0
+            RETURN this0 AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"isAuthenticated\\": true,
+                \\"jwt\\": {
+                    \\"roles\\": [],
+                    \\"custom_value\\": \\"hello\\"
+                }
+            }"
+        `);
+    });
+
+    test("With authorization on @cypher field using @cypher return value", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Query {
+                getMovies: [Movie!]! @cypher(statement: "MATCH (m:Movie) RETURN m", columnName: "m")
+            }
+
+            type Movie @node {
+                title: String
+                custom_field: String
+                    @cypher(
+                        statement: """
+                        RETURN "hello" AS s
+                        """
+                        columnName: "s"
+                    )
+                    @authorization(filter: [{ where: { node: { custom_field: { eq: "$jwt.custom_value" } } } }])
+                actors: [Actor!]! @relationship(type: "ACTED_IN", direction: IN)
+            }
+
+            type Actor @node {
+                name: String
+                movies: [Movie!]! @relationship(type: "ACTED_IN", direction: OUT)
+            }
+        `;
+
+        const token = createBearerToken("secret", { custom_value: "hello" });
+
+        const query = /* GraphQL */ `
+            query {
+                getMovies {
+                    custom_field
+                }
+            }
+        `;
+
+        const neoSchema: Neo4jGraphQL = new Neo4jGraphQL({
+            typeDefs,
+            features: {
+                authorization: {
+                    key: "secret",
+                },
+            },
+        });
+
+        const result = await translateQuery(neoSchema, query, { token });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "CYPHER 5
+            CALL {
+                MATCH (m:Movie) RETURN m
+            }
+            WITH m AS this0
+            CALL (this0) {
+                CALL (this0) {
+                    WITH this0 AS this
+                    RETURN \\"hello\\" AS s
+                }
+                WITH s AS this1
+                RETURN this1 AS var2
+            }
+            CALL (this0) {
+                CALL (this0) {
+                    WITH this0 AS this
+                    RETURN \\"hello\\" AS s
+                }
+                WITH s AS this3
+                RETURN this3 AS var4
+            }
+            WITH *
+            WHERE ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND var4 IS NOT NULL AND var4 = $jwt.custom_value))
+            WITH this0 { custom_field: var2 } AS this0
+            RETURN this0 AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"isAuthenticated\\": true,
+                \\"jwt\\": {
+                    \\"roles\\": [],
+                    \\"custom_value\\": \\"hello\\"
+                }
+            }"
+        `);
+    });
+
+    test("With authorization on @cypher field using different field return value", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Query {
+                getMovies: [Movie!]! @cypher(statement: "MATCH (m:Movie) RETURN m", columnName: "m")
+            }
+
+            type Movie @node {
+                title: String
+                custom_field: String
+                    @cypher(
+                        statement: """
+                        RETURN "hello" AS s
+                        """
+                        columnName: "s"
+                    )
+                    @authorization(filter: [{ where: { node: { title: { eq: "$jwt.custom_value" } } } }])
+                actors: [Actor!]! @relationship(type: "ACTED_IN", direction: IN)
+            }
+
+            type Actor @node {
+                name: String
+                movies: [Movie!]! @relationship(type: "ACTED_IN", direction: OUT)
+            }
+        `;
+
+        const token = createBearerToken("secret", { custom_value: "hello" });
+
+        const query = /* GraphQL */ `
+            query {
+                getMovies {
+                    title
+                }
+            }
+        `;
+
+        const neoSchema: Neo4jGraphQL = new Neo4jGraphQL({
+            typeDefs,
+            features: {
+                authorization: {
+                    key: "secret",
+                },
+            },
+        });
+
+        const result = await translateQuery(neoSchema, query, { token });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "CYPHER 5
+            CALL {
+                MATCH (m:Movie) RETURN m
+            }
+            WITH m AS this0
+            WITH this0 { .title } AS this0
+            RETURN this0 AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
+    });
+
+    test("With authorization on Actor type field using nested Movie's @cypher field return value", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Query {
+                getMovies: [Movie!]! @cypher(statement: "MATCH (m:Movie) RETURN m", columnName: "m")
+            }
+
+            type Movie @node {
+                title: String
+                custom_field: String
+                    @cypher(
+                        statement: """
+                        RETURN "hello" AS s
+                        """
+                        columnName: "s"
+                    )
+                actors: [Actor!]! @relationship(type: "ACTED_IN", direction: IN)
+            }
+
+            type Actor
+                @node
+                @authorization(
+                    filter: [{ where: { node: { movies: { some: { custom_field: { eq: "$jwt.custom_value" } } } } } }]
+                ) {
+                name: String
+                movies: [Movie!]! @relationship(type: "ACTED_IN", direction: OUT)
+            }
+        `;
+
+        const token = createBearerToken("secret", { custom_value: "hello" });
+
+        const query = /* GraphQL */ `
+            query {
+                actors {
+                    name
+                }
+            }
+        `;
+
+        const neoSchema: Neo4jGraphQL = new Neo4jGraphQL({
+            typeDefs,
+            features: {
+                authorization: {
+                    key: "secret",
+                },
+            },
+        });
+
+        const result = await translateQuery(neoSchema, query, { token });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "CYPHER 5
+            MATCH (this:Actor)
+            CALL (this) {
+                MATCH (this)-[:ACTED_IN]->(this0:Movie)
+                CALL (this0) {
+                    CALL (this0) {
+                        WITH this0 AS this
+                        RETURN \\"hello\\" AS s
+                    }
+                    WITH s AS this1
+                    RETURN this1 AS var2
+                }
+                WITH *
+                WHERE ($jwt.custom_value IS NOT NULL AND var2 IS NOT NULL AND var2 = $jwt.custom_value)
+                RETURN count(this0) > 0 AS var3
+            }
+            WITH *
+            WHERE ($isAuthenticated = true AND var3 = true)
+            RETURN this { .name } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"jwt\\": {
+                    \\"roles\\": [],
+                    \\"custom_value\\": \\"hello\\"
+                },
+                \\"isAuthenticated\\": true
+            }"
+        `);
+    });
+
+    test("With authorization on a different field than the @cypher field", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Query {
+                getMovies: [Movie!]! @cypher(statement: "MATCH (m:Movie) RETURN m", columnName: "m")
+            }
+
+            type Movie @node {
+                title: String
+                    @authorization(filter: [{ where: { node: { custom_field: { eq: "$jwt.custom_value" } } } }])
+                custom_field: String
+                    @cypher(
+                        statement: """
+                        RETURN "hello" AS s
+                        """
+                        columnName: "s"
+                    )
+                actors: [Actor!]! @relationship(type: "ACTED_IN", direction: IN)
+            }
+
+            type Actor @node {
+                name: String
+                movies: [Movie!]! @relationship(type: "ACTED_IN", direction: OUT)
+            }
+        `;
+
+        const token = createBearerToken("secret", { custom_value: "hello" });
+
+        const query = /* GraphQL */ `
+            query {
+                getMovies {
+                    title
+                }
+            }
+        `;
+
+        const neoSchema: Neo4jGraphQL = new Neo4jGraphQL({
+            typeDefs,
+            features: {
+                authorization: {
+                    key: "secret",
+                },
+            },
+        });
+
+        const result = await translateQuery(neoSchema, query, { token });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "CYPHER 5
+            CALL {
+                MATCH (m:Movie) RETURN m
+            }
+            WITH m AS this0
+            CALL (this0) {
+                CALL (this0) {
+                    WITH this0 AS this
+                    RETURN \\"hello\\" AS s
+                }
+                WITH s AS this1
+                RETURN this1 AS var2
+            }
+            WITH *
+            WHERE ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND var2 IS NOT NULL AND var2 = $jwt.custom_value))
+            WITH this0 { .title } AS this0
+            RETURN this0 AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"isAuthenticated\\": true,
+                \\"jwt\\": {
+                    \\"roles\\": [],
+                    \\"custom_value\\": \\"hello\\"
+                }
+            }"
+        `);
+    });
+
+    test("With authorization on type using @cypher return value, with validate", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Query {
+                getMovies: [Movie!]! @cypher(statement: "MATCH (m:Movie) RETURN m", columnName: "m")
+            }
+
+            type Movie
+                @node
+                @authorization(validate: [{ where: { node: { custom_field: { eq: "$jwt.custom_value" } } } }]) {
+                title: String
+                custom_field: String
+                    @cypher(
+                        statement: """
+                        MATCH (this)
+                        RETURN this.custom_field AS s
+                        """
+                        columnName: "s"
+                    )
+                actors: [Actor!]! @relationship(type: "ACTED_IN", direction: IN)
+            }
+
+            type Actor @node {
+                name: String
+                movies: [Movie!]! @relationship(type: "ACTED_IN", direction: OUT)
+            }
+        `;
+
+        const token = createBearerToken("secret", { custom_value: "hello" });
+
+        const query = /* GraphQL */ `
+            query {
+                getMovies {
+                    title
+                }
+            }
+        `;
+
+        const neoSchema: Neo4jGraphQL = new Neo4jGraphQL({
+            typeDefs,
+            features: {
+                authorization: {
+                    key: "secret",
+                },
+            },
+        });
+
+        const result = await translateQuery(neoSchema, query, { token });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "CYPHER 5
+            CALL {
+                MATCH (m:Movie) RETURN m
+            }
+            WITH m AS this0
+            CALL (this0) {
+                CALL (this0) {
+                    WITH this0 AS this
+                    MATCH (this)
+                    RETURN this.custom_field AS s
+                }
+                WITH s AS this1
+                RETURN this1 AS var2
+            }
+            WITH *
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND var2 IS NOT NULL AND var2 = $jwt.custom_value)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WITH this0 { .title } AS this0
+            RETURN this0 AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"isAuthenticated\\": true,
+                \\"jwt\\": {
+                    \\"roles\\": [],
+                    \\"custom_value\\": \\"hello\\"
+                }
+            }"
+        `);
+    });
+});


### PR DESCRIPTION
# Description

This PR simply adds some additional tests for top-level cypher queries using the authorization directive.