### PR TITLE
Fix flaky test connect-union.int

### DIFF
--- a/packages/graphql/tests/integration/relationship-properties/connect-union.int.test.ts
+++ b/packages/graphql/tests/integration/relationship-properties/connect-union.int.test.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import { generate } from "randomstring";
 import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../../utils/tests-helper";
 
@@ -27,7 +26,7 @@ describe("Relationship properties - connect on union", () => {
     let Show: UniqueType;
     let testHelper: TestHelper;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
         testHelper = new TestHelper();
         Movie = testHelper.createUniqueType("Movie");
         Actor = testHelper.createUniqueType("Actor");
@@ -57,14 +56,14 @@ describe("Relationship properties - connect on union", () => {
         await testHelper.initNeo4jGraphQL({ typeDefs });
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
         await testHelper.close();
     });
 
     test("should create an actor while connecting a relationship that has properties", async () => {
-        const movieTitle = generate({ charset: "alphabetic" });
-        const actorName = generate({ charset: "alphabetic" });
-        const screenTime = Math.floor((Math.random() * 1e3) / Math.random());
+        const movieTitle = "Scent of a Koala";
+        const actorName = "Mofli";
+        const screenTime = 560;
 
         const source = /* GraphQL */ `
             mutation ($movieTitle: String!, $screenTime: Int!, $actorName: String!) {
@@ -118,9 +117,9 @@ describe("Relationship properties - connect on union", () => {
     });
 
     test("should update an actor while connecting a relationship that has properties(with Union)", async () => {
-        const movieTitle = generate({ charset: "alphabetic" });
-        const actorName = generate({ charset: "alphabetic" });
-        const screenTime = Math.floor((Math.random() * 1e3) / Math.random());
+        const movieTitle = "Scent of a Robot";
+        const actorName = "Marvin";
+        const screenTime = 60;
 
         const source = /* GraphQL */ `
             mutation($movieTitle: String!, $screenTime: Int!, $actorName: String!) {
@@ -172,9 +171,9 @@ describe("Relationship properties - connect on union", () => {
     });
 
     test("should update an actor while connecting an existing relationship that has properties(with Union)", async () => {
-        const movieTitle = generate({ charset: "alphabetic" });
-        const actorName = generate({ charset: "alphabetic" });
-        const screenTime = Math.floor((Math.random() * 1e3) / Math.random());
+        const movieTitle = "The Woman in Purple";
+        const actorName = "Dan Rad";
+        const screenTime = 190;
 
         const source = /* GraphQL */ `
             mutation($movieTitle: String!, $screenTime: Int!, $actorName: String!) {


### PR DESCRIPTION
# Description

These tests were failing when the value `screenTime` was 0.

This PR changes all the random values in tests to be explicit values
