### PR TITLE
Add case insensitive support to Cypher filter

### DIFF
--- a/.changeset/dirty-carrots-march.md
+++ b/.changeset/dirty-carrots-march.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+Add case insensitive support to Cypher filter

--- a/packages/graphql/src/translate/queryAST/ast/filters/Filter.ts
+++ b/packages/graphql/src/translate/queryAST/ast/filters/Filter.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import type Cypher from "@neo4j/cypher-builder";
+import Cypher from "@neo4j/cypher-builder";
 import type { QueryASTContext } from "../QueryASTContext";
 import { QueryASTNode } from "../QueryASTNode";
 
@@ -52,4 +52,26 @@ export function isRelationshipOperator(operator: string): operator is Relationsh
 
 export abstract class Filter extends QueryASTNode {
     public abstract getPredicate(context: QueryASTContext): Cypher.Predicate | undefined;
+
+    protected applyCaseInsensitive(
+        operator: FilterOperator,
+        property: Cypher.Expr,
+        param: Cypher.Expr
+    ): { operator: FilterOperator; property: Cypher.Expr; param: Cypher.Expr } {
+        if (operator === "IN") {
+            const x = new Cypher.Variable();
+            const lowercaseList = new Cypher.ListComprehension(x).in(param).map(Cypher.toLower(x));
+            return {
+                operator,
+                property: Cypher.toLower(property),
+                param: lowercaseList,
+            };
+        }
+
+        return {
+            operator,
+            property: Cypher.toLower(property),
+            param: Cypher.toLower(param),
+        };
+    }
 }

--- a/packages/graphql/src/translate/queryAST/ast/filters/property-filters/CypherFilter.ts
+++ b/packages/graphql/src/translate/queryAST/ast/filters/property-filters/CypherFilter.ts
@@ -39,6 +39,7 @@ export class CypherFilter extends Filter {
     private operator: FilterOperator;
     protected comparisonValue: Cypher.Param | Cypher.Variable | Cypher.Property;
     private checkIsNotNull: boolean;
+    protected caseInsensitive: boolean;
 
     constructor({
         selection,
@@ -46,12 +47,14 @@ export class CypherFilter extends Filter {
         operator,
         comparisonValue,
         checkIsNotNull = false,
+        caseInsensitive = false,
     }: {
         selection: CustomCypherSelection;
         attribute: AttributeAdapter;
         operator: FilterOperator;
         comparisonValue: Cypher.Param | Cypher.Variable | Cypher.Property;
         checkIsNotNull?: boolean;
+        caseInsensitive?: boolean;
     }) {
         super();
         this.selection = selection;
@@ -59,6 +62,7 @@ export class CypherFilter extends Filter {
         this.operator = operator;
         this.comparisonValue = comparisonValue;
         this.checkIsNotNull = checkIsNotNull;
+        this.caseInsensitive = caseInsensitive;
     }
 
     public getChildren(): QueryASTNode[] {
@@ -147,6 +151,10 @@ export class CypherFilter extends Filter {
             });
         }
 
-        return createComparisonOperation({ operator, property: coalesceProperty, param });
+        if (this.caseInsensitive) {
+            return createComparisonOperation({ ...this.applyCaseInsensitive(operator, coalesceProperty, param) });
+        } else {
+            return createComparisonOperation({ operator, property: coalesceProperty, param });
+        }
     }
 }

--- a/packages/graphql/src/translate/queryAST/ast/filters/property-filters/PropertyFilter.ts
+++ b/packages/graphql/src/translate/queryAST/ast/filters/property-filters/PropertyFilter.ts
@@ -154,18 +154,7 @@ export class PropertyFilter extends Filter {
         const coalesceProperty = coalesceValueIfNeeded(this.attribute, property);
 
         if (this.caseInsensitive) {
-            // Need to map all the items in the list to make case insensitive checks for lists
-            if (operator === "IN") {
-                const x = new Cypher.Variable();
-                const lowercaseList = new Cypher.ListComprehension(x, param).map(Cypher.toLower(x));
-                return Cypher.in(Cypher.toLower(coalesceProperty), lowercaseList);
-            }
-
-            return createComparisonOperation({
-                operator,
-                property: Cypher.toLower(coalesceProperty),
-                param: Cypher.toLower(param),
-            });
+            return createComparisonOperation({ ...this.applyCaseInsensitive(operator, coalesceProperty, param) });
         } else {
             return createComparisonOperation({ operator, property: coalesceProperty, param });
         }

--- a/packages/graphql/src/translate/queryAST/factory/FilterFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/FilterFactory.ts
@@ -180,10 +180,12 @@ export class FilterFactory {
         attribute,
         comparisonValue,
         operator,
+        caseInsensitive,
     }: {
         attribute: AttributeAdapter;
         comparisonValue: GraphQLWhereArg;
         operator: FilterOperator | undefined;
+        caseInsensitive?: boolean;
     }): Filter | Filter[] {
         const selection = new CustomCypherSelection({
             operationField: attribute,
@@ -228,6 +230,7 @@ export class FilterFactory {
             attribute,
             comparisonValue: comparisonValueParam,
             operator: operator ?? "EQ",
+            caseInsensitive,
         });
     }
 
@@ -251,6 +254,7 @@ export class FilterFactory {
                 attribute,
                 comparisonValue,
                 operator,
+                caseInsensitive,
             });
         }
         // Implicit _EQ filters are removed but the argument "operator" can still be undefined in some cases, for instance:

