### PR TITLE
Change NeoExpectRelationship

### DIFF
--- a/packages/graphql/tests/utils/neo-expect/expect-relationship.ts
+++ b/packages/graphql/tests/utils/neo-expect/expect-relationship.ts
@@ -56,7 +56,10 @@ export class NeoExpectRelationship extends NeoExpect {
         }
     }
 
-    /** Use this if expectation is a list an elements order does not matter */
+    /**
+     * Use this if expectation is a list an elements order does not matter
+     * This fn does not use the toIncludeSameMembers on jest bc aura test teardown runs without jest-extended
+     */
     public async toIncludeSameMembers(expectation: any[]): Promise<void> {
         const result = await this.getAll();
         try {

--- a/packages/graphql/tests/utils/neo-expect/expect-relationship.ts
+++ b/packages/graphql/tests/utils/neo-expect/expect-relationship.ts
@@ -60,7 +60,7 @@ export class NeoExpectRelationship extends NeoExpect {
     public async toIncludeSameMembers(expectation: any[]): Promise<void> {
         const result = await this.getAll();
         try {
-            expect(result).toIncludeSameMembers(expectation);
+            expect(new Set(result)).toEqual(new Set(expectation));
         } catch (err: any) {
             const typeStr = this.type ? `[${this.type}]` : "-";
             err.message = `Error on ${this.from} ${typeStr} ${this.to}\n\n ${err.message}`;


### PR DESCRIPTION
# Description

Implement toIncludeSameMembers using toEqual to avoid jest-extended missing on integration/teardown tests

## Complexity

Complexity: Low

# Issue

> **Note**
>
>  Please link to the GitHub issue(s) in which the proposal for this work was discussed
>  
>  To link to multiple issues, use full syntax for each, for example `Closes #1, closes #2, closes #3`

Closes 

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
