### PR TITLE
Adds populatedByOperation to context passed to populatedBy callback

### DIFF
--- a/.changeset/hot-heads-arrive.md
+++ b/.changeset/hot-heads-arrive.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": minor
+---
+
+Add populatedByOperation field in context passed to populatedBy callbacks

--- a/packages/graphql/src/translate/queryAST/factory/Operations/ConnectFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/Operations/ConnectFactory.ts
@@ -254,6 +254,7 @@ export class ConnectFactory {
                 param: relCallbackParam,
                 parent: input.edge,
                 type: attribute.type,
+                operation: "UPDATE",
             });
         });
     }

--- a/packages/graphql/src/translate/queryAST/factory/Operations/CreateFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/Operations/CreateFactory.ts
@@ -491,6 +491,7 @@ export class CreateFactory {
                 param: callbackParam,
                 parent: callbackParent,
                 type: attribute.type,
+                operation: "CREATE",
             });
         });
 
@@ -516,6 +517,7 @@ export class CreateFactory {
                     param: relCallbackParam,
                     parent: input.edge,
                     type: attribute.type,
+                    operation: "CREATE",
                 });
             });
         }

--- a/packages/graphql/src/translate/queryAST/factory/Operations/UpdateFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/Operations/UpdateFactory.ts
@@ -492,6 +492,7 @@ export class UpdateFactory {
                 param: callbackParam,
                 parent: callbackParent,
                 type: attribute.type,
+                operation: "UPDATE",
             });
         });
 
@@ -517,6 +518,7 @@ export class UpdateFactory {
                     param: relCallbackParam,
                     parent: input,
                     type: attribute.type,
+                    operation: "UPDATE",
                 });
             });
         }

--- a/packages/graphql/src/translate/queryAST/utils/callback-bucket.ts
+++ b/packages/graphql/src/translate/queryAST/utils/callback-bucket.ts
@@ -38,6 +38,7 @@ interface Callback {
     param: Cypher.Param;
     parent?: Record<string, unknown>;
     type: AttributeType;
+    operation: "CREATE" | "UPDATE";
 }
 
 type CallbackResult =