--- a/packages/graphql/tests/integration/directives/cypher/filtering/cypher-filtering-scalar.int.test.ts
+++ b/packages/graphql/tests/integration/directives/cypher/filtering/cypher-filtering-scalar.int.test.ts
@@ -98,29 +98,29 @@ describe("cypher directive filtering - Scalar", () => {
     test.each([
         {
             title: "String cypher field: exact match",
-            filter: `nickname: { eq: "test"}`,
+            filter: `special_word: { eq: "test"}`,
         },
         {
             title: "String cypher field: CONTAINS",
-            filter: `nickname: { contains: "es"}`,
+            filter: `special_word: { contains: "es"}`,
         },
         {
             title: "String cypher field: ENDS_WITH",
-            filter: `nickname:{ endsWith: "est"}`,
+            filter: `special_word: { endsWith: "est"}`,
         },
         {
             title: "String cypher field: STARTS_WITH",
-            filter: `nickname:{ startsWith: "tes"}`,
+            filter: `special_word: { startsWith: "tes"}`,
         },
         {
             title: "String cypher field: IN",
-            filter: `nickname:{ in: ["test", "test2"]}`,
+            filter: `special_word: { in: ["test", "test2"]}`,
         },
     ] as const)("$title", async ({ filter }) => {
         const typeDefs = /* GraphQL */ `
             type ${CustomType} @node {
                 title: String
-                nickname: String
+                special_word: String
                     @cypher(
                         statement: """
                         RETURN "test" as s
@@ -288,29 +288,29 @@ describe("cypher directive filtering - Scalar", () => {
     test.each([
         {
             title: "String cypher field: caseInsensitive eq",
-            filter: `nickname: { caseInsensitive: { eq: "toyota" } }`,
+            filter: `special_word: { caseInsensitive: { eq: "toyota" } }`,
         },
         {
             title: "String cypher field: caseInsensitive contains",
-            filter: `nickname: { caseInsensitive: { contains: "YO" } }`,
+            filter: `special_word: { caseInsensitive: { contains: "YO" } }`,
         },
         {
             title: "String cypher field: caseInsensitive startsWith",
-            filter: `nickname: { caseInsensitive: { startsWith: "to" } }`,
+            filter: `special_word: { caseInsensitive: { startsWith: "to" } }`,
         },
         {
             title: "String cypher field: caseInsensitive endsWith",
-            filter: `nickname: { caseInsensitive: { endsWith: "tA" } }`,
+            filter: `special_word: { caseInsensitive: { endsWith: "tA" } }`,
         },
         {
             title: "String cypher field: caseInsensitive in",
-            filter: `nickname: { caseInsensitive: { in: ["toyota"] } }`,
+            filter: `special_word: { caseInsensitive: { in: ["toyota"] } }`,
         },
     ] as const)("$title", async ({ filter }) => {
         const typeDefs = /* GraphQL */ `
             type ${CustomType} @node {
                 title: String
-                nickname: String
+                special_word: String
                     @cypher(
                         statement: """
                         RETURN "Toyota" as s

--- a/packages/graphql/tests/integration/directives/cypher/filtering/cypher-filtering-scalar.int.test.ts
+++ b/packages/graphql/tests/integration/directives/cypher/filtering/cypher-filtering-scalar.int.test.ts
@@ -98,29 +98,29 @@ describe("cypher directive filtering - Scalar", () => {
     test.each([
         {
             title: "String cypher field: exact match",
-            filter: `special_word: { eq: "test"}`,
+            filter: `nickname: { eq: "test"}`,
         },
         {
             title: "String cypher field: CONTAINS",
-            filter: `special_word: { contains: "es"}`,
+            filter: `nickname: { contains: "es"}`,
         },
         {
             title: "String cypher field: ENDS_WITH",
-            filter: `special_word:{ endsWith: "est"}`,
+            filter: `nickname:{ endsWith: "est"}`,
         },
         {
             title: "String cypher field: STARTS_WITH",
-            filter: `special_word:{ startsWith: "tes"}`,
+            filter: `nickname:{ startsWith: "tes"}`,
         },
         {
             title: "String cypher field: IN",
-            filter: `special_word:{ in: ["test", "test2"]}`,
+            filter: `nickname:{ in: ["test", "test2"]}`,
         },
     ] as const)("$title", async ({ filter }) => {
         const typeDefs = /* GraphQL */ `
             type ${CustomType} @node {
                 title: String
-                special_word: String
+                nickname: String
                     @cypher(
                         statement: """
                         RETURN "test" as s
@@ -280,6 +280,73 @@ describe("cypher directive filtering - Scalar", () => {
             [CustomType.plural]: [
                 {
                     title: "test",
+                },
+            ],
+        });
+    });
+
+    test.each([
+        {
+            title: "String cypher field: caseInsensitive eq",
+            filter: `nickname: { caseInsensitive: { eq: "toyota" } }`,
+        },
+        {
+            title: "String cypher field: caseInsensitive contains",
+            filter: `nickname: { caseInsensitive: { contains: "YO" } }`,
+        },
+        {
+            title: "String cypher field: caseInsensitive startsWith",
+            filter: `nickname: { caseInsensitive: { startsWith: "to" } }`,
+        },
+        {
+            title: "String cypher field: caseInsensitive endsWith",
+            filter: `nickname: { caseInsensitive: { endsWith: "tA" } }`,
+        },
+        {
+            title: "String cypher field: caseInsensitive in",
+            filter: `nickname: { caseInsensitive: { in: ["toyota"] } }`,
+        },
+    ] as const)("$title", async ({ filter }) => {
+        const typeDefs = /* GraphQL */ `
+            type ${CustomType} @node {
+                title: String
+                nickname: String
+                    @cypher(
+                        statement: """
+                        RETURN "Toyota" as s
+                        """
+                        columnName: "s"
+                    )
+            }
+        `;
+
+        await testHelper.initNeo4jGraphQL({
+            typeDefs,
+            features: {
+                filters: {
+                    String: {
+                        CASE_INSENSITIVE: true,
+                    },
+                },
+            },
+        });
+        await testHelper.executeCypher(`CREATE (m:${CustomType} { title: "Toyota" })`, {});
+
+        const query = /* GraphQL */ `
+            query {
+                ${CustomType.plural}(where: { ${filter} }) {
+                    title
+                }
+            }
+        `;
+
+        const gqlResult = await testHelper.executeGraphQL(query);
+
+        expect(gqlResult.errors).toBeFalsy();
+        expect(gqlResult?.data).toEqual({
+            [CustomType.plural]: [
+                {
+                    title: "Toyota",
                 },
             ],
         });

--- a/packages/graphql/tests/integration/issues/6800.int.test.ts
+++ b/packages/graphql/tests/integration/issues/6800.int.test.ts
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { UniqueType } from "../../utils/graphql-types";
+import { TestHelper } from "../../utils/tests-helper";
+
+describe("https://github.com/neo4j/graphql/issues/6800", () => {
+    const testHelper = new TestHelper();
+    let typeDefs: string;
+
+    let Person: UniqueType;
+
+    beforeAll(async () => {
+        Person = new UniqueType("Person");
+        typeDefs = /* GraphQL */ `
+            type ${Person} @node {
+                name: String
+                nickname: String!
+                    @cypher(
+                        statement: """
+                        RETURN this.name AS result
+                        """
+                        columnName: "result"
+                    )
+            }
+        `;
+
+        await testHelper.initNeo4jGraphQL({
+            typeDefs,
+            features: {
+                filters: {
+                    String: {
+                        CASE_INSENSITIVE: true,
+                    },
+                },
+            },
+        });
+
+        await testHelper.executeCypher(`
+            CREATE (:${Person} { name: "Toyota" })
+            CREATE (:${Person} { name: "Marvin" })
+        `);
+    });
+
+    afterAll(async () => {
+        await testHelper.close();
+    });
+
+    test("should filter string field using case insensitive", async () => {
+        const query = /* GraphQL */ `
+            query {
+                eq: ${Person.plural}(where: { name: { caseInsensitive: { eq: "toyota" } } }) {
+                    name
+                }
+                contains: ${Person.plural}(where: { name: { caseInsensitive: { contains: "YO" } } }) {
+                    name
+                }
+                startsWith: ${Person.plural}(where: { name: { caseInsensitive: { startsWith: "to" } } }) {
+                    name
+                }
+                endsWith: ${Person.plural}(where: { name: { caseInsensitive: { endsWith: "tA" } } }) {
+                    name
+                }
+                in: ${Person.plural}(where: { name: { caseInsensitive: { in: ["toyota"] } } }) {
+                    name
+                }
+            }
+        `;
+
+        const queryResult = await testHelper.executeGraphQL(query);
+
+        expect(queryResult.errors).toBeUndefined();
+        expect(queryResult.data).toEqual({
+            eq: [
+                {
+                    name: "Toyota",
+                },
+            ],
+            contains: [
+                {
+                    name: "Toyota",
+                },
+            ],
+            startsWith: [
+                {
+                    name: "Toyota",
+                },
+            ],
+            endsWith: [
+                {
+                    name: "Toyota",
+                },
+            ],
+            in: [
+                {
+                    name: "Toyota",
+                },
+            ],
+        });
+    });
+
+    test("should filter cypher field using case insensitive", async () => {
+        const query = /* GraphQL */ `
+            query {
+                eq: ${Person.plural}(where: { nickname: { caseInsensitive: { eq: "toyota" } } }) {
+                    name
+                }
+                contains: ${Person.plural}(where: { nickname: { caseInsensitive: { contains: "YO" } } }) {
+                    name
+                }
+                startsWith: ${Person.plural}(where: { nickname: { caseInsensitive: { startsWith: "to" } } }) {
+                    name
+                }
+                endsWith: ${Person.plural}(where: { nickname: { caseInsensitive: { endsWith: "tA" } } }) {
+                    name
+                }
+                in: ${Person.plural}(where: { nickname: { caseInsensitive: { in: ["toyota"] } } }) {
+                    name
+                }
+            }
+        `;
+
+        const queryResult = await testHelper.executeGraphQL(query);
+
+        expect(queryResult.errors).toBeUndefined();
+        expect(queryResult.data).toEqual({
+            eq: [
+                {
+                    name: "Toyota",
+                },
+            ],
+            contains: [
+                {
+                    name: "Toyota",
+                },
+            ],
+            startsWith: [
+                {
+                    name: "Toyota",
+                },
+            ],
+            endsWith: [
+                {
+                    name: "Toyota",
+                },
+            ],
+            in: [
+                {
+                    name: "Toyota",
+                },
+            ],
+        });
+    });
+});

--- a/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-scalar.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-scalar.test.ts
@@ -208,4 +208,296 @@ describe("cypher directive filtering", () => {
             }"
         `);
     });
+
+    test("String cypher field: case insensitive eq", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Movie @node {
+                title: String
+                nickname: String
+                    @cypher(
+                        statement: """
+                        RETURN "Toyota" as s
+                        """
+                        columnName: "s"
+                    )
+            }
+        `;
+
+        const query = /* GraphQL */ `
+            query {
+                movies(where: { nickname: { caseInsensitive: { eq: "toyota" } } }) {
+                    title
+                }
+            }
+        `;
+
+        const neoSchema: Neo4jGraphQL = new Neo4jGraphQL({
+            typeDefs,
+            features: {
+                filters: {
+                    String: {
+                        CASE_INSENSITIVE: true,
+                    },
+                },
+            },
+        });
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "CYPHER 5
+            MATCH (this:Movie)
+            CALL (this) {
+                CALL (this) {
+                    WITH this AS this
+                    RETURN \\"Toyota\\" as s
+                }
+                WITH s AS this0
+                RETURN this0 AS var1
+            }
+            WITH *
+            WHERE toLower(var1) = toLower($param0)
+            RETURN this { .title } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"toyota\\"
+            }"
+        `);
+    });
+
+    test("String cypher field: case insensitive contains", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Movie @node {
+                title: String
+                nickname: String
+                    @cypher(
+                        statement: """
+                        RETURN "Toyota" as s
+                        """
+                        columnName: "s"
+                    )
+            }
+        `;
+
+        const query = /* GraphQL */ `
+            query {
+                movies(where: { nickname: { caseInsensitive: { contains: "YO" } } }) {
+                    title
+                }
+            }
+        `;
+
+        const neoSchema: Neo4jGraphQL = new Neo4jGraphQL({
+            typeDefs,
+            features: {
+                filters: {
+                    String: {
+                        CASE_INSENSITIVE: true,
+                    },
+                },
+            },
+        });
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "CYPHER 5
+            MATCH (this:Movie)
+            CALL (this) {
+                CALL (this) {
+                    WITH this AS this
+                    RETURN \\"Toyota\\" as s
+                }
+                WITH s AS this0
+                RETURN this0 AS var1
+            }
+            WITH *
+            WHERE toLower(var1) CONTAINS toLower($param0)
+            RETURN this { .title } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"YO\\"
+            }"
+        `);
+    });
+
+    test("String cypher field: case insensitive startsWith", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Movie @node {
+                title: String
+                nickname: String
+                    @cypher(
+                        statement: """
+                        RETURN "Toyota" as s
+                        """
+                        columnName: "s"
+                    )
+            }
+        `;
+
+        const query = /* GraphQL */ `
+            query {
+                movies(where: { nickname: { caseInsensitive: { startsWith: "to" } } }) {
+                    title
+                }
+            }
+        `;
+
+        const neoSchema: Neo4jGraphQL = new Neo4jGraphQL({
+            typeDefs,
+            features: {
+                filters: {
+                    String: {
+                        CASE_INSENSITIVE: true,
+                    },
+                },
+            },
+        });
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "CYPHER 5
+            MATCH (this:Movie)
+            CALL (this) {
+                CALL (this) {
+                    WITH this AS this
+                    RETURN \\"Toyota\\" as s
+                }
+                WITH s AS this0
+                RETURN this0 AS var1
+            }
+            WITH *
+            WHERE toLower(var1) STARTS WITH toLower($param0)
+            RETURN this { .title } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"to\\"
+            }"
+        `);
+    });
+
+    test("String cypher field: case insensitive endsWith", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Movie @node {
+                title: String
+                nickname: String
+                    @cypher(
+                        statement: """
+                        RETURN "Toyota" as s
+                        """
+                        columnName: "s"
+                    )
+            }
+        `;
+
+        const query = /* GraphQL */ `
+            query {
+                movies(where: { nickname: { caseInsensitive: { endsWith: "tA" } } }) {
+                    title
+                }
+            }
+        `;
+
+        const neoSchema: Neo4jGraphQL = new Neo4jGraphQL({
+            typeDefs,
+            features: {
+                filters: {
+                    String: {
+                        CASE_INSENSITIVE: true,
+                    },
+                },
+            },
+        });
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "CYPHER 5
+            MATCH (this:Movie)
+            CALL (this) {
+                CALL (this) {
+                    WITH this AS this
+                    RETURN \\"Toyota\\" as s
+                }
+                WITH s AS this0
+                RETURN this0 AS var1
+            }
+            WITH *
+            WHERE toLower(var1) ENDS WITH toLower($param0)
+            RETURN this { .title } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"tA\\"
+            }"
+        `);
+    });
+
+    test("String cypher field: case insensitive in", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Movie @node {
+                title: String
+                nickname: String
+                    @cypher(
+                        statement: """
+                        RETURN "Toyota" as s
+                        """
+                        columnName: "s"
+                    )
+            }
+        `;
+
+        const query = /* GraphQL */ `
+            query {
+                movies(where: { nickname: { caseInsensitive: { in: ["toyota"] } } }) {
+                    title
+                }
+            }
+        `;
+
+        const neoSchema: Neo4jGraphQL = new Neo4jGraphQL({
+            typeDefs,
+            features: {
+                filters: {
+                    String: {
+                        CASE_INSENSITIVE: true,
+                    },
+                },
+            },
+        });
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "CYPHER 5
+            MATCH (this:Movie)
+            CALL (this) {
+                CALL (this) {
+                    WITH this AS this
+                    RETURN \\"Toyota\\" as s
+                }
+                WITH s AS this0
+                RETURN this0 AS var1
+            }
+            WITH *
+            WHERE toLower(var1) IN [var2 IN $param0 | toLower(var2)]
+            RETURN this { .title } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": [
+                    \\"toyota\\"
+                ]
+            }"
+        `);
+    });
 });


### PR DESCRIPTION
# Description

Adds a protected method to the base Filter class which is then conditionally used by the `PropertyFilter` and `CypherFilter` classes.

## Complexity

Low

# Issue

Closes #6800 

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [x] TCK tests have been updated
- [x] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
