### PR TITLE
Update nodejs in workflows

### DIFF
--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6
         with:
-          node-version: 20
+          node-version: 24
           package-manager-cache: false
 
       - name: Target Branch - Check out

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
       - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6
         with:
-          node-version: 18.20.8
+          node-version: 24
           cache: yarn
           package-manager-cache: false
       - name: Install dependencies

--- a/.github/workflows/reusable-api-library-tests.yml
+++ b/.github/workflows/reusable-api-library-tests.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
       - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6
         with:
-          node-version: 20
+          node-version: 24
           cache: yarn
           package-manager-cache: false
       - name: Install dependencies
@@ -71,7 +71,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
       - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6
         with:
-          node-version: 20
+          node-version: 24
           cache: yarn
           package-manager-cache: false
       - name: Install dependencies
@@ -86,7 +86,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
       - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6
         with:
-          node-version: 20
+          node-version: 24
           cache: yarn
           package-manager-cache: false
       - name: Install dependencies

--- a/.github/workflows/reusable-aura-tests.yml
+++ b/.github/workflows/reusable-aura-tests.yml
@@ -65,7 +65,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
       - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6
         with:
-          node-version: 20
+          node-version: 24
           cache: yarn
           package-manager-cache: false
       - name: Install dependencies

--- a/.github/workflows/reusable-integration-tests-on-prem-nightly.yml
+++ b/.github/workflows/reusable-integration-tests-on-prem-nightly.yml
@@ -38,7 +38,7 @@ jobs:
       - ecr-login
 
     strategy:
-      matrix:
+      matrix: # This matrix tests the minimum supported version of Node.js as well as the current lts
         node: [{ name: "20", coverage_name: "20" }, { name: "lts/*", coverage_name: "lts" }]
         packages:
           [

--- a/.github/workflows/reusable-integration-tests-on-prem.yml
+++ b/.github/workflows/reusable-integration-tests-on-prem.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
       - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6
         with:
-          node-version: 20
+          node-version: 24
           cache: yarn
           package-manager-cache: false
       - name: Install dependencies

--- a/.github/workflows/reusable-package-tests.yml
+++ b/.github/workflows/reusable-package-tests.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
       - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6
         with:
-          node-version: 18.20.8
+          node-version: 20 # Should match package.json minimum node engine
           cache: yarn
           package-manager-cache: false
       - name: Install dependencies

--- a/.github/workflows/reusable-unit-tests.yml
+++ b/.github/workflows/reusable-unit-tests.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
       - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6
         with:
-          node-version: lts/*
+          node-version: 24
           cache: yarn
           package-manager-cache: false
       - name: Install dependencies


### PR DESCRIPTION
# Description

Update node version in our workflows. 

Only nightly integration tests and reusable package tests are kept to Nodejs 20 for testing compatibility