@@ -78,7 +79,11 @@ export class CallbackBucket {
             this.callbacks.map(async (cb) => {
                 const callbackFunction = callbacksList[cb.functionName];
                 if (callbackFunction) {
-                    const paramValue = await callbackFunction(cb.parent, {}, this.context);
+                    const paramValue = await callbackFunction(
+                        cb.parent,
+                        {},
+                        { ...this.context, populatedByOperation: cb.operation }
+                    );
                     if (paramValue === undefined) {
                         cb.param.value = undefined;
                     } else if (paramValue === null) {

--- a/packages/graphql/src/types/index.ts
+++ b/packages/graphql/src/types/index.ts
@@ -207,7 +207,7 @@ export type CallbackReturnValue = string | number | boolean | undefined | null |
 export type Neo4jGraphQLCallback = (
     parent: Record<string, unknown> | undefined,
     args: Record<string, never>,
-    context: Neo4jGraphQLContext
+    context: Neo4jGraphQLContext & { populatedByOperation: "CREATE" | "UPDATE" }
 ) => CallbackReturnValue | Promise<CallbackReturnValue>;
 
 export type Neo4jGraphQLCallbacks = Record<string, Neo4jGraphQLCallback>;

--- a/packages/graphql/tests/integration/directives/populatedBy/populatedBy-arguments.int.test.ts
+++ b/packages/graphql/tests/integration/directives/populatedBy/populatedBy-arguments.int.test.ts
@@ -258,7 +258,7 @@ describe("populatedBy arguments", () => {
             mutation {
                 updatePeople(
                     update: {
-                        actedIn: [{ update: { node: { title_SET: "Test" }, edge: { screenTime: { set: 100 } } } }]
+                        actedIn: [{ update: { node: { title: { set: "Test" } }, edge: { screenTime: { set: 100 } } } }]
                     }
                 ) {
                     people {

--- a/packages/graphql/tests/integration/directives/populatedBy/populatedBy-arguments.int.test.ts
+++ b/packages/graphql/tests/integration/directives/populatedBy/populatedBy-arguments.int.test.ts
@@ -273,7 +273,7 @@ describe("populatedBy arguments", () => {
 
         expect(nodeMockCallback).toHaveBeenCalledWith(
             {
-                title_SET: "Test",
+                title: { set: "Test" },
             },
             {},
             expect.objectContaining({

--- a/packages/graphql/tests/integration/directives/populatedBy/populatedBy-arguments.int.test.ts
+++ b/packages/graphql/tests/integration/directives/populatedBy/populatedBy-arguments.int.test.ts
@@ -96,7 +96,9 @@ describe("populatedBy arguments", () => {
                 title: "The Matrix",
             },
             {},
-            expect.toBeObject()
+            expect.objectContaining({
+                populatedByOperation: "CREATE",
+            })
         );
         expect(edgeMockCallback).not.toHaveBeenCalled();
     });
@@ -120,7 +122,9 @@ describe("populatedBy arguments", () => {
                 title_SET: "The Matrix",
             },
             {},
-            expect.toBeObject()
+            expect.objectContaining({
+                populatedByOperation: "UPDATE",
+            })
         );
         expect(edgeMockCallback).not.toHaveBeenCalled();
     });
@@ -144,9 +148,17 @@ describe("populatedBy arguments", () => {
                 title: "Matrix",
             },
             {},
-            expect.toBeObject()
+            expect.objectContaining({
+                populatedByOperation: "CREATE",
+            })
         );
-        expect(edgeMockCallback).toHaveBeenCalledWith({}, {}, expect.toBeObject());
+        expect(edgeMockCallback).toHaveBeenCalledWith(
+            {},
+            {},
+            expect.objectContaining({
+                populatedByOperation: "CREATE",
+            })
+        );
     });
 
     test("nested update", async () => {
@@ -168,7 +180,9 @@ describe("populatedBy arguments", () => {
                 title_SET: "Test",
             },
             {},
-            expect.toBeObject()
+            expect.objectContaining({
+                populatedByOperation: "UPDATE",
+            })
         );
         expect(edgeMockCallback).not.toHaveBeenCalled();
     });
@@ -189,13 +203,91 @@ describe("populatedBy arguments", () => {
         const queryResult = await testHelper.executeGraphQL(query);
         expect(queryResult.errors).toBeUndefined();
 
-        expect(nodeMockCallback).toHaveBeenCalledWith({}, {}, expect.toBeObject());
+        expect(nodeMockCallback).toHaveBeenCalledWith(
+            {},
+            {},
+            expect.objectContaining({
+                populatedByOperation: "CREATE",
+            })
+        );
         expect(edgeMockCallback).toHaveBeenCalledWith(
             {
                 screenTime: new neo4j.Integer(10),
             },
             {},
-            expect.toBeObject()
+            expect.objectContaining({
+                populatedByOperation: "CREATE",
+            })
+        );
+    });
+
+    test("nested update -> create", async () => {
+        const query = /* GraphQL */ `
+            mutation {
+                updatePeople(update: { actedIn: { create: [{ node: { title: "Matrix" } }] } }) {
+                    people {
+                        name
+                    }
+                }
+            }
+        `;
+
+        const queryResult = await testHelper.executeGraphQL(query);
+        expect(queryResult.errors).toBeUndefined();
+
+        expect(nodeMockCallback).toHaveBeenCalledWith(
+            {
+                title: "Matrix",
+            },
+            {},
+            expect.objectContaining({
+                populatedByOperation: "CREATE",
+            })
+        );
+        expect(edgeMockCallback).toHaveBeenCalledWith(
+            {},
+            {},
+            expect.objectContaining({
+                populatedByOperation: "CREATE",
+            })
+        );
+    });
+
+    test("update relationships", async () => {
+        const query = /* GraphQL */ `
+            mutation {
+                updatePeople(
+                    update: {
+                        actedIn: [{ update: { node: { title_SET: "Test" }, edge: { screenTime: { set: 100 } } } }]
+                    }
+                ) {
+                    people {
+                        name
+                    }
+                }
+            }
+        `;
+
+        const queryResult = await testHelper.executeGraphQL(query);
+        expect(queryResult.errors).toBeUndefined();
+
+        expect(nodeMockCallback).toHaveBeenCalledWith(
+            {
+                title_SET: "Test",
+            },
+            {},
+            expect.objectContaining({
+                populatedByOperation: "UPDATE",
+            })
+        );
+        expect(edgeMockCallback).toHaveBeenCalledWith(
+            {
+                screenTime: { set: new neo4j.Integer(100) },
+            },
+            {},
+            expect.objectContaining({
+                populatedByOperation: "UPDATE",
+            })
         );
     });
 });

--- a/packages/graphql/tests/integration/directives/populatedBy/populatedBy-callback.int.test.ts
+++ b/packages/graphql/tests/integration/directives/populatedBy/populatedBy-callback.int.test.ts
@@ -1,0 +1,103 @@
+import type { Neo4jGraphQLContext } from "../../../../src";
+import type { UniqueType } from "../../../utils/graphql-types";
+import { TestHelper } from "../../../utils/tests-helper";
+
+describe("@populatedBy directive - operation parameters", () => {
+    const testHelper = new TestHelper();
+
+    let testMovie: UniqueType;
+
+    beforeEach(async () => {
+        testMovie = testHelper.createUniqueType("Movie");
+
+        const callback = (
+            parent: Record<string, unknown> | undefined,
+            args: Record<string, never>,
+            context: Neo4jGraphQLContext & { populatedByOperation: "CREATE" | "UPDATE" }
+        ) => {
+            return Promise.resolve(context.populatedByOperation);
+        };
+
+        const typeDefs = /* GraphQL */ `
+                    type ${testMovie.name} @node {
+                        id: ID
+                        callback: String! @populatedBy(operations: [CREATE, UPDATE], callback: "callback")
+                    }
+                `;
+
+        await testHelper.initNeo4jGraphQL({
+            typeDefs,
+            features: {
+                populatedBy: {
+                    callbacks: {
+                        callback,
+                    },
+                },
+            },
+        });
+    });
+
+    afterEach(async () => {
+        await testHelper.close();
+    });
+
+    test("Use create operation in callback", async () => {
+        const movieId = "movie_id";
+
+        const mutation = `
+                    mutation {
+                        ${testMovie.operations.create}(input: [{ id: "${movieId}" }]) {
+                            ${testMovie.plural} {
+                                id
+                                callback
+                            }
+                        }
+                    }
+                `;
+
+        const result = await testHelper.executeGraphQL(mutation);
+
+        expect(result.errors).toBeUndefined();
+        expect(result.data as any).toMatchObject({
+            [testMovie.operations.create]: {
+                [testMovie.plural]: [
+                    {
+                        id: movieId,
+                        callback: "CREATE",
+                    },
+                ],
+            },
+        });
+    });
+
+    test("Use update operation in callback", async () => {
+        const movieId = "movie_id";
+
+        await testHelper.executeCypher(`CREATE(:${testMovie} {id: "test-id"})`);
+
+        const mutation = `
+                    mutation {
+                        ${testMovie.operations.update}(update: { id: {set: "${movieId}"} }) {
+                            ${testMovie.plural} {
+                                id
+                                callback
+                            }
+                        }
+                    }
+                `;
+
+        const result = await testHelper.executeGraphQL(mutation);
+
+        expect(result.errors).toBeUndefined();
+        expect(result.data as any).toMatchObject({
+            [testMovie.operations.update]: {
+                [testMovie.plural]: [
+                    {
+                        id: movieId,
+                        callback: "UPDATE",
+                    },
+                ],
+            },
+        });
+    });
+});

--- a/packages/graphql/tests/utils/tests-helper.ts
+++ b/packages/graphql/tests/utils/tests-helper.ts
@@ -195,6 +195,12 @@ export class TestHelper {
         });
     }
 
+    /**
+     * Gracefully closes a test neo4jGraphQl created {@link initNeo4jGraphQL} and cleans all nodes
+     * with labels created with ${@link createUniqueType}
+     * Use this in `afterEach` or `afterAll`.This method fails if called with an unopened server.
+     * @param preClose - A callback to execute before closing and cleaning the nodes
+     */
     public async close(preClose?: () => Promise<void>): Promise<void> {
         if (!this.driver) {
             this.reset();


### PR DESCRIPTION
# Description
Add `populatedByOperation` field in context passed to populatedBy callbacks. This allows to change the behaviour depending on whether the `populatedBy` callback is triggered by a create or update operation using `context.populatedByOperation`.

For example:

```js
const typeDefs = /* GraphQL */ `
    type Movie @node {
        title: String
        actors: [Person!]! @relationship(type: "ACTED_IN", direction: IN, properties: "ActedIn")
        modified: Boolean! @populatedBy(callback: "modified", operations: [CREATE, UPDATE])
    }
`;

const neoSchema = new Neo4jGraphQL({
    typeDefs,
    features: {
        populatedBy: {
            callbacks: {
                modified(parent, args, context) {
                    if (context.populatedByOperation === "CREATE") {
                        return false;
                    } else {
                        return true;
                    }
                },
            },
        },
    },
});

```