### PR TITLE
Setup  for npm trusted publishers 6.x

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,6 @@
-name: changesets
+# NOTE: This filename must be called release.yml. If changed, update the Trusted Publisher settings in npm
+
+name: Release
 
 on:
   push:
@@ -8,6 +10,9 @@ on:
       - "*.x"
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+permissions:
+  id-token: write # Required for OIDC
 
 jobs:
   release:
@@ -33,6 +38,11 @@ jobs:
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4
         with:
           node-version: lts/*
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+
+      - name: Update npm # Need at least 11.5.1 for OIDC publishing
+        run: npm install -g npm@latest
 
       - name: Install Dependencies
         run: yarn
@@ -41,15 +51,6 @@ jobs:
         run: |
           git config --global user.name 'Neo4j Team GraphQL'
           git config --global user.email 'team-graphql@neotechnology.com'
-
-      - name: Creating .npmrc
-        run: |
-          cat << EOF > "$HOME/.npmrc"
-            @neo4j:registry https://registry.npmjs.org
-            //registry.npmjs.org/:_authToken=$NPM_TOKEN
-          EOF
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create release PR or release
         id: changesets
@@ -62,16 +63,13 @@ jobs:
           setupGitUser: false
         env:
           GITHUB_TOKEN: ${{ secrets.NEO4J_TEAM_GRAPHQL_PERSONAL_ACCESS_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
           BRANCH: ${{ github.ref_name }}
 
   slack-notify:
     needs:
       - release
-
     if: ${{ needs.release.outputs.published == 'true' }}
-
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -11,6 +11,10 @@
     "bugs": {
         "url": "https://github.com/neo4j/graphql/issues"
     },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/neo4j/graphql.git"
+    },
     "homepage": "https://github.com/neo4j/graphql/tree/dev/packages/graphql",
     "exports": "./dist/index.js",
     "main": "./dist/index.js",

--- a/packages/introspector/package.json
+++ b/packages/introspector/package.json
@@ -11,6 +11,10 @@
     "bugs": {
         "url": "https://github.com/neo4j/graphql/issues"
     },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/neo4j/graphql.git"
+    },
     "homepage": "https://github.com/neo4j/graphql/tree/dev/packages/introspector",
     "exports": "./dist/index.js",
     "main": "./dist/index.js",


### PR DESCRIPTION

This is the 6.x port of https://github.com/neo4j/graphql/pull/6747 and https://github.com/neo4j/graphql/pull/6750
