### PR TITLE
Fix 1-many empty input types generated

### DIFF
--- a/packages/graphql/src/schema-model/entity/model-adapters/ConcreteEntityAdapter.ts
+++ b/packages/graphql/src/schema-model/entity/model-adapters/ConcreteEntityAdapter.ts
@@ -253,6 +253,10 @@ export class ConcreteEntityAdapter {
         return this.relationships.get(name);
     }
 
+    public hasListRelationship(): boolean {
+        return !![...this.relationships.values()].find((r) => r.isList);
+    }
+
     // TODO: identify usage of old Node.[getLabels | getLabelsString] and migrate them if needed
     public getLabels(): string[] {
         return Array.from(this.labels);

--- a/packages/graphql/src/schema/generation/augment-object-or-interface.ts
+++ b/packages/graphql/src/schema/generation/augment-object-or-interface.ts
@@ -61,6 +61,10 @@ export function augmentObjectOrInterfaceTypeWithRelationshipField({
         }
     }
 
+    if (!relationshipAdapter.isList) {
+        generateRelFieldArgs = false;
+    }
+
     if (generateRelFieldArgs) {
         const relationshipTarget =
             relationshipAdapter instanceof RelationshipAdapter && relationshipAdapter.originalTarget
@@ -73,19 +77,17 @@ export function augmentObjectOrInterfaceTypeWithRelationshipField({
             where: whereTypeName,
         };
 
-        if (relationshipAdapter.isList) {
-            nodeFieldsArgs["limit"] = features?.limitRequired ? new GraphQLNonNull(GraphQLInt) : GraphQLInt;
-            nodeFieldsArgs["offset"] = GraphQLInt;
+        nodeFieldsArgs["limit"] = features?.limitRequired ? new GraphQLNonNull(GraphQLInt) : GraphQLInt;
+        nodeFieldsArgs["offset"] = GraphQLInt;
 
-            if (!(relationshipTarget instanceof UnionEntityAdapter)) {
-                const sortConfig = makeSortInput({
-                    entityAdapter: relationshipTarget,
-                    userDefinedFieldDirectives: new Map(),
-                    composer,
-                });
-                if (sortConfig) {
-                    nodeFieldsArgs["sort"] = sortConfig.NonNull.List;
-                }
+        if (!(relationshipTarget instanceof UnionEntityAdapter)) {
+            const sortConfig = makeSortInput({
+                entityAdapter: relationshipTarget,
+                userDefinedFieldDirectives: new Map(),
+                composer,
+            });
+            if (sortConfig) {
+                nodeFieldsArgs["sort"] = sortConfig.NonNull.List;
             }
         }
 
@@ -110,13 +112,14 @@ export function augmentObjectOrInterfaceTypeWithConnectionField(
             (directive) => directive.name.value === DEPRECATED
         )
     );
-    const composeNodeArgs: ObjectTypeComposerArgumentConfigMapDefinition = {
-        where: makeConnectionWhereInputType({
+    const composeNodeArgs: ObjectTypeComposerArgumentConfigMapDefinition = {};
+
+    if (relationshipAdapter.isList) {
+        composeNodeArgs.where = makeConnectionWhereInputType({
             relationshipAdapter,
             composer: schemaComposer,
-        }),
-    };
-    if (relationshipAdapter.isList) {
+        });
+
         composeNodeArgs.first = {
             type: features?.limitRequired ? new GraphQLNonNull(GraphQLInt) : GraphQLInt,
         };

--- a/packages/graphql/src/schema/generation/connect-input.ts
+++ b/packages/graphql/src/schema/generation/connect-input.ts
@@ -41,7 +41,7 @@ function withConnectInputType({
     composer: SchemaComposer;
 }): InputTypeComposer | undefined {
     if (entityAdapter instanceof ConcreteEntityAdapter) {
-        if (![...entityAdapter.relationships.values()].find((r) => r.isList)) {
+        if (!entityAdapter.hasListRelationship()) {
             return undefined;
         }
         return composer.getOrCreateITC(entityAdapter.operations.connectInputTypeName);

--- a/packages/graphql/src/schema/generation/connect-input.ts
+++ b/packages/graphql/src/schema/generation/connect-input.ts
@@ -41,6 +41,9 @@ function withConnectInputType({
     composer: SchemaComposer;
 }): InputTypeComposer | undefined {
     if (entityAdapter instanceof ConcreteEntityAdapter) {
+        if (![...entityAdapter.relationships.values()].find((r) => r.isList)) {
+            return undefined;
+        }
         return composer.getOrCreateITC(entityAdapter.operations.connectInputTypeName);
     }
 
@@ -194,9 +197,14 @@ export function withConnectFieldInputType({
         return composer.getITC(typeName);
     }
 
+    const fields = makeConnectFieldInputTypeFields({ relationshipAdapter, composer, ifUnionMemberEntity });
+    if (!relationshipAdapter.isList) {
+        return undefined;
+    }
+
     const connectFieldInput = composer.createInputTC({
         name: typeName,
-        fields: makeConnectFieldInputTypeFields({ relationshipAdapter, composer, ifUnionMemberEntity }),
+        fields,
     });
     return connectFieldInput;
 }

--- a/packages/graphql/src/schema/generation/delete-input.ts
+++ b/packages/graphql/src/schema/generation/delete-input.ts
@@ -42,6 +42,9 @@ function withDeleteInputType({
     composer: SchemaComposer;
 }): InputTypeComposer | undefined {
     if (entityAdapter instanceof ConcreteEntityAdapter) {
+        if (![...entityAdapter.relationships.values()].find((r) => r.isList)) {
+            return undefined;
+        }
         return composer.getOrCreateITC(entityAdapter.operations.updateMutationArgumentNames.delete);
     }
 

--- a/packages/graphql/src/schema/generation/delete-input.ts
+++ b/packages/graphql/src/schema/generation/delete-input.ts
@@ -42,7 +42,7 @@ function withDeleteInputType({
     composer: SchemaComposer;
 }): InputTypeComposer | undefined {
     if (entityAdapter instanceof ConcreteEntityAdapter) {
-        if (![...entityAdapter.relationships.values()].find((r) => r.isList)) {
+        if (!entityAdapter.hasListRelationship()) {
             return undefined;
         }
         return composer.getOrCreateITC(entityAdapter.operations.updateMutationArgumentNames.delete);

--- a/packages/graphql/src/schema/generation/disconnect-input.ts
+++ b/packages/graphql/src/schema/generation/disconnect-input.ts
@@ -42,7 +42,7 @@ function withDisconnectInputType({
     composer: SchemaComposer;
 }): InputTypeComposer | undefined {
     if (entityAdapter instanceof ConcreteEntityAdapter) {
-        if (![...entityAdapter.relationships.values()].find((r) => r.isList)) {
+        if (!entityAdapter.hasListRelationship()) {
             return undefined;
         }
         return composer.getOrCreateITC(entityAdapter.operations.updateMutationArgumentNames.disconnect);

--- a/packages/graphql/src/schema/generation/disconnect-input.ts
+++ b/packages/graphql/src/schema/generation/disconnect-input.ts
@@ -42,6 +42,9 @@ function withDisconnectInputType({
     composer: SchemaComposer;
 }): InputTypeComposer | undefined {
     if (entityAdapter instanceof ConcreteEntityAdapter) {
+        if (![...entityAdapter.relationships.values()].find((r) => r.isList)) {
+            return undefined;
+        }
         return composer.getOrCreateITC(entityAdapter.operations.updateMutationArgumentNames.disconnect);
     }
 

--- a/packages/graphql/src/schema/generation/relation-input.ts
+++ b/packages/graphql/src/schema/generation/relation-input.ts
@@ -202,14 +202,18 @@ export function withCreateFieldInputType({
     if (composer.has(createName)) {
         return composer.getITC(createName);
     }
+    const fields = makeCreateFieldInputTypeFields({
+        relationshipAdapter,
+        composer,
+        ifUnionMemberEntity,
+        userDefinedFieldDirectives,
+    });
+    if (!Object.keys(fields).length) {
+        return undefined;
+    }
     const createFieldInput = composer.createInputTC({
         name: createName,
-        fields: makeCreateFieldInputTypeFields({
-            relationshipAdapter,
-            composer,
-            ifUnionMemberEntity,
-            userDefinedFieldDirectives,
-        }),
+        fields,
     });
     return createFieldInput;
 }

--- a/packages/graphql/src/schema/validation/validate-document.test.ts
+++ b/packages/graphql/src/schema/validation/validate-document.test.ts
@@ -858,7 +858,7 @@ describe("validation 2.0", () => {
                 expect(executeValidate).not.toThrow();
             });
 
-            test("Error on 1-1 relationships", () => {
+            test("1-1 relationships allowed", () => {
                 const doc = gql`
                     type Movie @node {
                         id: ID
@@ -872,18 +872,7 @@ describe("validation 2.0", () => {
                 `;
 
                 const executeValidate = () => validateDocument({ document: doc, features: {}, additionalDefinitions });
-                const errors = getError(executeValidate);
-                expect(errors).toHaveLength(2);
-                expect(errors[0]).not.toBeInstanceOf(NoErrorThrownError);
-                expect(errors[1]).not.toBeInstanceOf(NoErrorThrownError);
-                expect(errors[0]).toHaveProperty(
-                    "message",
-                    `Using @relationship directive on a non-list property "actors" is not supported.`
-                );
-                expect(errors[1]).toHaveProperty(
-                    "message",
-                    `Using @relationship directive on a non-list property "movie" is not supported.`
-                );
+                expect(executeValidate).not.toThrow();
             });
         });
     });

--- a/packages/graphql/tests/integration/directives/relationship/interface-declaredRelationship-1-many.int.test.ts
+++ b/packages/graphql/tests/integration/directives/relationship/interface-declaredRelationship-1-many.int.test.ts
@@ -20,11 +20,11 @@
 import type { UniqueType } from "../../../utils/graphql-types";
 import { TestHelper } from "../../../utils/tests-helper";
 
-describe("1-* relationship involving Interface type", () => {
+describe("1-* relationship involving Interface type declared relationship", () => {
     let Movie: UniqueType;
     let Person: UniqueType;
     let Dog: UniqueType;
-    let AI: UniqueType;
+    let Series: UniqueType;
 
     const testHelper = new TestHelper();
 
@@ -32,32 +32,42 @@ describe("1-* relationship involving Interface type", () => {
         Movie = testHelper.createUniqueType("Movie");
         Person = testHelper.createUniqueType("Person");
         Dog = testHelper.createUniqueType("Dog");
-        AI = testHelper.createUniqueType("AI");
+        Series = testHelper.createUniqueType("Series");
 
         const typeDefs = /* GraphQL */ `
             interface Actor {
                 name: String!
+                actedIn: Production! @declareRelationship
+                directed: [Production!]! @declareRelationship
             }
-            interface Director {
-                years: Int!
+            interface Production {
+                title: String!
+                actor: [Actor!]! @declareRelationship
+                director: ${Person}! @declareRelationship
             }
 
-            type ${Movie} @node {
+            type ${Movie} implements Production @node {
                 title: String!
-                actor: [${Dog}!]! @relationship(type: "ACTED_IN", direction: IN)
+                actor: [Actor!]! @relationship(type: "ACTED_IN", direction: IN)
+                director: ${Person}! @relationship(type: "DIRECTED", direction: IN)
+            }
+
+            type ${Series} implements Production @node {
+                title: String!
+                actor: [Actor!]! @relationship(type: "ACTED_IN", direction: IN)
                 director: ${Person}! @relationship(type: "DIRECTED", direction: IN)
             }
 
             type ${Dog} implements Actor @node {
                 name: String!
-                actedIn: ${Movie}! @relationship(type: "ACTED_IN", direction: OUT)
+                actedIn: Production! @relationship(type: "ACTED_IN", direction: OUT)
+                directed: [Production!]! @relationship(type: "DIRECTED", direction: OUT)
             }
 
-            type ${Person} implements Actor & Director @node{
+            type ${Person} implements Actor @node{
                 name: String!
-                years: Int!
-                actedIn: ${Movie}! @relationship(type: "ACTED_IN", direction: OUT)
-                directed: [${Movie}!]! @relationship(type: "DIRECTED", direction: OUT)
+                actedIn: Production! @relationship(type: "ACTED_IN", direction: OUT)
+                directed: [Production!]! @relationship(type: "DIRECTED", direction: OUT)
              }
         `;
 
@@ -74,14 +84,15 @@ describe("1-* relationship involving Interface type", () => {
         await testHelper.executeCypher(`
             CREATE(m:${Movie} { title: "The Matrix"})<-[:ACTED_IN]-(a:${Dog} { name: "Hachiko"})
             CREATE(m)<-[:ACTED_IN]-(:${Person} { name: "Keanu"})
-            CREATE(m)<-[:DIRECTED]-(d:${Person} { name: "Director", years: 10})
-            CREATE(d)-[:DIRECTED]->(m2:${Movie} { title: "The Office"})
-            CREATE(a)-[:ACTED_IN]->(m2)
+            CREATE(m)<-[:DIRECTED]-(d:${Person} { name: "Director"})
+            CREATE(d)-[:DIRECTED]->(s:${Series} { title: "The Office"})
+            CREATE(a)-[:ACTED_IN]->(s)
+
         `);
 
         const query = `
             query {
-               ${Movie.plural} {
+              productions {
                     actor {
                         name
                         actedIn {
@@ -89,10 +100,10 @@ describe("1-* relationship involving Interface type", () => {
                         }
                     }
                     director {
-                       years
+                       name
                        directed {
                             title
-                        }
+                       }
                     }
                 }
             }
@@ -101,7 +112,7 @@ describe("1-* relationship involving Interface type", () => {
         const result = await testHelper.executeGraphQL(query);
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
-            [Movie.plural]: [
+            productions: [
                 {
                     actor: [
                         {
@@ -110,16 +121,20 @@ describe("1-* relationship involving Interface type", () => {
                                 title: "The Matrix",
                             },
                         },
+                        {
+                            name: "Keanu",
+                            actedIn: {
+                                title: "The Matrix",
+                            },
+                        },
                     ],
                     director: {
-                        years: 10,
+                        name: "Director",
                         directed: [
                             {
                                 title: "The Matrix",
                             },
-                            {
-                                title: "The Office",
-                            },
+                            { title: "The Office" },
                         ],
                     },
                 },
@@ -133,14 +148,12 @@ describe("1-* relationship involving Interface type", () => {
                         },
                     ],
                     director: {
-                        years: 10,
+                        name: "Director",
                         directed: [
                             {
                                 title: "The Matrix",
                             },
-                            {
-                                title: "The Office",
-                            },
+                            { title: "The Office" },
                         ],
                     },
                 },
@@ -148,29 +161,29 @@ describe("1-* relationship involving Interface type", () => {
         });
     });
 
-    test("returns filtered", async () => {
+    test("returns filtered fields", async () => {
         await testHelper.executeCypher(`
             CREATE(m:${Movie} { title: "The Matrix"})<-[:ACTED_IN]-(a:${Dog} { name: "Hachiko"})
             CREATE(m)<-[:ACTED_IN]-(:${Person} { name: "Keanu"})
-            CREATE(m)<-[:DIRECTED]-(d:${Person} { name: "Director", years: 10})
-            CREATE(d)-[:DIRECTED]->(m2:${Movie} { title: "The Office"})
-            CREATE(a)-[:ACTED_IN]->(m2)
+            CREATE(m)<-[:DIRECTED]-(d:${Person} { name: "Director"})
+            CREATE(d)-[:DIRECTED]->(s:${Series} { title: "The Office"})
+            CREATE(a)-[:ACTED_IN]->(s)
         `);
 
         const query = `
             query {
-               ${Movie.plural}(where: {title: {eq: "The Matrix"}}) {
-                    actor(where: { name: {startsWith: "K" } }) {
+              productions {
+                    actor(where: { name: { eq: "Hachiko" }}) {
                         name
                         actedIn {
                             title
                         }
                     }
                     director {
-                       years
-                       directed(where: {title: { eq: "The Office"} }) {
+                       name
+                       directed(where: { title: { eq: "The Office"} }) {
                             title
-                        }
+                       }
                     }
                 }
             }
@@ -179,16 +192,33 @@ describe("1-* relationship involving Interface type", () => {
         const result = await testHelper.executeGraphQL(query);
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
-            [Movie.plural]: [
+            productions: [
                 {
-                    actor: [],
-                    director: {
-                        years: 10,
-                        directed: [
-                            {
-                                title: "The Office",
+                    actor: [
+                        {
+                            name: "Hachiko",
+                            actedIn: {
+                                title: "The Matrix",
                             },
-                        ],
+                        },
+                    ],
+                    director: {
+                        name: "Director",
+                        directed: [{ title: "The Office" }],
+                    },
+                },
+                {
+                    actor: [
+                        {
+                            name: "Hachiko",
+                            actedIn: {
+                                title: "The Matrix",
+                            },
+                        },
+                    ],
+                    director: {
+                        name: "Director",
+                        directed: [{ title: "The Office" }],
                     },
                 },
             ],
@@ -199,25 +229,25 @@ describe("1-* relationship involving Interface type", () => {
         await testHelper.executeCypher(`
             CREATE(m:${Movie} { title: "The Matrix"})<-[:ACTED_IN]-(a:${Dog} { name: "Hachiko"})
             CREATE(m)<-[:ACTED_IN]-(:${Person} { name: "Keanu"})
-            CREATE(m)<-[:DIRECTED]-(d:${Person} { name: "Director", years: 10})
-            CREATE(d)-[:DIRECTED]->(m2:${Movie} { title: "The Office"})
-            CREATE(a)-[:ACTED_IN]->(m2)
+            CREATE(m)<-[:DIRECTED]-(d:${Person} { name: "Director"})
+            CREATE(d)-[:DIRECTED]->(s:${Series} { title: "The Office"})
+            CREATE(a)-[:ACTED_IN]->(s)
         `);
 
         const query = `
             query {
-               ${Movie.plural} {
+              productions {
                     actor {
                         name
                         actedIn {
                             title
                         }
                     }
-                    director(where: {name: { eq: "Keanu"} }) {
-                       years
+                    director(where: { name: { eq: "Hachiko" }}) {
+                       name
                        directed {
                             title
-                        }
+                       }
                     }
                 }
             }
@@ -226,7 +256,7 @@ describe("1-* relationship involving Interface type", () => {
         const result = await testHelper.executeGraphQL(query);
         expect(result.errors).toHaveLength(1);
         expect((result.errors?.[0] || { message: "" }).message).toBe(
-            `Unknown argument "where" on field "${Movie}.director".`
+            `Unknown argument "where" on field "Production.director".`
         );
     });
 });

--- a/packages/graphql/tests/integration/directives/relationship/interface-relationship-1-many.int.test.ts
+++ b/packages/graphql/tests/integration/directives/relationship/interface-relationship-1-many.int.test.ts
@@ -1,0 +1,473 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { UniqueType } from "../../../utils/graphql-types";
+import { TestHelper } from "../../../utils/tests-helper";
+
+describe("1-* relationship involving Interface type", () => {
+    let Movie: UniqueType;
+    let Person: UniqueType;
+    let Dog: UniqueType;
+    let AI: UniqueType;
+
+    const testHelper = new TestHelper();
+
+    beforeEach(async () => {
+        Movie = testHelper.createUniqueType("Movie");
+        Person = testHelper.createUniqueType("Person");
+        Dog = testHelper.createUniqueType("Dog");
+        AI = testHelper.createUniqueType("AI");
+
+        const typeDefs = /* GraphQL */ `
+            interface Actor {
+                name: String!
+            }
+            interface Director {
+                years: Int!
+            }
+
+            type ${Movie} @node {
+                title: String!
+                actor: [${Dog}!]! @relationship(type: "ACTED_IN", direction: IN)
+                director: ${Person}! @relationship(type: "DIRECTED", direction: IN)
+            }
+
+            type ${Dog} implements Actor @node {
+                name: String!
+                actedIn: ${Movie}! @relationship(type: "ACTED_IN", direction: OUT)
+            }
+
+            type ${Person} implements Actor & Director @node{
+                name: String!
+                years: Int!
+                actedIn: ${Movie}! @relationship(type: "ACTED_IN", direction: OUT)
+                directed: [${Movie}!]! @relationship(type: "DIRECTED", direction: OUT)
+             }
+        `;
+
+        await testHelper.initNeo4jGraphQL({
+            typeDefs,
+        });
+    });
+
+    afterEach(async () => {
+        await testHelper.close();
+    });
+
+    test("returns all fields", async () => {
+        await testHelper.executeCypher(`
+            CREATE(m:${Movie} { title: "The Matrix"})<-[:ACTED_IN]-(a:${Dog} { name: "Hachiko"})
+            CREATE(m)<-[:ACTED_IN]-(:${Person} { name: "Keanu"})
+            CREATE(m)<-[:DIRECTED]-(d:${Person} { name: "Director", years: 10})
+            CREATE(d)-[:DIRECTED]->(m2:${Movie} { title: "The Office"})
+            CREATE(a)-[:ACTED_IN]->(m2)
+        `);
+
+        const query = `
+            query {
+               ${Movie.plural} {
+                    actor {
+                        name
+                        actedIn {
+                            title
+                        }
+                    }
+                    director {
+                       years
+                       directed {
+                            title
+                        }
+                    }
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+        expect(result.errors).toBeFalsy();
+        expect(result.data).toEqual({
+            [Movie.plural]: [
+                {
+                    actor: [
+                        {
+                            name: "Hachiko",
+                            actedIn: {
+                                title: "The Matrix",
+                            },
+                        },
+                    ],
+                    director: {
+                        years: 10,
+                        directed: [
+                            {
+                                title: "The Matrix",
+                            },
+                            {
+                                title: "The Office",
+                            },
+                        ],
+                    },
+                },
+                {
+                    actor: [
+                        {
+                            name: "Hachiko",
+                            actedIn: {
+                                title: "The Matrix",
+                            },
+                        },
+                    ],
+                    director: {
+                        years: 10,
+                        directed: [
+                            {
+                                title: "The Matrix",
+                            },
+                            {
+                                title: "The Office",
+                            },
+                        ],
+                    },
+                },
+            ],
+        });
+    });
+
+    test("returns filtered", async () => {
+        await testHelper.executeCypher(`
+            CREATE(m:${Movie} { title: "The Matrix"})<-[:ACTED_IN]-(a:${Dog} { name: "Hachiko"})
+            CREATE(m)<-[:ACTED_IN]-(:${Person} { name: "Keanu"})
+            CREATE(m)<-[:DIRECTED]-(d:${Person} { name: "Director", years: 10})
+            CREATE(d)-[:DIRECTED]->(m2:${Movie} { title: "The Office"})
+            CREATE(a)-[:ACTED_IN]->(m2)
+        `);
+
+        const query = `
+            query {
+               ${Movie.plural}(where: {title: {eq: "The Matrix"}}) {
+                    actor(where: { name: {startsWith: "K" } }) {
+                        name
+                        actedIn {
+                            title
+                        }
+                    }
+                    director {
+                       years
+                       directed(where: {title: { eq: "The Office"} }) {
+                            title
+                        }
+                    }
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+        expect(result.errors).toBeFalsy();
+        expect(result.data).toEqual({
+            [Movie.plural]: [
+                {
+                    actor: [],
+                    director: {
+                        years: 10,
+                        directed: [
+                            {
+                                title: "The Office",
+                            },
+                        ],
+                    },
+                },
+            ],
+        });
+    });
+
+    test("no filter from the 1- relationship side", async () => {
+        await testHelper.executeCypher(`
+            CREATE(m:${Movie} { title: "The Matrix"})<-[:ACTED_IN]-(a:${Dog} { name: "Hachiko"})
+            CREATE(m)<-[:ACTED_IN]-(:${Person} { name: "Keanu"})
+            CREATE(m)<-[:DIRECTED]-(d:${Person} { name: "Director", years: 10})
+            CREATE(d)-[:DIRECTED]->(m2:${Movie} { title: "The Office"})
+            CREATE(a)-[:ACTED_IN]->(m2)
+        `);
+
+        const query = `
+            query {
+               ${Movie.plural} {
+                    actor {
+                        name
+                        actedIn {
+                            title
+                        }
+                    }
+                    director(where: {name: { eq: "Keanu"} }) {
+                       years
+                       directed {
+                            title
+                        }
+                    }
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+        expect(result.errors).toHaveLength(1);
+        expect((result.errors?.[0] || { message: "" }).message).toBe(
+            `Unknown argument "where" on field "${Movie}.director".`
+        );
+    });
+});
+
+describe("1-* relationship involving Interface type declared relationship", () => {
+    let Movie: UniqueType;
+    let Person: UniqueType;
+    let Dog: UniqueType;
+    let Series: UniqueType;
+
+    const testHelper = new TestHelper();
+
+    beforeEach(async () => {
+        Movie = testHelper.createUniqueType("Movie");
+        Person = testHelper.createUniqueType("Person");
+        Dog = testHelper.createUniqueType("Dog");
+        Series = testHelper.createUniqueType("Series");
+
+        const typeDefs = /* GraphQL */ `
+            interface Actor {
+                name: String!
+                actedIn: Production! @declareRelationship
+                directed: [Production!]! @declareRelationship
+            }
+            interface Production {
+                title: String!
+                actor: [Actor!]! @declareRelationship
+                director: ${Person}! @declareRelationship
+            }
+
+            type ${Movie} implements Production @node {
+                title: String!
+                actor: [Actor!]! @relationship(type: "ACTED_IN", direction: IN)
+                director: ${Person}! @relationship(type: "DIRECTED", direction: IN)
+            }
+
+            type ${Series} implements Production @node {
+                title: String!
+                actor: [Actor!]! @relationship(type: "ACTED_IN", direction: IN)
+                director: ${Person}! @relationship(type: "DIRECTED", direction: IN)
+            }
+
+            type ${Dog} implements Actor @node {
+                name: String!
+                actedIn: Production! @relationship(type: "ACTED_IN", direction: OUT)
+                directed: [Production!]! @relationship(type: "DIRECTED", direction: OUT)
+            }
+
+            type ${Person} implements Actor @node{
+                name: String!
+                actedIn: Production! @relationship(type: "ACTED_IN", direction: OUT)
+                directed: [Production!]! @relationship(type: "DIRECTED", direction: OUT)
+             }
+        `;
+
+        await testHelper.initNeo4jGraphQL({
+            typeDefs,
+        });
+    });
+
+    afterEach(async () => {
+        await testHelper.close();
+    });
+
+    test("returns all fields", async () => {
+        await testHelper.executeCypher(`
+            CREATE(m:${Movie} { title: "The Matrix"})<-[:ACTED_IN]-(a:${Dog} { name: "Hachiko"})
+            CREATE(m)<-[:ACTED_IN]-(:${Person} { name: "Keanu"})
+            CREATE(m)<-[:DIRECTED]-(d:${Person} { name: "Director"})
+            CREATE(d)-[:DIRECTED]->(s:${Series} { title: "The Office"})
+            CREATE(a)-[:ACTED_IN]->(s)
+
+        `);
+
+        const query = `
+            query {
+              productions {
+                    actor {
+                        name
+                        actedIn {
+                            title
+                        }
+                    }
+                    director {
+                       name
+                       directed {
+                            title
+                       }
+                    }
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+        expect(result.errors).toBeFalsy();
+        expect(result.data).toEqual({
+            productions: [
+                {
+                    actor: [
+                        {
+                            name: "Hachiko",
+                            actedIn: {
+                                title: "The Matrix",
+                            },
+                        },
+                        {
+                            name: "Keanu",
+                            actedIn: {
+                                title: "The Matrix",
+                            },
+                        },
+                    ],
+                    director: {
+                        name: "Director",
+                        directed: [
+                            {
+                                title: "The Matrix",
+                            },
+                            { title: "The Office" },
+                        ],
+                    },
+                },
+                {
+                    actor: [
+                        {
+                            name: "Hachiko",
+                            actedIn: {
+                                title: "The Matrix",
+                            },
+                        },
+                    ],
+                    director: {
+                        name: "Director",
+                        directed: [
+                            {
+                                title: "The Matrix",
+                            },
+                            { title: "The Office" },
+                        ],
+                    },
+                },
+            ],
+        });
+    });
+
+    test("returns filtered fields", async () => {
+        await testHelper.executeCypher(`
+            CREATE(m:${Movie} { title: "The Matrix"})<-[:ACTED_IN]-(a:${Dog} { name: "Hachiko"})
+            CREATE(m)<-[:ACTED_IN]-(:${Person} { name: "Keanu"})
+            CREATE(m)<-[:DIRECTED]-(d:${Person} { name: "Director"})
+            CREATE(d)-[:DIRECTED]->(s:${Series} { title: "The Office"})
+            CREATE(a)-[:ACTED_IN]->(s)
+        `);
+
+        const query = `
+            query {
+              productions {
+                    actor(where: { name: { eq: "Hachiko" }}) {
+                        name
+                        actedIn {
+                            title
+                        }
+                    }
+                    director {
+                       name
+                       directed(where: { title: { eq: "The Office"} }) {
+                            title
+                       }
+                    }
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+        expect(result.errors).toBeFalsy();
+        expect(result.data).toEqual({
+            productions: [
+                {
+                    actor: [
+                        {
+                            name: "Hachiko",
+                            actedIn: {
+                                title: "The Matrix",
+                            },
+                        },
+                    ],
+                    director: {
+                        name: "Director",
+                        directed: [{ title: "The Office" }],
+                    },
+                },
+                {
+                    actor: [
+                        {
+                            name: "Hachiko",
+                            actedIn: {
+                                title: "The Matrix",
+                            },
+                        },
+                    ],
+                    director: {
+                        name: "Director",
+                        directed: [{ title: "The Office" }],
+                    },
+                },
+            ],
+        });
+    });
+
+    test("no filter from the 1- relationship side", async () => {
+        await testHelper.executeCypher(`
+            CREATE(m:${Movie} { title: "The Matrix"})<-[:ACTED_IN]-(a:${Dog} { name: "Hachiko"})
+            CREATE(m)<-[:ACTED_IN]-(:${Person} { name: "Keanu"})
+            CREATE(m)<-[:DIRECTED]-(d:${Person} { name: "Director"})
+            CREATE(d)-[:DIRECTED]->(s:${Series} { title: "The Office"})
+            CREATE(a)-[:ACTED_IN]->(s)
+        `);
+
+        const query = `
+            query {
+              productions {
+                    actor {
+                        name
+                        actedIn {
+                            title
+                        }
+                    }
+                    director(where: { name: { eq: "Hachiko" }}) {
+                       name
+                       directed {
+                            title
+                       }
+                    }
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+        expect(result.errors).toHaveLength(1);
+        expect((result.errors?.[0] || { message: "" }).message).toBe(
+            `Unknown argument "where" on field "Production.director".`
+        );
+    });
+});

--- a/packages/graphql/tests/integration/directives/relationship/simple-relationship-1-many.int.test.ts
+++ b/packages/graphql/tests/integration/directives/relationship/simple-relationship-1-many.int.test.ts
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { UniqueType } from "../../../utils/graphql-types";
+import { TestHelper } from "../../../utils/tests-helper";
+
+describe("1-* simple relationship", () => {
+    let Movie: UniqueType;
+    let Person: UniqueType;
+
+    const testHelper = new TestHelper();
+
+    beforeEach(async () => {
+        Movie = testHelper.createUniqueType("Movie");
+        Person = testHelper.createUniqueType("Person");
+
+        const typeDefs = /* GraphQL */ `
+            type ${Movie} @node {
+                title: String!
+                director: ${Person}! @relationship(type: "DIRECTED", direction: IN)
+            }
+
+            type ${Person} @node {
+                name: String!
+                directed: [${Movie}!]! @relationship(type: "DIRECTED", direction: OUT)
+            }
+        `;
+
+        await testHelper.initNeo4jGraphQL({
+            typeDefs,
+        });
+    });
+
+    afterEach(async () => {
+        await testHelper.close();
+    });
+
+    test("returns all relationships", async () => {
+        await testHelper.executeCypher(`
+            CREATE(m:${Movie} { title: "The Matrix"})<-[:DIRECTED]-(a:${Person} { name: "Keanu"})
+            CREATE(a)-[:DIRECTED]->(:${Movie} { title: "The Matrix 2"})
+        `);
+
+        const query = `
+            query {
+               ${Person.plural} {
+                    directed {
+                        title
+                    }
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+        expect(result.errors).toBeFalsy();
+        expect(result.data).toEqual({
+            [Person.plural]: [
+                {
+                    directed: [
+                        {
+                            title: "The Matrix",
+                        },
+                        {
+                            title: "The Matrix 2",
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+
+    test("filter returns 1 element", async () => {
+        await testHelper.executeCypher(`
+            CREATE(m:${Movie} { title: "The Matrix"})<-[:DIRECTED]-(a:${Person} { name: "Keanu"})
+            CREATE(a)-[:DIRECTED]->(:${Movie} { title: "The Matrix 2"})
+        `);
+
+        const query = `
+            query {
+               ${Person.plural} {
+                    directed(where: { title: {eq: "The Matrix"} }) {
+                        title
+                    }
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+        expect(result.errors).toBeFalsy();
+        expect(result.data).toEqual({
+            [Person.plural]: [
+                {
+                    directed: [
+                        {
+                            title: "The Matrix",
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+
+    test("filter returns > 1 element", async () => {
+        await testHelper.executeCypher(`
+            CREATE(m:${Movie} { title: "The Matrix"})<-[:DIRECTED]-(a:${Person} { name: "Keanu"})
+            CREATE(a)-[:DIRECTED]->(:${Movie} { title: "The Matrix 2"})
+        `);
+
+        const query = `
+            query {
+               ${Person.plural} {
+                    directed(where: { title: {startsWith: "The Matrix"} }) {
+                        title
+                    }
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+        expect(result.errors).toBeFalsy();
+        expect(result.data).toEqual({
+            [Person.plural]: [
+                {
+                    directed: [
+                        {
+                            title: "The Matrix",
+                        },
+                        {
+                            title: "The Matrix 2",
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+
+    test("fails on 1-1 non nullable relationship", async () => {
+        await testHelper.executeCypher(`
+            CREATE(m:${Movie} { title: "The Matrix"})
+        `);
+
+        const query = `
+            query {
+                ${Movie.plural} {
+                    director {
+                        name
+                    }
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+        expect(result.errors).toEqual([
+            expect.objectContaining({
+                message: `Cannot return null for non-nullable field ${Movie}.director.`,
+            }),
+        ]);
+    });
+
+    test("no filter from the 1- relationship side", async () => {
+        await testHelper.executeCypher(`
+            CREATE(m:${Movie} { title: "The Matrix"})<-[:DIRECTED]-(a:${Person} { name: "Keanu"})
+        `);
+
+        const query = `
+            query {
+               ${Movie.plural} {
+                    director(where: { name: {startsWith: "The Matrix"} }) {
+                        name
+                    }
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+        expect(result.errors).toHaveLength(1);
+        expect((result.errors?.[0] || { message: "" }).message).toBe(
+            `Unknown argument "where" on field "${Movie}.director".`
+        );
+    });
+});

--- a/packages/graphql/tests/integration/directives/relationship/union-relationship-1-many.int.test.ts
+++ b/packages/graphql/tests/integration/directives/relationship/union-relationship-1-many.int.test.ts
@@ -1,0 +1,267 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { UniqueType } from "../../../utils/graphql-types";
+import { TestHelper } from "../../../utils/tests-helper";
+
+describe("1-* relationships involving Union type", () => {
+    let Movie: UniqueType;
+    let Person: UniqueType;
+    let Dog: UniqueType;
+    let AI: UniqueType;
+
+    const testHelper = new TestHelper();
+
+    beforeEach(async () => {
+        Movie = testHelper.createUniqueType("Movie");
+        Person = testHelper.createUniqueType("Person");
+        Dog = testHelper.createUniqueType("Dog");
+        AI = testHelper.createUniqueType("AI");
+
+        const typeDefs = /* GraphQL */ `
+            union Actor =  ${Dog} | ${Person} 
+            union Director = ${Person} | ${AI}
+            type ${Movie} @node {
+                title: String!
+                actor: [Actor!]! @relationship(type: "ACTED_IN", direction: IN)
+                director: Director! @relationship(type: "DIRECTED", direction: IN)
+            }
+
+            type ${Person} @node {
+                name: String!
+                actedIn: ${Movie}! @relationship(type: "ACTED_IN", direction: OUT)
+                directed: [${Movie}!]! @relationship(type: "DIRECTED", direction: OUT)
+            }
+
+            type ${Dog} @node {
+                nickName: String!
+                actedIn: ${Movie}! @relationship(type: "ACTED_IN", direction: OUT)
+            }
+            type ${AI} @node {
+                model: String!
+                directed: [${Movie}!]! @relationship(type: "DIRECTED", direction: OUT)
+            }
+        `;
+
+        await testHelper.initNeo4jGraphQL({
+            typeDefs,
+        });
+    });
+
+    afterEach(async () => {
+        await testHelper.close();
+    });
+
+    test("returns all relationships", async () => {
+        await testHelper.executeCypher(`
+            CREATE(m:${Movie} { title: "The Matrix"})<-[:ACTED_IN]-(:${Dog} { nickName: "Hachiko"})
+            CREATE(m)<-[:ACTED_IN]-(:${Person} { name: "Keanu"})
+            CREATE(m)<-[:DIRECTED]-(a:${AI} { model: "T-800"})
+            CREATE(:${Movie} { title: "The Apartment"})<-[:DIRECTED]-(a)
+        `);
+
+        const query = `
+            query {
+               ${Movie.plural}(where: {title: {eq: "The Matrix"}}) {
+                    actor {
+                        ... on ${Person} {
+                            name
+                            actedIn {
+                                title
+                            }
+                        }
+                        ... on ${Dog} {
+                            nickName
+                            actedIn {
+                                title
+                            }
+                        }
+                    }
+                    director {
+                        ... on ${Person} {
+                            name
+                            directed {
+                                title
+                            }
+                        }
+                        ... on ${AI} {
+                            model
+                            directed {
+                                title
+                            }
+                        }
+                    }
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+        expect(result.errors).toBeFalsy();
+        expect(result.data).toEqual({
+            [Movie.plural]: [
+                {
+                    actor: [
+                        {
+                            nickName: "Hachiko",
+                            actedIn: {
+                                title: "The Matrix",
+                            },
+                        },
+                        {
+                            name: "Keanu",
+                            actedIn: {
+                                title: "The Matrix",
+                            },
+                        },
+                    ],
+                    director: {
+                        model: "T-800",
+                        directed: [
+                            {
+                                title: "The Matrix",
+                            },
+                            {
+                                title: "The Apartment",
+                            },
+                        ],
+                    },
+                },
+            ],
+        });
+    });
+
+    test("filter returns 1 element", async () => {
+        await testHelper.executeCypher(`
+            CREATE(m:${Movie} { title: "The Matrix"})<-[:ACTED_IN]-(:${Dog} { nickName: "Hachiko"})
+            CREATE(m)<-[:ACTED_IN]-(:${Person} { name: "Keanu"})
+            CREATE(m)<-[:DIRECTED]-(a:${AI} { model: "T-800"})
+            CREATE(:${Movie} { title: "The Apartment"})<-[:DIRECTED]-(a)
+        `);
+
+        const query = `
+            query {
+               ${Movie.plural}(where: {title: {eq: "The Matrix"}}) {
+                    actor(where: { ${Person}: { name: { eq: "Albert" } }, ${Dog}: { nickName: { eq: "Hachiko" } } }) {
+                        ... on ${Person} {
+                            name
+                            actedIn {
+                                title
+                            }
+                        }
+                        ... on ${Dog} {
+                            nickName
+                            actedIn {
+                                title
+                            }
+                        }
+                    }
+                    director {
+                        ... on ${Person} {
+                            name
+                            directed {
+                                title
+                            }
+                        }
+                        ... on ${AI} {
+                            model
+                            directed(where: { title: { eq: "The Apartment" } }) {
+                                title
+                            }
+                        }
+                    }
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+        expect(result.errors).toBeFalsy();
+        expect(result.data).toEqual({
+            [Movie.plural]: [
+                {
+                    actor: [
+                        {
+                            nickName: "Hachiko",
+                            actedIn: {
+                                title: "The Matrix",
+                            },
+                        },
+                    ],
+                    director: {
+                        model: "T-800",
+                        directed: [
+                            {
+                                title: "The Apartment",
+                            },
+                        ],
+                    },
+                },
+            ],
+        });
+    });
+
+    test("no filter from the 1- relationship side", async () => {
+        await testHelper.executeCypher(`
+            CREATE(m:${Movie} { title: "The Matrix"})<-[:ACTED_IN]-(:${Dog} { nickName: "Hachiko"})
+            CREATE(m)<-[:ACTED_IN]-(:${Person} { name: "Keanu"})
+            CREATE(m)<-[:DIRECTED]-(a:${AI} { model: "T-800"})
+            CREATE(:${Movie} { title: "The Apartment"})<-[:DIRECTED]-(a)
+        `);
+
+        const query = `
+            query {
+               ${Movie.plural}(where: {title: {eq: "The Matrix"}}) {
+                    actor {
+                        ... on ${Person} {
+                            name
+                            actedIn {
+                                title
+                            }
+                        }
+                        ... on ${Dog} {
+                            nickName
+                            actedIn {
+                                title
+                            }
+                        }
+                    }
+                    director(where: { ${Person}: { name: { eq: "Albert" } } }) {
+                        ... on ${Person} {
+                            name
+                            directed {
+                                title
+                            }
+                        }
+                        ... on ${AI} {
+                            model
+                            directed {
+                                title
+                            }
+                        }
+                    }
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+        expect(result.errors).toHaveLength(1);
+        expect((result.errors?.[0] || { message: "" }).message).toBe(
+            `Unknown argument "where" on field "${Movie}.director".`
+        );
+    });
+});

--- a/packages/graphql/tests/schema/relationship/single-element-declared-relationship-interface.test.ts
+++ b/packages/graphql/tests/schema/relationship/single-element-declared-relationship-interface.test.ts
@@ -23,7 +23,7 @@ import { lexicographicSortSchema } from "graphql/utilities";
 import { Neo4jGraphQL } from "../../../src";
 
 describe("single item relationships from a declared relationship", () => {
-    test("1-* relationship", async () => {
+    test("1-1 relationship", async () => {
         const typeDefs = gql`
             interface Actor {
                 name: String!
@@ -34,14 +34,14 @@ describe("single item relationships from a declared relationship", () => {
                 director: Person! @declareRelationship
             }
 
-            type Movie @node {
+            type Movie implements Production @node {
                 title: String!
                 actor: Actor @relationship(type: "ACTED_IN", direction: IN)
                 director: Person! @relationship(type: "DIRECTED", direction: IN)
             }
 
-            type Series @node {
-                name: String!
+            type Series implements Production @node {
+                title: String!
                 actor: Actor @relationship(type: "ACTED_IN", direction: IN)
                 director: Person! @relationship(type: "DIRECTED", direction: IN)
             }
@@ -206,30 +206,12 @@ describe("single item relationships from a declared relationship", () => {
               totalCount: Int!
             }
 
-            type Movie {
-              actor(where: ActorWhere): Actor
-              actorConnection(where: MovieActorConnectionWhere): MovieActorConnection!
-              director(where: PersonWhere): Person!
-              directorConnection(where: MovieDirectorConnectionWhere): MovieDirectorConnection!
+            type Movie implements Production {
+              actor: Actor
+              actorConnection: ProductionActorConnection!
+              director: Person!
+              directorConnection: ProductionDirectorConnection!
               title: String!
-            }
-
-            type MovieActorConnection {
-              edges: [MovieActorRelationship!]!
-              pageInfo: PageInfo!
-              totalCount: Int!
-            }
-
-            input MovieActorConnectionWhere {
-              AND: [MovieActorConnectionWhere!]
-              NOT: MovieActorConnectionWhere
-              OR: [MovieActorConnectionWhere!]
-              node: ActorWhere
-            }
-
-            type MovieActorRelationship {
-              cursor: String!
-              node: Actor!
             }
 
             type MovieAggregate {
@@ -243,24 +225,6 @@ describe("single item relationships from a declared relationship", () => {
 
             input MovieCreateInput {
               title: String!
-            }
-
-            type MovieDirectorConnection {
-              edges: [MovieDirectorRelationship!]!
-              pageInfo: PageInfo!
-              totalCount: Int!
-            }
-
-            input MovieDirectorConnectionWhere {
-              AND: [MovieDirectorConnectionWhere!]
-              NOT: MovieDirectorConnectionWhere
-              OR: [MovieDirectorConnectionWhere!]
-              node: PersonWhere
-            }
-
-            type MovieDirectorRelationship {
-              cursor: String!
-              node: Person!
             }
 
             type MovieEdge {
@@ -363,6 +327,77 @@ describe("single item relationships from a declared relationship", () => {
               name: StringScalarFilters
             }
 
+            interface Production {
+              actor: Actor
+              actorConnection: ProductionActorConnection!
+              director: Person!
+              directorConnection: ProductionDirectorConnection!
+              title: String!
+            }
+
+            type ProductionActorConnection {
+              edges: [ProductionActorRelationship!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type ProductionActorRelationship {
+              cursor: String!
+              node: Actor!
+            }
+
+            type ProductionAggregate {
+              count: Count!
+              node: ProductionAggregateNode!
+            }
+
+            type ProductionAggregateNode {
+              title: StringAggregateSelection!
+            }
+
+            type ProductionDirectorConnection {
+              edges: [ProductionDirectorRelationship!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type ProductionDirectorRelationship {
+              cursor: String!
+              node: Person!
+            }
+
+            type ProductionEdge {
+              cursor: String!
+              node: Production!
+            }
+
+            enum ProductionImplementation {
+              Movie
+              Series
+            }
+
+            \\"\\"\\"
+            Fields to sort Productions by. The order in which sorts are applied is not guaranteed when specifying many fields in one ProductionSort object.
+            \\"\\"\\"
+            input ProductionSort {
+              title: SortDirection
+            }
+
+            input ProductionWhere {
+              AND: [ProductionWhere!]
+              NOT: ProductionWhere
+              OR: [ProductionWhere!]
+              title: StringScalarFilters
+              typename: [ProductionImplementation!]
+            }
+
+            type ProductionsConnection {
+              aggregate: ProductionAggregate!
+              edges: [ProductionEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
             type Query {
               actors(limit: Int, offset: Int, sort: [ActorSort!], where: ActorWhere): [Actor!]!
               actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
@@ -372,34 +407,18 @@ describe("single item relationships from a declared relationship", () => {
               moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
               people(limit: Int, offset: Int, sort: [PersonSort!], where: PersonWhere): [Person!]!
               peopleConnection(after: String, first: Int, sort: [PersonSort!], where: PersonWhere): PeopleConnection!
+              productions(limit: Int, offset: Int, sort: [ProductionSort!], where: ProductionWhere): [Production!]!
+              productionsConnection(after: String, first: Int, sort: [ProductionSort!], where: ProductionWhere): ProductionsConnection!
               series(limit: Int, offset: Int, sort: [SeriesSort!], where: SeriesWhere): [Series!]!
               seriesConnection(after: String, first: Int, sort: [SeriesSort!], where: SeriesWhere): SeriesConnection!
             }
 
-            type Series {
-              actor(where: ActorWhere): Actor
-              actorConnection(where: SeriesActorConnectionWhere): SeriesActorConnection!
-              director(where: PersonWhere): Person!
-              directorConnection(where: SeriesDirectorConnectionWhere): SeriesDirectorConnection!
-              name: String!
-            }
-
-            type SeriesActorConnection {
-              edges: [SeriesActorRelationship!]!
-              pageInfo: PageInfo!
-              totalCount: Int!
-            }
-
-            input SeriesActorConnectionWhere {
-              AND: [SeriesActorConnectionWhere!]
-              NOT: SeriesActorConnectionWhere
-              OR: [SeriesActorConnectionWhere!]
-              node: ActorWhere
-            }
-
-            type SeriesActorRelationship {
-              cursor: String!
-              node: Actor!
+            type Series implements Production {
+              actor: Actor
+              actorConnection: ProductionActorConnection!
+              director: Person!
+              directorConnection: ProductionDirectorConnection!
+              title: String!
             }
 
             type SeriesAggregate {
@@ -408,7 +427,7 @@ describe("single item relationships from a declared relationship", () => {
             }
 
             type SeriesAggregateNode {
-              name: StringAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             type SeriesConnection {
@@ -419,25 +438,7 @@ describe("single item relationships from a declared relationship", () => {
             }
 
             input SeriesCreateInput {
-              name: String!
-            }
-
-            type SeriesDirectorConnection {
-              edges: [SeriesDirectorRelationship!]!
-              pageInfo: PageInfo!
-              totalCount: Int!
-            }
-
-            input SeriesDirectorConnectionWhere {
-              AND: [SeriesDirectorConnectionWhere!]
-              NOT: SeriesDirectorConnectionWhere
-              OR: [SeriesDirectorConnectionWhere!]
-              node: PersonWhere
-            }
-
-            type SeriesDirectorRelationship {
-              cursor: String!
-              node: Person!
+              title: String!
             }
 
             type SeriesEdge {
@@ -449,18 +450,18 @@ describe("single item relationships from a declared relationship", () => {
             Fields to sort Series by. The order in which sorts are applied is not guaranteed when specifying many fields in one SeriesSort object.
             \\"\\"\\"
             input SeriesSort {
-              name: SortDirection
+              title: SortDirection
             }
 
             input SeriesUpdateInput {
-              name: StringScalarMutations
+              title: StringScalarMutations
             }
 
             input SeriesWhere {
               AND: [SeriesWhere!]
               NOT: SeriesWhere
               OR: [SeriesWhere!]
-              name: StringScalarFilters
+              title: StringScalarFilters
             }
 
             \\"\\"\\"An enum for sorting in either ascending or descending order.\\"\\"\\"
@@ -474,6 +475,1147 @@ describe("single item relationships from a declared relationship", () => {
             type StringAggregateSelection {
               longest: String
               shortest: String
+            }
+
+            \\"\\"\\"String filters\\"\\"\\"
+            input StringScalarFilters {
+              contains: String
+              endsWith: String
+              eq: String
+              in: [String!]
+              startsWith: String
+            }
+
+            \\"\\"\\"String mutations\\"\\"\\"
+            input StringScalarMutations {
+              set: String
+            }
+
+            type UpdateDogsMutationResponse {
+              dogs: [Dog!]!
+              info: UpdateInfo!
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships created and deleted during an update mutation
+            \\"\\"\\"
+            type UpdateInfo {
+              nodesCreated: Int!
+              nodesDeleted: Int!
+              relationshipsCreated: Int!
+              relationshipsDeleted: Int!
+            }
+
+            type UpdateMoviesMutationResponse {
+              info: UpdateInfo!
+              movies: [Movie!]!
+            }
+
+            type UpdatePeopleMutationResponse {
+              info: UpdateInfo!
+              people: [Person!]!
+            }
+
+            type UpdateSeriesMutationResponse {
+              info: UpdateInfo!
+              series: [Series!]!
+            }"
+        `);
+    });
+    test("1-* relationship", async () => {
+        const typeDefs = gql`
+            interface Actor {
+                name: String!
+                actedIn: Production! @declareRelationship
+                directed: [Production!]! @declareRelationship
+            }
+            interface Production {
+                title: String!
+                actor: [Actor!]! @declareRelationship
+                director: Person! @declareRelationship
+            }
+
+            type Movie implements Production @node {
+                title: String!
+                actor: [Actor!]! @relationship(type: "ACTED_IN", direction: IN)
+                director: Person! @relationship(type: "DIRECTED", direction: IN)
+            }
+
+            type Series implements Production @node {
+                title: String!
+                actor: [Actor!]! @relationship(type: "ACTED_IN", direction: IN)
+                director: Person! @relationship(type: "DIRECTED", direction: IN)
+            }
+
+            type Dog implements Actor @node {
+                name: String!
+                actedIn: Production! @relationship(type: "ACTED_IN", direction: OUT)
+                directed: [Production!]! @relationship(type: "DIRECTED", direction: OUT)
+            }
+
+            type Person implements Actor @node {
+                name: String!
+                actedIn: Production! @relationship(type: "ACTED_IN", direction: OUT)
+                directed: [Production!]! @relationship(type: "DIRECTED", direction: OUT)
+            }
+        `;
+        const neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            features: {
+                excludeDeprecatedFields: {
+                    mutationOperations: true,
+                    aggregationFilters: true,
+                    aggregationFiltersOutsideConnection: true,
+                    relationshipFilters: true,
+                    attributeFilters: true,
+                },
+            },
+        });
+        const printedSchema = printSchemaWithDirectives(lexicographicSortSchema(await neoSchema.getSchema()));
+
+        expect(printedSchema).toMatchInlineSnapshot(`
+            "schema {
+              query: Query
+              mutation: Mutation
+            }
+
+            interface Actor {
+              actedIn: Production!
+              actedInConnection: ActorActedInConnection!
+              directed(limit: Int, offset: Int, sort: [ProductionSort!], where: ProductionWhere): [Production!]!
+              directedConnection(after: String, first: Int, sort: [ActorDirectedConnectionSort!], where: ActorDirectedConnectionWhere): ActorDirectedConnection!
+              name: String!
+            }
+
+            type ActorActedInConnection {
+              edges: [ActorActedInRelationship!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type ActorActedInRelationship {
+              cursor: String!
+              node: Production!
+            }
+
+            type ActorAggregate {
+              count: Count!
+              node: ActorAggregateNode!
+            }
+
+            type ActorAggregateNode {
+              name: StringAggregateSelection!
+            }
+
+            input ActorConnectInput {
+              directed: [ActorDirectedConnectFieldInput!]
+            }
+
+            input ActorConnectWhere {
+              node: ActorWhere!
+            }
+
+            input ActorCreateInput {
+              Dog: DogCreateInput
+              Person: PersonCreateInput
+            }
+
+            input ActorDeleteInput {
+              directed: [ActorDirectedDeleteFieldInput!]
+            }
+
+            input ActorDirectedConnectFieldInput {
+              connect: ProductionConnectInput
+              where: ProductionConnectWhere
+            }
+
+            type ActorDirectedConnection {
+              edges: [ActorDirectedRelationship!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            input ActorDirectedConnectionAggregateInput {
+              AND: [ActorDirectedConnectionAggregateInput!]
+              NOT: ActorDirectedConnectionAggregateInput
+              OR: [ActorDirectedConnectionAggregateInput!]
+              count: ConnectionAggregationCountFilterInput
+              node: ActorDirectedNodeAggregationWhereInput
+            }
+
+            input ActorDirectedConnectionFilters {
+              \\"\\"\\"
+              Filter Actors by aggregating results on related ActorDirectedConnections
+              \\"\\"\\"
+              aggregate: ActorDirectedConnectionAggregateInput
+              \\"\\"\\"
+              Return Actors where all of the related ActorDirectedConnections match this filter
+              \\"\\"\\"
+              all: ActorDirectedConnectionWhere
+              \\"\\"\\"
+              Return Actors where none of the related ActorDirectedConnections match this filter
+              \\"\\"\\"
+              none: ActorDirectedConnectionWhere
+              \\"\\"\\"
+              Return Actors where one of the related ActorDirectedConnections match this filter
+              \\"\\"\\"
+              single: ActorDirectedConnectionWhere
+              \\"\\"\\"
+              Return Actors where some of the related ActorDirectedConnections match this filter
+              \\"\\"\\"
+              some: ActorDirectedConnectionWhere
+            }
+
+            input ActorDirectedConnectionSort {
+              node: ProductionSort
+            }
+
+            input ActorDirectedConnectionWhere {
+              AND: [ActorDirectedConnectionWhere!]
+              NOT: ActorDirectedConnectionWhere
+              OR: [ActorDirectedConnectionWhere!]
+              node: ProductionWhere
+            }
+
+            input ActorDirectedCreateFieldInput {
+              node: ProductionCreateInput!
+            }
+
+            input ActorDirectedDeleteFieldInput {
+              delete: ProductionDeleteInput
+              where: ActorDirectedConnectionWhere
+            }
+
+            input ActorDirectedDisconnectFieldInput {
+              disconnect: ProductionDisconnectInput
+              where: ActorDirectedConnectionWhere
+            }
+
+            input ActorDirectedNodeAggregationWhereInput {
+              AND: [ActorDirectedNodeAggregationWhereInput!]
+              NOT: ActorDirectedNodeAggregationWhereInput
+              OR: [ActorDirectedNodeAggregationWhereInput!]
+              title: StringScalarAggregationFilters
+            }
+
+            type ActorDirectedRelationship {
+              cursor: String!
+              node: Production!
+            }
+
+            input ActorDirectedUpdateConnectionInput {
+              node: ProductionUpdateInput
+              where: ActorDirectedConnectionWhere
+            }
+
+            input ActorDirectedUpdateFieldInput {
+              connect: [ActorDirectedConnectFieldInput!]
+              create: [ActorDirectedCreateFieldInput!]
+              delete: [ActorDirectedDeleteFieldInput!]
+              disconnect: [ActorDirectedDisconnectFieldInput!]
+              update: ActorDirectedUpdateConnectionInput
+            }
+
+            input ActorDisconnectInput {
+              directed: [ActorDirectedDisconnectFieldInput!]
+            }
+
+            type ActorEdge {
+              cursor: String!
+              node: Actor!
+            }
+
+            enum ActorImplementation {
+              Dog
+              Person
+            }
+
+            input ActorRelationshipFilters {
+              \\"\\"\\"Filter type where all of the related Actors match this filter\\"\\"\\"
+              all: ActorWhere
+              \\"\\"\\"Filter type where none of the related Actors match this filter\\"\\"\\"
+              none: ActorWhere
+              \\"\\"\\"Filter type where one of the related Actors match this filter\\"\\"\\"
+              single: ActorWhere
+              \\"\\"\\"Filter type where some of the related Actors match this filter\\"\\"\\"
+              some: ActorWhere
+            }
+
+            \\"\\"\\"
+            Fields to sort Actors by. The order in which sorts are applied is not guaranteed when specifying many fields in one ActorSort object.
+            \\"\\"\\"
+            input ActorSort {
+              name: SortDirection
+            }
+
+            input ActorUpdateInput {
+              directed: [ActorDirectedUpdateFieldInput!]
+              name: StringScalarMutations
+            }
+
+            input ActorWhere {
+              AND: [ActorWhere!]
+              NOT: ActorWhere
+              OR: [ActorWhere!]
+              directed: ProductionRelationshipFilters
+              directedConnection: ActorDirectedConnectionFilters
+              name: StringScalarFilters
+              typename: [ActorImplementation!]
+            }
+
+            type ActorsConnection {
+              aggregate: ActorAggregate!
+              edges: [ActorEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            input ConnectionAggregationCountFilterInput {
+              edges: IntScalarFilters
+              nodes: IntScalarFilters
+            }
+
+            type Count {
+              nodes: Int!
+            }
+
+            type CreateDogsMutationResponse {
+              dogs: [Dog!]!
+              info: CreateInfo!
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships created during a create mutation
+            \\"\\"\\"
+            type CreateInfo {
+              nodesCreated: Int!
+              relationshipsCreated: Int!
+            }
+
+            type CreateMoviesMutationResponse {
+              info: CreateInfo!
+              movies: [Movie!]!
+            }
+
+            type CreatePeopleMutationResponse {
+              info: CreateInfo!
+              people: [Person!]!
+            }
+
+            type CreateSeriesMutationResponse {
+              info: CreateInfo!
+              series: [Series!]!
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships deleted during a delete mutation
+            \\"\\"\\"
+            type DeleteInfo {
+              nodesDeleted: Int!
+              relationshipsDeleted: Int!
+            }
+
+            type Dog implements Actor {
+              actedIn: Production!
+              actedInConnection: ActorActedInConnection!
+              directed(limit: Int, offset: Int, sort: [ProductionSort!], where: ProductionWhere): [Production!]!
+              directedConnection(after: String, first: Int, sort: [ActorDirectedConnectionSort!], where: ActorDirectedConnectionWhere): ActorDirectedConnection!
+              name: String!
+            }
+
+            type DogAggregate {
+              count: Count!
+              node: DogAggregateNode!
+            }
+
+            type DogAggregateNode {
+              name: StringAggregateSelection!
+            }
+
+            input DogCreateInput {
+              directed: DogDirectedFieldInput
+              name: String!
+            }
+
+            input DogDeleteInput {
+              directed: [DogDirectedDeleteFieldInput!]
+            }
+
+            input DogDirectedConnectFieldInput {
+              connect: ProductionConnectInput
+              where: ProductionConnectWhere
+            }
+
+            input DogDirectedConnectionAggregateInput {
+              AND: [DogDirectedConnectionAggregateInput!]
+              NOT: DogDirectedConnectionAggregateInput
+              OR: [DogDirectedConnectionAggregateInput!]
+              count: ConnectionAggregationCountFilterInput
+              node: DogDirectedNodeAggregationWhereInput
+            }
+
+            input DogDirectedConnectionFilters {
+              \\"\\"\\"Filter Dogs by aggregating results on related ActorDirectedConnections\\"\\"\\"
+              aggregate: DogDirectedConnectionAggregateInput
+              \\"\\"\\"
+              Return Dogs where all of the related ActorDirectedConnections match this filter
+              \\"\\"\\"
+              all: ActorDirectedConnectionWhere
+              \\"\\"\\"
+              Return Dogs where none of the related ActorDirectedConnections match this filter
+              \\"\\"\\"
+              none: ActorDirectedConnectionWhere
+              \\"\\"\\"
+              Return Dogs where one of the related ActorDirectedConnections match this filter
+              \\"\\"\\"
+              single: ActorDirectedConnectionWhere
+              \\"\\"\\"
+              Return Dogs where some of the related ActorDirectedConnections match this filter
+              \\"\\"\\"
+              some: ActorDirectedConnectionWhere
+            }
+
+            input DogDirectedCreateFieldInput {
+              node: ProductionCreateInput!
+            }
+
+            input DogDirectedDeleteFieldInput {
+              delete: ProductionDeleteInput
+              where: ActorDirectedConnectionWhere
+            }
+
+            input DogDirectedDisconnectFieldInput {
+              disconnect: ProductionDisconnectInput
+              where: ActorDirectedConnectionWhere
+            }
+
+            input DogDirectedFieldInput {
+              connect: [DogDirectedConnectFieldInput!]
+              create: [DogDirectedCreateFieldInput!]
+            }
+
+            input DogDirectedNodeAggregationWhereInput {
+              AND: [DogDirectedNodeAggregationWhereInput!]
+              NOT: DogDirectedNodeAggregationWhereInput
+              OR: [DogDirectedNodeAggregationWhereInput!]
+              title: StringScalarAggregationFilters
+            }
+
+            input DogDirectedUpdateConnectionInput {
+              node: ProductionUpdateInput
+              where: ActorDirectedConnectionWhere
+            }
+
+            input DogDirectedUpdateFieldInput {
+              connect: [DogDirectedConnectFieldInput!]
+              create: [DogDirectedCreateFieldInput!]
+              delete: [DogDirectedDeleteFieldInput!]
+              disconnect: [DogDirectedDisconnectFieldInput!]
+              update: DogDirectedUpdateConnectionInput
+            }
+
+            type DogEdge {
+              cursor: String!
+              node: Dog!
+            }
+
+            \\"\\"\\"
+            Fields to sort Dogs by. The order in which sorts are applied is not guaranteed when specifying many fields in one DogSort object.
+            \\"\\"\\"
+            input DogSort {
+              name: SortDirection
+            }
+
+            input DogUpdateInput {
+              directed: [DogDirectedUpdateFieldInput!]
+              name: StringScalarMutations
+            }
+
+            input DogWhere {
+              AND: [DogWhere!]
+              NOT: DogWhere
+              OR: [DogWhere!]
+              directed: ProductionRelationshipFilters
+              directedConnection: DogDirectedConnectionFilters
+              name: StringScalarFilters
+            }
+
+            type DogsConnection {
+              aggregate: DogAggregate!
+              edges: [DogEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            \\"\\"\\"Float filters\\"\\"\\"
+            input FloatScalarFilters {
+              eq: Float
+              gt: Float
+              gte: Float
+              in: [Float!]
+              lt: Float
+              lte: Float
+            }
+
+            \\"\\"\\"Int filters\\"\\"\\"
+            input IntScalarFilters {
+              eq: Int
+              gt: Int
+              gte: Int
+              in: [Int!]
+              lt: Int
+              lte: Int
+            }
+
+            type Movie implements Production {
+              actor(limit: Int, offset: Int, sort: [ActorSort!], where: ActorWhere): [Actor!]!
+              actorConnection(after: String, first: Int, sort: [ProductionActorConnectionSort!], where: ProductionActorConnectionWhere): ProductionActorConnection!
+              director: Person!
+              directorConnection: ProductionDirectorConnection!
+              title: String!
+            }
+
+            input MovieActorConnectFieldInput {
+              connect: ActorConnectInput
+              where: ActorConnectWhere
+            }
+
+            input MovieActorConnectionAggregateInput {
+              AND: [MovieActorConnectionAggregateInput!]
+              NOT: MovieActorConnectionAggregateInput
+              OR: [MovieActorConnectionAggregateInput!]
+              count: ConnectionAggregationCountFilterInput
+              node: MovieActorNodeAggregationWhereInput
+            }
+
+            input MovieActorConnectionFilters {
+              \\"\\"\\"
+              Filter Movies by aggregating results on related ProductionActorConnections
+              \\"\\"\\"
+              aggregate: MovieActorConnectionAggregateInput
+              \\"\\"\\"
+              Return Movies where all of the related ProductionActorConnections match this filter
+              \\"\\"\\"
+              all: ProductionActorConnectionWhere
+              \\"\\"\\"
+              Return Movies where none of the related ProductionActorConnections match this filter
+              \\"\\"\\"
+              none: ProductionActorConnectionWhere
+              \\"\\"\\"
+              Return Movies where one of the related ProductionActorConnections match this filter
+              \\"\\"\\"
+              single: ProductionActorConnectionWhere
+              \\"\\"\\"
+              Return Movies where some of the related ProductionActorConnections match this filter
+              \\"\\"\\"
+              some: ProductionActorConnectionWhere
+            }
+
+            input MovieActorCreateFieldInput {
+              node: ActorCreateInput!
+            }
+
+            input MovieActorDeleteFieldInput {
+              delete: ActorDeleteInput
+              where: ProductionActorConnectionWhere
+            }
+
+            input MovieActorDisconnectFieldInput {
+              disconnect: ActorDisconnectInput
+              where: ProductionActorConnectionWhere
+            }
+
+            input MovieActorFieldInput {
+              connect: [MovieActorConnectFieldInput!]
+              create: [MovieActorCreateFieldInput!]
+            }
+
+            input MovieActorNodeAggregationWhereInput {
+              AND: [MovieActorNodeAggregationWhereInput!]
+              NOT: MovieActorNodeAggregationWhereInput
+              OR: [MovieActorNodeAggregationWhereInput!]
+              name: StringScalarAggregationFilters
+            }
+
+            input MovieActorUpdateConnectionInput {
+              node: ActorUpdateInput
+              where: ProductionActorConnectionWhere
+            }
+
+            input MovieActorUpdateFieldInput {
+              connect: [MovieActorConnectFieldInput!]
+              create: [MovieActorCreateFieldInput!]
+              delete: [MovieActorDeleteFieldInput!]
+              disconnect: [MovieActorDisconnectFieldInput!]
+              update: MovieActorUpdateConnectionInput
+            }
+
+            type MovieAggregate {
+              count: Count!
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              title: StringAggregateSelection!
+            }
+
+            input MovieCreateInput {
+              actor: MovieActorFieldInput
+              title: String!
+            }
+
+            input MovieDeleteInput {
+              actor: [MovieActorDeleteFieldInput!]
+            }
+
+            type MovieEdge {
+              cursor: String!
+              node: Movie!
+            }
+
+            \\"\\"\\"
+            Fields to sort Movies by. The order in which sorts are applied is not guaranteed when specifying many fields in one MovieSort object.
+            \\"\\"\\"
+            input MovieSort {
+              title: SortDirection
+            }
+
+            input MovieUpdateInput {
+              actor: [MovieActorUpdateFieldInput!]
+              title: StringScalarMutations
+            }
+
+            input MovieWhere {
+              AND: [MovieWhere!]
+              NOT: MovieWhere
+              OR: [MovieWhere!]
+              actor: ActorRelationshipFilters
+              actorConnection: MovieActorConnectionFilters
+              title: StringScalarFilters
+            }
+
+            type MoviesConnection {
+              aggregate: MovieAggregate!
+              edges: [MovieEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type Mutation {
+              createDogs(input: [DogCreateInput!]!): CreateDogsMutationResponse!
+              createMovies(input: [MovieCreateInput!]!): CreateMoviesMutationResponse!
+              createPeople(input: [PersonCreateInput!]!): CreatePeopleMutationResponse!
+              createSeries(input: [SeriesCreateInput!]!): CreateSeriesMutationResponse!
+              deleteDogs(delete: DogDeleteInput, where: DogWhere): DeleteInfo!
+              deleteMovies(delete: MovieDeleteInput, where: MovieWhere): DeleteInfo!
+              deletePeople(delete: PersonDeleteInput, where: PersonWhere): DeleteInfo!
+              deleteSeries(delete: SeriesDeleteInput, where: SeriesWhere): DeleteInfo!
+              updateDogs(update: DogUpdateInput, where: DogWhere): UpdateDogsMutationResponse!
+              updateMovies(update: MovieUpdateInput, where: MovieWhere): UpdateMoviesMutationResponse!
+              updatePeople(update: PersonUpdateInput, where: PersonWhere): UpdatePeopleMutationResponse!
+              updateSeries(update: SeriesUpdateInput, where: SeriesWhere): UpdateSeriesMutationResponse!
+            }
+
+            \\"\\"\\"Pagination information (Relay)\\"\\"\\"
+            type PageInfo {
+              endCursor: String
+              hasNextPage: Boolean!
+              hasPreviousPage: Boolean!
+              startCursor: String
+            }
+
+            type PeopleConnection {
+              aggregate: PersonAggregate!
+              edges: [PersonEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type Person implements Actor {
+              actedIn: Production!
+              actedInConnection: ActorActedInConnection!
+              directed(limit: Int, offset: Int, sort: [ProductionSort!], where: ProductionWhere): [Production!]!
+              directedConnection(after: String, first: Int, sort: [ActorDirectedConnectionSort!], where: ActorDirectedConnectionWhere): ActorDirectedConnection!
+              name: String!
+            }
+
+            type PersonAggregate {
+              count: Count!
+              node: PersonAggregateNode!
+            }
+
+            type PersonAggregateNode {
+              name: StringAggregateSelection!
+            }
+
+            input PersonCreateInput {
+              directed: PersonDirectedFieldInput
+              name: String!
+            }
+
+            input PersonDeleteInput {
+              directed: [PersonDirectedDeleteFieldInput!]
+            }
+
+            input PersonDirectedConnectFieldInput {
+              connect: ProductionConnectInput
+              where: ProductionConnectWhere
+            }
+
+            input PersonDirectedConnectionAggregateInput {
+              AND: [PersonDirectedConnectionAggregateInput!]
+              NOT: PersonDirectedConnectionAggregateInput
+              OR: [PersonDirectedConnectionAggregateInput!]
+              count: ConnectionAggregationCountFilterInput
+              node: PersonDirectedNodeAggregationWhereInput
+            }
+
+            input PersonDirectedConnectionFilters {
+              \\"\\"\\"
+              Filter People by aggregating results on related ActorDirectedConnections
+              \\"\\"\\"
+              aggregate: PersonDirectedConnectionAggregateInput
+              \\"\\"\\"
+              Return People where all of the related ActorDirectedConnections match this filter
+              \\"\\"\\"
+              all: ActorDirectedConnectionWhere
+              \\"\\"\\"
+              Return People where none of the related ActorDirectedConnections match this filter
+              \\"\\"\\"
+              none: ActorDirectedConnectionWhere
+              \\"\\"\\"
+              Return People where one of the related ActorDirectedConnections match this filter
+              \\"\\"\\"
+              single: ActorDirectedConnectionWhere
+              \\"\\"\\"
+              Return People where some of the related ActorDirectedConnections match this filter
+              \\"\\"\\"
+              some: ActorDirectedConnectionWhere
+            }
+
+            input PersonDirectedCreateFieldInput {
+              node: ProductionCreateInput!
+            }
+
+            input PersonDirectedDeleteFieldInput {
+              delete: ProductionDeleteInput
+              where: ActorDirectedConnectionWhere
+            }
+
+            input PersonDirectedDisconnectFieldInput {
+              disconnect: ProductionDisconnectInput
+              where: ActorDirectedConnectionWhere
+            }
+
+            input PersonDirectedFieldInput {
+              connect: [PersonDirectedConnectFieldInput!]
+              create: [PersonDirectedCreateFieldInput!]
+            }
+
+            input PersonDirectedNodeAggregationWhereInput {
+              AND: [PersonDirectedNodeAggregationWhereInput!]
+              NOT: PersonDirectedNodeAggregationWhereInput
+              OR: [PersonDirectedNodeAggregationWhereInput!]
+              title: StringScalarAggregationFilters
+            }
+
+            input PersonDirectedUpdateConnectionInput {
+              node: ProductionUpdateInput
+              where: ActorDirectedConnectionWhere
+            }
+
+            input PersonDirectedUpdateFieldInput {
+              connect: [PersonDirectedConnectFieldInput!]
+              create: [PersonDirectedCreateFieldInput!]
+              delete: [PersonDirectedDeleteFieldInput!]
+              disconnect: [PersonDirectedDisconnectFieldInput!]
+              update: PersonDirectedUpdateConnectionInput
+            }
+
+            type PersonEdge {
+              cursor: String!
+              node: Person!
+            }
+
+            \\"\\"\\"
+            Fields to sort People by. The order in which sorts are applied is not guaranteed when specifying many fields in one PersonSort object.
+            \\"\\"\\"
+            input PersonSort {
+              name: SortDirection
+            }
+
+            input PersonUpdateInput {
+              directed: [PersonDirectedUpdateFieldInput!]
+              name: StringScalarMutations
+            }
+
+            input PersonWhere {
+              AND: [PersonWhere!]
+              NOT: PersonWhere
+              OR: [PersonWhere!]
+              directed: ProductionRelationshipFilters
+              directedConnection: PersonDirectedConnectionFilters
+              name: StringScalarFilters
+            }
+
+            interface Production {
+              actor(limit: Int, offset: Int, sort: [ActorSort!], where: ActorWhere): [Actor!]!
+              actorConnection(after: String, first: Int, sort: [ProductionActorConnectionSort!], where: ProductionActorConnectionWhere): ProductionActorConnection!
+              director: Person!
+              directorConnection: ProductionDirectorConnection!
+              title: String!
+            }
+
+            input ProductionActorConnectFieldInput {
+              connect: ActorConnectInput
+              where: ActorConnectWhere
+            }
+
+            type ProductionActorConnection {
+              edges: [ProductionActorRelationship!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            input ProductionActorConnectionAggregateInput {
+              AND: [ProductionActorConnectionAggregateInput!]
+              NOT: ProductionActorConnectionAggregateInput
+              OR: [ProductionActorConnectionAggregateInput!]
+              count: ConnectionAggregationCountFilterInput
+              node: ProductionActorNodeAggregationWhereInput
+            }
+
+            input ProductionActorConnectionFilters {
+              \\"\\"\\"
+              Filter Productions by aggregating results on related ProductionActorConnections
+              \\"\\"\\"
+              aggregate: ProductionActorConnectionAggregateInput
+              \\"\\"\\"
+              Return Productions where all of the related ProductionActorConnections match this filter
+              \\"\\"\\"
+              all: ProductionActorConnectionWhere
+              \\"\\"\\"
+              Return Productions where none of the related ProductionActorConnections match this filter
+              \\"\\"\\"
+              none: ProductionActorConnectionWhere
+              \\"\\"\\"
+              Return Productions where one of the related ProductionActorConnections match this filter
+              \\"\\"\\"
+              single: ProductionActorConnectionWhere
+              \\"\\"\\"
+              Return Productions where some of the related ProductionActorConnections match this filter
+              \\"\\"\\"
+              some: ProductionActorConnectionWhere
+            }
+
+            input ProductionActorConnectionSort {
+              node: ActorSort
+            }
+
+            input ProductionActorConnectionWhere {
+              AND: [ProductionActorConnectionWhere!]
+              NOT: ProductionActorConnectionWhere
+              OR: [ProductionActorConnectionWhere!]
+              node: ActorWhere
+            }
+
+            input ProductionActorCreateFieldInput {
+              node: ActorCreateInput!
+            }
+
+            input ProductionActorDeleteFieldInput {
+              delete: ActorDeleteInput
+              where: ProductionActorConnectionWhere
+            }
+
+            input ProductionActorDisconnectFieldInput {
+              disconnect: ActorDisconnectInput
+              where: ProductionActorConnectionWhere
+            }
+
+            input ProductionActorNodeAggregationWhereInput {
+              AND: [ProductionActorNodeAggregationWhereInput!]
+              NOT: ProductionActorNodeAggregationWhereInput
+              OR: [ProductionActorNodeAggregationWhereInput!]
+              name: StringScalarAggregationFilters
+            }
+
+            type ProductionActorRelationship {
+              cursor: String!
+              node: Actor!
+            }
+
+            input ProductionActorUpdateConnectionInput {
+              node: ActorUpdateInput
+              where: ProductionActorConnectionWhere
+            }
+
+            input ProductionActorUpdateFieldInput {
+              connect: [ProductionActorConnectFieldInput!]
+              create: [ProductionActorCreateFieldInput!]
+              delete: [ProductionActorDeleteFieldInput!]
+              disconnect: [ProductionActorDisconnectFieldInput!]
+              update: ProductionActorUpdateConnectionInput
+            }
+
+            type ProductionAggregate {
+              count: Count!
+              node: ProductionAggregateNode!
+            }
+
+            type ProductionAggregateNode {
+              title: StringAggregateSelection!
+            }
+
+            input ProductionConnectInput {
+              actor: [ProductionActorConnectFieldInput!]
+            }
+
+            input ProductionConnectWhere {
+              node: ProductionWhere!
+            }
+
+            input ProductionCreateInput {
+              Movie: MovieCreateInput
+              Series: SeriesCreateInput
+            }
+
+            input ProductionDeleteInput {
+              actor: [ProductionActorDeleteFieldInput!]
+            }
+
+            type ProductionDirectorConnection {
+              edges: [ProductionDirectorRelationship!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type ProductionDirectorRelationship {
+              cursor: String!
+              node: Person!
+            }
+
+            input ProductionDisconnectInput {
+              actor: [ProductionActorDisconnectFieldInput!]
+            }
+
+            type ProductionEdge {
+              cursor: String!
+              node: Production!
+            }
+
+            enum ProductionImplementation {
+              Movie
+              Series
+            }
+
+            input ProductionRelationshipFilters {
+              \\"\\"\\"Filter type where all of the related Productions match this filter\\"\\"\\"
+              all: ProductionWhere
+              \\"\\"\\"Filter type where none of the related Productions match this filter\\"\\"\\"
+              none: ProductionWhere
+              \\"\\"\\"Filter type where one of the related Productions match this filter\\"\\"\\"
+              single: ProductionWhere
+              \\"\\"\\"Filter type where some of the related Productions match this filter\\"\\"\\"
+              some: ProductionWhere
+            }
+
+            \\"\\"\\"
+            Fields to sort Productions by. The order in which sorts are applied is not guaranteed when specifying many fields in one ProductionSort object.
+            \\"\\"\\"
+            input ProductionSort {
+              title: SortDirection
+            }
+
+            input ProductionUpdateInput {
+              actor: [ProductionActorUpdateFieldInput!]
+              title: StringScalarMutations
+            }
+
+            input ProductionWhere {
+              AND: [ProductionWhere!]
+              NOT: ProductionWhere
+              OR: [ProductionWhere!]
+              actor: ActorRelationshipFilters
+              actorConnection: ProductionActorConnectionFilters
+              title: StringScalarFilters
+              typename: [ProductionImplementation!]
+            }
+
+            type ProductionsConnection {
+              aggregate: ProductionAggregate!
+              edges: [ProductionEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type Query {
+              actors(limit: Int, offset: Int, sort: [ActorSort!], where: ActorWhere): [Actor!]!
+              actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
+              dogs(limit: Int, offset: Int, sort: [DogSort!], where: DogWhere): [Dog!]!
+              dogsConnection(after: String, first: Int, sort: [DogSort!], where: DogWhere): DogsConnection!
+              movies(limit: Int, offset: Int, sort: [MovieSort!], where: MovieWhere): [Movie!]!
+              moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
+              people(limit: Int, offset: Int, sort: [PersonSort!], where: PersonWhere): [Person!]!
+              peopleConnection(after: String, first: Int, sort: [PersonSort!], where: PersonWhere): PeopleConnection!
+              productions(limit: Int, offset: Int, sort: [ProductionSort!], where: ProductionWhere): [Production!]!
+              productionsConnection(after: String, first: Int, sort: [ProductionSort!], where: ProductionWhere): ProductionsConnection!
+              series(limit: Int, offset: Int, sort: [SeriesSort!], where: SeriesWhere): [Series!]!
+              seriesConnection(after: String, first: Int, sort: [SeriesSort!], where: SeriesWhere): SeriesConnection!
+            }
+
+            type Series implements Production {
+              actor(limit: Int, offset: Int, sort: [ActorSort!], where: ActorWhere): [Actor!]!
+              actorConnection(after: String, first: Int, sort: [ProductionActorConnectionSort!], where: ProductionActorConnectionWhere): ProductionActorConnection!
+              director: Person!
+              directorConnection: ProductionDirectorConnection!
+              title: String!
+            }
+
+            input SeriesActorConnectFieldInput {
+              connect: ActorConnectInput
+              where: ActorConnectWhere
+            }
+
+            input SeriesActorConnectionAggregateInput {
+              AND: [SeriesActorConnectionAggregateInput!]
+              NOT: SeriesActorConnectionAggregateInput
+              OR: [SeriesActorConnectionAggregateInput!]
+              count: ConnectionAggregationCountFilterInput
+              node: SeriesActorNodeAggregationWhereInput
+            }
+
+            input SeriesActorConnectionFilters {
+              \\"\\"\\"
+              Filter Series by aggregating results on related ProductionActorConnections
+              \\"\\"\\"
+              aggregate: SeriesActorConnectionAggregateInput
+              \\"\\"\\"
+              Return Series where all of the related ProductionActorConnections match this filter
+              \\"\\"\\"
+              all: ProductionActorConnectionWhere
+              \\"\\"\\"
+              Return Series where none of the related ProductionActorConnections match this filter
+              \\"\\"\\"
+              none: ProductionActorConnectionWhere
+              \\"\\"\\"
+              Return Series where one of the related ProductionActorConnections match this filter
+              \\"\\"\\"
+              single: ProductionActorConnectionWhere
+              \\"\\"\\"
+              Return Series where some of the related ProductionActorConnections match this filter
+              \\"\\"\\"
+              some: ProductionActorConnectionWhere
+            }
+
+            input SeriesActorCreateFieldInput {
+              node: ActorCreateInput!
+            }
+
+            input SeriesActorDeleteFieldInput {
+              delete: ActorDeleteInput
+              where: ProductionActorConnectionWhere
+            }
+
+            input SeriesActorDisconnectFieldInput {
+              disconnect: ActorDisconnectInput
+              where: ProductionActorConnectionWhere
+            }
+
+            input SeriesActorFieldInput {
+              connect: [SeriesActorConnectFieldInput!]
+              create: [SeriesActorCreateFieldInput!]
+            }
+
+            input SeriesActorNodeAggregationWhereInput {
+              AND: [SeriesActorNodeAggregationWhereInput!]
+              NOT: SeriesActorNodeAggregationWhereInput
+              OR: [SeriesActorNodeAggregationWhereInput!]
+              name: StringScalarAggregationFilters
+            }
+
+            input SeriesActorUpdateConnectionInput {
+              node: ActorUpdateInput
+              where: ProductionActorConnectionWhere
+            }
+
+            input SeriesActorUpdateFieldInput {
+              connect: [SeriesActorConnectFieldInput!]
+              create: [SeriesActorCreateFieldInput!]
+              delete: [SeriesActorDeleteFieldInput!]
+              disconnect: [SeriesActorDisconnectFieldInput!]
+              update: SeriesActorUpdateConnectionInput
+            }
+
+            type SeriesAggregate {
+              count: Count!
+              node: SeriesAggregateNode!
+            }
+
+            type SeriesAggregateNode {
+              title: StringAggregateSelection!
+            }
+
+            type SeriesConnection {
+              aggregate: SeriesAggregate!
+              edges: [SeriesEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            input SeriesCreateInput {
+              actor: SeriesActorFieldInput
+              title: String!
+            }
+
+            input SeriesDeleteInput {
+              actor: [SeriesActorDeleteFieldInput!]
+            }
+
+            type SeriesEdge {
+              cursor: String!
+              node: Series!
+            }
+
+            \\"\\"\\"
+            Fields to sort Series by. The order in which sorts are applied is not guaranteed when specifying many fields in one SeriesSort object.
+            \\"\\"\\"
+            input SeriesSort {
+              title: SortDirection
+            }
+
+            input SeriesUpdateInput {
+              actor: [SeriesActorUpdateFieldInput!]
+              title: StringScalarMutations
+            }
+
+            input SeriesWhere {
+              AND: [SeriesWhere!]
+              NOT: SeriesWhere
+              OR: [SeriesWhere!]
+              actor: ActorRelationshipFilters
+              actorConnection: SeriesActorConnectionFilters
+              title: StringScalarFilters
+            }
+
+            \\"\\"\\"An enum for sorting in either ascending or descending order.\\"\\"\\"
+            enum SortDirection {
+              \\"\\"\\"Sort by field values in ascending order.\\"\\"\\"
+              ASC
+              \\"\\"\\"Sort by field values in descending order.\\"\\"\\"
+              DESC
+            }
+
+            type StringAggregateSelection {
+              longest: String
+              shortest: String
+            }
+
+            \\"\\"\\"Filters for an aggregation of a string field\\"\\"\\"
+            input StringScalarAggregationFilters {
+              averageLength: FloatScalarFilters
+              longestLength: IntScalarFilters
+              shortestLength: IntScalarFilters
             }
 
             \\"\\"\\"String filters\\"\\"\\"

--- a/packages/graphql/tests/schema/relationship/single-element-relationship-to-interface.test.ts
+++ b/packages/graphql/tests/schema/relationship/single-element-relationship-to-interface.test.ts
@@ -23,7 +23,7 @@ import { lexicographicSortSchema } from "graphql/utilities";
 import { Neo4jGraphQL } from "../../../src";
 
 describe("single item relationships to an Interface type", () => {
-    test("1-* relationship", async () => {
+    test("1-1 relationship", async () => {
         const typeDefs = gql`
             interface Actor {
                 name: String!
@@ -327,10 +327,10 @@ describe("single item relationships to an Interface type", () => {
             }
 
             type Movie {
-              actor(where: ActorWhere): Actor
-              actorConnection(where: MovieActorConnectionWhere): MovieActorConnection!
-              director(where: DirectorWhere): Director!
-              directorConnection(where: MovieDirectorConnectionWhere): MovieDirectorConnection!
+              actor: Actor
+              actorConnection: MovieActorConnection!
+              director: Director!
+              directorConnection: MovieDirectorConnection!
               title: String!
             }
 
@@ -338,13 +338,6 @@ describe("single item relationships to an Interface type", () => {
               edges: [MovieActorRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
-            }
-
-            input MovieActorConnectionWhere {
-              AND: [MovieActorConnectionWhere!]
-              NOT: MovieActorConnectionWhere
-              OR: [MovieActorConnectionWhere!]
-              node: ActorWhere
             }
 
             type MovieActorRelationship {
@@ -369,13 +362,6 @@ describe("single item relationships to an Interface type", () => {
               edges: [MovieDirectorRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
-            }
-
-            input MovieDirectorConnectionWhere {
-              AND: [MovieDirectorConnectionWhere!]
-              NOT: MovieDirectorConnectionWhere
-              OR: [MovieDirectorConnectionWhere!]
-              node: DirectorWhere
             }
 
             type MovieDirectorRelationship {
@@ -515,6 +501,849 @@ describe("single item relationships to an Interface type", () => {
             type StringAggregateSelection {
               longest: String
               shortest: String
+            }
+
+            \\"\\"\\"String filters\\"\\"\\"
+            input StringScalarFilters {
+              contains: String
+              endsWith: String
+              eq: String
+              in: [String!]
+              startsWith: String
+            }
+
+            \\"\\"\\"String mutations\\"\\"\\"
+            input StringScalarMutations {
+              set: String
+            }
+
+            type UpdateAisMutationResponse {
+              ais: [AI!]!
+              info: UpdateInfo!
+            }
+
+            type UpdateDogsMutationResponse {
+              dogs: [Dog!]!
+              info: UpdateInfo!
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships created and deleted during an update mutation
+            \\"\\"\\"
+            type UpdateInfo {
+              nodesCreated: Int!
+              nodesDeleted: Int!
+              relationshipsCreated: Int!
+              relationshipsDeleted: Int!
+            }
+
+            type UpdateMoviesMutationResponse {
+              info: UpdateInfo!
+              movies: [Movie!]!
+            }
+
+            type UpdatePeopleMutationResponse {
+              info: UpdateInfo!
+              people: [Person!]!
+            }"
+        `);
+    });
+
+    test("1-* relationship", async () => {
+        const typeDefs = gql`
+            interface Actor {
+                name: String!
+            }
+            interface Director {
+                years: Int!
+            }
+
+            type Movie @node {
+                title: String!
+                actor: [Actor!]! @relationship(type: "ACTED_IN", direction: IN)
+                director: Director! @relationship(type: "DIRECTED", direction: IN)
+            }
+
+            type Dog implements Actor @node {
+                name: String!
+                actedIn: Movie! @relationship(type: "ACTED_IN", direction: OUT)
+            }
+
+            type Person implements Actor & Director @node {
+                name: String!
+                years: Int!
+                actedIn: Movie! @relationship(type: "ACTED_IN", direction: OUT)
+            }
+
+            type AI implements Director @node {
+                model: String!
+                years: Int!
+                directed: [Movie!]! @relationship(type: "DIRECTED", direction: OUT)
+            }
+        `;
+        const neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            features: {
+                excludeDeprecatedFields: {
+                    mutationOperations: true,
+                    aggregationFilters: true,
+                    aggregationFiltersOutsideConnection: true,
+                    relationshipFilters: true,
+                    attributeFilters: true,
+                },
+            },
+        });
+        const printedSchema = printSchemaWithDirectives(lexicographicSortSchema(await neoSchema.getSchema()));
+
+        expect(printedSchema).toMatchInlineSnapshot(`
+            "schema {
+              query: Query
+              mutation: Mutation
+            }
+
+            type AI implements Director {
+              directed(limit: Int, offset: Int, sort: [MovieSort!], where: MovieWhere): [Movie!]!
+              directedConnection(after: String, first: Int, sort: [AIDirectedConnectionSort!], where: AIDirectedConnectionWhere): AIDirectedConnection!
+              model: String!
+              years: Int!
+            }
+
+            type AIAggregate {
+              count: Count!
+              node: AIAggregateNode!
+            }
+
+            type AIAggregateNode {
+              model: StringAggregateSelection!
+              years: IntAggregateSelection!
+            }
+
+            input AICreateInput {
+              directed: AIDirectedFieldInput
+              model: String!
+              years: Int!
+            }
+
+            input AIDeleteInput {
+              directed: [AIDirectedDeleteFieldInput!]
+            }
+
+            input AIDirectedConnectFieldInput {
+              connect: [MovieConnectInput!]
+              where: MovieConnectWhere
+            }
+
+            type AIDirectedConnection {
+              aggregate: AIMovieDirectedAggregateSelection!
+              edges: [AIDirectedRelationship!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            input AIDirectedConnectionAggregateInput {
+              AND: [AIDirectedConnectionAggregateInput!]
+              NOT: AIDirectedConnectionAggregateInput
+              OR: [AIDirectedConnectionAggregateInput!]
+              count: ConnectionAggregationCountFilterInput
+              node: AIDirectedNodeAggregationWhereInput
+            }
+
+            input AIDirectedConnectionFilters {
+              \\"\\"\\"Filter AIS by aggregating results on related AIDirectedConnections\\"\\"\\"
+              aggregate: AIDirectedConnectionAggregateInput
+              \\"\\"\\"
+              Return AIS where all of the related AIDirectedConnections match this filter
+              \\"\\"\\"
+              all: AIDirectedConnectionWhere
+              \\"\\"\\"
+              Return AIS where none of the related AIDirectedConnections match this filter
+              \\"\\"\\"
+              none: AIDirectedConnectionWhere
+              \\"\\"\\"
+              Return AIS where one of the related AIDirectedConnections match this filter
+              \\"\\"\\"
+              single: AIDirectedConnectionWhere
+              \\"\\"\\"
+              Return AIS where some of the related AIDirectedConnections match this filter
+              \\"\\"\\"
+              some: AIDirectedConnectionWhere
+            }
+
+            input AIDirectedConnectionSort {
+              node: MovieSort
+            }
+
+            input AIDirectedConnectionWhere {
+              AND: [AIDirectedConnectionWhere!]
+              NOT: AIDirectedConnectionWhere
+              OR: [AIDirectedConnectionWhere!]
+              node: MovieWhere
+            }
+
+            input AIDirectedCreateFieldInput {
+              node: MovieCreateInput!
+            }
+
+            input AIDirectedDeleteFieldInput {
+              delete: MovieDeleteInput
+              where: AIDirectedConnectionWhere
+            }
+
+            input AIDirectedDisconnectFieldInput {
+              disconnect: MovieDisconnectInput
+              where: AIDirectedConnectionWhere
+            }
+
+            input AIDirectedFieldInput {
+              connect: [AIDirectedConnectFieldInput!]
+              create: [AIDirectedCreateFieldInput!]
+            }
+
+            input AIDirectedNodeAggregationWhereInput {
+              AND: [AIDirectedNodeAggregationWhereInput!]
+              NOT: AIDirectedNodeAggregationWhereInput
+              OR: [AIDirectedNodeAggregationWhereInput!]
+              title: StringScalarAggregationFilters
+            }
+
+            type AIDirectedRelationship {
+              cursor: String!
+              node: Movie!
+            }
+
+            input AIDirectedUpdateConnectionInput {
+              node: MovieUpdateInput
+              where: AIDirectedConnectionWhere
+            }
+
+            input AIDirectedUpdateFieldInput {
+              connect: [AIDirectedConnectFieldInput!]
+              create: [AIDirectedCreateFieldInput!]
+              delete: [AIDirectedDeleteFieldInput!]
+              disconnect: [AIDirectedDisconnectFieldInput!]
+              update: AIDirectedUpdateConnectionInput
+            }
+
+            type AIEdge {
+              cursor: String!
+              node: AI!
+            }
+
+            type AIMovieDirectedAggregateSelection {
+              count: CountConnection!
+              node: AIMovieDirectedNodeAggregateSelection
+            }
+
+            type AIMovieDirectedNodeAggregateSelection {
+              title: StringAggregateSelection!
+            }
+
+            \\"\\"\\"
+            Fields to sort Ais by. The order in which sorts are applied is not guaranteed when specifying many fields in one AISort object.
+            \\"\\"\\"
+            input AISort {
+              model: SortDirection
+              years: SortDirection
+            }
+
+            input AIUpdateInput {
+              directed: [AIDirectedUpdateFieldInput!]
+              model: StringScalarMutations
+              years: IntScalarMutations
+            }
+
+            input AIWhere {
+              AND: [AIWhere!]
+              NOT: AIWhere
+              OR: [AIWhere!]
+              directed: MovieRelationshipFilters
+              directedConnection: AIDirectedConnectionFilters
+              model: StringScalarFilters
+              years: IntScalarFilters
+            }
+
+            interface Actor {
+              name: String!
+            }
+
+            type ActorAggregate {
+              count: Count!
+              node: ActorAggregateNode!
+            }
+
+            type ActorAggregateNode {
+              name: StringAggregateSelection!
+            }
+
+            input ActorConnectWhere {
+              node: ActorWhere!
+            }
+
+            input ActorCreateInput {
+              Dog: DogCreateInput
+              Person: PersonCreateInput
+            }
+
+            type ActorEdge {
+              cursor: String!
+              node: Actor!
+            }
+
+            enum ActorImplementation {
+              Dog
+              Person
+            }
+
+            input ActorRelationshipFilters {
+              \\"\\"\\"Filter type where all of the related Actors match this filter\\"\\"\\"
+              all: ActorWhere
+              \\"\\"\\"Filter type where none of the related Actors match this filter\\"\\"\\"
+              none: ActorWhere
+              \\"\\"\\"Filter type where one of the related Actors match this filter\\"\\"\\"
+              single: ActorWhere
+              \\"\\"\\"Filter type where some of the related Actors match this filter\\"\\"\\"
+              some: ActorWhere
+            }
+
+            \\"\\"\\"
+            Fields to sort Actors by. The order in which sorts are applied is not guaranteed when specifying many fields in one ActorSort object.
+            \\"\\"\\"
+            input ActorSort {
+              name: SortDirection
+            }
+
+            input ActorUpdateInput {
+              name: StringScalarMutations
+            }
+
+            input ActorWhere {
+              AND: [ActorWhere!]
+              NOT: ActorWhere
+              OR: [ActorWhere!]
+              name: StringScalarFilters
+              typename: [ActorImplementation!]
+            }
+
+            type ActorsConnection {
+              aggregate: ActorAggregate!
+              edges: [ActorEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type AisConnection {
+              aggregate: AIAggregate!
+              edges: [AIEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            input ConnectionAggregationCountFilterInput {
+              edges: IntScalarFilters
+              nodes: IntScalarFilters
+            }
+
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
+            type CreateAisMutationResponse {
+              ais: [AI!]!
+              info: CreateInfo!
+            }
+
+            type CreateDogsMutationResponse {
+              dogs: [Dog!]!
+              info: CreateInfo!
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships created during a create mutation
+            \\"\\"\\"
+            type CreateInfo {
+              nodesCreated: Int!
+              relationshipsCreated: Int!
+            }
+
+            type CreateMoviesMutationResponse {
+              info: CreateInfo!
+              movies: [Movie!]!
+            }
+
+            type CreatePeopleMutationResponse {
+              info: CreateInfo!
+              people: [Person!]!
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships deleted during a delete mutation
+            \\"\\"\\"
+            type DeleteInfo {
+              nodesDeleted: Int!
+              relationshipsDeleted: Int!
+            }
+
+            interface Director {
+              years: Int!
+            }
+
+            type DirectorAggregate {
+              count: Count!
+              node: DirectorAggregateNode!
+            }
+
+            type DirectorAggregateNode {
+              years: IntAggregateSelection!
+            }
+
+            type DirectorEdge {
+              cursor: String!
+              node: Director!
+            }
+
+            enum DirectorImplementation {
+              AI
+              Person
+            }
+
+            \\"\\"\\"
+            Fields to sort Directors by. The order in which sorts are applied is not guaranteed when specifying many fields in one DirectorSort object.
+            \\"\\"\\"
+            input DirectorSort {
+              years: SortDirection
+            }
+
+            input DirectorWhere {
+              AND: [DirectorWhere!]
+              NOT: DirectorWhere
+              OR: [DirectorWhere!]
+              typename: [DirectorImplementation!]
+              years: IntScalarFilters
+            }
+
+            type DirectorsConnection {
+              aggregate: DirectorAggregate!
+              edges: [DirectorEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type Dog implements Actor {
+              actedIn: Movie!
+              actedInConnection: DogActedInConnection!
+              name: String!
+            }
+
+            type DogActedInConnection {
+              edges: [DogActedInRelationship!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type DogActedInRelationship {
+              cursor: String!
+              node: Movie!
+            }
+
+            type DogAggregate {
+              count: Count!
+              node: DogAggregateNode!
+            }
+
+            type DogAggregateNode {
+              name: StringAggregateSelection!
+            }
+
+            input DogCreateInput {
+              name: String!
+            }
+
+            type DogEdge {
+              cursor: String!
+              node: Dog!
+            }
+
+            \\"\\"\\"
+            Fields to sort Dogs by. The order in which sorts are applied is not guaranteed when specifying many fields in one DogSort object.
+            \\"\\"\\"
+            input DogSort {
+              name: SortDirection
+            }
+
+            input DogUpdateInput {
+              name: StringScalarMutations
+            }
+
+            input DogWhere {
+              AND: [DogWhere!]
+              NOT: DogWhere
+              OR: [DogWhere!]
+              name: StringScalarFilters
+            }
+
+            type DogsConnection {
+              aggregate: DogAggregate!
+              edges: [DogEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            \\"\\"\\"Float filters\\"\\"\\"
+            input FloatScalarFilters {
+              eq: Float
+              gt: Float
+              gte: Float
+              in: [Float!]
+              lt: Float
+              lte: Float
+            }
+
+            type IntAggregateSelection {
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
+            }
+
+            \\"\\"\\"Int filters\\"\\"\\"
+            input IntScalarFilters {
+              eq: Int
+              gt: Int
+              gte: Int
+              in: [Int!]
+              lt: Int
+              lte: Int
+            }
+
+            \\"\\"\\"Int mutations\\"\\"\\"
+            input IntScalarMutations {
+              add: Int
+              set: Int
+              subtract: Int
+            }
+
+            type Movie {
+              actor(limit: Int, offset: Int, sort: [ActorSort!], where: ActorWhere): [Actor!]!
+              actorConnection(after: String, first: Int, sort: [MovieActorConnectionSort!], where: MovieActorConnectionWhere): MovieActorConnection!
+              director: Director!
+              directorConnection: MovieDirectorConnection!
+              title: String!
+            }
+
+            type MovieActorActorAggregateSelection {
+              count: CountConnection!
+              node: MovieActorActorNodeAggregateSelection
+            }
+
+            type MovieActorActorNodeAggregateSelection {
+              name: StringAggregateSelection!
+            }
+
+            input MovieActorConnectFieldInput {
+              where: ActorConnectWhere
+            }
+
+            type MovieActorConnection {
+              aggregate: MovieActorActorAggregateSelection!
+              edges: [MovieActorRelationship!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            input MovieActorConnectionAggregateInput {
+              AND: [MovieActorConnectionAggregateInput!]
+              NOT: MovieActorConnectionAggregateInput
+              OR: [MovieActorConnectionAggregateInput!]
+              count: ConnectionAggregationCountFilterInput
+              node: MovieActorNodeAggregationWhereInput
+            }
+
+            input MovieActorConnectionFilters {
+              \\"\\"\\"Filter Movies by aggregating results on related MovieActorConnections\\"\\"\\"
+              aggregate: MovieActorConnectionAggregateInput
+              \\"\\"\\"
+              Return Movies where all of the related MovieActorConnections match this filter
+              \\"\\"\\"
+              all: MovieActorConnectionWhere
+              \\"\\"\\"
+              Return Movies where none of the related MovieActorConnections match this filter
+              \\"\\"\\"
+              none: MovieActorConnectionWhere
+              \\"\\"\\"
+              Return Movies where one of the related MovieActorConnections match this filter
+              \\"\\"\\"
+              single: MovieActorConnectionWhere
+              \\"\\"\\"
+              Return Movies where some of the related MovieActorConnections match this filter
+              \\"\\"\\"
+              some: MovieActorConnectionWhere
+            }
+
+            input MovieActorConnectionSort {
+              node: ActorSort
+            }
+
+            input MovieActorConnectionWhere {
+              AND: [MovieActorConnectionWhere!]
+              NOT: MovieActorConnectionWhere
+              OR: [MovieActorConnectionWhere!]
+              node: ActorWhere
+            }
+
+            input MovieActorCreateFieldInput {
+              node: ActorCreateInput!
+            }
+
+            input MovieActorDeleteFieldInput {
+              where: MovieActorConnectionWhere
+            }
+
+            input MovieActorDisconnectFieldInput {
+              where: MovieActorConnectionWhere
+            }
+
+            input MovieActorFieldInput {
+              connect: [MovieActorConnectFieldInput!]
+              create: [MovieActorCreateFieldInput!]
+            }
+
+            input MovieActorNodeAggregationWhereInput {
+              AND: [MovieActorNodeAggregationWhereInput!]
+              NOT: MovieActorNodeAggregationWhereInput
+              OR: [MovieActorNodeAggregationWhereInput!]
+              name: StringScalarAggregationFilters
+            }
+
+            type MovieActorRelationship {
+              cursor: String!
+              node: Actor!
+            }
+
+            input MovieActorUpdateConnectionInput {
+              node: ActorUpdateInput
+              where: MovieActorConnectionWhere
+            }
+
+            input MovieActorUpdateFieldInput {
+              connect: [MovieActorConnectFieldInput!]
+              create: [MovieActorCreateFieldInput!]
+              delete: [MovieActorDeleteFieldInput!]
+              disconnect: [MovieActorDisconnectFieldInput!]
+              update: MovieActorUpdateConnectionInput
+            }
+
+            type MovieAggregate {
+              count: Count!
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              title: StringAggregateSelection!
+            }
+
+            input MovieConnectInput {
+              actor: [MovieActorConnectFieldInput!]
+            }
+
+            input MovieConnectWhere {
+              node: MovieWhere!
+            }
+
+            input MovieCreateInput {
+              actor: MovieActorFieldInput
+              title: String!
+            }
+
+            input MovieDeleteInput {
+              actor: [MovieActorDeleteFieldInput!]
+            }
+
+            type MovieDirectorConnection {
+              edges: [MovieDirectorRelationship!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type MovieDirectorRelationship {
+              cursor: String!
+              node: Director!
+            }
+
+            input MovieDisconnectInput {
+              actor: [MovieActorDisconnectFieldInput!]
+            }
+
+            type MovieEdge {
+              cursor: String!
+              node: Movie!
+            }
+
+            input MovieRelationshipFilters {
+              \\"\\"\\"Filter type where all of the related Movies match this filter\\"\\"\\"
+              all: MovieWhere
+              \\"\\"\\"Filter type where none of the related Movies match this filter\\"\\"\\"
+              none: MovieWhere
+              \\"\\"\\"Filter type where one of the related Movies match this filter\\"\\"\\"
+              single: MovieWhere
+              \\"\\"\\"Filter type where some of the related Movies match this filter\\"\\"\\"
+              some: MovieWhere
+            }
+
+            \\"\\"\\"
+            Fields to sort Movies by. The order in which sorts are applied is not guaranteed when specifying many fields in one MovieSort object.
+            \\"\\"\\"
+            input MovieSort {
+              title: SortDirection
+            }
+
+            input MovieUpdateInput {
+              actor: [MovieActorUpdateFieldInput!]
+              title: StringScalarMutations
+            }
+
+            input MovieWhere {
+              AND: [MovieWhere!]
+              NOT: MovieWhere
+              OR: [MovieWhere!]
+              actor: ActorRelationshipFilters
+              actorConnection: MovieActorConnectionFilters
+              title: StringScalarFilters
+            }
+
+            type MoviesConnection {
+              aggregate: MovieAggregate!
+              edges: [MovieEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type Mutation {
+              createAis(input: [AICreateInput!]!): CreateAisMutationResponse!
+              createDogs(input: [DogCreateInput!]!): CreateDogsMutationResponse!
+              createMovies(input: [MovieCreateInput!]!): CreateMoviesMutationResponse!
+              createPeople(input: [PersonCreateInput!]!): CreatePeopleMutationResponse!
+              deleteAis(delete: AIDeleteInput, where: AIWhere): DeleteInfo!
+              deleteDogs(where: DogWhere): DeleteInfo!
+              deleteMovies(delete: MovieDeleteInput, where: MovieWhere): DeleteInfo!
+              deletePeople(where: PersonWhere): DeleteInfo!
+              updateAis(update: AIUpdateInput, where: AIWhere): UpdateAisMutationResponse!
+              updateDogs(update: DogUpdateInput, where: DogWhere): UpdateDogsMutationResponse!
+              updateMovies(update: MovieUpdateInput, where: MovieWhere): UpdateMoviesMutationResponse!
+              updatePeople(update: PersonUpdateInput, where: PersonWhere): UpdatePeopleMutationResponse!
+            }
+
+            \\"\\"\\"Pagination information (Relay)\\"\\"\\"
+            type PageInfo {
+              endCursor: String
+              hasNextPage: Boolean!
+              hasPreviousPage: Boolean!
+              startCursor: String
+            }
+
+            type PeopleConnection {
+              aggregate: PersonAggregate!
+              edges: [PersonEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type Person implements Actor & Director {
+              actedIn: Movie!
+              actedInConnection: PersonActedInConnection!
+              name: String!
+              years: Int!
+            }
+
+            type PersonActedInConnection {
+              edges: [PersonActedInRelationship!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type PersonActedInRelationship {
+              cursor: String!
+              node: Movie!
+            }
+
+            type PersonAggregate {
+              count: Count!
+              node: PersonAggregateNode!
+            }
+
+            type PersonAggregateNode {
+              name: StringAggregateSelection!
+              years: IntAggregateSelection!
+            }
+
+            input PersonCreateInput {
+              name: String!
+              years: Int!
+            }
+
+            type PersonEdge {
+              cursor: String!
+              node: Person!
+            }
+
+            \\"\\"\\"
+            Fields to sort People by. The order in which sorts are applied is not guaranteed when specifying many fields in one PersonSort object.
+            \\"\\"\\"
+            input PersonSort {
+              name: SortDirection
+              years: SortDirection
+            }
+
+            input PersonUpdateInput {
+              name: StringScalarMutations
+              years: IntScalarMutations
+            }
+
+            input PersonWhere {
+              AND: [PersonWhere!]
+              NOT: PersonWhere
+              OR: [PersonWhere!]
+              name: StringScalarFilters
+              years: IntScalarFilters
+            }
+
+            type Query {
+              actors(limit: Int, offset: Int, sort: [ActorSort!], where: ActorWhere): [Actor!]!
+              actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
+              ais(limit: Int, offset: Int, sort: [AISort!], where: AIWhere): [AI!]!
+              aisConnection(after: String, first: Int, sort: [AISort!], where: AIWhere): AisConnection!
+              directors(limit: Int, offset: Int, sort: [DirectorSort!], where: DirectorWhere): [Director!]!
+              directorsConnection(after: String, first: Int, sort: [DirectorSort!], where: DirectorWhere): DirectorsConnection!
+              dogs(limit: Int, offset: Int, sort: [DogSort!], where: DogWhere): [Dog!]!
+              dogsConnection(after: String, first: Int, sort: [DogSort!], where: DogWhere): DogsConnection!
+              movies(limit: Int, offset: Int, sort: [MovieSort!], where: MovieWhere): [Movie!]!
+              moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
+              people(limit: Int, offset: Int, sort: [PersonSort!], where: PersonWhere): [Person!]!
+              peopleConnection(after: String, first: Int, sort: [PersonSort!], where: PersonWhere): PeopleConnection!
+            }
+
+            \\"\\"\\"An enum for sorting in either ascending or descending order.\\"\\"\\"
+            enum SortDirection {
+              \\"\\"\\"Sort by field values in ascending order.\\"\\"\\"
+              ASC
+              \\"\\"\\"Sort by field values in descending order.\\"\\"\\"
+              DESC
+            }
+
+            type StringAggregateSelection {
+              longest: String
+              shortest: String
+            }
+
+            \\"\\"\\"Filters for an aggregation of a string field\\"\\"\\"
+            input StringScalarAggregationFilters {
+              averageLength: FloatScalarFilters
+              longestLength: IntScalarFilters
+              shortestLength: IntScalarFilters
             }
 
             \\"\\"\\"String filters\\"\\"\\"

--- a/packages/graphql/tests/schema/relationship/single-element-relationship-to-union.test.ts
+++ b/packages/graphql/tests/schema/relationship/single-element-relationship-to-union.test.ts
@@ -23,7 +23,7 @@ import { lexicographicSortSchema } from "graphql/utilities";
 import { Neo4jGraphQL } from "../../../src";
 
 describe("single item relationships to an Union type", () => {
-    test("1-* relationship", async () => {
+    test("1-1 relationship", async () => {
         const typeDefs = gql`
             union Actor = Dog | Person
             union Director = Person | AI
@@ -215,10 +215,10 @@ describe("single item relationships to an Union type", () => {
             }
 
             type Movie {
-              actor(where: ActorWhere): Actor
-              actorConnection(where: MovieActorConnectionWhere): MovieActorConnection!
-              director(where: DirectorWhere): Director!
-              directorConnection(where: MovieDirectorConnectionWhere): MovieDirectorConnection!
+              actor: Actor
+              actorConnection: MovieActorConnection!
+              director: Director!
+              directorConnection: MovieDirectorConnection!
               title: String!
             }
 
@@ -226,25 +226,6 @@ describe("single item relationships to an Union type", () => {
               edges: [MovieActorRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
-            }
-
-            input MovieActorConnectionWhere {
-              Dog: MovieActorDogConnectionWhere
-              Person: MovieActorPersonConnectionWhere
-            }
-
-            input MovieActorDogConnectionWhere {
-              AND: [MovieActorDogConnectionWhere!]
-              NOT: MovieActorDogConnectionWhere
-              OR: [MovieActorDogConnectionWhere!]
-              node: DogWhere
-            }
-
-            input MovieActorPersonConnectionWhere {
-              AND: [MovieActorPersonConnectionWhere!]
-              NOT: MovieActorPersonConnectionWhere
-              OR: [MovieActorPersonConnectionWhere!]
-              node: PersonWhere
             }
 
             type MovieActorRelationship {
@@ -265,29 +246,10 @@ describe("single item relationships to an Union type", () => {
               title: String!
             }
 
-            input MovieDirectorAIConnectionWhere {
-              AND: [MovieDirectorAIConnectionWhere!]
-              NOT: MovieDirectorAIConnectionWhere
-              OR: [MovieDirectorAIConnectionWhere!]
-              node: AIWhere
-            }
-
             type MovieDirectorConnection {
               edges: [MovieDirectorRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
-            }
-
-            input MovieDirectorConnectionWhere {
-              AI: MovieDirectorAIConnectionWhere
-              Person: MovieDirectorPersonConnectionWhere
-            }
-
-            input MovieDirectorPersonConnectionWhere {
-              AND: [MovieDirectorPersonConnectionWhere!]
-              NOT: MovieDirectorPersonConnectionWhere
-              OR: [MovieDirectorPersonConnectionWhere!]
-              node: PersonWhere
             }
 
             type MovieDirectorRelationship {
@@ -419,6 +381,902 @@ describe("single item relationships to an Union type", () => {
             type StringAggregateSelection {
               longest: String
               shortest: String
+            }
+
+            \\"\\"\\"String filters\\"\\"\\"
+            input StringScalarFilters {
+              contains: String
+              endsWith: String
+              eq: String
+              in: [String!]
+              startsWith: String
+            }
+
+            \\"\\"\\"String mutations\\"\\"\\"
+            input StringScalarMutations {
+              set: String
+            }
+
+            type UpdateAisMutationResponse {
+              ais: [AI!]!
+              info: UpdateInfo!
+            }
+
+            type UpdateDogsMutationResponse {
+              dogs: [Dog!]!
+              info: UpdateInfo!
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships created and deleted during an update mutation
+            \\"\\"\\"
+            type UpdateInfo {
+              nodesCreated: Int!
+              nodesDeleted: Int!
+              relationshipsCreated: Int!
+              relationshipsDeleted: Int!
+            }
+
+            type UpdateMoviesMutationResponse {
+              info: UpdateInfo!
+              movies: [Movie!]!
+            }
+
+            type UpdatePeopleMutationResponse {
+              info: UpdateInfo!
+              people: [Person!]!
+            }"
+        `);
+    });
+    test("1-* relationship", async () => {
+        const typeDefs = gql`
+            union Actor = Dog | Person
+            union Director = Person | AI
+
+            type Movie @node {
+                title: String!
+                actor: [Actor!]! @relationship(type: "ACTED_IN", direction: IN)
+                director: Director! @relationship(type: "DIRECTED", direction: IN)
+            }
+
+            type Person @node {
+                name: String!
+                actedIn: Movie! @relationship(type: "ACTED_IN", direction: OUT)
+                directed: [Movie!]! @relationship(type: "DIRECTED", direction: OUT)
+            }
+
+            type Dog @node {
+                nickName: String!
+                actedIn: Movie! @relationship(type: "ACTED_IN", direction: OUT)
+            }
+
+            type AI @node {
+                model: String!
+                directed: [Movie!]! @relationship(type: "DIRECTED", direction: OUT)
+            }
+        `;
+        const neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            features: {
+                excludeDeprecatedFields: {
+                    mutationOperations: true,
+                    aggregationFilters: true,
+                    aggregationFiltersOutsideConnection: true,
+                    relationshipFilters: true,
+                    attributeFilters: true,
+                },
+            },
+        });
+        const printedSchema = printSchemaWithDirectives(lexicographicSortSchema(await neoSchema.getSchema()));
+
+        expect(printedSchema).toMatchInlineSnapshot(`
+            "schema {
+              query: Query
+              mutation: Mutation
+            }
+
+            type AI {
+              directed(limit: Int, offset: Int, sort: [MovieSort!], where: MovieWhere): [Movie!]!
+              directedConnection(after: String, first: Int, sort: [AIDirectedConnectionSort!], where: AIDirectedConnectionWhere): AIDirectedConnection!
+              model: String!
+            }
+
+            type AIAggregate {
+              count: Count!
+              node: AIAggregateNode!
+            }
+
+            type AIAggregateNode {
+              model: StringAggregateSelection!
+            }
+
+            input AICreateInput {
+              directed: AIDirectedFieldInput
+              model: String!
+            }
+
+            input AIDeleteInput {
+              directed: [AIDirectedDeleteFieldInput!]
+            }
+
+            input AIDirectedConnectFieldInput {
+              connect: [MovieConnectInput!]
+              where: MovieConnectWhere
+            }
+
+            type AIDirectedConnection {
+              aggregate: AIMovieDirectedAggregateSelection!
+              edges: [AIDirectedRelationship!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            input AIDirectedConnectionAggregateInput {
+              AND: [AIDirectedConnectionAggregateInput!]
+              NOT: AIDirectedConnectionAggregateInput
+              OR: [AIDirectedConnectionAggregateInput!]
+              count: ConnectionAggregationCountFilterInput
+              node: AIDirectedNodeAggregationWhereInput
+            }
+
+            input AIDirectedConnectionFilters {
+              \\"\\"\\"Filter AIS by aggregating results on related AIDirectedConnections\\"\\"\\"
+              aggregate: AIDirectedConnectionAggregateInput
+              \\"\\"\\"
+              Return AIS where all of the related AIDirectedConnections match this filter
+              \\"\\"\\"
+              all: AIDirectedConnectionWhere
+              \\"\\"\\"
+              Return AIS where none of the related AIDirectedConnections match this filter
+              \\"\\"\\"
+              none: AIDirectedConnectionWhere
+              \\"\\"\\"
+              Return AIS where one of the related AIDirectedConnections match this filter
+              \\"\\"\\"
+              single: AIDirectedConnectionWhere
+              \\"\\"\\"
+              Return AIS where some of the related AIDirectedConnections match this filter
+              \\"\\"\\"
+              some: AIDirectedConnectionWhere
+            }
+
+            input AIDirectedConnectionSort {
+              node: MovieSort
+            }
+
+            input AIDirectedConnectionWhere {
+              AND: [AIDirectedConnectionWhere!]
+              NOT: AIDirectedConnectionWhere
+              OR: [AIDirectedConnectionWhere!]
+              node: MovieWhere
+            }
+
+            input AIDirectedCreateFieldInput {
+              node: MovieCreateInput!
+            }
+
+            input AIDirectedDeleteFieldInput {
+              delete: MovieDeleteInput
+              where: AIDirectedConnectionWhere
+            }
+
+            input AIDirectedDisconnectFieldInput {
+              disconnect: MovieDisconnectInput
+              where: AIDirectedConnectionWhere
+            }
+
+            input AIDirectedFieldInput {
+              connect: [AIDirectedConnectFieldInput!]
+              create: [AIDirectedCreateFieldInput!]
+            }
+
+            input AIDirectedNodeAggregationWhereInput {
+              AND: [AIDirectedNodeAggregationWhereInput!]
+              NOT: AIDirectedNodeAggregationWhereInput
+              OR: [AIDirectedNodeAggregationWhereInput!]
+              title: StringScalarAggregationFilters
+            }
+
+            type AIDirectedRelationship {
+              cursor: String!
+              node: Movie!
+            }
+
+            input AIDirectedUpdateConnectionInput {
+              node: MovieUpdateInput
+              where: AIDirectedConnectionWhere
+            }
+
+            input AIDirectedUpdateFieldInput {
+              connect: [AIDirectedConnectFieldInput!]
+              create: [AIDirectedCreateFieldInput!]
+              delete: [AIDirectedDeleteFieldInput!]
+              disconnect: [AIDirectedDisconnectFieldInput!]
+              update: AIDirectedUpdateConnectionInput
+            }
+
+            type AIEdge {
+              cursor: String!
+              node: AI!
+            }
+
+            type AIMovieDirectedAggregateSelection {
+              count: CountConnection!
+              node: AIMovieDirectedNodeAggregateSelection
+            }
+
+            type AIMovieDirectedNodeAggregateSelection {
+              title: StringAggregateSelection!
+            }
+
+            \\"\\"\\"
+            Fields to sort Ais by. The order in which sorts are applied is not guaranteed when specifying many fields in one AISort object.
+            \\"\\"\\"
+            input AISort {
+              model: SortDirection
+            }
+
+            input AIUpdateInput {
+              directed: [AIDirectedUpdateFieldInput!]
+              model: StringScalarMutations
+            }
+
+            input AIWhere {
+              AND: [AIWhere!]
+              NOT: AIWhere
+              OR: [AIWhere!]
+              directed: MovieRelationshipFilters
+              directedConnection: AIDirectedConnectionFilters
+              model: StringScalarFilters
+            }
+
+            union Actor = Dog | Person
+
+            input ActorRelationshipFilters {
+              \\"\\"\\"Filter type where all of the related Actors match this filter\\"\\"\\"
+              all: ActorWhere
+              \\"\\"\\"Filter type where none of the related Actors match this filter\\"\\"\\"
+              none: ActorWhere
+              \\"\\"\\"Filter type where one of the related Actors match this filter\\"\\"\\"
+              single: ActorWhere
+              \\"\\"\\"Filter type where some of the related Actors match this filter\\"\\"\\"
+              some: ActorWhere
+            }
+
+            input ActorWhere {
+              Dog: DogWhere
+              Person: PersonWhere
+            }
+
+            type AisConnection {
+              aggregate: AIAggregate!
+              edges: [AIEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            input ConnectionAggregationCountFilterInput {
+              edges: IntScalarFilters
+              nodes: IntScalarFilters
+            }
+
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
+            type CreateAisMutationResponse {
+              ais: [AI!]!
+              info: CreateInfo!
+            }
+
+            type CreateDogsMutationResponse {
+              dogs: [Dog!]!
+              info: CreateInfo!
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships created during a create mutation
+            \\"\\"\\"
+            type CreateInfo {
+              nodesCreated: Int!
+              relationshipsCreated: Int!
+            }
+
+            type CreateMoviesMutationResponse {
+              info: CreateInfo!
+              movies: [Movie!]!
+            }
+
+            type CreatePeopleMutationResponse {
+              info: CreateInfo!
+              people: [Person!]!
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships deleted during a delete mutation
+            \\"\\"\\"
+            type DeleteInfo {
+              nodesDeleted: Int!
+              relationshipsDeleted: Int!
+            }
+
+            union Director = AI | Person
+
+            input DirectorWhere {
+              AI: AIWhere
+              Person: PersonWhere
+            }
+
+            type Dog {
+              actedIn: Movie!
+              actedInConnection: DogActedInConnection!
+              nickName: String!
+            }
+
+            type DogActedInConnection {
+              edges: [DogActedInRelationship!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type DogActedInRelationship {
+              cursor: String!
+              node: Movie!
+            }
+
+            type DogAggregate {
+              count: Count!
+              node: DogAggregateNode!
+            }
+
+            type DogAggregateNode {
+              nickName: StringAggregateSelection!
+            }
+
+            input DogConnectWhere {
+              node: DogWhere!
+            }
+
+            input DogCreateInput {
+              nickName: String!
+            }
+
+            type DogEdge {
+              cursor: String!
+              node: Dog!
+            }
+
+            \\"\\"\\"
+            Fields to sort Dogs by. The order in which sorts are applied is not guaranteed when specifying many fields in one DogSort object.
+            \\"\\"\\"
+            input DogSort {
+              nickName: SortDirection
+            }
+
+            input DogUpdateInput {
+              nickName: StringScalarMutations
+            }
+
+            input DogWhere {
+              AND: [DogWhere!]
+              NOT: DogWhere
+              OR: [DogWhere!]
+              nickName: StringScalarFilters
+            }
+
+            type DogsConnection {
+              aggregate: DogAggregate!
+              edges: [DogEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            \\"\\"\\"Float filters\\"\\"\\"
+            input FloatScalarFilters {
+              eq: Float
+              gt: Float
+              gte: Float
+              in: [Float!]
+              lt: Float
+              lte: Float
+            }
+
+            \\"\\"\\"Int filters\\"\\"\\"
+            input IntScalarFilters {
+              eq: Int
+              gt: Int
+              gte: Int
+              in: [Int!]
+              lt: Int
+              lte: Int
+            }
+
+            type Movie {
+              actor(limit: Int, offset: Int, where: ActorWhere): [Actor!]!
+              actorConnection(after: String, first: Int, where: MovieActorConnectionWhere): MovieActorConnection!
+              director: Director!
+              directorConnection: MovieDirectorConnection!
+              title: String!
+            }
+
+            input MovieActorConnectInput {
+              Dog: [MovieActorDogConnectFieldInput!]
+              Person: [MovieActorPersonConnectFieldInput!]
+            }
+
+            type MovieActorConnection {
+              edges: [MovieActorRelationship!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            input MovieActorConnectionFilters {
+              \\"\\"\\"
+              Return Movies where all of the related MovieActorConnections match this filter
+              \\"\\"\\"
+              all: MovieActorConnectionWhere
+              \\"\\"\\"
+              Return Movies where none of the related MovieActorConnections match this filter
+              \\"\\"\\"
+              none: MovieActorConnectionWhere
+              \\"\\"\\"
+              Return Movies where one of the related MovieActorConnections match this filter
+              \\"\\"\\"
+              single: MovieActorConnectionWhere
+              \\"\\"\\"
+              Return Movies where some of the related MovieActorConnections match this filter
+              \\"\\"\\"
+              some: MovieActorConnectionWhere
+            }
+
+            input MovieActorConnectionWhere {
+              Dog: MovieActorDogConnectionWhere
+              Person: MovieActorPersonConnectionWhere
+            }
+
+            input MovieActorCreateInput {
+              Dog: MovieActorDogFieldInput
+              Person: MovieActorPersonFieldInput
+            }
+
+            input MovieActorDeleteInput {
+              Dog: [MovieActorDogDeleteFieldInput!]
+              Person: [MovieActorPersonDeleteFieldInput!]
+            }
+
+            input MovieActorDisconnectInput {
+              Dog: [MovieActorDogDisconnectFieldInput!]
+              Person: [MovieActorPersonDisconnectFieldInput!]
+            }
+
+            input MovieActorDogConnectFieldInput {
+              where: DogConnectWhere
+            }
+
+            input MovieActorDogConnectionWhere {
+              AND: [MovieActorDogConnectionWhere!]
+              NOT: MovieActorDogConnectionWhere
+              OR: [MovieActorDogConnectionWhere!]
+              node: DogWhere
+            }
+
+            input MovieActorDogCreateFieldInput {
+              node: DogCreateInput!
+            }
+
+            input MovieActorDogDeleteFieldInput {
+              where: MovieActorDogConnectionWhere
+            }
+
+            input MovieActorDogDisconnectFieldInput {
+              where: MovieActorDogConnectionWhere
+            }
+
+            input MovieActorDogFieldInput {
+              connect: [MovieActorDogConnectFieldInput!]
+              create: [MovieActorDogCreateFieldInput!]
+            }
+
+            input MovieActorDogUpdateConnectionInput {
+              node: DogUpdateInput
+              where: MovieActorDogConnectionWhere
+            }
+
+            input MovieActorDogUpdateFieldInput {
+              connect: [MovieActorDogConnectFieldInput!]
+              create: [MovieActorDogCreateFieldInput!]
+              delete: [MovieActorDogDeleteFieldInput!]
+              disconnect: [MovieActorDogDisconnectFieldInput!]
+              update: MovieActorDogUpdateConnectionInput
+            }
+
+            input MovieActorPersonConnectFieldInput {
+              connect: [PersonConnectInput!]
+              where: PersonConnectWhere
+            }
+
+            input MovieActorPersonConnectionWhere {
+              AND: [MovieActorPersonConnectionWhere!]
+              NOT: MovieActorPersonConnectionWhere
+              OR: [MovieActorPersonConnectionWhere!]
+              node: PersonWhere
+            }
+
+            input MovieActorPersonCreateFieldInput {
+              node: PersonCreateInput!
+            }
+
+            input MovieActorPersonDeleteFieldInput {
+              delete: PersonDeleteInput
+              where: MovieActorPersonConnectionWhere
+            }
+
+            input MovieActorPersonDisconnectFieldInput {
+              disconnect: PersonDisconnectInput
+              where: MovieActorPersonConnectionWhere
+            }
+
+            input MovieActorPersonFieldInput {
+              connect: [MovieActorPersonConnectFieldInput!]
+              create: [MovieActorPersonCreateFieldInput!]
+            }
+
+            input MovieActorPersonUpdateConnectionInput {
+              node: PersonUpdateInput
+              where: MovieActorPersonConnectionWhere
+            }
+
+            input MovieActorPersonUpdateFieldInput {
+              connect: [MovieActorPersonConnectFieldInput!]
+              create: [MovieActorPersonCreateFieldInput!]
+              delete: [MovieActorPersonDeleteFieldInput!]
+              disconnect: [MovieActorPersonDisconnectFieldInput!]
+              update: MovieActorPersonUpdateConnectionInput
+            }
+
+            type MovieActorRelationship {
+              cursor: String!
+              node: Actor!
+            }
+
+            input MovieActorUpdateInput {
+              Dog: [MovieActorDogUpdateFieldInput!]
+              Person: [MovieActorPersonUpdateFieldInput!]
+            }
+
+            type MovieAggregate {
+              count: Count!
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              title: StringAggregateSelection!
+            }
+
+            input MovieConnectInput {
+              actor: MovieActorConnectInput
+            }
+
+            input MovieConnectWhere {
+              node: MovieWhere!
+            }
+
+            input MovieCreateInput {
+              actor: MovieActorCreateInput
+              title: String!
+            }
+
+            input MovieDeleteInput {
+              actor: MovieActorDeleteInput
+            }
+
+            type MovieDirectorConnection {
+              edges: [MovieDirectorRelationship!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type MovieDirectorRelationship {
+              cursor: String!
+              node: Director!
+            }
+
+            input MovieDisconnectInput {
+              actor: MovieActorDisconnectInput
+            }
+
+            type MovieEdge {
+              cursor: String!
+              node: Movie!
+            }
+
+            input MovieRelationshipFilters {
+              \\"\\"\\"Filter type where all of the related Movies match this filter\\"\\"\\"
+              all: MovieWhere
+              \\"\\"\\"Filter type where none of the related Movies match this filter\\"\\"\\"
+              none: MovieWhere
+              \\"\\"\\"Filter type where one of the related Movies match this filter\\"\\"\\"
+              single: MovieWhere
+              \\"\\"\\"Filter type where some of the related Movies match this filter\\"\\"\\"
+              some: MovieWhere
+            }
+
+            \\"\\"\\"
+            Fields to sort Movies by. The order in which sorts are applied is not guaranteed when specifying many fields in one MovieSort object.
+            \\"\\"\\"
+            input MovieSort {
+              title: SortDirection
+            }
+
+            input MovieUpdateInput {
+              actor: MovieActorUpdateInput
+              title: StringScalarMutations
+            }
+
+            input MovieWhere {
+              AND: [MovieWhere!]
+              NOT: MovieWhere
+              OR: [MovieWhere!]
+              actor: ActorRelationshipFilters
+              actorConnection: MovieActorConnectionFilters
+              title: StringScalarFilters
+            }
+
+            type MoviesConnection {
+              aggregate: MovieAggregate!
+              edges: [MovieEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type Mutation {
+              createAis(input: [AICreateInput!]!): CreateAisMutationResponse!
+              createDogs(input: [DogCreateInput!]!): CreateDogsMutationResponse!
+              createMovies(input: [MovieCreateInput!]!): CreateMoviesMutationResponse!
+              createPeople(input: [PersonCreateInput!]!): CreatePeopleMutationResponse!
+              deleteAis(delete: AIDeleteInput, where: AIWhere): DeleteInfo!
+              deleteDogs(where: DogWhere): DeleteInfo!
+              deleteMovies(delete: MovieDeleteInput, where: MovieWhere): DeleteInfo!
+              deletePeople(delete: PersonDeleteInput, where: PersonWhere): DeleteInfo!
+              updateAis(update: AIUpdateInput, where: AIWhere): UpdateAisMutationResponse!
+              updateDogs(update: DogUpdateInput, where: DogWhere): UpdateDogsMutationResponse!
+              updateMovies(update: MovieUpdateInput, where: MovieWhere): UpdateMoviesMutationResponse!
+              updatePeople(update: PersonUpdateInput, where: PersonWhere): UpdatePeopleMutationResponse!
+            }
+
+            \\"\\"\\"Pagination information (Relay)\\"\\"\\"
+            type PageInfo {
+              endCursor: String
+              hasNextPage: Boolean!
+              hasPreviousPage: Boolean!
+              startCursor: String
+            }
+
+            type PeopleConnection {
+              aggregate: PersonAggregate!
+              edges: [PersonEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type Person {
+              actedIn: Movie!
+              actedInConnection: PersonActedInConnection!
+              directed(limit: Int, offset: Int, sort: [MovieSort!], where: MovieWhere): [Movie!]!
+              directedConnection(after: String, first: Int, sort: [PersonDirectedConnectionSort!], where: PersonDirectedConnectionWhere): PersonDirectedConnection!
+              name: String!
+            }
+
+            type PersonActedInConnection {
+              edges: [PersonActedInRelationship!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type PersonActedInRelationship {
+              cursor: String!
+              node: Movie!
+            }
+
+            type PersonAggregate {
+              count: Count!
+              node: PersonAggregateNode!
+            }
+
+            type PersonAggregateNode {
+              name: StringAggregateSelection!
+            }
+
+            input PersonConnectInput {
+              directed: [PersonDirectedConnectFieldInput!]
+            }
+
+            input PersonConnectWhere {
+              node: PersonWhere!
+            }
+
+            input PersonCreateInput {
+              directed: PersonDirectedFieldInput
+              name: String!
+            }
+
+            input PersonDeleteInput {
+              directed: [PersonDirectedDeleteFieldInput!]
+            }
+
+            input PersonDirectedConnectFieldInput {
+              connect: [MovieConnectInput!]
+              where: MovieConnectWhere
+            }
+
+            type PersonDirectedConnection {
+              aggregate: PersonMovieDirectedAggregateSelection!
+              edges: [PersonDirectedRelationship!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            input PersonDirectedConnectionAggregateInput {
+              AND: [PersonDirectedConnectionAggregateInput!]
+              NOT: PersonDirectedConnectionAggregateInput
+              OR: [PersonDirectedConnectionAggregateInput!]
+              count: ConnectionAggregationCountFilterInput
+              node: PersonDirectedNodeAggregationWhereInput
+            }
+
+            input PersonDirectedConnectionFilters {
+              \\"\\"\\"
+              Filter People by aggregating results on related PersonDirectedConnections
+              \\"\\"\\"
+              aggregate: PersonDirectedConnectionAggregateInput
+              \\"\\"\\"
+              Return People where all of the related PersonDirectedConnections match this filter
+              \\"\\"\\"
+              all: PersonDirectedConnectionWhere
+              \\"\\"\\"
+              Return People where none of the related PersonDirectedConnections match this filter
+              \\"\\"\\"
+              none: PersonDirectedConnectionWhere
+              \\"\\"\\"
+              Return People where one of the related PersonDirectedConnections match this filter
+              \\"\\"\\"
+              single: PersonDirectedConnectionWhere
+              \\"\\"\\"
+              Return People where some of the related PersonDirectedConnections match this filter
+              \\"\\"\\"
+              some: PersonDirectedConnectionWhere
+            }
+
+            input PersonDirectedConnectionSort {
+              node: MovieSort
+            }
+
+            input PersonDirectedConnectionWhere {
+              AND: [PersonDirectedConnectionWhere!]
+              NOT: PersonDirectedConnectionWhere
+              OR: [PersonDirectedConnectionWhere!]
+              node: MovieWhere
+            }
+
+            input PersonDirectedCreateFieldInput {
+              node: MovieCreateInput!
+            }
+
+            input PersonDirectedDeleteFieldInput {
+              delete: MovieDeleteInput
+              where: PersonDirectedConnectionWhere
+            }
+
+            input PersonDirectedDisconnectFieldInput {
+              disconnect: MovieDisconnectInput
+              where: PersonDirectedConnectionWhere
+            }
+
+            input PersonDirectedFieldInput {
+              connect: [PersonDirectedConnectFieldInput!]
+              create: [PersonDirectedCreateFieldInput!]
+            }
+
+            input PersonDirectedNodeAggregationWhereInput {
+              AND: [PersonDirectedNodeAggregationWhereInput!]
+              NOT: PersonDirectedNodeAggregationWhereInput
+              OR: [PersonDirectedNodeAggregationWhereInput!]
+              title: StringScalarAggregationFilters
+            }
+
+            type PersonDirectedRelationship {
+              cursor: String!
+              node: Movie!
+            }
+
+            input PersonDirectedUpdateConnectionInput {
+              node: MovieUpdateInput
+              where: PersonDirectedConnectionWhere
+            }
+
+            input PersonDirectedUpdateFieldInput {
+              connect: [PersonDirectedConnectFieldInput!]
+              create: [PersonDirectedCreateFieldInput!]
+              delete: [PersonDirectedDeleteFieldInput!]
+              disconnect: [PersonDirectedDisconnectFieldInput!]
+              update: PersonDirectedUpdateConnectionInput
+            }
+
+            input PersonDisconnectInput {
+              directed: [PersonDirectedDisconnectFieldInput!]
+            }
+
+            type PersonEdge {
+              cursor: String!
+              node: Person!
+            }
+
+            type PersonMovieDirectedAggregateSelection {
+              count: CountConnection!
+              node: PersonMovieDirectedNodeAggregateSelection
+            }
+
+            type PersonMovieDirectedNodeAggregateSelection {
+              title: StringAggregateSelection!
+            }
+
+            \\"\\"\\"
+            Fields to sort People by. The order in which sorts are applied is not guaranteed when specifying many fields in one PersonSort object.
+            \\"\\"\\"
+            input PersonSort {
+              name: SortDirection
+            }
+
+            input PersonUpdateInput {
+              directed: [PersonDirectedUpdateFieldInput!]
+              name: StringScalarMutations
+            }
+
+            input PersonWhere {
+              AND: [PersonWhere!]
+              NOT: PersonWhere
+              OR: [PersonWhere!]
+              directed: MovieRelationshipFilters
+              directedConnection: PersonDirectedConnectionFilters
+              name: StringScalarFilters
+            }
+
+            type Query {
+              actors(limit: Int, offset: Int, where: ActorWhere): [Actor!]!
+              ais(limit: Int, offset: Int, sort: [AISort!], where: AIWhere): [AI!]!
+              aisConnection(after: String, first: Int, sort: [AISort!], where: AIWhere): AisConnection!
+              directors(limit: Int, offset: Int, where: DirectorWhere): [Director!]!
+              dogs(limit: Int, offset: Int, sort: [DogSort!], where: DogWhere): [Dog!]!
+              dogsConnection(after: String, first: Int, sort: [DogSort!], where: DogWhere): DogsConnection!
+              movies(limit: Int, offset: Int, sort: [MovieSort!], where: MovieWhere): [Movie!]!
+              moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
+              people(limit: Int, offset: Int, sort: [PersonSort!], where: PersonWhere): [Person!]!
+              peopleConnection(after: String, first: Int, sort: [PersonSort!], where: PersonWhere): PeopleConnection!
+            }
+
+            \\"\\"\\"An enum for sorting in either ascending or descending order.\\"\\"\\"
+            enum SortDirection {
+              \\"\\"\\"Sort by field values in ascending order.\\"\\"\\"
+              ASC
+              \\"\\"\\"Sort by field values in descending order.\\"\\"\\"
+              DESC
+            }
+
+            type StringAggregateSelection {
+              longest: String
+              shortest: String
+            }
+
+            \\"\\"\\"Filters for an aggregation of a string field\\"\\"\\"
+            input StringScalarAggregationFilters {
+              averageLength: FloatScalarFilters
+              longestLength: IntScalarFilters
+              shortestLength: IntScalarFilters
             }
 
             \\"\\"\\"String filters\\"\\"\\"

--- a/packages/graphql/tests/schema/relationship/single-element-relationship.test.ts
+++ b/packages/graphql/tests/schema/relationship/single-element-relationship.test.ts
@@ -23,7 +23,7 @@ import { lexicographicSortSchema } from "graphql/utilities";
 import { Neo4jGraphQL } from "../../../src";
 
 describe("single item relationships", () => {
-    test("1-* relationship", async () => {
+    test("1-1 relationship", async () => {
         const typeDefs = gql`
             type Movie @node {
                 title: String!
@@ -86,10 +86,10 @@ describe("single item relationships", () => {
             }
 
             type Movie {
-              actor(where: PersonWhere): Person
-              actorConnection(where: MovieActorConnectionWhere): MovieActorConnection!
-              director(where: PersonWhere): Person!
-              directorConnection(where: MovieDirectorConnectionWhere): MovieDirectorConnection!
+              actor: Person
+              actorConnection: MovieActorConnection!
+              director: Person!
+              directorConnection: MovieDirectorConnection!
               title: String!
             }
 
@@ -97,13 +97,6 @@ describe("single item relationships", () => {
               edges: [MovieActorRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
-            }
-
-            input MovieActorConnectionWhere {
-              AND: [MovieActorConnectionWhere!]
-              NOT: MovieActorConnectionWhere
-              OR: [MovieActorConnectionWhere!]
-              node: PersonWhere
             }
 
             type MovieActorRelationship {
@@ -128,13 +121,6 @@ describe("single item relationships", () => {
               edges: [MovieDirectorRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
-            }
-
-            input MovieDirectorConnectionWhere {
-              AND: [MovieDirectorConnectionWhere!]
-              NOT: MovieDirectorConnectionWhere
-              OR: [MovieDirectorConnectionWhere!]
-              node: PersonWhere
             }
 
             type MovieDirectorRelationship {
@@ -254,6 +240,413 @@ describe("single item relationships", () => {
             type StringAggregateSelection {
               longest: String
               shortest: String
+            }
+
+            \\"\\"\\"String filters\\"\\"\\"
+            input StringScalarFilters {
+              contains: String
+              endsWith: String
+              eq: String
+              in: [String!]
+              startsWith: String
+            }
+
+            \\"\\"\\"String mutations\\"\\"\\"
+            input StringScalarMutations {
+              set: String
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships created and deleted during an update mutation
+            \\"\\"\\"
+            type UpdateInfo {
+              nodesCreated: Int!
+              nodesDeleted: Int!
+              relationshipsCreated: Int!
+              relationshipsDeleted: Int!
+            }
+
+            type UpdateMoviesMutationResponse {
+              info: UpdateInfo!
+              movies: [Movie!]!
+            }
+
+            type UpdatePeopleMutationResponse {
+              info: UpdateInfo!
+              people: [Person!]!
+            }"
+        `);
+    });
+    test("1-* relationship", async () => {
+        const typeDefs = gql`
+            type Movie @node {
+                title: String!
+                director: Person! @relationship(type: "DIRECTED", direction: IN)
+            }
+
+            type Person @node {
+                name: String!
+                directed: [Movie!]! @relationship(type: "DIRECTED", direction: OUT)
+            }
+        `;
+        const neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            features: {
+                excludeDeprecatedFields: {
+                    mutationOperations: true,
+                    aggregationFilters: true,
+                    aggregationFiltersOutsideConnection: true,
+                    relationshipFilters: true,
+                    attributeFilters: true,
+                },
+            },
+        });
+        const printedSchema = printSchemaWithDirectives(lexicographicSortSchema(await neoSchema.getSchema()));
+
+        expect(printedSchema).toMatchInlineSnapshot(`
+            "schema {
+              query: Query
+              mutation: Mutation
+            }
+
+            input ConnectionAggregationCountFilterInput {
+              edges: IntScalarFilters
+              nodes: IntScalarFilters
+            }
+
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships created during a create mutation
+            \\"\\"\\"
+            type CreateInfo {
+              nodesCreated: Int!
+              relationshipsCreated: Int!
+            }
+
+            type CreateMoviesMutationResponse {
+              info: CreateInfo!
+              movies: [Movie!]!
+            }
+
+            type CreatePeopleMutationResponse {
+              info: CreateInfo!
+              people: [Person!]!
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships deleted during a delete mutation
+            \\"\\"\\"
+            type DeleteInfo {
+              nodesDeleted: Int!
+              relationshipsDeleted: Int!
+            }
+
+            \\"\\"\\"Float filters\\"\\"\\"
+            input FloatScalarFilters {
+              eq: Float
+              gt: Float
+              gte: Float
+              in: [Float!]
+              lt: Float
+              lte: Float
+            }
+
+            \\"\\"\\"Int filters\\"\\"\\"
+            input IntScalarFilters {
+              eq: Int
+              gt: Int
+              gte: Int
+              in: [Int!]
+              lt: Int
+              lte: Int
+            }
+
+            type Movie {
+              director: Person!
+              directorConnection: MovieDirectorConnection!
+              title: String!
+            }
+
+            type MovieAggregate {
+              count: Count!
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              title: StringAggregateSelection!
+            }
+
+            input MovieConnectWhere {
+              node: MovieWhere!
+            }
+
+            input MovieCreateInput {
+              title: String!
+            }
+
+            type MovieDirectorConnection {
+              edges: [MovieDirectorRelationship!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type MovieDirectorRelationship {
+              cursor: String!
+              node: Person!
+            }
+
+            type MovieEdge {
+              cursor: String!
+              node: Movie!
+            }
+
+            input MovieRelationshipFilters {
+              \\"\\"\\"Filter type where all of the related Movies match this filter\\"\\"\\"
+              all: MovieWhere
+              \\"\\"\\"Filter type where none of the related Movies match this filter\\"\\"\\"
+              none: MovieWhere
+              \\"\\"\\"Filter type where one of the related Movies match this filter\\"\\"\\"
+              single: MovieWhere
+              \\"\\"\\"Filter type where some of the related Movies match this filter\\"\\"\\"
+              some: MovieWhere
+            }
+
+            \\"\\"\\"
+            Fields to sort Movies by. The order in which sorts are applied is not guaranteed when specifying many fields in one MovieSort object.
+            \\"\\"\\"
+            input MovieSort {
+              title: SortDirection
+            }
+
+            input MovieUpdateInput {
+              title: StringScalarMutations
+            }
+
+            input MovieWhere {
+              AND: [MovieWhere!]
+              NOT: MovieWhere
+              OR: [MovieWhere!]
+              title: StringScalarFilters
+            }
+
+            type MoviesConnection {
+              aggregate: MovieAggregate!
+              edges: [MovieEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type Mutation {
+              createMovies(input: [MovieCreateInput!]!): CreateMoviesMutationResponse!
+              createPeople(input: [PersonCreateInput!]!): CreatePeopleMutationResponse!
+              deleteMovies(where: MovieWhere): DeleteInfo!
+              deletePeople(delete: PersonDeleteInput, where: PersonWhere): DeleteInfo!
+              updateMovies(update: MovieUpdateInput, where: MovieWhere): UpdateMoviesMutationResponse!
+              updatePeople(update: PersonUpdateInput, where: PersonWhere): UpdatePeopleMutationResponse!
+            }
+
+            \\"\\"\\"Pagination information (Relay)\\"\\"\\"
+            type PageInfo {
+              endCursor: String
+              hasNextPage: Boolean!
+              hasPreviousPage: Boolean!
+              startCursor: String
+            }
+
+            type PeopleConnection {
+              aggregate: PersonAggregate!
+              edges: [PersonEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type Person {
+              directed(limit: Int, offset: Int, sort: [MovieSort!], where: MovieWhere): [Movie!]!
+              directedConnection(after: String, first: Int, sort: [PersonDirectedConnectionSort!], where: PersonDirectedConnectionWhere): PersonDirectedConnection!
+              name: String!
+            }
+
+            type PersonAggregate {
+              count: Count!
+              node: PersonAggregateNode!
+            }
+
+            type PersonAggregateNode {
+              name: StringAggregateSelection!
+            }
+
+            input PersonCreateInput {
+              directed: PersonDirectedFieldInput
+              name: String!
+            }
+
+            input PersonDeleteInput {
+              directed: [PersonDirectedDeleteFieldInput!]
+            }
+
+            input PersonDirectedConnectFieldInput {
+              where: MovieConnectWhere
+            }
+
+            type PersonDirectedConnection {
+              aggregate: PersonMovieDirectedAggregateSelection!
+              edges: [PersonDirectedRelationship!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            input PersonDirectedConnectionAggregateInput {
+              AND: [PersonDirectedConnectionAggregateInput!]
+              NOT: PersonDirectedConnectionAggregateInput
+              OR: [PersonDirectedConnectionAggregateInput!]
+              count: ConnectionAggregationCountFilterInput
+              node: PersonDirectedNodeAggregationWhereInput
+            }
+
+            input PersonDirectedConnectionFilters {
+              \\"\\"\\"
+              Filter People by aggregating results on related PersonDirectedConnections
+              \\"\\"\\"
+              aggregate: PersonDirectedConnectionAggregateInput
+              \\"\\"\\"
+              Return People where all of the related PersonDirectedConnections match this filter
+              \\"\\"\\"
+              all: PersonDirectedConnectionWhere
+              \\"\\"\\"
+              Return People where none of the related PersonDirectedConnections match this filter
+              \\"\\"\\"
+              none: PersonDirectedConnectionWhere
+              \\"\\"\\"
+              Return People where one of the related PersonDirectedConnections match this filter
+              \\"\\"\\"
+              single: PersonDirectedConnectionWhere
+              \\"\\"\\"
+              Return People where some of the related PersonDirectedConnections match this filter
+              \\"\\"\\"
+              some: PersonDirectedConnectionWhere
+            }
+
+            input PersonDirectedConnectionSort {
+              node: MovieSort
+            }
+
+            input PersonDirectedConnectionWhere {
+              AND: [PersonDirectedConnectionWhere!]
+              NOT: PersonDirectedConnectionWhere
+              OR: [PersonDirectedConnectionWhere!]
+              node: MovieWhere
+            }
+
+            input PersonDirectedCreateFieldInput {
+              node: MovieCreateInput!
+            }
+
+            input PersonDirectedDeleteFieldInput {
+              where: PersonDirectedConnectionWhere
+            }
+
+            input PersonDirectedDisconnectFieldInput {
+              where: PersonDirectedConnectionWhere
+            }
+
+            input PersonDirectedFieldInput {
+              connect: [PersonDirectedConnectFieldInput!]
+              create: [PersonDirectedCreateFieldInput!]
+            }
+
+            input PersonDirectedNodeAggregationWhereInput {
+              AND: [PersonDirectedNodeAggregationWhereInput!]
+              NOT: PersonDirectedNodeAggregationWhereInput
+              OR: [PersonDirectedNodeAggregationWhereInput!]
+              title: StringScalarAggregationFilters
+            }
+
+            type PersonDirectedRelationship {
+              cursor: String!
+              node: Movie!
+            }
+
+            input PersonDirectedUpdateConnectionInput {
+              node: MovieUpdateInput
+              where: PersonDirectedConnectionWhere
+            }
+
+            input PersonDirectedUpdateFieldInput {
+              connect: [PersonDirectedConnectFieldInput!]
+              create: [PersonDirectedCreateFieldInput!]
+              delete: [PersonDirectedDeleteFieldInput!]
+              disconnect: [PersonDirectedDisconnectFieldInput!]
+              update: PersonDirectedUpdateConnectionInput
+            }
+
+            type PersonEdge {
+              cursor: String!
+              node: Person!
+            }
+
+            type PersonMovieDirectedAggregateSelection {
+              count: CountConnection!
+              node: PersonMovieDirectedNodeAggregateSelection
+            }
+
+            type PersonMovieDirectedNodeAggregateSelection {
+              title: StringAggregateSelection!
+            }
+
+            \\"\\"\\"
+            Fields to sort People by. The order in which sorts are applied is not guaranteed when specifying many fields in one PersonSort object.
+            \\"\\"\\"
+            input PersonSort {
+              name: SortDirection
+            }
+
+            input PersonUpdateInput {
+              directed: [PersonDirectedUpdateFieldInput!]
+              name: StringScalarMutations
+            }
+
+            input PersonWhere {
+              AND: [PersonWhere!]
+              NOT: PersonWhere
+              OR: [PersonWhere!]
+              directed: MovieRelationshipFilters
+              directedConnection: PersonDirectedConnectionFilters
+              name: StringScalarFilters
+            }
+
+            type Query {
+              movies(limit: Int, offset: Int, sort: [MovieSort!], where: MovieWhere): [Movie!]!
+              moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
+              people(limit: Int, offset: Int, sort: [PersonSort!], where: PersonWhere): [Person!]!
+              peopleConnection(after: String, first: Int, sort: [PersonSort!], where: PersonWhere): PeopleConnection!
+            }
+
+            \\"\\"\\"An enum for sorting in either ascending or descending order.\\"\\"\\"
+            enum SortDirection {
+              \\"\\"\\"Sort by field values in ascending order.\\"\\"\\"
+              ASC
+              \\"\\"\\"Sort by field values in descending order.\\"\\"\\"
+              DESC
+            }
+
+            type StringAggregateSelection {
+              longest: String
+              shortest: String
+            }
+
+            \\"\\"\\"Filters for an aggregation of a string field\\"\\"\\"
+            input StringScalarAggregationFilters {
+              averageLength: FloatScalarFilters
+              longestLength: IntScalarFilters
+              shortestLength: IntScalarFilters
             }
 
             \\"\\"\\"String filters\\"\\"\\"


### PR DESCRIPTION
# Description

For 1-many relationships, schema generation created the following input types empty of fields. They allow for nested operations from the many side.
 [
    [GraphQLError: Input Object type SfRFowWPMovieConnectInput must define one or more fields.], 
    [GraphQLError: Input Object type SfRFowWPMovieDeleteInput must define one or more fields.], 
    [GraphQLError: Input Object type SfRFowWPMovieDisconnectInput must define one or more fields.]
]
This PR fixes the generation (these types are no longer being generated), together with the fields up the chain.
This PR also removes the where argument from single relationship fields.

## Complexity

Complexity: Low

# Issue

> **Note**
>
>  Please link to the GitHub issue(s) in which the proposal for this work was discussed
>  
>  To link to multiple issues, use full syntax for each, for example `Closes #1, closes #2, closes #3`

Closes 

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
