### PR TITLE
fix 6917 

### DIFF
--- a/packages/graphql/src/translate/queryAST/factory/FilterFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/FilterFactory.ts
@@ -480,6 +480,9 @@ export class FilterFactory {
         relationship?: RelationshipAdapter;
     }): Filter | Filter[] {
         const valueAsArray = asArray(value);
+        if (key === "edge") {
+            return [];
+        }
         if (isLogicalOperator(key)) {
             const nestedFilters = valueAsArray.flatMap((nestedWhere) => {
                 const nestedOfNestedFilters = Object.entries(nestedWhere).flatMap(([nestedKey, nestedValue]) => {
@@ -499,6 +502,16 @@ export class FilterFactory {
             return new LogicalFilter({
                 operation: key,
                 filters: nestedFilters,
+            });
+        }
+        if (key === "node") {
+            const key = Object.keys(value)[0] as string;
+            return this.parseEntryFilter({
+                entity,
+                key: Object.keys(value)[0] as string,
+                value: value[key],
+                targetEntity,
+                relationship,
             });
         }
         const { fieldName, operator, isConnection, isAggregate } = parseWhereField(key);
@@ -554,7 +567,6 @@ export class FilterFactory {
         if (!operator && !attribute.annotations.cypher?.targetEntity && typeof value === "object") {
             return this.parseGenericFilters(targetEntity ?? entity, fieldName, value, relationship);
         }
-
         return this.createPropertyFilter({
             attribute,
             comparisonValue: value,
@@ -794,6 +806,9 @@ export class FilterFactory {
 
     public createEdgeFilters(relationship: RelationshipAdapter, where: GraphQLWhereArg): Filter[] {
         const filterASTs = Object.entries(where).flatMap(([key, value]): Filter | Filter[] | undefined => {
+            if (key === "node") {
+                return [];
+            }
             if (isLogicalOperator(key)) {
                 const nestedFilters = asArray(value).flatMap((nestedWhere) => {
                     return this.createEdgeFilters(relationship, nestedWhere);
@@ -802,6 +817,9 @@ export class FilterFactory {
                     operation: key,
                     filters: nestedFilters,
                 });
+            }
+            if (key === "edge") {
+                return this.createEdgeFilters(relationship, value);
             }
             const { fieldName, operator } = parseWhereField(key);
 

--- a/packages/graphql/src/translate/queryAST/factory/Operations/AggregateFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/Operations/AggregateFactory.ts
@@ -447,10 +447,13 @@ export class AggregateFactory {
                 );
                 operation.addFilters(...nodeFilters, ...edgefilters);
             } else {
-                const nodeFilters = this.queryASTFactory.filterFactory.createNodeFilters(entity, whereArgs.node ?? {}); // Aggregation filters only apply to target node
+                const nodeFilters = this.queryASTFactory.filterFactory.createNodeFilters(
+                    entity,
+                    whereArgs.node ?? whereArgs ?? {}
+                ); // Aggregation filters only apply to target node
                 const edgeFilters = this.queryASTFactory.filterFactory.createEdgeFilters(
                     relationship,
-                    whereArgs.edge ?? {}
+                    whereArgs.edge ?? whereArgs ?? {}
                 ); // Aggregation filters only apply to target node
                 operation.addFilters(...nodeFilters, ...edgeFilters);
 

--- a/packages/graphql/tests/integration/issues/6917.int.test.ts
+++ b/packages/graphql/tests/integration/issues/6917.int.test.ts
@@ -60,7 +60,7 @@ describe("https://github.com/neo4j/graphql/issues/6917", () => {
         await testHelper.close();
     });
 
-    test("should match 1 edge, aggregate count 1", async () => {
+    test("should match 1 edge by node filter, aggregate count 1", async () => {
         const query = `
         query {
             ${personType.plural}(where: {name: { eq: "Michael" } } ) {
@@ -114,7 +114,61 @@ describe("https://github.com/neo4j/graphql/issues/6917", () => {
         });
     });
 
-    test("should not matcha any edge, aggregate count 0", async () => {
+    test("should match 1 edge by edge filter, aggregate count 1", async () => {
+        const query = `
+        query {
+            ${personType.plural}(where: {name: { eq: "Michael" } } ) {
+                name
+                carsConnection(where: { edge: { order: { eq: 1 } } }) {
+                    edges {
+                        properties {
+                            order
+                        }
+                        node {
+                            color
+                            name
+                        }
+                    }
+                    aggregate {
+                        count {
+                            edges
+                        }
+                    }
+                }
+            }
+        }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+        expect(result.errors).toBeUndefined();
+        expect(result.data as any).toEqual({
+            [personType.plural]: [
+                {
+                    name: "Michael",
+                    carsConnection: {
+                        edges: [
+                            {
+                                properties: {
+                                    order: 1,
+                                },
+                                node: {
+                                    color: "black",
+                                    name: "Jeep",
+                                },
+                            },
+                        ],
+                        aggregate: {
+                            count: {
+                                edges: 1,
+                            },
+                        },
+                    },
+                },
+            ],
+        });
+    });
+
+    test("should not match any edge by node filter, aggregate count 0", async () => {
         const query = `
         query {
             ${personType.plural}(where: {name: { eq: "Michael" } } ) {
@@ -158,7 +212,51 @@ describe("https://github.com/neo4j/graphql/issues/6917", () => {
         });
     });
 
-    test("should not match any edge, aggregate count 0 - fails to apply filter", async () => {
+    test("should not matcha any edge by edge filter, aggregate count 0", async () => {
+        const query = `
+        query {
+            ${personType.plural}(where: {name: { eq: "Michael" } } ) {
+                name
+                carsConnection(where: { edge: { order: { gt: 1 } } }) {
+                    edges {
+                        properties {
+                            order
+                        }
+                        node {
+                            color
+                            name
+                        }
+                    }
+                    aggregate {
+                        count {
+                            edges
+                        }
+                    }
+                }
+            }
+        }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+        expect(result.errors).toBeUndefined();
+        expect(result.data as any).toEqual({
+            [personType.plural]: [
+                {
+                    name: "Michael",
+                    carsConnection: {
+                        edges: [],
+                        aggregate: {
+                            count: {
+                                edges: 0,
+                            },
+                        },
+                    },
+                },
+            ],
+        });
+    });
+
+    test("should not match any edge by node filter in logical operator, aggregate count 0", async () => {
         const query = `
         query {
             ${personType.plural}(where: {name: { eq: "Michael" } } ) {
@@ -193,8 +291,51 @@ describe("https://github.com/neo4j/graphql/issues/6917", () => {
                         edges: [],
                         aggregate: {
                             count: {
-                                // TODO: should be 0
-                                edges: 1,
+                                edges: 0,
+                            },
+                        },
+                    },
+                },
+            ],
+        });
+    });
+
+    test("should not match any edge by edge filter in logical operator, aggregate count 0", async () => {
+        const query = `
+        query {
+            ${personType.plural}(where: {name: { eq: "Michael" } } ) {
+                name
+                carsConnection( where: { OR: [ { edge: { order: { gt: 1 } } } ] } ) {
+                    edges {
+                        properties {
+                            order
+                        }
+                        node {
+                            color
+                            name
+                        }
+                    }
+                    aggregate {
+                        count {
+                            edges
+                        }
+                    }
+                }
+            }
+        }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+        expect(result.errors).toBeUndefined();
+        expect(result.data as any).toEqual({
+            [personType.plural]: [
+                {
+                    name: "Michael",
+                    carsConnection: {
+                        edges: [],
+                        aggregate: {
+                            count: {
+                                edges: 0,
                             },
                         },
                     },

--- a/packages/graphql/tests/integration/issues/6917.int.test.ts
+++ b/packages/graphql/tests/integration/issues/6917.int.test.ts
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { UniqueType } from "../../utils/graphql-types";
+import { TestHelper } from "../../utils/tests-helper";
+
+describe("https://github.com/neo4j/graphql/issues/6917", () => {
+    let personType: UniqueType;
+    let carType: UniqueType;
+
+    const testHelper = new TestHelper();
+
+    beforeAll(async () => {
+        personType = testHelper.createUniqueType("Person");
+        carType = testHelper.createUniqueType("Car");
+
+        const typeDefs = `
+            type ${personType.name} @node {
+                name: String
+                cars: [${carType.name}!]! @relationship (type: "CAR_IS_OWNED_BY_PERSON", properties: "CarIsOwnedByPersonProperties", direction: IN, nestedOperations: [CREATE, UPDATE, DELETE, CONNECT, DISCONNECT], queryDirection: DIRECTED) @settable(onCreate: true, onUpdate: true)
+            }
+
+            type ${carType.name} @node {
+                name: String
+                color: String
+                owner: [${personType.name}!]! @relationship (type: "CAR_IS_OWNED_BY_PERSON", properties: "CarIsOwnedByPersonProperties", direction: OUT, nestedOperations: [CREATE, UPDATE, DELETE, CONNECT, DISCONNECT], queryDirection: DIRECTED) @settable(onCreate: true, onUpdate: true)
+            }
+
+            type CarIsOwnedByPersonProperties @relationshipProperties {
+                order: Int!
+            }
+        `;
+
+        await testHelper.initNeo4jGraphQL({
+            typeDefs,
+        });
+
+        await testHelper.executeCypher(`
+            CREATE (:${personType.name}{name:"Michael"})<-[:CAR_IS_OWNED_BY_PERSON{order:1}]-(:${carType.name}{name:"Jeep", color:"black"});
+        `);
+    });
+
+    afterAll(async () => {
+        await testHelper.close();
+    });
+
+    test("should match 1 edge, aggregate count 1", async () => {
+        const query = `
+        query {
+            ${personType.plural}(where: {name: { eq: "Michael" } } ) {
+                name
+                carsConnection {
+                    edges {
+                        properties {
+                            order
+                        }
+                        node {
+                            color
+                            name
+                        }
+                    }
+                    aggregate {
+                        count {
+                            edges
+                        }
+                    }
+                }
+            }
+        }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+        expect(result.errors).toBeUndefined();
+        expect(result.data as any).toEqual({
+            [personType.plural]: [
+                {
+                    name: "Michael",
+                    carsConnection: {
+                        edges: [
+                            {
+                                properties: {
+                                    order: 1,
+                                },
+                                node: {
+                                    color: "black",
+                                    name: "Jeep",
+                                },
+                            },
+                        ],
+                        aggregate: {
+                            count: {
+                                edges: 1,
+                            },
+                        },
+                    },
+                },
+            ],
+        });
+    });
+
+    test("should not matcha any edge, aggregate count 0", async () => {
+        const query = `
+        query {
+            ${personType.plural}(where: {name: { eq: "Michael" } } ) {
+                name
+                carsConnection(where: { node: { color: { contains: "red" } } }) {
+                    edges {
+                        properties {
+                            order
+                        }
+                        node {
+                            color
+                            name
+                        }
+                    }
+                    aggregate {
+                        count {
+                            edges
+                        }
+                    }
+                }
+            }
+        }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+        expect(result.errors).toBeUndefined();
+        expect(result.data as any).toEqual({
+            [personType.plural]: [
+                {
+                    name: "Michael",
+                    carsConnection: {
+                        edges: [],
+                        aggregate: {
+                            count: {
+                                edges: 0,
+                            },
+                        },
+                    },
+                },
+            ],
+        });
+    });
+
+    test("should not match any edge, aggregate count 0 - fails to apply filter", async () => {
+        const query = `
+        query {
+            ${personType.plural}(where: {name: { eq: "Michael" } } ) {
+                name
+                carsConnection( where: { OR: [ { node: { color: { contains: "red" } } } ] } ) {
+                    edges {
+                        properties {
+                            order
+                        }
+                        node {
+                            color
+                            name
+                        }
+                    }
+                    aggregate {
+                        count {
+                            edges
+                        }
+                    }
+                }
+            }
+        }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+        expect(result.errors).toBeUndefined();
+        expect(result.data as any).toEqual({
+            [personType.plural]: [
+                {
+                    name: "Michael",
+                    carsConnection: {
+                        edges: [],
+                        aggregate: {
+                            count: {
+                                // TODO: should be 0
+                                edges: 1,
+                            },
+                        },
+                    },
+                },
+            ],
+        });
+    });
+});


### PR DESCRIPTION
# Description

Logical operators in filters on connection fields were not being added to the Query AST for aggregations. This PR fixes it both for filters on node and edge fields.

## Complexity 

Complexity: Low

# Issue

Closes #6917 

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
