### PR TITLE
Add memory to performance tests summary

### DIFF
--- a/packages/graphql/tests/performance/databaseQuery/TestRunner.ts
+++ b/packages/graphql/tests/performance/databaseQuery/TestRunner.ts
@@ -18,7 +18,7 @@
  */
 
 import assert from "assert";
-import type { Driver, ProfiledPlan } from "neo4j-driver";
+import type { Driver, Integer, ProfiledPlan } from "neo4j-driver";
 import type Neo4jGraphQL from "../../../src/classes/Neo4jGraphQL";
 import { translateQuery } from "../../tck/utils/tck-test-utils";
 import type * as Performance from "../types";
@@ -120,6 +120,7 @@ export class TestRunner {
         const nodeResult: Performance.ProfileResult = {
             maxRows: plan.rows,
             dbHits: plan.dbHits,
+            memory: this.getMemoryFromPlan(plan),
             cache: {
                 hits: plan.pageCacheHits,
                 misses: plan.pageCacheMisses,
@@ -133,6 +134,7 @@ export class TestRunner {
             return {
                 maxRows: Math.max(agg.maxRows, childResult.maxRows),
                 dbHits: agg.dbHits + childResult.dbHits,
+                memory: agg.memory + childResult.memory,
                 cache: {
                     hits: agg.cache.hits + childResult.cache.hits,
                     misses: agg.cache.misses + childResult.cache.misses,
@@ -141,5 +143,13 @@ export class TestRunner {
         }, nodeResult);
 
         return result;
+    }
+
+    private getMemoryFromPlan(plan: ProfiledPlan): number {
+        const rawMemory = plan.arguments["Memory"] as Integer | undefined;
+        if (!rawMemory) {
+            return 0;
+        }
+        return rawMemory.toInt();
     }
 }

--- a/packages/graphql/tests/performance/graphql/fulltext.graphql
+++ b/packages/graphql/tests/performance/graphql/fulltext.graphql
@@ -24,3 +24,14 @@ query FulltextWithNestedQuery {
         }
     }
 }
+
+query FulltextWithSort {
+    movieTaglineFulltextQuery(first: 1000, phrase: "*", sort: [{ node: { title: ASC } }]) {
+        edges {
+            node {
+                title
+                tagline
+            }
+        }
+    }
+}

--- a/packages/graphql/tests/performance/graphql/query.graphql
+++ b/packages/graphql/tests/performance/graphql/query.graphql
@@ -36,51 +36,7 @@ query Nested {
     }
 }
 
-query DeeplyNested_skip {
-    movies {
-        actors {
-            name
-            movies {
-                title
-                actors {
-                    name
-                    movies {
-                        title
-                        actors {
-                            name
-                        }
-                        directors {
-                            name
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
-query OrFilterOnRelationships {
-    movies(
-        where: {
-            OR: [
-                { actors_SOME: { born: { eq: 1997 } } }
-                { actors_SOME: { born: { eq: 1998 } } }
-                { actors_SOME: { born: { eq: 1999 } } }
-                { actors_SOME: { born: { eq: 1956 } } }
-                { actors_SOME: { born: { eq: 1975 } } }
-                { actors_SOME: { born: { eq: 1976 } } }
-            ]
-        }
-    ) {
-        title
-        actors {
-            name
-            born
-        }
-    }
-}
-
-query OrFilterOnRelationshipsAndNested {
+query OrFilterOnRelationshipsAndNestedFilters {
     movies(
         where: {
             OR: [

--- a/packages/graphql/tests/performance/graphql/unions.graphql
+++ b/packages/graphql/tests/performance/graphql/unions.graphql
@@ -45,22 +45,3 @@ query NestedUnion {
         }
     }
 }
-
-query NestedUnionWithMissingFields {
-    people {
-        name
-        likes {
-            ... on Person {
-                name
-                likes {
-                    ... on Person {
-                        name
-                    }
-                    ... on Movie {
-                        title
-                    }
-                }
-            }
-        }
-    }
-}

--- a/packages/graphql/tests/performance/schema/schema-performance.ts
+++ b/packages/graphql/tests/performance/schema/schema-performance.ts
@@ -19,7 +19,7 @@
 
 import Neo4jGraphQL from "../../../src/classes/Neo4jGraphQL";
 
-const basicTypeDefs = `
+const basicTypeDefs = /* GraphQL */ `
     type Journalist @node {
         articles: [Article!]! @relationship(type: "HAS_ARTICLE", direction: OUT, properties: "HasArticle")
     }
@@ -29,12 +29,12 @@ const basicTypeDefs = `
     }
 
     type Article @authorization(filter: [{ where: { node: { id: { eq: "$jwt.sub" } } } }]) @node {
-        id: ID! @id  @authorization(filter: [{ where: { node: { id: { eq: "$jwt.sub" } } } }])
+        id: ID! @id @authorization(filter: [{ where: { node: { id: { eq: "$jwt.sub" } } } }])
         blocks: [Block!]! @relationship(type: "HAS_BLOCK", direction: OUT, properties: "HasBlock")
         images: [Image!]! @relationship(type: "HAS_IMAGE", direction: OUT)
     }
 
-    type HasBlock @relationshipProperties @node {
+    type HasBlock @relationshipProperties {
         order: Int!
     }
 

--- a/packages/graphql/tests/performance/schema/subgraph-schema-performance.ts
+++ b/packages/graphql/tests/performance/schema/subgraph-schema-performance.ts
@@ -19,7 +19,7 @@
 
 import Neo4jGraphQL from "../../../src/classes/Neo4jGraphQL";
 
-const basicTypeDefs = `
+const basicTypeDefs = /* GraphQL */ `
     extend schema @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
 
     type Journalist @node {
@@ -31,12 +31,12 @@ const basicTypeDefs = `
     }
 
     type Article @authorization(filter: [{ where: { node: { id: { eq: "$jwt.sub" } } } }]) @node {
-        id: ID! @id  @authorization(filter: [{ where: { node: { id: { eq: "$jwt.sub" } } } }])
+        id: ID! @id @authorization(filter: [{ where: { node: { id: { eq: "$jwt.sub" } } } }])
         blocks: [Block!]! @relationship(type: "HAS_BLOCK", direction: OUT, properties: "HasBlock")
         images: [Image!]! @relationship(type: "HAS_IMAGE", direction: OUT)
     }
 
-    type HasBlock @relationshipProperties @node {
+    type HasBlock @relationshipProperties {
         order: Int!
     }
 

--- a/packages/graphql/tests/performance/types.ts
+++ b/packages/graphql/tests/performance/types.ts
@@ -24,6 +24,7 @@ export type ProfileResult = {
         hits: number;
         misses: number;
     };
+    memory: number;
 };
 
 export type Result = ProfileResult & { time: number };


### PR DESCRIPTION
# Description

Returns the memory in the performance tests summary. Also removes some performance test cases that are redundant
