### PR TITLE
Add ReleaseOps Aura Tests workflow

### DIFF
--- a/.github/workflows/releaseops-aura-tests.yml
+++ b/.github/workflows/releaseops-aura-tests.yml
@@ -1,7 +1,7 @@
 name: "ReleaseOps Aura Tests"
-
+# Executes graphql tests in the ReleaseOps Aura environment as part of the Neo4j ReleaseOps pipeline. 
+# Triggered by ReleaseOps from TeamCity, to validate the new database version, before a release.
 on:
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/releaseops-aura-tests.yml
+++ b/.github/workflows/releaseops-aura-tests.yml
@@ -1,0 +1,28 @@
+name: "ReleaseOps Aura Tests"
+
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+  pull_request_target:
+    branches:
+      - dev
+    paths:
+      - "**/CHANGELOG.md"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}-aura
+  cancel-in-progress: true
+
+jobs:
+  aura-professional-5-tests:
+    if: |
+      github.event_name != 'pull_request_target' ||
+      github.event.pull_request.user.login == 'neo4j-team-graphql' &&
+      startsWith(github.head_ref, 'changeset-release/')
+    uses: ./.github/workflows/reusable-aura-tests.yml
+    with:
+      BRANCH: ${{ github.head_ref || github.ref }}
+    secrets:
+      URI: ${{ secrets.RELEASEOPS_AURA_PROFESSIONAL_5_URI }}
+      PASSWORD: ${{ secrets.RELEASEOPS_AURA_PROFESSIONAL_5_PASSWORD }}
+    concurrency: aura-professional-5

--- a/.github/workflows/releaseops-aura-tests.yml
+++ b/.github/workflows/releaseops-aura-tests.yml
@@ -3,11 +3,6 @@ name: "ReleaseOps Aura Tests"
 on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
-  pull_request_target:
-    branches:
-      - dev
-    paths:
-      - "**/CHANGELOG.md"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}-aura
@@ -15,10 +10,6 @@ concurrency:
 
 jobs:
   aura-professional-5-tests:
-    if: |
-      github.event_name != 'pull_request_target' ||
-      github.event.pull_request.user.login == 'neo4j-team-graphql' &&
-      startsWith(github.head_ref, 'changeset-release/')
     uses: ./.github/workflows/reusable-aura-tests.yml
     with:
       BRANCH: ${{ github.head_ref || github.ref }}


### PR DESCRIPTION
To run as a smoke test before a release of Neo4j, against the ReleaseOps Aura environment.

Complexity:

Low