### PR TITLE
Update Introspector to use executeRead

### DIFF
--- a/.changeset/quick-moments-push.md
+++ b/.changeset/quick-moments-push.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/introspector": patch
+---
+
+Replaces usage of readTransaction with executeRead in introspector to pave the way for a future upgrade to neo4j-driver v6.

--- a/packages/introspector/src/to-internal-struct.ts
+++ b/packages/introspector/src/to-internal-struct.ts
@@ -51,7 +51,7 @@ async function introspectNodes(sessionFactory: () => Session): Promise<NodeMap> 
     const nodes: NodeMap = {};
     // Label properties
     const session = sessionFactory();
-    const labelPropsRes = await session.readTransaction((tx) =>
+    const labelPropsRes = await session.executeRead((tx) =>
         tx.run(`CALL db.schema.nodeTypeProperties()
     YIELD nodeType, nodeLabels, propertyName, propertyTypes, mandatory
     RETURN *`)
@@ -85,7 +85,7 @@ async function introspectRelationships(sessionFactory: () => Session): Promise<R
     const rels: RelationshipMap = {};
 
     // Find all relationship types and their properties (if any)
-    const typePropsRes = await relSession.readTransaction((tx) =>
+    const typePropsRes = await relSession.executeRead((tx) =>
         tx.run(`CALL db.schema.relTypeProperties()
     YIELD relType, propertyName, propertyTypes, mandatory
     RETURN *`)
@@ -114,7 +114,7 @@ async function introspectRelationships(sessionFactory: () => Session): Promise<R
             });
 
             const escapedType = escapeLabel(cleanTypeName(relType));
-            const relationshipsRes = await conSession.readTransaction((tx) =>
+            const relationshipsRes = await conSession.executeRead((tx) =>
                 tx.run(`
             MATCH (n)-[r:${escapedType}]->(m)
             WITH DISTINCT labels(n) AS from, labels(m) AS to


### PR DESCRIPTION
`executeRead` replaces the deprecated `readTransaction` in version 5 of the driver. In version 6 `readTransaction` is removed completely.