### PR TITLE
Implement nested filters on 1-1 relationship fields

### DIFF
--- a/packages/graphql/src/schema/generation/augment-object-or-interface.ts
+++ b/packages/graphql/src/schema/generation/augment-object-or-interface.ts
@@ -114,12 +114,14 @@ export function augmentObjectOrInterfaceTypeWithConnectionField(
     );
     const composeNodeArgs: ObjectTypeComposerArgumentConfigMapDefinition = {};
 
-    if (relationshipAdapter.isList) {
-        composeNodeArgs.where = makeConnectionWhereInputType({
-            relationshipAdapter,
-            composer: schemaComposer,
-        });
+    // we want this type to be created for single relationships, but don't want to set the argument
+    const connectionWhereInput = makeConnectionWhereInputType({
+        relationshipAdapter,
+        composer: schemaComposer,
+    });
 
+    if (relationshipAdapter.isList) {
+        composeNodeArgs.where = connectionWhereInput;
         composeNodeArgs.first = {
             type: features?.limitRequired ? new GraphQLNonNull(GraphQLInt) : GraphQLInt,
         };

--- a/packages/graphql/src/schema/generation/augment-where-input.ts
+++ b/packages/graphql/src/schema/generation/augment-where-input.ts
@@ -51,6 +51,16 @@ export function augmentWhereInputWithRelationshipFilters({
     features?: Neo4jFeaturesSettings;
 }) {
     if (!relationshipAdapter.isList) {
+        whereInput.addFields({
+            [relationshipAdapter.name]: {
+                type: relationshipAdapter.target.operations.whereInputTypeName,
+            },
+        });
+        whereInput.addFields({
+            [relationshipAdapter.operations.connectionFieldName]: {
+                type: relationshipAdapter.operations.getConnectionWhereTypename(),
+            },
+        });
         return {};
     }
     if (!relationshipAdapter.isFilterableByAggregate() && !relationshipAdapter.isFilterableByValue()) {

--- a/packages/graphql/src/translate/queryAST/factory/FilterFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/FilterFactory.ts
@@ -730,6 +730,12 @@ export class FilterFactory {
                 isDeprecated: true,
             });
         }
+        if (!relationship.isList) {
+            if (isConnection) {
+                return this.createConnectionFilter(relationship, value as ConnectionWhereArg, "SOME");
+            }
+            return this.createRelationshipFilter(relationship, value as GraphQLWhereArg, undefined);
+        }
         if (!operator) {
             const genericFilters = Object.entries(value).flatMap(([genericOperator, predicate]) => {
                 if (genericOperator === "aggregate") {

--- a/packages/graphql/tests/integration/directives/relationship/interface-declaredRelationship-1-1.int.test.ts
+++ b/packages/graphql/tests/integration/directives/relationship/interface-declaredRelationship-1-1.int.test.ts
@@ -20,11 +20,11 @@
 import type { UniqueType } from "../../../utils/graphql-types";
 import { TestHelper } from "../../../utils/tests-helper";
 
-describe("Entity api on single element relationships to an Interface type", () => {
+describe("Entity api on single element relationships from an Interface type using declared relationship", () => {
     let Movie: UniqueType;
     let Person: UniqueType;
     let Dog: UniqueType;
-    let AI: UniqueType;
+    let Series: UniqueType;
 
     const testHelper = new TestHelper();
 
@@ -32,35 +32,37 @@ describe("Entity api on single element relationships to an Interface type", () =
         Movie = testHelper.createUniqueType("Movie");
         Person = testHelper.createUniqueType("Person");
         Dog = testHelper.createUniqueType("Dog");
-        AI = testHelper.createUniqueType("AI");
+        Series = testHelper.createUniqueType("Series");
 
         const typeDefs = /* GraphQL */ `
             interface Actor {
                 name: String!
             }
-            interface Director {
-                years: Int!
+            interface Production {
+                title: String!
+                actor: Actor @declareRelationship
+                director: ${Person}! @declareRelationship
             }
 
-            type ${Movie} @node {
+            type ${Movie} implements Production @node {
                 title: String!
                 actor: Actor @relationship(type: "ACTED_IN", direction: IN)
-                director: Director! @relationship(type: "DIRECTED", direction: IN)
+                director: ${Person}! @relationship(type: "DIRECTED", direction: IN)
+            }
+
+            type ${Series} @node {
+                name: String!
+                actor: Actor @relationship(type: "ACTED_IN", direction: IN)
+                director: ${Person}! @relationship(type: "DIRECTED", direction: IN)
             }
 
             type ${Dog} implements Actor @node {
                 name: String!
             }
 
-            type ${Person} implements Actor & Director @node{
+            type ${Person} implements Actor @node{
                 name: String!
-                years: Int!
              }
-
-            type ${AI} implements Director @node {
-                model: String!
-                years: Int!
-            }
         `;
 
         await testHelper.initNeo4jGraphQL({
@@ -72,12 +74,49 @@ describe("Entity api on single element relationships to an Interface type", () =
         await testHelper.close();
     });
 
-    test("returns first element of 1-1 relationship with multiple relationships", async () => {
+    test("returns first element of 1-1 relationship with multiple relationships on top level interface query", async () => {
         await testHelper.executeCypher(`
             CREATE(m:${Movie} { title: "The Matrix"})<-[:ACTED_IN]-(a:${Dog} { name: "Hachiko"})
             CREATE(m)<-[:ACTED_IN]-(:${Person} { name: "Keanu"})
-            CREATE(m)<-[:DIRECTED]-(:${Person} { name: "Director", years: 10})
-            CREATE(m)<-[:DIRECTED]-(:${AI} { model: "T-800", years: 1})
+            CREATE(m)<-[:DIRECTED]-(:${Person} { name: "Director"})
+            CREATE(m)<-[:DIRECTED]-(:${Series} { name: "T-800"})
+        `);
+
+        const query = `
+            query {
+              productions {
+                    actor {
+                        name
+                    }
+                    director {
+                       name
+                    }
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+        expect(result.errors).toBeFalsy();
+        expect(result.data).toEqual({
+            productions: [
+                {
+                    actor: {
+                        name: "Hachiko",
+                    },
+                    director: {
+                        name: "Director",
+                    },
+                },
+            ],
+        });
+    });
+
+    test("returns first element of 1-1 relationship with multiple relationships on top level type query", async () => {
+        await testHelper.executeCypher(`
+            CREATE(m:${Movie} { title: "The Matrix"})<-[:ACTED_IN]-(a:${Dog} { name: "Hachiko"})
+            CREATE(m)<-[:ACTED_IN]-(:${Person} { name: "Keanu"})
+            CREATE(m)<-[:DIRECTED]-(:${Person} { name: "Director"})
+            CREATE(m)<-[:DIRECTED]-(:${Series} { name: "T-800"})
         `);
 
         const query = `
@@ -87,7 +126,7 @@ describe("Entity api on single element relationships to an Interface type", () =
                         name
                     }
                     director {
-                       years
+                       name
                     }
                 }
             }
@@ -102,7 +141,7 @@ describe("Entity api on single element relationships to an Interface type", () =
                         name: "Hachiko",
                     },
                     director: {
-                        years: 10,
+                        name: "Director",
                     },
                 },
             ],
@@ -144,7 +183,7 @@ describe("Entity api on single element relationships to an Interface type", () =
             query {
                 ${Movie.plural} {
                     director {
-                        years
+                        name
                     }
                 }
             }

--- a/packages/graphql/tests/integration/directives/relationship/interface-declaredRelationship-1-many.int.test.ts
+++ b/packages/graphql/tests/integration/directives/relationship/interface-declaredRelationship-1-many.int.test.ts
@@ -48,27 +48,39 @@ describe("1-* relationship involving Interface type declared relationship", () =
 
             type ${Movie} implements Production @node {
                 title: String!
-                actor: [Actor!]! @relationship(type: "ACTED_IN", direction: IN)
-                director: ${Person}! @relationship(type: "DIRECTED", direction: IN)
+                actor: [Actor!]! @relationship(type: "ACTED_IN", direction: IN, properties: "ActedInMovie")
+                director: ${Person}! @relationship(type: "DIRECTED", direction: IN, properties: "Directed")
             }
 
             type ${Series} implements Production @node {
                 title: String!
-                actor: [Actor!]! @relationship(type: "ACTED_IN", direction: IN)
-                director: ${Person}! @relationship(type: "DIRECTED", direction: IN)
+                actor: [Actor!]! @relationship(type: "ACTED_IN", direction: IN , properties: "ActedInSeries")
+                director: ${Person}! @relationship(type: "DIRECTED", direction: IN, properties: "Directed")
             }
 
             type ${Dog} implements Actor @node {
                 name: String!
-                actedIn: Production! @relationship(type: "ACTED_IN", direction: OUT)
-                directed: [Production!]! @relationship(type: "DIRECTED", direction: OUT)
+                actedIn: Production! @relationship(type: "ACTED_IN", direction: OUT, properties: "ActedInMovie")
+                directed: [Production!]! @relationship(type: "DIRECTED", direction: OUT, properties: "Directed")
             }
 
             type ${Person} implements Actor @node{
                 name: String!
-                actedIn: Production! @relationship(type: "ACTED_IN", direction: OUT)
-                directed: [Production!]! @relationship(type: "DIRECTED", direction: OUT)
+                actedIn: Production! @relationship(type: "ACTED_IN", direction: OUT, properties: "ActedInSeries")
+                directed: [Production!]! @relationship(type: "DIRECTED", direction: OUT, properties: "Directed")
              }
+
+            type ActedInMovie @relationshipProperties {
+                screenTime: Int
+            }
+
+            type ActedInSeries @relationshipProperties {
+                episodes: Int
+            }
+
+            type Directed @relationshipProperties {
+                year: Int
+            }
         `;
 
         await testHelper.initNeo4jGraphQL({
@@ -220,6 +232,140 @@ describe("1-* relationship involving Interface type declared relationship", () =
                         name: "Director",
                         directed: [{ title: "The Office" }],
                     },
+                },
+            ],
+        });
+    });
+
+    test("nested filter", async () => {
+        await testHelper.executeCypher(`
+            CREATE(m:${Movie} { title: "The Matrix"})<-[:ACTED_IN]-(a:${Dog} { name: "Hachiko"})
+            CREATE(m)<-[:ACTED_IN]-(:${Person} { name: "Keanu"})
+            CREATE(m)<-[:DIRECTED]-(d:${Person} { name: "Director"})
+            CREATE(d)-[:DIRECTED]->(s:${Series} { title: "The Office"})
+            CREATE(a)-[:ACTED_IN]->(s)
+        `);
+
+        const query = `
+            query {
+               productions(where: { director: { name: { eq: "Director" } } }) {
+                    title
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+        console.log(result.errors);
+        expect(result.errors).toBeFalsy();
+        expect(result.data).toEqual({
+            productions: [
+                {
+                    title: "The Matrix",
+                },
+                {
+                    title: "The Office",
+                },
+            ],
+        });
+    });
+
+    test("double nested filter", async () => {
+        await testHelper.executeCypher(`
+            CREATE(m:${Movie} { title: "The Matrix"})<-[:ACTED_IN]-(a:${Dog} { name: "Hachiko"})
+            CREATE(m)<-[:ACTED_IN]-(:${Person} { name: "Keanu"})
+            CREATE(m)<-[:DIRECTED]-(d:${Person} { name: "Director"})
+            CREATE(d)-[:DIRECTED]->(s:${Series} { title: "The Office"})
+            CREATE(a)-[:ACTED_IN]->(s)
+        `);
+
+        const query = `
+            query {
+                actors(where: { actedIn: { director: { name: { eq: "Director" } } } }) {
+                    name
+                    actedIn {
+                        title
+                    }
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+        console.log(result.errors);
+        expect(result.errors).toBeFalsy();
+        expect(result.data).toEqual({
+            actors: [
+                {
+                    name: "Hachiko",
+                    actedIn: {
+                        title: "The Matrix",
+                    },
+                },
+                {
+                    name: "Keanu",
+                    actedIn: {
+                        title: "The Matrix",
+                    },
+                },
+            ],
+        });
+    });
+
+    test("nested filter with edge properties", async () => {
+        await testHelper.executeCypher(`
+            CREATE(m:${Movie} { title: "The Matrix"})<-[:ACTED_IN {screenTime: 100}]-(a:${Dog} { name: "Hachiko"})
+            CREATE(m)<-[:ACTED_IN {screenTime: 40, episodes: 2}]-(:${Person} { name: "Keanu"})
+            CREATE(m)<-[:DIRECTED {year: 1992}]-(d:${Person} { name: "Director"})
+            CREATE(d)-[:DIRECTED {year: 2000}]->(s:${Series} { title: "The Office"})
+            CREATE(a)-[:ACTED_IN {screenTime: 20, episodes: 5}]->(s)
+        `);
+
+        const query = `
+            query {
+               productions(where: { directorConnection: { edge: { Directed: { year: { gt: 1992 } } } } }) {
+                    title
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+        console.log(result.errors);
+        expect(result.errors).toBeFalsy();
+        expect(result.data).toEqual({
+            productions: [
+                {
+                    title: "The Office",
+                },
+            ],
+        });
+    });
+
+    test("double nested filter with edge properties", async () => {
+        await testHelper.executeCypher(`
+            CREATE(m:${Movie} { title: "The Matrix"})<-[:ACTED_IN {screenTime: 100}]-(a:${Dog} { name: "Hachiko"})
+            CREATE(m)<-[:ACTED_IN {screenTime: 40, episodes: 2}]-(:${Person} { name: "Keanu"})
+            CREATE(m)<-[:DIRECTED {year: 1992}]-(d:${Person} { name: "Director"})
+            CREATE(d)-[:DIRECTED {year: 2000}]->(s:${Series} { title: "The Office"})
+            CREATE(a)-[:ACTED_IN {screenTime: 20, episodes: 5}]->(s)
+        `);
+
+        const query = `
+            query {
+               actors(where: { actedInConnection: { node: { directorConnection: { OR: [{ edge: { Directed: { year: { gt: 1996 } } } }, { node: { name: { eq: "Director" } } }] } } }  }) {
+                    name
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+        console.log(result.errors);
+        expect(result.errors).toBeFalsy();
+        expect(result.data).toEqual({
+            actors: [
+                {
+                    name: "Hachiko",
+                },
+                {
+                    name: "Keanu",
                 },
             ],
         });

--- a/packages/graphql/tests/integration/directives/relationship/interface-declaredRelationship-1-many.int.test.ts
+++ b/packages/graphql/tests/integration/directives/relationship/interface-declaredRelationship-1-many.int.test.ts
@@ -255,7 +255,6 @@ describe("1-* relationship involving Interface type declared relationship", () =
         `;
 
         const result = await testHelper.executeGraphQL(query);
-        console.log(result.errors);
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
             productions: [
@@ -290,7 +289,6 @@ describe("1-* relationship involving Interface type declared relationship", () =
         `;
 
         const result = await testHelper.executeGraphQL(query);
-        console.log(result.errors);
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
             actors: [
@@ -328,7 +326,6 @@ describe("1-* relationship involving Interface type declared relationship", () =
         `;
 
         const result = await testHelper.executeGraphQL(query);
-        console.log(result.errors);
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
             productions: [
@@ -357,7 +354,6 @@ describe("1-* relationship involving Interface type declared relationship", () =
         `;
 
         const result = await testHelper.executeGraphQL(query);
-        console.log(result.errors);
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
             actors: [

--- a/packages/graphql/tests/integration/directives/relationship/interface-relationship-1-many.int.test.ts
+++ b/packages/graphql/tests/integration/directives/relationship/interface-relationship-1-many.int.test.ts
@@ -219,7 +219,6 @@ describe("1-* relationship involving Interface type", () => {
         `;
 
         const result = await testHelper.executeGraphQL(query);
-        console.log(result.errors);
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
             [Movie.plural]: [
@@ -256,7 +255,6 @@ describe("1-* relationship involving Interface type", () => {
         `;
 
         const result = await testHelper.executeGraphQL(query);
-        console.log(result.errors);
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
             [Person.plural]: [
@@ -299,7 +297,6 @@ describe("1-* relationship involving Interface type", () => {
         `;
 
         const result = await testHelper.executeGraphQL(query);
-        console.log(result.errors);
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
             [Movie.plural]: [
@@ -339,7 +336,6 @@ describe("1-* relationship involving Interface type", () => {
         `;
 
         const result = await testHelper.executeGraphQL(query);
-        console.log(result.errors);
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
             [Movie.plural]: [

--- a/packages/graphql/tests/integration/directives/relationship/interface-relationship-1-many.int.test.ts
+++ b/packages/graphql/tests/integration/directives/relationship/interface-relationship-1-many.int.test.ts
@@ -24,7 +24,6 @@ describe("1-* relationship involving Interface type", () => {
     let Movie: UniqueType;
     let Person: UniqueType;
     let Dog: UniqueType;
-    let AI: UniqueType;
 
     const testHelper = new TestHelper();
 
@@ -32,7 +31,6 @@ describe("1-* relationship involving Interface type", () => {
         Movie = testHelper.createUniqueType("Movie");
         Person = testHelper.createUniqueType("Person");
         Dog = testHelper.createUniqueType("Dog");
-        AI = testHelper.createUniqueType("AI");
 
         const typeDefs = /* GraphQL */ `
             interface Actor {
@@ -44,21 +42,29 @@ describe("1-* relationship involving Interface type", () => {
 
             type ${Movie} @node {
                 title: String!
-                actor: [${Dog}!]! @relationship(type: "ACTED_IN", direction: IN)
-                director: ${Person}! @relationship(type: "DIRECTED", direction: IN)
+                actor: [${Dog}!]! @relationship(type: "ACTED_IN", direction: IN, properties: "ActedIn")
+                director: ${Person}! @relationship(type: "DIRECTED", direction: IN, properties: "Directed")
             }
 
             type ${Dog} implements Actor @node {
                 name: String!
-                actedIn: ${Movie}! @relationship(type: "ACTED_IN", direction: OUT)
+                actedIn: ${Movie}! @relationship(type: "ACTED_IN", direction: OUT, properties: "ActedIn")
             }
 
             type ${Person} implements Actor & Director @node{
                 name: String!
                 years: Int!
-                actedIn: ${Movie}! @relationship(type: "ACTED_IN", direction: OUT)
-                directed: [${Movie}!]! @relationship(type: "DIRECTED", direction: OUT)
+                actedIn: ${Movie}! @relationship(type: "ACTED_IN", direction: OUT, properties: "ActedIn")
+                directed: [${Movie}!]! @relationship(type: "DIRECTED", direction: OUT, properties: "Directed")
              }
+
+            type ActedIn @relationshipProperties {
+                screenTime: Int!
+            }
+
+            type Directed @relationshipProperties {
+                year: Int
+            }
         `;
 
         await testHelper.initNeo4jGraphQL({
@@ -190,6 +196,158 @@ describe("1-* relationship involving Interface type", () => {
                             },
                         ],
                     },
+                },
+            ],
+        });
+    });
+
+    test("nested filter", async () => {
+        await testHelper.executeCypher(`
+            CREATE(m:${Movie} { title: "The Matrix"})<-[:ACTED_IN]-(a:${Dog} { name: "Hachiko"})
+            CREATE(m)<-[:ACTED_IN]-(:${Person} { name: "Keanu"})
+            CREATE(m)<-[:DIRECTED]-(d:${Person} { name: "Director", years: 10})
+            CREATE(d)-[:DIRECTED]->(m2:${Movie} { title: "The Office"})
+            CREATE(a)-[:ACTED_IN]->(m2)
+        `);
+
+        const query = `
+            query {
+               ${Movie.plural}(where: { director: { name: { eq: "Director" } } }) {
+                    title
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+        console.log(result.errors);
+        expect(result.errors).toBeFalsy();
+        expect(result.data).toEqual({
+            [Movie.plural]: [
+                {
+                    title: "The Matrix",
+                },
+                {
+                    title: "The Office",
+                },
+            ],
+        });
+    });
+
+    test("double nested filter", async () => {
+        await testHelper.executeCypher(`
+            CREATE(m:${Movie} { title: "The Matrix"})<-[:ACTED_IN]-(a:${Dog} { name: "Hachiko"})
+            CREATE(m)<-[:ACTED_IN]-(:${Person} { name: "Keanu"})
+            CREATE(m)<-[:DIRECTED]-(d:${Person} { name: "Director", years: 10})
+            CREATE(d)-[:DIRECTED]->(m2:${Movie} { title: "The Office"})
+            CREATE(a)-[:ACTED_IN]->(m2)
+        `);
+
+        const query = `
+            query {
+               ${Person.plural}(where: { actedIn: { director: { years: { eq: 10 } } } }) {
+                    actedIn {
+                        title
+                        director {
+                            name
+                        }
+                    }
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+        console.log(result.errors);
+        expect(result.errors).toBeFalsy();
+        expect(result.data).toEqual({
+            [Person.plural]: [
+                {
+                    actedIn: {
+                        title: "The Matrix",
+                        director: {
+                            name: "Director",
+                        },
+                    },
+                },
+            ],
+        });
+    });
+
+    test("nested filter with edge properties", async () => {
+        await testHelper.executeCypher(`
+            CREATE(m:${Movie} { title: "The Matrix"})<-[:ACTED_IN {screenTime: 100}]-(a:${Dog} { name: "Hachiko"})
+            CREATE(m)<-[:ACTED_IN {screenTime: 20}]-(:${Person} { name: "Keanu"})
+            CREATE(m)<-[:DIRECTED {year: 2020}]-(d:${Person} { name: "Director", years: 10})
+            CREATE(d)-[:DIRECTED {year: 1995}]->(m2:${Movie} { title: "The Office"})
+            CREATE(a)-[:ACTED_IN {screenTime: 50}]->(m2)
+        `);
+
+        const query = `
+            query {
+               ${Movie.plural}(where: { directorConnection: { edge: { year: { gt: 1999 } } } }) {
+                    directorConnection {
+                        edges {
+                            node {
+                                name
+                            }
+                            properties {
+                                year
+                            }
+                        }
+                    }
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+        console.log(result.errors);
+        expect(result.errors).toBeFalsy();
+        expect(result.data).toEqual({
+            [Movie.plural]: [
+                {
+                    directorConnection: {
+                        edges: [
+                            {
+                                node: {
+                                    name: "Director",
+                                },
+                                properties: {
+                                    year: 2020,
+                                },
+                            },
+                        ],
+                    },
+                },
+            ],
+        });
+    });
+
+    test("double nested filter with edge properties", async () => {
+        await testHelper.executeCypher(`
+            CREATE(m:${Movie} { title: "The Matrix"})<-[:ACTED_IN {screenTime: 100}]-(a:${Dog} { name: "Hachiko"})
+            CREATE(m)<-[:ACTED_IN {screenTime: 20}]-(:${Person} { name: "Keanu"})
+            CREATE(m)<-[:DIRECTED {year: 2020}]-(d:${Person} { name: "Director", years: 10})
+            CREATE(d)-[:DIRECTED {year: 1995}]->(m2:${Movie} { title: "The Office"})
+            CREATE(a)-[:ACTED_IN {screenTime: 50}]->(m2)
+        `);
+
+        const query = `
+            query {
+               ${Movie.plural}(where: { actorConnection: { some: { node: { actedInConnection: { OR: [{ edge: { screenTime: { gt: 20 } } }, { node: { title: { eq: "The Matrix" } } }] } } } } }) {
+                    title
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+        console.log(result.errors);
+        expect(result.errors).toBeFalsy();
+        expect(result.data).toEqual({
+            [Movie.plural]: [
+                {
+                    title: "The Matrix",
+                },
+                {
+                    title: "The Office",
                 },
             ],
         });

--- a/packages/graphql/tests/integration/directives/relationship/simple-relationship-1-many.int.test.ts
+++ b/packages/graphql/tests/integration/directives/relationship/simple-relationship-1-many.int.test.ts
@@ -72,14 +72,44 @@ describe("1-* simple relationship", () => {
         expect(result.data).toEqual({
             [Person.plural]: [
                 {
-                    directed: [
+                    directed: expect.toIncludeSameMembers([
                         {
                             title: "The Matrix",
                         },
                         {
                             title: "The Matrix 2",
                         },
-                    ],
+                    ]),
+                },
+            ],
+        });
+    });
+
+    test("nested filter", async () => {
+        await testHelper.executeCypher(`
+            CREATE(m:${Movie} { title: "The Matrix"})<-[:DIRECTED]-(a:${Person} { name: "Keanu"})
+            CREATE (:${Movie} { title: "The Apartment"})
+        `);
+
+        const query = `
+            query {
+               ${Movie.plural}(where: { director: { name: { eq: "Keanu" } } }) {
+                    director {
+                        name
+                    }
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+        console.log(result.errors);
+        expect(result.errors).toBeFalsy();
+        expect(result.data).toEqual({
+            [Movie.plural]: [
+                {
+                    director: {
+                        name: "Keanu",
+                    },
                 },
             ],
         });
@@ -137,14 +167,14 @@ describe("1-* simple relationship", () => {
         expect(result.data).toEqual({
             [Person.plural]: [
                 {
-                    directed: [
+                    directed: expect.toIncludeSameMembers([
                         {
                             title: "The Matrix",
                         },
                         {
                             title: "The Matrix 2",
                         },
-                    ],
+                    ]),
                 },
             ],
         });

--- a/packages/graphql/tests/integration/directives/relationship/simple-relationship-1-many.int.test.ts
+++ b/packages/graphql/tests/integration/directives/relationship/simple-relationship-1-many.int.test.ts
@@ -33,12 +33,16 @@ describe("1-* simple relationship", () => {
         const typeDefs = /* GraphQL */ `
             type ${Movie} @node {
                 title: String!
-                director: ${Person}! @relationship(type: "DIRECTED", direction: IN)
+                director: ${Person}! @relationship(type: "DIRECTED", direction: IN, properties: "Directed")
             }
 
             type ${Person} @node {
                 name: String!
-                directed: [${Movie}!]! @relationship(type: "DIRECTED", direction: OUT)
+                directed: [${Movie}!]! @relationship(type: "DIRECTED", direction: OUT, properties: "Directed")
+            }
+            
+            type Directed @relationshipProperties {
+                year: Int
             }
         `;
 
@@ -109,6 +113,152 @@ describe("1-* simple relationship", () => {
                 {
                     director: {
                         name: "Keanu",
+                    },
+                },
+            ],
+        });
+    });
+
+    test("double nested filter", async () => {
+        await testHelper.executeCypher(`
+            CREATE(m:${Movie} { title: "The Matrix"})<-[:DIRECTED]-(a:${Person} { name: "Keanu"})
+            CREATE (:${Movie} { title: "The Apartment"})
+        `);
+
+        const query = `
+            query {
+               ${Person.plural}(where: { directed: { some: { director: { name: { eq: "Keanu" } } } } }) {
+                    directed {
+                        title
+                        director {
+                            name
+                        }
+                    }
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+        console.log(result.errors);
+        expect(result.errors).toBeFalsy();
+        expect(result.data).toEqual({
+            [Person.plural]: [
+                {
+                    directed: [
+                        {
+                            title: "The Matrix",
+                            director: {
+                                name: "Keanu",
+                            },
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+
+    test("nested filter with edge properties", async () => {
+        await testHelper.executeCypher(`
+            CREATE(m:${Movie} { title: "The Matrix"})<-[:DIRECTED {year: 1999}]-(a:${Person} { name: "Keanu"})
+            CREATE (:${Movie} { title: "The Apartment"})
+        `);
+
+        const query = `
+            query {
+               ${Movie.plural}(where: { directorConnection: { edge: { year: { eq: 1999 } } } }) {
+                    directorConnection {
+                        edges {
+                            node {
+                                name
+                            }
+                            properties {
+                                year
+                            }
+                        }
+                    }
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+        console.log(result.errors);
+        expect(result.errors).toBeFalsy();
+        expect(result.data).toEqual({
+            [Movie.plural]: [
+                {
+                    directorConnection: {
+                        edges: [
+                            {
+                                node: {
+                                    name: "Keanu",
+                                },
+                                properties: {
+                                    year: 1999,
+                                },
+                            },
+                        ],
+                    },
+                },
+            ],
+        });
+    });
+
+    test("double nested filter with edge properties", async () => {
+        await testHelper.executeCypher(`
+            CREATE(m:${Movie} { title: "The Matrix"})<-[:DIRECTED {year: 1999}]-(a:${Person} { name: "Keanu"})
+            CREATE (:${Movie} { title: "The Apartment"})
+        `);
+
+        const query = `
+            query {
+               ${Person.plural}(where: { directedConnection: { some: { node: { directorConnection: { OR: [{ edge: { year: { gt: 2000 } } }, { node: { name: { startsWith: "K" } } }] } } } } }) {
+                    directedConnection {
+                        edges {
+                            node {
+                                title
+                                directorConnection {
+                                    edges {
+                                        node {
+                                            name
+                                        }
+                                    }
+                                }
+                            }
+                            properties {
+                                year
+                            }
+                        }
+                    }
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+        console.log(result.errors);
+        expect(result.errors).toBeFalsy();
+        expect(result.data).toEqual({
+            [Person.plural]: [
+                {
+                    directedConnection: {
+                        edges: [
+                            {
+                                node: {
+                                    title: "The Matrix",
+                                    directorConnection: {
+                                        edges: [
+                                            {
+                                                node: {
+                                                    name: "Keanu",
+                                                },
+                                            },
+                                        ],
+                                    },
+                                },
+                                properties: {
+                                    year: 1999,
+                                },
+                            },
+                        ],
                     },
                 },
             ],

--- a/packages/graphql/tests/integration/directives/relationship/simple-relationship-1-many.int.test.ts
+++ b/packages/graphql/tests/integration/directives/relationship/simple-relationship-1-many.int.test.ts
@@ -55,7 +55,7 @@ describe("1-* simple relationship", () => {
         await testHelper.close();
     });
 
-    test.only("returns all relationships", async () => {
+    test("returns all relationships", async () => {
         await testHelper.executeCypher(`
             CREATE(m:${Movie} { title: "The Matrix"})<-[:DIRECTED]-(a:${Person} { name: "Keanu"})
             CREATE(a)-[:DIRECTED]->(:${Movie} { title: "The Matrix 2"})

--- a/packages/graphql/tests/integration/directives/relationship/simple-relationship-1-many.int.test.ts
+++ b/packages/graphql/tests/integration/directives/relationship/simple-relationship-1-many.int.test.ts
@@ -55,7 +55,7 @@ describe("1-* simple relationship", () => {
         await testHelper.close();
     });
 
-    test("returns all relationships", async () => {
+    test.only("returns all relationships", async () => {
         await testHelper.executeCypher(`
             CREATE(m:${Movie} { title: "The Matrix"})<-[:DIRECTED]-(a:${Person} { name: "Keanu"})
             CREATE(a)-[:DIRECTED]->(:${Movie} { title: "The Matrix 2"})
@@ -106,7 +106,6 @@ describe("1-* simple relationship", () => {
         `;
 
         const result = await testHelper.executeGraphQL(query);
-        console.log(result.errors);
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
             [Movie.plural]: [
@@ -139,7 +138,6 @@ describe("1-* simple relationship", () => {
         `;
 
         const result = await testHelper.executeGraphQL(query);
-        console.log(result.errors);
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
             [Person.plural]: [
@@ -181,7 +179,6 @@ describe("1-* simple relationship", () => {
         `;
 
         const result = await testHelper.executeGraphQL(query);
-        console.log(result.errors);
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
             [Movie.plural]: [
@@ -234,7 +231,6 @@ describe("1-* simple relationship", () => {
         `;
 
         const result = await testHelper.executeGraphQL(query);
-        console.log(result.errors);
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
             [Person.plural]: [

--- a/packages/graphql/tests/integration/directives/relationship/union-relationship-1-many.int.test.ts
+++ b/packages/graphql/tests/integration/directives/relationship/union-relationship-1-many.int.test.ts
@@ -39,23 +39,31 @@ describe("1-* relationships involving Union type", () => {
             union Director = ${Person} | ${AI}
             type ${Movie} @node {
                 title: String!
-                actor: [Actor!]! @relationship(type: "ACTED_IN", direction: IN)
-                director: Director! @relationship(type: "DIRECTED", direction: IN)
+                actor: [Actor!]! @relationship(type: "ACTED_IN", direction: IN, properties: "ActedIn")
+                director: Director! @relationship(type: "DIRECTED", direction: IN, properties: "Directed")
             }
 
             type ${Person} @node {
                 name: String!
-                actedIn: ${Movie}! @relationship(type: "ACTED_IN", direction: OUT)
-                directed: [${Movie}!]! @relationship(type: "DIRECTED", direction: OUT)
+                actedIn: ${Movie}! @relationship(type: "ACTED_IN", direction: OUT, properties: "ActedIn")
+                directed: [${Movie}!]! @relationship(type: "DIRECTED", direction: OUT, properties: "Directed")
             }
 
             type ${Dog} @node {
                 nickName: String!
-                actedIn: ${Movie}! @relationship(type: "ACTED_IN", direction: OUT)
+                actedIn: ${Movie}! @relationship(type: "ACTED_IN", direction: OUT, properties: "ActedIn")
             }
             type ${AI} @node {
                 model: String!
-                directed: [${Movie}!]! @relationship(type: "DIRECTED", direction: OUT)
+                directed: [${Movie}!]! @relationship(type: "DIRECTED", direction: OUT, properties: "Directed")
+            }
+
+            type ActedIn @relationshipProperties {
+                screenTime: Int
+            }
+
+            type Directed @relationshipProperties {
+                year: Int
             }
         `;
 
@@ -212,6 +220,129 @@ describe("1-* relationships involving Union type", () => {
                     },
                 },
             ],
+        });
+    });
+
+    test("nested filter", async () => {
+        await testHelper.executeCypher(`
+            CREATE(m:${Movie} { title: "The Matrix"})<-[:ACTED_IN]-(:${Dog} { nickName: "Hachiko"})
+            CREATE(m)<-[:ACTED_IN]-(:${Person} { name: "Keanu"})
+            CREATE(m)<-[:DIRECTED]-(a:${AI} { model: "T-800"})
+            CREATE(:${Movie} { title: "The Apartment"})<-[:DIRECTED]-(a)
+        `);
+
+        const query = `
+            query {
+               ${Movie.plural}(where: { director: { ${AI}: { model: { eq: "T-800" } } } }) {
+                    title
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+        console.log(result.errors);
+        expect(result.errors).toBeFalsy();
+        expect(result.data).toEqual({
+            [Movie.plural]: [
+                {
+                    title: "The Matrix",
+                },
+                {
+                    title: "The Apartment",
+                },
+            ],
+        });
+    });
+
+    test("double nested filter", async () => {
+        await testHelper.executeCypher(`
+            CREATE(m:${Movie} { title: "The Matrix"})<-[:ACTED_IN]-(:${Dog} { nickName: "Hachiko"})
+            CREATE(m)<-[:ACTED_IN]-(:${Person} { name: "Keanu"})
+            CREATE(m)<-[:DIRECTED]-(a:${AI} { model: "T-800"})
+            CREATE(:${Movie} { title: "The Apartment"})<-[:DIRECTED]-(a)
+        `);
+
+        const query = `
+            query {
+               ${Person.plural}(where: { actedIn: { director: { ${AI}: { model: { eq: "T-800" } } } } }) {
+                    name
+                    actedIn {
+                        title
+                    }
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+        console.log(result.errors);
+        expect(result.errors).toBeFalsy();
+        expect(result.data).toEqual({
+            [Person.plural]: [
+                {
+                    name: "Keanu",
+                    actedIn: {
+                        title: "The Matrix",
+                    },
+                },
+            ],
+        });
+    });
+
+    test("nested filter with edge properties", async () => {
+        await testHelper.executeCypher(`
+            CREATE(m:${Movie} { title: "The Matrix"})<-[:ACTED_IN {screenTime: 120}]-(:${Dog} { nickName: "Hachiko"})
+            CREATE(m)<-[:ACTED_IN {screenTime: 150}]-(d:${Person} { name: "Keanu"})
+            CREATE(m)<-[:DIRECTED {year: 1999}]-(a:${AI} { model: "T-800"})
+            CREATE(:${Movie} { title: "The Apartment"})<-[:DIRECTED {year: 1996}]-(d)
+        `);
+
+        const query = `
+            query {
+               ${Movie.plural}(where: { directorConnection: { ${Person}: { edge: { year: { gt: 1990 } } } } }) {
+                   title
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+        console.log(result.errors);
+        expect(result.errors).toBeFalsy();
+        expect(result.data).toEqual({
+            [Movie.plural]: [
+                {
+                    title: "The Apartment",
+                },
+            ],
+        });
+    });
+
+    test("double nested filter with edge properties", async () => {
+        await testHelper.executeCypher(`
+            CREATE(m:${Movie} { title: "The Matrix"})<-[:ACTED_IN {screenTime: 120}]-(:${Dog} { nickName: "Hachiko"})
+            CREATE(m)<-[:ACTED_IN {screenTime: 150}]-(:${Person} { name: "Keanu"})
+            CREATE(m)<-[:DIRECTED {year: 1999}]-(a:${AI} { model: "T-800"})
+            CREATE(:${Movie} { title: "The Apartment"})<-[:DIRECTED {year: 1996}]-(a)
+        `);
+
+        const query = `
+            query {
+               ${Movie.plural}(where: { directorConnection: { ${AI}: { node: { directedConnection: { some: { OR: [{ edge: { year: { gt: 1997 } } }, { node: { title: { eq: "The Apartment" } } }] } } } } } }) {
+                    title
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+        expect(result.errors).toBeFalsy();
+        expect(result.data).toEqual({
+            [Movie.plural]: expect.toIncludeSameMembers([
+                {
+                    title: "The Apartment",
+                },
+                {
+                    title: "The Matrix",
+                },
+            ]),
         });
     });
 

--- a/packages/graphql/tests/integration/directives/relationship/union-relationship-1-many.int.test.ts
+++ b/packages/graphql/tests/integration/directives/relationship/union-relationship-1-many.int.test.ts
@@ -240,7 +240,6 @@ describe("1-* relationships involving Union type", () => {
         `;
 
         const result = await testHelper.executeGraphQL(query);
-        console.log(result.errors);
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
             [Movie.plural]: [
@@ -274,7 +273,6 @@ describe("1-* relationships involving Union type", () => {
         `;
 
         const result = await testHelper.executeGraphQL(query);
-        console.log(result.errors);
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
             [Person.plural]: [
@@ -305,7 +303,6 @@ describe("1-* relationships involving Union type", () => {
         `;
 
         const result = await testHelper.executeGraphQL(query);
-        console.log(result.errors);
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
             [Movie.plural]: [

--- a/packages/graphql/tests/schema/relationship/single-element-declared-relationship-interface.test.ts
+++ b/packages/graphql/tests/schema/relationship/single-element-declared-relationship-interface.test.ts
@@ -247,6 +247,10 @@ describe("single item relationships from a declared relationship", () => {
               AND: [MovieWhere!]
               NOT: MovieWhere
               OR: [MovieWhere!]
+              actor: ActorWhere
+              actorConnection: ProductionActorConnectionWhere
+              director: PersonWhere
+              directorConnection: ProductionDirectorConnectionWhere
               title: StringScalarFilters
             }
 
@@ -341,6 +345,13 @@ describe("single item relationships from a declared relationship", () => {
               totalCount: Int!
             }
 
+            input ProductionActorConnectionWhere {
+              AND: [ProductionActorConnectionWhere!]
+              NOT: ProductionActorConnectionWhere
+              OR: [ProductionActorConnectionWhere!]
+              node: ActorWhere
+            }
+
             type ProductionActorRelationship {
               cursor: String!
               node: Actor!
@@ -359,6 +370,13 @@ describe("single item relationships from a declared relationship", () => {
               edges: [ProductionDirectorRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
+            }
+
+            input ProductionDirectorConnectionWhere {
+              AND: [ProductionDirectorConnectionWhere!]
+              NOT: ProductionDirectorConnectionWhere
+              OR: [ProductionDirectorConnectionWhere!]
+              node: PersonWhere
             }
 
             type ProductionDirectorRelationship {
@@ -387,6 +405,10 @@ describe("single item relationships from a declared relationship", () => {
               AND: [ProductionWhere!]
               NOT: ProductionWhere
               OR: [ProductionWhere!]
+              actor: ActorWhere
+              actorConnection: ProductionActorConnectionWhere
+              director: PersonWhere
+              directorConnection: ProductionDirectorConnectionWhere
               title: StringScalarFilters
               typename: [ProductionImplementation!]
             }
@@ -461,6 +483,10 @@ describe("single item relationships from a declared relationship", () => {
               AND: [SeriesWhere!]
               NOT: SeriesWhere
               OR: [SeriesWhere!]
+              actor: ActorWhere
+              actorConnection: ProductionActorConnectionWhere
+              director: PersonWhere
+              directorConnection: ProductionDirectorConnectionWhere
               title: StringScalarFilters
             }
 
@@ -591,6 +617,13 @@ describe("single item relationships from a declared relationship", () => {
               edges: [ActorActedInRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
+            }
+
+            input ActorActedInConnectionWhere {
+              AND: [ActorActedInConnectionWhere!]
+              NOT: ActorActedInConnectionWhere
+              OR: [ActorActedInConnectionWhere!]
+              node: ProductionWhere
             }
 
             type ActorActedInRelationship {
@@ -757,6 +790,8 @@ describe("single item relationships from a declared relationship", () => {
               AND: [ActorWhere!]
               NOT: ActorWhere
               OR: [ActorWhere!]
+              actedIn: ProductionWhere
+              actedInConnection: ActorActedInConnectionWhere
               directed: ProductionRelationshipFilters
               directedConnection: ActorDirectedConnectionFilters
               name: StringScalarFilters
@@ -935,6 +970,8 @@ describe("single item relationships from a declared relationship", () => {
               AND: [DogWhere!]
               NOT: DogWhere
               OR: [DogWhere!]
+              actedIn: ProductionWhere
+              actedInConnection: ActorActedInConnectionWhere
               directed: ProductionRelationshipFilters
               directedConnection: DogDirectedConnectionFilters
               name: StringScalarFilters
@@ -1091,6 +1128,8 @@ describe("single item relationships from a declared relationship", () => {
               OR: [MovieWhere!]
               actor: ActorRelationshipFilters
               actorConnection: MovieActorConnectionFilters
+              director: PersonWhere
+              directorConnection: ProductionDirectorConnectionWhere
               title: StringScalarFilters
             }
 
@@ -1253,6 +1292,8 @@ describe("single item relationships from a declared relationship", () => {
               AND: [PersonWhere!]
               NOT: PersonWhere
               OR: [PersonWhere!]
+              actedIn: ProductionWhere
+              actedInConnection: ActorActedInConnectionWhere
               directed: ProductionRelationshipFilters
               directedConnection: PersonDirectedConnectionFilters
               name: StringScalarFilters
@@ -1390,6 +1431,13 @@ describe("single item relationships from a declared relationship", () => {
               totalCount: Int!
             }
 
+            input ProductionDirectorConnectionWhere {
+              AND: [ProductionDirectorConnectionWhere!]
+              NOT: ProductionDirectorConnectionWhere
+              OR: [ProductionDirectorConnectionWhere!]
+              node: PersonWhere
+            }
+
             type ProductionDirectorRelationship {
               cursor: String!
               node: Person!
@@ -1438,6 +1486,8 @@ describe("single item relationships from a declared relationship", () => {
               OR: [ProductionWhere!]
               actor: ActorRelationshipFilters
               actorConnection: ProductionActorConnectionFilters
+              director: PersonWhere
+              directorConnection: ProductionDirectorConnectionWhere
               title: StringScalarFilters
               typename: [ProductionImplementation!]
             }
@@ -1595,6 +1645,1186 @@ describe("single item relationships from a declared relationship", () => {
               OR: [SeriesWhere!]
               actor: ActorRelationshipFilters
               actorConnection: SeriesActorConnectionFilters
+              director: PersonWhere
+              directorConnection: ProductionDirectorConnectionWhere
+              title: StringScalarFilters
+            }
+
+            \\"\\"\\"An enum for sorting in either ascending or descending order.\\"\\"\\"
+            enum SortDirection {
+              \\"\\"\\"Sort by field values in ascending order.\\"\\"\\"
+              ASC
+              \\"\\"\\"Sort by field values in descending order.\\"\\"\\"
+              DESC
+            }
+
+            type StringAggregateSelection {
+              longest: String
+              shortest: String
+            }
+
+            \\"\\"\\"Filters for an aggregation of a string field\\"\\"\\"
+            input StringScalarAggregationFilters {
+              averageLength: FloatScalarFilters
+              longestLength: IntScalarFilters
+              shortestLength: IntScalarFilters
+            }
+
+            \\"\\"\\"String filters\\"\\"\\"
+            input StringScalarFilters {
+              contains: String
+              endsWith: String
+              eq: String
+              in: [String!]
+              startsWith: String
+            }
+
+            \\"\\"\\"String mutations\\"\\"\\"
+            input StringScalarMutations {
+              set: String
+            }
+
+            type UpdateDogsMutationResponse {
+              dogs: [Dog!]!
+              info: UpdateInfo!
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships created and deleted during an update mutation
+            \\"\\"\\"
+            type UpdateInfo {
+              nodesCreated: Int!
+              nodesDeleted: Int!
+              relationshipsCreated: Int!
+              relationshipsDeleted: Int!
+            }
+
+            type UpdateMoviesMutationResponse {
+              info: UpdateInfo!
+              movies: [Movie!]!
+            }
+
+            type UpdatePeopleMutationResponse {
+              info: UpdateInfo!
+              people: [Person!]!
+            }
+
+            type UpdateSeriesMutationResponse {
+              info: UpdateInfo!
+              series: [Series!]!
+            }"
+        `);
+    });
+
+    test("1-* relationship with edge properties", async () => {
+        const typeDefs = gql`
+            interface Actor {
+                name: String!
+                actedIn: Production! @declareRelationship
+                directed: [Production!]! @declareRelationship
+            }
+            interface Production {
+                title: String!
+                actor: [Actor!]! @declareRelationship
+                director: Person! @declareRelationship
+            }
+
+            type Movie implements Production @node {
+                title: String!
+                actor: [Actor!]! @relationship(type: "ACTED_IN", direction: IN, properties: "ActedInMovie")
+                director: Person! @relationship(type: "DIRECTED", direction: IN, properties: "Directed")
+            }
+
+            type Series implements Production @node {
+                title: String!
+                actor: [Actor!]! @relationship(type: "ACTED_IN", direction: IN, properties: "ActedInSeries")
+                director: Person! @relationship(type: "DIRECTED", direction: IN, properties: "Directed")
+            }
+
+            type Dog implements Actor @node {
+                name: String!
+                actedIn: Production! @relationship(type: "ACTED_IN", direction: OUT, properties: "ActedInMovie")
+                directed: [Production!]! @relationship(type: "DIRECTED", direction: OUT, properties: "Directed")
+            }
+
+            type Person implements Actor @node {
+                name: String!
+                actedIn: Production! @relationship(type: "ACTED_IN", direction: OUT, properties: "ActedInSeries")
+                directed: [Production!]! @relationship(type: "DIRECTED", direction: OUT, properties: "Directed")
+            }
+
+            type ActedInMovie @relationshipProperties {
+                scenes: Int!
+            }
+            type ActedInSeries @relationshipProperties {
+                episodes: Int!
+            }
+            type Directed @relationshipProperties {
+                year: Int!
+            }
+        `;
+        const neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            features: {
+                excludeDeprecatedFields: {
+                    mutationOperations: true,
+                    aggregationFilters: true,
+                    aggregationFiltersOutsideConnection: true,
+                    relationshipFilters: true,
+                    attributeFilters: true,
+                },
+            },
+        });
+        const printedSchema = printSchemaWithDirectives(lexicographicSortSchema(await neoSchema.getSchema()));
+
+        expect(printedSchema).toMatchInlineSnapshot(`
+            "schema {
+              query: Query
+              mutation: Mutation
+            }
+
+            interface Actor {
+              actedIn: Production!
+              actedInConnection: ActorActedInConnection!
+              directed(limit: Int, offset: Int, sort: [ProductionSort!], where: ProductionWhere): [Production!]!
+              directedConnection(after: String, first: Int, sort: [ActorDirectedConnectionSort!], where: ActorDirectedConnectionWhere): ActorDirectedConnection!
+              name: String!
+            }
+
+            type ActorActedInConnection {
+              edges: [ActorActedInRelationship!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            input ActorActedInConnectionWhere {
+              AND: [ActorActedInConnectionWhere!]
+              NOT: ActorActedInConnectionWhere
+              OR: [ActorActedInConnectionWhere!]
+              node: ProductionWhere
+            }
+
+            type ActorActedInRelationship {
+              cursor: String!
+              node: Production!
+            }
+
+            type ActorAggregate {
+              count: Count!
+              node: ActorAggregateNode!
+            }
+
+            type ActorAggregateNode {
+              name: StringAggregateSelection!
+            }
+
+            input ActorConnectInput {
+              directed: [ActorDirectedConnectFieldInput!]
+            }
+
+            input ActorConnectWhere {
+              node: ActorWhere!
+            }
+
+            input ActorCreateInput {
+              Dog: DogCreateInput
+              Person: PersonCreateInput
+            }
+
+            input ActorDeleteInput {
+              directed: [ActorDirectedDeleteFieldInput!]
+            }
+
+            input ActorDirectedConnectFieldInput {
+              connect: ProductionConnectInput
+              where: ProductionConnectWhere
+            }
+
+            type ActorDirectedConnection {
+              edges: [ActorDirectedRelationship!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            input ActorDirectedConnectionAggregateInput {
+              AND: [ActorDirectedConnectionAggregateInput!]
+              NOT: ActorDirectedConnectionAggregateInput
+              OR: [ActorDirectedConnectionAggregateInput!]
+              count: ConnectionAggregationCountFilterInput
+              node: ActorDirectedNodeAggregationWhereInput
+            }
+
+            input ActorDirectedConnectionFilters {
+              \\"\\"\\"
+              Filter Actors by aggregating results on related ActorDirectedConnections
+              \\"\\"\\"
+              aggregate: ActorDirectedConnectionAggregateInput
+              \\"\\"\\"
+              Return Actors where all of the related ActorDirectedConnections match this filter
+              \\"\\"\\"
+              all: ActorDirectedConnectionWhere
+              \\"\\"\\"
+              Return Actors where none of the related ActorDirectedConnections match this filter
+              \\"\\"\\"
+              none: ActorDirectedConnectionWhere
+              \\"\\"\\"
+              Return Actors where one of the related ActorDirectedConnections match this filter
+              \\"\\"\\"
+              single: ActorDirectedConnectionWhere
+              \\"\\"\\"
+              Return Actors where some of the related ActorDirectedConnections match this filter
+              \\"\\"\\"
+              some: ActorDirectedConnectionWhere
+            }
+
+            input ActorDirectedConnectionSort {
+              node: ProductionSort
+            }
+
+            input ActorDirectedConnectionWhere {
+              AND: [ActorDirectedConnectionWhere!]
+              NOT: ActorDirectedConnectionWhere
+              OR: [ActorDirectedConnectionWhere!]
+              node: ProductionWhere
+            }
+
+            input ActorDirectedCreateFieldInput {
+              node: ProductionCreateInput!
+            }
+
+            input ActorDirectedDeleteFieldInput {
+              delete: ProductionDeleteInput
+              where: ActorDirectedConnectionWhere
+            }
+
+            input ActorDirectedDisconnectFieldInput {
+              disconnect: ProductionDisconnectInput
+              where: ActorDirectedConnectionWhere
+            }
+
+            input ActorDirectedNodeAggregationWhereInput {
+              AND: [ActorDirectedNodeAggregationWhereInput!]
+              NOT: ActorDirectedNodeAggregationWhereInput
+              OR: [ActorDirectedNodeAggregationWhereInput!]
+              title: StringScalarAggregationFilters
+            }
+
+            type ActorDirectedRelationship {
+              cursor: String!
+              node: Production!
+            }
+
+            input ActorDirectedUpdateConnectionInput {
+              node: ProductionUpdateInput
+              where: ActorDirectedConnectionWhere
+            }
+
+            input ActorDirectedUpdateFieldInput {
+              connect: [ActorDirectedConnectFieldInput!]
+              create: [ActorDirectedCreateFieldInput!]
+              delete: [ActorDirectedDeleteFieldInput!]
+              disconnect: [ActorDirectedDisconnectFieldInput!]
+              update: ActorDirectedUpdateConnectionInput
+            }
+
+            input ActorDisconnectInput {
+              directed: [ActorDirectedDisconnectFieldInput!]
+            }
+
+            type ActorEdge {
+              cursor: String!
+              node: Actor!
+            }
+
+            enum ActorImplementation {
+              Dog
+              Person
+            }
+
+            input ActorRelationshipFilters {
+              \\"\\"\\"Filter type where all of the related Actors match this filter\\"\\"\\"
+              all: ActorWhere
+              \\"\\"\\"Filter type where none of the related Actors match this filter\\"\\"\\"
+              none: ActorWhere
+              \\"\\"\\"Filter type where one of the related Actors match this filter\\"\\"\\"
+              single: ActorWhere
+              \\"\\"\\"Filter type where some of the related Actors match this filter\\"\\"\\"
+              some: ActorWhere
+            }
+
+            \\"\\"\\"
+            Fields to sort Actors by. The order in which sorts are applied is not guaranteed when specifying many fields in one ActorSort object.
+            \\"\\"\\"
+            input ActorSort {
+              name: SortDirection
+            }
+
+            input ActorUpdateInput {
+              directed: [ActorDirectedUpdateFieldInput!]
+              name: StringScalarMutations
+            }
+
+            input ActorWhere {
+              AND: [ActorWhere!]
+              NOT: ActorWhere
+              OR: [ActorWhere!]
+              actedIn: ProductionWhere
+              actedInConnection: ActorActedInConnectionWhere
+              directed: ProductionRelationshipFilters
+              directedConnection: ActorDirectedConnectionFilters
+              name: StringScalarFilters
+              typename: [ActorImplementation!]
+            }
+
+            type ActorsConnection {
+              aggregate: ActorAggregate!
+              edges: [ActorEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            input ConnectionAggregationCountFilterInput {
+              edges: IntScalarFilters
+              nodes: IntScalarFilters
+            }
+
+            type Count {
+              nodes: Int!
+            }
+
+            type CreateDogsMutationResponse {
+              dogs: [Dog!]!
+              info: CreateInfo!
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships created during a create mutation
+            \\"\\"\\"
+            type CreateInfo {
+              nodesCreated: Int!
+              relationshipsCreated: Int!
+            }
+
+            type CreateMoviesMutationResponse {
+              info: CreateInfo!
+              movies: [Movie!]!
+            }
+
+            type CreatePeopleMutationResponse {
+              info: CreateInfo!
+              people: [Person!]!
+            }
+
+            type CreateSeriesMutationResponse {
+              info: CreateInfo!
+              series: [Series!]!
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships deleted during a delete mutation
+            \\"\\"\\"
+            type DeleteInfo {
+              nodesDeleted: Int!
+              relationshipsDeleted: Int!
+            }
+
+            type Dog implements Actor {
+              actedIn: Production!
+              actedInConnection: ActorActedInConnection!
+              directed(limit: Int, offset: Int, sort: [ProductionSort!], where: ProductionWhere): [Production!]!
+              directedConnection(after: String, first: Int, sort: [ActorDirectedConnectionSort!], where: ActorDirectedConnectionWhere): ActorDirectedConnection!
+              name: String!
+            }
+
+            type DogAggregate {
+              count: Count!
+              node: DogAggregateNode!
+            }
+
+            type DogAggregateNode {
+              name: StringAggregateSelection!
+            }
+
+            input DogCreateInput {
+              directed: DogDirectedFieldInput
+              name: String!
+            }
+
+            input DogDeleteInput {
+              directed: [DogDirectedDeleteFieldInput!]
+            }
+
+            input DogDirectedConnectFieldInput {
+              connect: ProductionConnectInput
+              where: ProductionConnectWhere
+            }
+
+            input DogDirectedConnectionAggregateInput {
+              AND: [DogDirectedConnectionAggregateInput!]
+              NOT: DogDirectedConnectionAggregateInput
+              OR: [DogDirectedConnectionAggregateInput!]
+              count: ConnectionAggregationCountFilterInput
+              node: DogDirectedNodeAggregationWhereInput
+            }
+
+            input DogDirectedConnectionFilters {
+              \\"\\"\\"Filter Dogs by aggregating results on related ActorDirectedConnections\\"\\"\\"
+              aggregate: DogDirectedConnectionAggregateInput
+              \\"\\"\\"
+              Return Dogs where all of the related ActorDirectedConnections match this filter
+              \\"\\"\\"
+              all: ActorDirectedConnectionWhere
+              \\"\\"\\"
+              Return Dogs where none of the related ActorDirectedConnections match this filter
+              \\"\\"\\"
+              none: ActorDirectedConnectionWhere
+              \\"\\"\\"
+              Return Dogs where one of the related ActorDirectedConnections match this filter
+              \\"\\"\\"
+              single: ActorDirectedConnectionWhere
+              \\"\\"\\"
+              Return Dogs where some of the related ActorDirectedConnections match this filter
+              \\"\\"\\"
+              some: ActorDirectedConnectionWhere
+            }
+
+            input DogDirectedCreateFieldInput {
+              node: ProductionCreateInput!
+            }
+
+            input DogDirectedDeleteFieldInput {
+              delete: ProductionDeleteInput
+              where: ActorDirectedConnectionWhere
+            }
+
+            input DogDirectedDisconnectFieldInput {
+              disconnect: ProductionDisconnectInput
+              where: ActorDirectedConnectionWhere
+            }
+
+            input DogDirectedFieldInput {
+              connect: [DogDirectedConnectFieldInput!]
+              create: [DogDirectedCreateFieldInput!]
+            }
+
+            input DogDirectedNodeAggregationWhereInput {
+              AND: [DogDirectedNodeAggregationWhereInput!]
+              NOT: DogDirectedNodeAggregationWhereInput
+              OR: [DogDirectedNodeAggregationWhereInput!]
+              title: StringScalarAggregationFilters
+            }
+
+            input DogDirectedUpdateConnectionInput {
+              node: ProductionUpdateInput
+              where: ActorDirectedConnectionWhere
+            }
+
+            input DogDirectedUpdateFieldInput {
+              connect: [DogDirectedConnectFieldInput!]
+              create: [DogDirectedCreateFieldInput!]
+              delete: [DogDirectedDeleteFieldInput!]
+              disconnect: [DogDirectedDisconnectFieldInput!]
+              update: DogDirectedUpdateConnectionInput
+            }
+
+            type DogEdge {
+              cursor: String!
+              node: Dog!
+            }
+
+            \\"\\"\\"
+            Fields to sort Dogs by. The order in which sorts are applied is not guaranteed when specifying many fields in one DogSort object.
+            \\"\\"\\"
+            input DogSort {
+              name: SortDirection
+            }
+
+            input DogUpdateInput {
+              directed: [DogDirectedUpdateFieldInput!]
+              name: StringScalarMutations
+            }
+
+            input DogWhere {
+              AND: [DogWhere!]
+              NOT: DogWhere
+              OR: [DogWhere!]
+              actedIn: ProductionWhere
+              actedInConnection: ActorActedInConnectionWhere
+              directed: ProductionRelationshipFilters
+              directedConnection: DogDirectedConnectionFilters
+              name: StringScalarFilters
+            }
+
+            type DogsConnection {
+              aggregate: DogAggregate!
+              edges: [DogEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            \\"\\"\\"Float filters\\"\\"\\"
+            input FloatScalarFilters {
+              eq: Float
+              gt: Float
+              gte: Float
+              in: [Float!]
+              lt: Float
+              lte: Float
+            }
+
+            \\"\\"\\"Int filters\\"\\"\\"
+            input IntScalarFilters {
+              eq: Int
+              gt: Int
+              gte: Int
+              in: [Int!]
+              lt: Int
+              lte: Int
+            }
+
+            type Movie implements Production {
+              actor(limit: Int, offset: Int, sort: [ActorSort!], where: ActorWhere): [Actor!]!
+              actorConnection(after: String, first: Int, sort: [ProductionActorConnectionSort!], where: ProductionActorConnectionWhere): ProductionActorConnection!
+              director: Person!
+              directorConnection: ProductionDirectorConnection!
+              title: String!
+            }
+
+            input MovieActorConnectFieldInput {
+              connect: ActorConnectInput
+              where: ActorConnectWhere
+            }
+
+            input MovieActorConnectionAggregateInput {
+              AND: [MovieActorConnectionAggregateInput!]
+              NOT: MovieActorConnectionAggregateInput
+              OR: [MovieActorConnectionAggregateInput!]
+              count: ConnectionAggregationCountFilterInput
+              node: MovieActorNodeAggregationWhereInput
+            }
+
+            input MovieActorConnectionFilters {
+              \\"\\"\\"
+              Filter Movies by aggregating results on related ProductionActorConnections
+              \\"\\"\\"
+              aggregate: MovieActorConnectionAggregateInput
+              \\"\\"\\"
+              Return Movies where all of the related ProductionActorConnections match this filter
+              \\"\\"\\"
+              all: ProductionActorConnectionWhere
+              \\"\\"\\"
+              Return Movies where none of the related ProductionActorConnections match this filter
+              \\"\\"\\"
+              none: ProductionActorConnectionWhere
+              \\"\\"\\"
+              Return Movies where one of the related ProductionActorConnections match this filter
+              \\"\\"\\"
+              single: ProductionActorConnectionWhere
+              \\"\\"\\"
+              Return Movies where some of the related ProductionActorConnections match this filter
+              \\"\\"\\"
+              some: ProductionActorConnectionWhere
+            }
+
+            input MovieActorCreateFieldInput {
+              node: ActorCreateInput!
+            }
+
+            input MovieActorDeleteFieldInput {
+              delete: ActorDeleteInput
+              where: ProductionActorConnectionWhere
+            }
+
+            input MovieActorDisconnectFieldInput {
+              disconnect: ActorDisconnectInput
+              where: ProductionActorConnectionWhere
+            }
+
+            input MovieActorFieldInput {
+              connect: [MovieActorConnectFieldInput!]
+              create: [MovieActorCreateFieldInput!]
+            }
+
+            input MovieActorNodeAggregationWhereInput {
+              AND: [MovieActorNodeAggregationWhereInput!]
+              NOT: MovieActorNodeAggregationWhereInput
+              OR: [MovieActorNodeAggregationWhereInput!]
+              name: StringScalarAggregationFilters
+            }
+
+            input MovieActorUpdateConnectionInput {
+              node: ActorUpdateInput
+              where: ProductionActorConnectionWhere
+            }
+
+            input MovieActorUpdateFieldInput {
+              connect: [MovieActorConnectFieldInput!]
+              create: [MovieActorCreateFieldInput!]
+              delete: [MovieActorDeleteFieldInput!]
+              disconnect: [MovieActorDisconnectFieldInput!]
+              update: MovieActorUpdateConnectionInput
+            }
+
+            type MovieAggregate {
+              count: Count!
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              title: StringAggregateSelection!
+            }
+
+            input MovieCreateInput {
+              actor: MovieActorFieldInput
+              title: String!
+            }
+
+            input MovieDeleteInput {
+              actor: [MovieActorDeleteFieldInput!]
+            }
+
+            type MovieEdge {
+              cursor: String!
+              node: Movie!
+            }
+
+            \\"\\"\\"
+            Fields to sort Movies by. The order in which sorts are applied is not guaranteed when specifying many fields in one MovieSort object.
+            \\"\\"\\"
+            input MovieSort {
+              title: SortDirection
+            }
+
+            input MovieUpdateInput {
+              actor: [MovieActorUpdateFieldInput!]
+              title: StringScalarMutations
+            }
+
+            input MovieWhere {
+              AND: [MovieWhere!]
+              NOT: MovieWhere
+              OR: [MovieWhere!]
+              actor: ActorRelationshipFilters
+              actorConnection: MovieActorConnectionFilters
+              director: PersonWhere
+              directorConnection: ProductionDirectorConnectionWhere
+              title: StringScalarFilters
+            }
+
+            type MoviesConnection {
+              aggregate: MovieAggregate!
+              edges: [MovieEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type Mutation {
+              createDogs(input: [DogCreateInput!]!): CreateDogsMutationResponse!
+              createMovies(input: [MovieCreateInput!]!): CreateMoviesMutationResponse!
+              createPeople(input: [PersonCreateInput!]!): CreatePeopleMutationResponse!
+              createSeries(input: [SeriesCreateInput!]!): CreateSeriesMutationResponse!
+              deleteDogs(delete: DogDeleteInput, where: DogWhere): DeleteInfo!
+              deleteMovies(delete: MovieDeleteInput, where: MovieWhere): DeleteInfo!
+              deletePeople(delete: PersonDeleteInput, where: PersonWhere): DeleteInfo!
+              deleteSeries(delete: SeriesDeleteInput, where: SeriesWhere): DeleteInfo!
+              updateDogs(update: DogUpdateInput, where: DogWhere): UpdateDogsMutationResponse!
+              updateMovies(update: MovieUpdateInput, where: MovieWhere): UpdateMoviesMutationResponse!
+              updatePeople(update: PersonUpdateInput, where: PersonWhere): UpdatePeopleMutationResponse!
+              updateSeries(update: SeriesUpdateInput, where: SeriesWhere): UpdateSeriesMutationResponse!
+            }
+
+            \\"\\"\\"Pagination information (Relay)\\"\\"\\"
+            type PageInfo {
+              endCursor: String
+              hasNextPage: Boolean!
+              hasPreviousPage: Boolean!
+              startCursor: String
+            }
+
+            type PeopleConnection {
+              aggregate: PersonAggregate!
+              edges: [PersonEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type Person implements Actor {
+              actedIn: Production!
+              actedInConnection: ActorActedInConnection!
+              directed(limit: Int, offset: Int, sort: [ProductionSort!], where: ProductionWhere): [Production!]!
+              directedConnection(after: String, first: Int, sort: [ActorDirectedConnectionSort!], where: ActorDirectedConnectionWhere): ActorDirectedConnection!
+              name: String!
+            }
+
+            type PersonAggregate {
+              count: Count!
+              node: PersonAggregateNode!
+            }
+
+            type PersonAggregateNode {
+              name: StringAggregateSelection!
+            }
+
+            input PersonCreateInput {
+              directed: PersonDirectedFieldInput
+              name: String!
+            }
+
+            input PersonDeleteInput {
+              directed: [PersonDirectedDeleteFieldInput!]
+            }
+
+            input PersonDirectedConnectFieldInput {
+              connect: ProductionConnectInput
+              where: ProductionConnectWhere
+            }
+
+            input PersonDirectedConnectionAggregateInput {
+              AND: [PersonDirectedConnectionAggregateInput!]
+              NOT: PersonDirectedConnectionAggregateInput
+              OR: [PersonDirectedConnectionAggregateInput!]
+              count: ConnectionAggregationCountFilterInput
+              node: PersonDirectedNodeAggregationWhereInput
+            }
+
+            input PersonDirectedConnectionFilters {
+              \\"\\"\\"
+              Filter People by aggregating results on related ActorDirectedConnections
+              \\"\\"\\"
+              aggregate: PersonDirectedConnectionAggregateInput
+              \\"\\"\\"
+              Return People where all of the related ActorDirectedConnections match this filter
+              \\"\\"\\"
+              all: ActorDirectedConnectionWhere
+              \\"\\"\\"
+              Return People where none of the related ActorDirectedConnections match this filter
+              \\"\\"\\"
+              none: ActorDirectedConnectionWhere
+              \\"\\"\\"
+              Return People where one of the related ActorDirectedConnections match this filter
+              \\"\\"\\"
+              single: ActorDirectedConnectionWhere
+              \\"\\"\\"
+              Return People where some of the related ActorDirectedConnections match this filter
+              \\"\\"\\"
+              some: ActorDirectedConnectionWhere
+            }
+
+            input PersonDirectedCreateFieldInput {
+              node: ProductionCreateInput!
+            }
+
+            input PersonDirectedDeleteFieldInput {
+              delete: ProductionDeleteInput
+              where: ActorDirectedConnectionWhere
+            }
+
+            input PersonDirectedDisconnectFieldInput {
+              disconnect: ProductionDisconnectInput
+              where: ActorDirectedConnectionWhere
+            }
+
+            input PersonDirectedFieldInput {
+              connect: [PersonDirectedConnectFieldInput!]
+              create: [PersonDirectedCreateFieldInput!]
+            }
+
+            input PersonDirectedNodeAggregationWhereInput {
+              AND: [PersonDirectedNodeAggregationWhereInput!]
+              NOT: PersonDirectedNodeAggregationWhereInput
+              OR: [PersonDirectedNodeAggregationWhereInput!]
+              title: StringScalarAggregationFilters
+            }
+
+            input PersonDirectedUpdateConnectionInput {
+              node: ProductionUpdateInput
+              where: ActorDirectedConnectionWhere
+            }
+
+            input PersonDirectedUpdateFieldInput {
+              connect: [PersonDirectedConnectFieldInput!]
+              create: [PersonDirectedCreateFieldInput!]
+              delete: [PersonDirectedDeleteFieldInput!]
+              disconnect: [PersonDirectedDisconnectFieldInput!]
+              update: PersonDirectedUpdateConnectionInput
+            }
+
+            type PersonEdge {
+              cursor: String!
+              node: Person!
+            }
+
+            \\"\\"\\"
+            Fields to sort People by. The order in which sorts are applied is not guaranteed when specifying many fields in one PersonSort object.
+            \\"\\"\\"
+            input PersonSort {
+              name: SortDirection
+            }
+
+            input PersonUpdateInput {
+              directed: [PersonDirectedUpdateFieldInput!]
+              name: StringScalarMutations
+            }
+
+            input PersonWhere {
+              AND: [PersonWhere!]
+              NOT: PersonWhere
+              OR: [PersonWhere!]
+              actedIn: ProductionWhere
+              actedInConnection: ActorActedInConnectionWhere
+              directed: ProductionRelationshipFilters
+              directedConnection: PersonDirectedConnectionFilters
+              name: StringScalarFilters
+            }
+
+            interface Production {
+              actor(limit: Int, offset: Int, sort: [ActorSort!], where: ActorWhere): [Actor!]!
+              actorConnection(after: String, first: Int, sort: [ProductionActorConnectionSort!], where: ProductionActorConnectionWhere): ProductionActorConnection!
+              director: Person!
+              directorConnection: ProductionDirectorConnection!
+              title: String!
+            }
+
+            input ProductionActorConnectFieldInput {
+              connect: ActorConnectInput
+              where: ActorConnectWhere
+            }
+
+            type ProductionActorConnection {
+              edges: [ProductionActorRelationship!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            input ProductionActorConnectionAggregateInput {
+              AND: [ProductionActorConnectionAggregateInput!]
+              NOT: ProductionActorConnectionAggregateInput
+              OR: [ProductionActorConnectionAggregateInput!]
+              count: ConnectionAggregationCountFilterInput
+              node: ProductionActorNodeAggregationWhereInput
+            }
+
+            input ProductionActorConnectionFilters {
+              \\"\\"\\"
+              Filter Productions by aggregating results on related ProductionActorConnections
+              \\"\\"\\"
+              aggregate: ProductionActorConnectionAggregateInput
+              \\"\\"\\"
+              Return Productions where all of the related ProductionActorConnections match this filter
+              \\"\\"\\"
+              all: ProductionActorConnectionWhere
+              \\"\\"\\"
+              Return Productions where none of the related ProductionActorConnections match this filter
+              \\"\\"\\"
+              none: ProductionActorConnectionWhere
+              \\"\\"\\"
+              Return Productions where one of the related ProductionActorConnections match this filter
+              \\"\\"\\"
+              single: ProductionActorConnectionWhere
+              \\"\\"\\"
+              Return Productions where some of the related ProductionActorConnections match this filter
+              \\"\\"\\"
+              some: ProductionActorConnectionWhere
+            }
+
+            input ProductionActorConnectionSort {
+              node: ActorSort
+            }
+
+            input ProductionActorConnectionWhere {
+              AND: [ProductionActorConnectionWhere!]
+              NOT: ProductionActorConnectionWhere
+              OR: [ProductionActorConnectionWhere!]
+              node: ActorWhere
+            }
+
+            input ProductionActorCreateFieldInput {
+              node: ActorCreateInput!
+            }
+
+            input ProductionActorDeleteFieldInput {
+              delete: ActorDeleteInput
+              where: ProductionActorConnectionWhere
+            }
+
+            input ProductionActorDisconnectFieldInput {
+              disconnect: ActorDisconnectInput
+              where: ProductionActorConnectionWhere
+            }
+
+            input ProductionActorNodeAggregationWhereInput {
+              AND: [ProductionActorNodeAggregationWhereInput!]
+              NOT: ProductionActorNodeAggregationWhereInput
+              OR: [ProductionActorNodeAggregationWhereInput!]
+              name: StringScalarAggregationFilters
+            }
+
+            type ProductionActorRelationship {
+              cursor: String!
+              node: Actor!
+            }
+
+            input ProductionActorUpdateConnectionInput {
+              node: ActorUpdateInput
+              where: ProductionActorConnectionWhere
+            }
+
+            input ProductionActorUpdateFieldInput {
+              connect: [ProductionActorConnectFieldInput!]
+              create: [ProductionActorCreateFieldInput!]
+              delete: [ProductionActorDeleteFieldInput!]
+              disconnect: [ProductionActorDisconnectFieldInput!]
+              update: ProductionActorUpdateConnectionInput
+            }
+
+            type ProductionAggregate {
+              count: Count!
+              node: ProductionAggregateNode!
+            }
+
+            type ProductionAggregateNode {
+              title: StringAggregateSelection!
+            }
+
+            input ProductionConnectInput {
+              actor: [ProductionActorConnectFieldInput!]
+            }
+
+            input ProductionConnectWhere {
+              node: ProductionWhere!
+            }
+
+            input ProductionCreateInput {
+              Movie: MovieCreateInput
+              Series: SeriesCreateInput
+            }
+
+            input ProductionDeleteInput {
+              actor: [ProductionActorDeleteFieldInput!]
+            }
+
+            type ProductionDirectorConnection {
+              edges: [ProductionDirectorRelationship!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            input ProductionDirectorConnectionWhere {
+              AND: [ProductionDirectorConnectionWhere!]
+              NOT: ProductionDirectorConnectionWhere
+              OR: [ProductionDirectorConnectionWhere!]
+              node: PersonWhere
+            }
+
+            type ProductionDirectorRelationship {
+              cursor: String!
+              node: Person!
+            }
+
+            input ProductionDisconnectInput {
+              actor: [ProductionActorDisconnectFieldInput!]
+            }
+
+            type ProductionEdge {
+              cursor: String!
+              node: Production!
+            }
+
+            enum ProductionImplementation {
+              Movie
+              Series
+            }
+
+            input ProductionRelationshipFilters {
+              \\"\\"\\"Filter type where all of the related Productions match this filter\\"\\"\\"
+              all: ProductionWhere
+              \\"\\"\\"Filter type where none of the related Productions match this filter\\"\\"\\"
+              none: ProductionWhere
+              \\"\\"\\"Filter type where one of the related Productions match this filter\\"\\"\\"
+              single: ProductionWhere
+              \\"\\"\\"Filter type where some of the related Productions match this filter\\"\\"\\"
+              some: ProductionWhere
+            }
+
+            \\"\\"\\"
+            Fields to sort Productions by. The order in which sorts are applied is not guaranteed when specifying many fields in one ProductionSort object.
+            \\"\\"\\"
+            input ProductionSort {
+              title: SortDirection
+            }
+
+            input ProductionUpdateInput {
+              actor: [ProductionActorUpdateFieldInput!]
+              title: StringScalarMutations
+            }
+
+            input ProductionWhere {
+              AND: [ProductionWhere!]
+              NOT: ProductionWhere
+              OR: [ProductionWhere!]
+              actor: ActorRelationshipFilters
+              actorConnection: ProductionActorConnectionFilters
+              director: PersonWhere
+              directorConnection: ProductionDirectorConnectionWhere
+              title: StringScalarFilters
+              typename: [ProductionImplementation!]
+            }
+
+            type ProductionsConnection {
+              aggregate: ProductionAggregate!
+              edges: [ProductionEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type Query {
+              actors(limit: Int, offset: Int, sort: [ActorSort!], where: ActorWhere): [Actor!]!
+              actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
+              dogs(limit: Int, offset: Int, sort: [DogSort!], where: DogWhere): [Dog!]!
+              dogsConnection(after: String, first: Int, sort: [DogSort!], where: DogWhere): DogsConnection!
+              movies(limit: Int, offset: Int, sort: [MovieSort!], where: MovieWhere): [Movie!]!
+              moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
+              people(limit: Int, offset: Int, sort: [PersonSort!], where: PersonWhere): [Person!]!
+              peopleConnection(after: String, first: Int, sort: [PersonSort!], where: PersonWhere): PeopleConnection!
+              productions(limit: Int, offset: Int, sort: [ProductionSort!], where: ProductionWhere): [Production!]!
+              productionsConnection(after: String, first: Int, sort: [ProductionSort!], where: ProductionWhere): ProductionsConnection!
+              series(limit: Int, offset: Int, sort: [SeriesSort!], where: SeriesWhere): [Series!]!
+              seriesConnection(after: String, first: Int, sort: [SeriesSort!], where: SeriesWhere): SeriesConnection!
+            }
+
+            type Series implements Production {
+              actor(limit: Int, offset: Int, sort: [ActorSort!], where: ActorWhere): [Actor!]!
+              actorConnection(after: String, first: Int, sort: [ProductionActorConnectionSort!], where: ProductionActorConnectionWhere): ProductionActorConnection!
+              director: Person!
+              directorConnection: ProductionDirectorConnection!
+              title: String!
+            }
+
+            input SeriesActorConnectFieldInput {
+              connect: ActorConnectInput
+              where: ActorConnectWhere
+            }
+
+            input SeriesActorConnectionAggregateInput {
+              AND: [SeriesActorConnectionAggregateInput!]
+              NOT: SeriesActorConnectionAggregateInput
+              OR: [SeriesActorConnectionAggregateInput!]
+              count: ConnectionAggregationCountFilterInput
+              node: SeriesActorNodeAggregationWhereInput
+            }
+
+            input SeriesActorConnectionFilters {
+              \\"\\"\\"
+              Filter Series by aggregating results on related ProductionActorConnections
+              \\"\\"\\"
+              aggregate: SeriesActorConnectionAggregateInput
+              \\"\\"\\"
+              Return Series where all of the related ProductionActorConnections match this filter
+              \\"\\"\\"
+              all: ProductionActorConnectionWhere
+              \\"\\"\\"
+              Return Series where none of the related ProductionActorConnections match this filter
+              \\"\\"\\"
+              none: ProductionActorConnectionWhere
+              \\"\\"\\"
+              Return Series where one of the related ProductionActorConnections match this filter
+              \\"\\"\\"
+              single: ProductionActorConnectionWhere
+              \\"\\"\\"
+              Return Series where some of the related ProductionActorConnections match this filter
+              \\"\\"\\"
+              some: ProductionActorConnectionWhere
+            }
+
+            input SeriesActorCreateFieldInput {
+              node: ActorCreateInput!
+            }
+
+            input SeriesActorDeleteFieldInput {
+              delete: ActorDeleteInput
+              where: ProductionActorConnectionWhere
+            }
+
+            input SeriesActorDisconnectFieldInput {
+              disconnect: ActorDisconnectInput
+              where: ProductionActorConnectionWhere
+            }
+
+            input SeriesActorFieldInput {
+              connect: [SeriesActorConnectFieldInput!]
+              create: [SeriesActorCreateFieldInput!]
+            }
+
+            input SeriesActorNodeAggregationWhereInput {
+              AND: [SeriesActorNodeAggregationWhereInput!]
+              NOT: SeriesActorNodeAggregationWhereInput
+              OR: [SeriesActorNodeAggregationWhereInput!]
+              name: StringScalarAggregationFilters
+            }
+
+            input SeriesActorUpdateConnectionInput {
+              node: ActorUpdateInput
+              where: ProductionActorConnectionWhere
+            }
+
+            input SeriesActorUpdateFieldInput {
+              connect: [SeriesActorConnectFieldInput!]
+              create: [SeriesActorCreateFieldInput!]
+              delete: [SeriesActorDeleteFieldInput!]
+              disconnect: [SeriesActorDisconnectFieldInput!]
+              update: SeriesActorUpdateConnectionInput
+            }
+
+            type SeriesAggregate {
+              count: Count!
+              node: SeriesAggregateNode!
+            }
+
+            type SeriesAggregateNode {
+              title: StringAggregateSelection!
+            }
+
+            type SeriesConnection {
+              aggregate: SeriesAggregate!
+              edges: [SeriesEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            input SeriesCreateInput {
+              actor: SeriesActorFieldInput
+              title: String!
+            }
+
+            input SeriesDeleteInput {
+              actor: [SeriesActorDeleteFieldInput!]
+            }
+
+            type SeriesEdge {
+              cursor: String!
+              node: Series!
+            }
+
+            \\"\\"\\"
+            Fields to sort Series by. The order in which sorts are applied is not guaranteed when specifying many fields in one SeriesSort object.
+            \\"\\"\\"
+            input SeriesSort {
+              title: SortDirection
+            }
+
+            input SeriesUpdateInput {
+              actor: [SeriesActorUpdateFieldInput!]
+              title: StringScalarMutations
+            }
+
+            input SeriesWhere {
+              AND: [SeriesWhere!]
+              NOT: SeriesWhere
+              OR: [SeriesWhere!]
+              actor: ActorRelationshipFilters
+              actorConnection: SeriesActorConnectionFilters
+              director: PersonWhere
+              directorConnection: ProductionDirectorConnectionWhere
               title: StringScalarFilters
             }
 

--- a/packages/graphql/tests/schema/relationship/single-element-declared-relationship-interface.test.ts
+++ b/packages/graphql/tests/schema/relationship/single-element-declared-relationship-interface.test.ts
@@ -1783,6 +1783,76 @@ describe("single item relationships from a declared relationship", () => {
               mutation: Mutation
             }
 
+            \\"\\"\\"
+            The edge properties for the following fields:
+            * Movie.actor
+            * Dog.actedIn
+            \\"\\"\\"
+            type ActedInMovie {
+              scenes: Int!
+            }
+
+            input ActedInMovieAggregationWhereInput {
+              AND: [ActedInMovieAggregationWhereInput!]
+              NOT: ActedInMovieAggregationWhereInput
+              OR: [ActedInMovieAggregationWhereInput!]
+              scenes: IntScalarAggregationFilters
+            }
+
+            input ActedInMovieCreateInput {
+              scenes: Int!
+            }
+
+            input ActedInMovieSort {
+              scenes: SortDirection
+            }
+
+            input ActedInMovieUpdateInput {
+              scenes: IntScalarMutations
+            }
+
+            input ActedInMovieWhere {
+              AND: [ActedInMovieWhere!]
+              NOT: ActedInMovieWhere
+              OR: [ActedInMovieWhere!]
+              scenes: IntScalarFilters
+            }
+
+            \\"\\"\\"
+            The edge properties for the following fields:
+            * Series.actor
+            * Person.actedIn
+            \\"\\"\\"
+            type ActedInSeries {
+              episodes: Int!
+            }
+
+            input ActedInSeriesAggregationWhereInput {
+              AND: [ActedInSeriesAggregationWhereInput!]
+              NOT: ActedInSeriesAggregationWhereInput
+              OR: [ActedInSeriesAggregationWhereInput!]
+              episodes: IntScalarAggregationFilters
+            }
+
+            input ActedInSeriesCreateInput {
+              episodes: Int!
+            }
+
+            input ActedInSeriesSort {
+              episodes: SortDirection
+            }
+
+            input ActedInSeriesUpdateInput {
+              episodes: IntScalarMutations
+            }
+
+            input ActedInSeriesWhere {
+              AND: [ActedInSeriesWhere!]
+              NOT: ActedInSeriesWhere
+              OR: [ActedInSeriesWhere!]
+              episodes: IntScalarFilters
+            }
+
             interface Actor {
               actedIn: Production!
               actedInConnection: ActorActedInConnection!
@@ -1801,13 +1871,30 @@ describe("single item relationships from a declared relationship", () => {
               AND: [ActorActedInConnectionWhere!]
               NOT: ActorActedInConnectionWhere
               OR: [ActorActedInConnectionWhere!]
+              edge: ActorActedInEdgeWhere
               node: ProductionWhere
+            }
+
+            input ActorActedInEdgeWhere {
+              \\"\\"\\"
+              Relationship properties when source node is of type:
+              * Dog
+              \\"\\"\\"
+              ActedInMovie: ActedInMovieWhere
+              \\"\\"\\"
+              Relationship properties when source node is of type:
+              * Person
+              \\"\\"\\"
+              ActedInSeries: ActedInSeriesWhere
             }
 
             type ActorActedInRelationship {
               cursor: String!
               node: Production!
+              properties: ActorActedInRelationshipProperties!
             }
+
+            union ActorActedInRelationshipProperties = ActedInMovie | ActedInSeries
 
             type ActorAggregate {
               count: Count!
@@ -1837,6 +1924,7 @@ describe("single item relationships from a declared relationship", () => {
 
             input ActorDirectedConnectFieldInput {
               connect: ProductionConnectInput
+              edge: ActorDirectedEdgeCreateInput!
               where: ProductionConnectWhere
             }
 
@@ -1851,6 +1939,7 @@ describe("single item relationships from a declared relationship", () => {
               NOT: ActorDirectedConnectionAggregateInput
               OR: [ActorDirectedConnectionAggregateInput!]
               count: ConnectionAggregationCountFilterInput
+              edge: ActorDirectedEdgeAggregationWhereInput
               node: ActorDirectedNodeAggregationWhereInput
             }
 
@@ -1878,6 +1967,7 @@ describe("single item relationships from a declared relationship", () => {
             }
 
             input ActorDirectedConnectionSort {
+              edge: ActorDirectedEdgeSort
               node: ProductionSort
             }
 
@@ -1885,10 +1975,12 @@ describe("single item relationships from a declared relationship", () => {
               AND: [ActorDirectedConnectionWhere!]
               NOT: ActorDirectedConnectionWhere
               OR: [ActorDirectedConnectionWhere!]
+              edge: ActorDirectedEdgeWhere
               node: ProductionWhere
             }
 
             input ActorDirectedCreateFieldInput {
+              edge: ActorDirectedEdgeCreateInput!
               node: ProductionCreateInput!
             }
 
@@ -1902,6 +1994,51 @@ describe("single item relationships from a declared relationship", () => {
               where: ActorDirectedConnectionWhere
             }
 
+            input ActorDirectedEdgeAggregationWhereInput {
+              \\"\\"\\"
+              Relationship properties when source node is of type:
+              * Dog
+              * Person
+              \\"\\"\\"
+              Directed: DirectedAggregationWhereInput
+            }
+
+            input ActorDirectedEdgeCreateInput {
+              \\"\\"\\"
+              Relationship properties when source node is of type:
+              * Dog
+              * Person
+              \\"\\"\\"
+              Directed: DirectedCreateInput!
+            }
+
+            input ActorDirectedEdgeSort {
+              \\"\\"\\"
+              Relationship properties when source node is of type:
+              * Dog
+              * Person
+              \\"\\"\\"
+              Directed: DirectedSort
+            }
+
+            input ActorDirectedEdgeUpdateInput {
+              \\"\\"\\"
+              Relationship properties when source node is of type:
+              * Dog
+              * Person
+              \\"\\"\\"
+              Directed: DirectedUpdateInput
+            }
+
+            input ActorDirectedEdgeWhere {
+              \\"\\"\\"
+              Relationship properties when source node is of type:
+              * Dog
+              * Person
+              \\"\\"\\"
+              Directed: DirectedWhere
+            }
+
             input ActorDirectedNodeAggregationWhereInput {
               AND: [ActorDirectedNodeAggregationWhereInput!]
               NOT: ActorDirectedNodeAggregationWhereInput
@@ -1912,9 +2049,13 @@ describe("single item relationships from a declared relationship", () => {
             type ActorDirectedRelationship {
               cursor: String!
               node: Production!
+              properties: ActorDirectedRelationshipProperties!
             }
 
+            union ActorDirectedRelationshipProperties = Directed
+
             input ActorDirectedUpdateConnectionInput {
+              edge: ActorDirectedEdgeUpdateInput
               node: ProductionUpdateInput
               where: ActorDirectedConnectionWhere
             }
@@ -2028,6 +2169,43 @@ describe("single item relationships from a declared relationship", () => {
               relationshipsDeleted: Int!
             }
 
+            \\"\\"\\"
+            The edge properties for the following fields:
+            * Movie.director
+            * Series.director
+            * Dog.directed
+            * Person.directed
+            \\"\\"\\"
+            type Directed {
+              year: Int!
+            }
+
+            input DirectedAggregationWhereInput {
+              AND: [DirectedAggregationWhereInput!]
+              NOT: DirectedAggregationWhereInput
+              OR: [DirectedAggregationWhereInput!]
+              year: IntScalarAggregationFilters
+            }
+
+            input DirectedCreateInput {
+              year: Int!
+            }
+
+            input DirectedSort {
+              year: SortDirection
+            }
+
+            input DirectedUpdateInput {
+              year: IntScalarMutations
+            }
+
+            input DirectedWhere {
+              AND: [DirectedWhere!]
+              NOT: DirectedWhere
+              OR: [DirectedWhere!]
+              year: IntScalarFilters
+            }
+
             type Dog implements Actor {
               actedIn: Production!
               actedInConnection: ActorActedInConnection!
@@ -2056,6 +2234,7 @@ describe("single item relationships from a declared relationship", () => {
 
             input DogDirectedConnectFieldInput {
               connect: ProductionConnectInput
+              edge: DirectedCreateInput!
               where: ProductionConnectWhere
             }
 
@@ -2064,6 +2243,7 @@ describe("single item relationships from a declared relationship", () => {
               NOT: DogDirectedConnectionAggregateInput
               OR: [DogDirectedConnectionAggregateInput!]
               count: ConnectionAggregationCountFilterInput
+              edge: DirectedAggregationWhereInput
               node: DogDirectedNodeAggregationWhereInput
             }
 
@@ -2089,6 +2269,7 @@ describe("single item relationships from a declared relationship", () => {
             }
 
             input DogDirectedCreateFieldInput {
+              edge: DirectedCreateInput!
               node: ProductionCreateInput!
             }
 
@@ -2115,6 +2296,7 @@ describe("single item relationships from a declared relationship", () => {
             }
 
             input DogDirectedUpdateConnectionInput {
+              edge: DirectedUpdateInput
               node: ProductionUpdateInput
               where: ActorDirectedConnectionWhere
             }
@@ -2172,6 +2354,14 @@ describe("single item relationships from a declared relationship", () => {
               lte: Float
             }
 
+            \\"\\"\\"Filters for an aggregation of an int field\\"\\"\\"
+            input IntScalarAggregationFilters {
+              average: FloatScalarFilters
+              max: IntScalarFilters
+              min: IntScalarFilters
+              sum: IntScalarFilters
+            }
+
             \\"\\"\\"Int filters\\"\\"\\"
             input IntScalarFilters {
               eq: Int
@@ -2180,6 +2370,13 @@ describe("single item relationships from a declared relationship", () => {
               in: [Int!]
               lt: Int
               lte: Int
+            }
+
+            \\"\\"\\"Int mutations\\"\\"\\"
+            input IntScalarMutations {
+              add: Int
+              set: Int
+              subtract: Int
             }
 
             type Movie implements Production {
@@ -2192,6 +2389,7 @@ describe("single item relationships from a declared relationship", () => {
 
             input MovieActorConnectFieldInput {
               connect: ActorConnectInput
+              edge: ActedInMovieCreateInput!
               where: ActorConnectWhere
             }
 
@@ -2200,6 +2398,7 @@ describe("single item relationships from a declared relationship", () => {
               NOT: MovieActorConnectionAggregateInput
               OR: [MovieActorConnectionAggregateInput!]
               count: ConnectionAggregationCountFilterInput
+              edge: ActedInMovieAggregationWhereInput
               node: MovieActorNodeAggregationWhereInput
             }
 
@@ -2227,6 +2426,7 @@ describe("single item relationships from a declared relationship", () => {
             }
 
             input MovieActorCreateFieldInput {
+              edge: ActedInMovieCreateInput!
               node: ActorCreateInput!
             }
 
@@ -2253,6 +2453,7 @@ describe("single item relationships from a declared relationship", () => {
             }
 
             input MovieActorUpdateConnectionInput {
+              edge: ActedInMovieUpdateInput
               node: ActorUpdateInput
               where: ProductionActorConnectionWhere
             }
@@ -2376,6 +2577,7 @@ describe("single item relationships from a declared relationship", () => {
 
             input PersonDirectedConnectFieldInput {
               connect: ProductionConnectInput
+              edge: DirectedCreateInput!
               where: ProductionConnectWhere
             }
 
@@ -2384,6 +2586,7 @@ describe("single item relationships from a declared relationship", () => {
               NOT: PersonDirectedConnectionAggregateInput
               OR: [PersonDirectedConnectionAggregateInput!]
               count: ConnectionAggregationCountFilterInput
+              edge: DirectedAggregationWhereInput
               node: PersonDirectedNodeAggregationWhereInput
             }
 
@@ -2411,6 +2614,7 @@ describe("single item relationships from a declared relationship", () => {
             }
 
             input PersonDirectedCreateFieldInput {
+              edge: DirectedCreateInput!
               node: ProductionCreateInput!
             }
 
@@ -2437,6 +2641,7 @@ describe("single item relationships from a declared relationship", () => {
             }
 
             input PersonDirectedUpdateConnectionInput {
+              edge: DirectedUpdateInput
               node: ProductionUpdateInput
               where: ActorDirectedConnectionWhere
             }
@@ -2487,6 +2692,7 @@ describe("single item relationships from a declared relationship", () => {
 
             input ProductionActorConnectFieldInput {
               connect: ActorConnectInput
+              edge: ProductionActorEdgeCreateInput!
               where: ActorConnectWhere
             }
 
@@ -2501,6 +2707,7 @@ describe("single item relationships from a declared relationship", () => {
               NOT: ProductionActorConnectionAggregateInput
               OR: [ProductionActorConnectionAggregateInput!]
               count: ConnectionAggregationCountFilterInput
+              edge: ProductionActorEdgeAggregationWhereInput
               node: ProductionActorNodeAggregationWhereInput
             }
 
@@ -2528,6 +2735,7 @@ describe("single item relationships from a declared relationship", () => {
             }
 
             input ProductionActorConnectionSort {
+              edge: ProductionActorEdgeSort
               node: ActorSort
             }
 
@@ -2535,10 +2743,12 @@ describe("single item relationships from a declared relationship", () => {
               AND: [ProductionActorConnectionWhere!]
               NOT: ProductionActorConnectionWhere
               OR: [ProductionActorConnectionWhere!]
+              edge: ProductionActorEdgeWhere
               node: ActorWhere
             }
 
             input ProductionActorCreateFieldInput {
+              edge: ProductionActorEdgeCreateInput!
               node: ActorCreateInput!
             }
 
@@ -2552,6 +2762,71 @@ describe("single item relationships from a declared relationship", () => {
               where: ProductionActorConnectionWhere
             }
 
+            input ProductionActorEdgeAggregationWhereInput {
+              \\"\\"\\"
+              Relationship properties when source node is of type:
+              * Movie
+              \\"\\"\\"
+              ActedInMovie: ActedInMovieAggregationWhereInput
+              \\"\\"\\"
+              Relationship properties when source node is of type:
+              * Series
+              \\"\\"\\"
+              ActedInSeries: ActedInSeriesAggregationWhereInput
+            }
+
+            input ProductionActorEdgeCreateInput {
+              \\"\\"\\"
+              Relationship properties when source node is of type:
+              * Movie
+              \\"\\"\\"
+              ActedInMovie: ActedInMovieCreateInput!
+              \\"\\"\\"
+              Relationship properties when source node is of type:
+              * Series
+              \\"\\"\\"
+              ActedInSeries: ActedInSeriesCreateInput!
+            }
+
+            input ProductionActorEdgeSort {
+              \\"\\"\\"
+              Relationship properties when source node is of type:
+              * Movie
+              \\"\\"\\"
+              ActedInMovie: ActedInMovieSort
+              \\"\\"\\"
+              Relationship properties when source node is of type:
+              * Series
+              \\"\\"\\"
+              ActedInSeries: ActedInSeriesSort
+            }
+
+            input ProductionActorEdgeUpdateInput {
+              \\"\\"\\"
+              Relationship properties when source node is of type:
+              * Movie
+              \\"\\"\\"
+              ActedInMovie: ActedInMovieUpdateInput
+              \\"\\"\\"
+              Relationship properties when source node is of type:
+              * Series
+              \\"\\"\\"
+              ActedInSeries: ActedInSeriesUpdateInput
+            }
+
+            input ProductionActorEdgeWhere {
+              \\"\\"\\"
+              Relationship properties when source node is of type:
+              * Movie
+              \\"\\"\\"
+              ActedInMovie: ActedInMovieWhere
+              \\"\\"\\"
+              Relationship properties when source node is of type:
+              * Series
+              \\"\\"\\"
+              ActedInSeries: ActedInSeriesWhere
+            }
+
             input ProductionActorNodeAggregationWhereInput {
               AND: [ProductionActorNodeAggregationWhereInput!]
               NOT: ProductionActorNodeAggregationWhereInput
@@ -2562,9 +2837,13 @@ describe("single item relationships from a declared relationship", () => {
             type ProductionActorRelationship {
               cursor: String!
               node: Actor!
+              properties: ProductionActorRelationshipProperties!
             }
 
+            union ProductionActorRelationshipProperties = ActedInMovie | ActedInSeries
+
             input ProductionActorUpdateConnectionInput {
+              edge: ProductionActorEdgeUpdateInput
               node: ActorUpdateInput
               where: ProductionActorConnectionWhere
             }
@@ -2613,13 +2892,26 @@ describe("single item relationships from a declared relationship", () => {
               AND: [ProductionDirectorConnectionWhere!]
               NOT: ProductionDirectorConnectionWhere
               OR: [ProductionDirectorConnectionWhere!]
+              edge: ProductionDirectorEdgeWhere
               node: PersonWhere
+            }
+
+            input ProductionDirectorEdgeWhere {
+              \\"\\"\\"
+              Relationship properties when source node is of type:
+              * Movie
+              * Series
+              \\"\\"\\"
+              Directed: DirectedWhere
             }
 
             type ProductionDirectorRelationship {
               cursor: String!
               node: Person!
+              properties: ProductionDirectorRelationshipProperties!
             }
+
+            union ProductionDirectorRelationshipProperties = Directed
 
             input ProductionDisconnectInput {
               actor: [ProductionActorDisconnectFieldInput!]
@@ -2702,6 +2994,7 @@ describe("single item relationships from a declared relationship", () => {
 
             input SeriesActorConnectFieldInput {
               connect: ActorConnectInput
+              edge: ActedInSeriesCreateInput!
               where: ActorConnectWhere
             }
 
@@ -2710,6 +3003,7 @@ describe("single item relationships from a declared relationship", () => {
               NOT: SeriesActorConnectionAggregateInput
               OR: [SeriesActorConnectionAggregateInput!]
               count: ConnectionAggregationCountFilterInput
+              edge: ActedInSeriesAggregationWhereInput
               node: SeriesActorNodeAggregationWhereInput
             }
 
@@ -2737,6 +3031,7 @@ describe("single item relationships from a declared relationship", () => {
             }
 
             input SeriesActorCreateFieldInput {
+              edge: ActedInSeriesCreateInput!
               node: ActorCreateInput!
             }
 
@@ -2763,6 +3058,7 @@ describe("single item relationships from a declared relationship", () => {
             }
 
             input SeriesActorUpdateConnectionInput {
+              edge: ActedInSeriesUpdateInput
               node: ActorUpdateInput
               where: ProductionActorConnectionWhere
             }

--- a/packages/graphql/tests/schema/relationship/single-element-relationship-to-interface.test.ts
+++ b/packages/graphql/tests/schema/relationship/single-element-relationship-to-interface.test.ts
@@ -1525,6 +1525,7 @@ describe("single item relationships to an Interface type", () => {
 
             input AIDirectedConnectFieldInput {
               connect: [MovieConnectInput!]
+              edge: DirectedCreateInput!
               where: MovieConnectWhere
             }
 
@@ -1540,6 +1541,7 @@ describe("single item relationships to an Interface type", () => {
               NOT: AIDirectedConnectionAggregateInput
               OR: [AIDirectedConnectionAggregateInput!]
               count: ConnectionAggregationCountFilterInput
+              edge: DirectedAggregationWhereInput
               node: AIDirectedNodeAggregationWhereInput
             }
 
@@ -1565,6 +1567,7 @@ describe("single item relationships to an Interface type", () => {
             }
 
             input AIDirectedConnectionSort {
+              edge: DirectedSort
               node: MovieSort
             }
 
@@ -1572,10 +1575,12 @@ describe("single item relationships to an Interface type", () => {
               AND: [AIDirectedConnectionWhere!]
               NOT: AIDirectedConnectionWhere
               OR: [AIDirectedConnectionWhere!]
+              edge: DirectedWhere
               node: MovieWhere
             }
 
             input AIDirectedCreateFieldInput {
+              edge: DirectedCreateInput!
               node: MovieCreateInput!
             }
 
@@ -1604,9 +1609,11 @@ describe("single item relationships to an Interface type", () => {
             type AIDirectedRelationship {
               cursor: String!
               node: Movie!
+              properties: Directed!
             }
 
             input AIDirectedUpdateConnectionInput {
+              edge: DirectedUpdateInput
               node: MovieUpdateInput
               where: AIDirectedConnectionWhere
             }
@@ -1626,7 +1633,12 @@ describe("single item relationships to an Interface type", () => {
 
             type AIMovieDirectedAggregateSelection {
               count: CountConnection!
+              edge: AIMovieDirectedEdgeAggregateSelection
               node: AIMovieDirectedNodeAggregateSelection
+            }
+
+            type AIMovieDirectedEdgeAggregateSelection {
+              year: IntAggregateSelection!
             }
 
             type AIMovieDirectedNodeAggregateSelection {
@@ -1655,6 +1667,42 @@ describe("single item relationships to an Interface type", () => {
               directedConnection: AIDirectedConnectionFilters
               model: StringScalarFilters
               years: IntScalarFilters
+            }
+
+            \\"\\"\\"
+            The edge properties for the following fields:
+            * Movie.actor
+            * Dog.actedIn
+            * Person.actedIn
+            \\"\\"\\"
+            type ActedIn {
+              scenes: Int!
+            }
+
+            input ActedInAggregationWhereInput {
+              AND: [ActedInAggregationWhereInput!]
+              NOT: ActedInAggregationWhereInput
+              OR: [ActedInAggregationWhereInput!]
+              scenes: IntScalarAggregationFilters
+            }
+
+            input ActedInCreateInput {
+              scenes: Int!
+            }
+
+            input ActedInSort {
+              scenes: SortDirection
+            }
+
+            input ActedInUpdateInput {
+              scenes: IntScalarMutations
+            }
+
+            input ActedInWhere {
+              AND: [ActedInWhere!]
+              NOT: ActedInWhere
+              OR: [ActedInWhere!]
+              scenes: IntScalarFilters
             }
 
             interface Actor {
@@ -1783,6 +1831,41 @@ describe("single item relationships to an Interface type", () => {
               relationshipsDeleted: Int!
             }
 
+            \\"\\"\\"
+            The edge properties for the following fields:
+            * Movie.director
+            * AI.directed
+            \\"\\"\\"
+            type Directed {
+              year: Int!
+            }
+
+            input DirectedAggregationWhereInput {
+              AND: [DirectedAggregationWhereInput!]
+              NOT: DirectedAggregationWhereInput
+              OR: [DirectedAggregationWhereInput!]
+              year: IntScalarAggregationFilters
+            }
+
+            input DirectedCreateInput {
+              year: Int!
+            }
+
+            input DirectedSort {
+              year: SortDirection
+            }
+
+            input DirectedUpdateInput {
+              year: IntScalarMutations
+            }
+
+            input DirectedWhere {
+              AND: [DirectedWhere!]
+              NOT: DirectedWhere
+              OR: [DirectedWhere!]
+              year: IntScalarFilters
+            }
+
             interface Director {
               years: Int!
             }
@@ -1844,12 +1927,14 @@ describe("single item relationships to an Interface type", () => {
               AND: [DogActedInConnectionWhere!]
               NOT: DogActedInConnectionWhere
               OR: [DogActedInConnectionWhere!]
+              edge: ActedInWhere
               node: MovieWhere
             }
 
             type DogActedInRelationship {
               cursor: String!
               node: Movie!
+              properties: ActedIn!
             }
 
             type DogAggregate {
@@ -1914,6 +1999,14 @@ describe("single item relationships to an Interface type", () => {
               sum: Int
             }
 
+            \\"\\"\\"Filters for an aggregation of an int field\\"\\"\\"
+            input IntScalarAggregationFilters {
+              average: FloatScalarFilters
+              max: IntScalarFilters
+              min: IntScalarFilters
+              sum: IntScalarFilters
+            }
+
             \\"\\"\\"Int filters\\"\\"\\"
             input IntScalarFilters {
               eq: Int
@@ -1941,7 +2034,12 @@ describe("single item relationships to an Interface type", () => {
 
             type MovieActorActorAggregateSelection {
               count: CountConnection!
+              edge: MovieActorActorEdgeAggregateSelection
               node: MovieActorActorNodeAggregateSelection
+            }
+
+            type MovieActorActorEdgeAggregateSelection {
+              scenes: IntAggregateSelection!
             }
 
             type MovieActorActorNodeAggregateSelection {
@@ -1949,6 +2047,7 @@ describe("single item relationships to an Interface type", () => {
             }
 
             input MovieActorConnectFieldInput {
+              edge: ActedInCreateInput!
               where: ActorConnectWhere
             }
 
@@ -1964,6 +2063,7 @@ describe("single item relationships to an Interface type", () => {
               NOT: MovieActorConnectionAggregateInput
               OR: [MovieActorConnectionAggregateInput!]
               count: ConnectionAggregationCountFilterInput
+              edge: ActedInAggregationWhereInput
               node: MovieActorNodeAggregationWhereInput
             }
 
@@ -1989,6 +2089,7 @@ describe("single item relationships to an Interface type", () => {
             }
 
             input MovieActorConnectionSort {
+              edge: ActedInSort
               node: ActorSort
             }
 
@@ -1996,10 +2097,12 @@ describe("single item relationships to an Interface type", () => {
               AND: [MovieActorConnectionWhere!]
               NOT: MovieActorConnectionWhere
               OR: [MovieActorConnectionWhere!]
+              edge: ActedInWhere
               node: ActorWhere
             }
 
             input MovieActorCreateFieldInput {
+              edge: ActedInCreateInput!
               node: ActorCreateInput!
             }
 
@@ -2026,9 +2129,11 @@ describe("single item relationships to an Interface type", () => {
             type MovieActorRelationship {
               cursor: String!
               node: Actor!
+              properties: ActedIn!
             }
 
             input MovieActorUpdateConnectionInput {
+              edge: ActedInUpdateInput
               node: ActorUpdateInput
               where: MovieActorConnectionWhere
             }
@@ -2077,12 +2182,14 @@ describe("single item relationships to an Interface type", () => {
               AND: [MovieDirectorConnectionWhere!]
               NOT: MovieDirectorConnectionWhere
               OR: [MovieDirectorConnectionWhere!]
+              edge: DirectedWhere
               node: DirectorWhere
             }
 
             type MovieDirectorRelationship {
               cursor: String!
               node: Director!
+              properties: Directed!
             }
 
             input MovieDisconnectInput {
@@ -2182,12 +2289,14 @@ describe("single item relationships to an Interface type", () => {
               AND: [PersonActedInConnectionWhere!]
               NOT: PersonActedInConnectionWhere
               OR: [PersonActedInConnectionWhere!]
+              edge: ActedInWhere
               node: MovieWhere
             }
 
             type PersonActedInRelationship {
               cursor: String!
               node: Movie!
+              properties: ActedIn!
             }
 
             type PersonAggregate {

--- a/packages/graphql/tests/schema/relationship/single-element-relationship-to-interface.test.ts
+++ b/packages/graphql/tests/schema/relationship/single-element-relationship-to-interface.test.ts
@@ -340,6 +340,13 @@ describe("single item relationships to an Interface type", () => {
               totalCount: Int!
             }
 
+            input MovieActorConnectionWhere {
+              AND: [MovieActorConnectionWhere!]
+              NOT: MovieActorConnectionWhere
+              OR: [MovieActorConnectionWhere!]
+              node: ActorWhere
+            }
+
             type MovieActorRelationship {
               cursor: String!
               node: Actor!
@@ -362,6 +369,13 @@ describe("single item relationships to an Interface type", () => {
               edges: [MovieDirectorRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
+            }
+
+            input MovieDirectorConnectionWhere {
+              AND: [MovieDirectorConnectionWhere!]
+              NOT: MovieDirectorConnectionWhere
+              OR: [MovieDirectorConnectionWhere!]
+              node: DirectorWhere
             }
 
             type MovieDirectorRelationship {
@@ -389,6 +403,10 @@ describe("single item relationships to an Interface type", () => {
               AND: [MovieWhere!]
               NOT: MovieWhere
               OR: [MovieWhere!]
+              actor: ActorWhere
+              actorConnection: MovieActorConnectionWhere
+              director: DirectorWhere
+              directorConnection: MovieDirectorConnectionWhere
               title: StringScalarFilters
             }
 
@@ -945,6 +963,13 @@ describe("single item relationships to an Interface type", () => {
               totalCount: Int!
             }
 
+            input DogActedInConnectionWhere {
+              AND: [DogActedInConnectionWhere!]
+              NOT: DogActedInConnectionWhere
+              OR: [DogActedInConnectionWhere!]
+              node: MovieWhere
+            }
+
             type DogActedInRelationship {
               cursor: String!
               node: Movie!
@@ -983,6 +1008,8 @@ describe("single item relationships to an Interface type", () => {
               AND: [DogWhere!]
               NOT: DogWhere
               OR: [DogWhere!]
+              actedIn: MovieWhere
+              actedInConnection: DogActedInConnectionWhere
               name: StringScalarFilters
             }
 
@@ -1169,6 +1196,13 @@ describe("single item relationships to an Interface type", () => {
               totalCount: Int!
             }
 
+            input MovieDirectorConnectionWhere {
+              AND: [MovieDirectorConnectionWhere!]
+              NOT: MovieDirectorConnectionWhere
+              OR: [MovieDirectorConnectionWhere!]
+              node: DirectorWhere
+            }
+
             type MovieDirectorRelationship {
               cursor: String!
               node: Director!
@@ -1212,6 +1246,8 @@ describe("single item relationships to an Interface type", () => {
               OR: [MovieWhere!]
               actor: ActorRelationshipFilters
               actorConnection: MovieActorConnectionFilters
+              director: DirectorWhere
+              directorConnection: MovieDirectorConnectionWhere
               title: StringScalarFilters
             }
 
@@ -1265,6 +1301,13 @@ describe("single item relationships to an Interface type", () => {
               totalCount: Int!
             }
 
+            input PersonActedInConnectionWhere {
+              AND: [PersonActedInConnectionWhere!]
+              NOT: PersonActedInConnectionWhere
+              OR: [PersonActedInConnectionWhere!]
+              node: MovieWhere
+            }
+
             type PersonActedInRelationship {
               cursor: String!
               node: Movie!
@@ -1307,6 +1350,885 @@ describe("single item relationships to an Interface type", () => {
               AND: [PersonWhere!]
               NOT: PersonWhere
               OR: [PersonWhere!]
+              actedIn: MovieWhere
+              actedInConnection: PersonActedInConnectionWhere
+              name: StringScalarFilters
+              years: IntScalarFilters
+            }
+
+            type Query {
+              actors(limit: Int, offset: Int, sort: [ActorSort!], where: ActorWhere): [Actor!]!
+              actorsConnection(after: String, first: Int, sort: [ActorSort!], where: ActorWhere): ActorsConnection!
+              ais(limit: Int, offset: Int, sort: [AISort!], where: AIWhere): [AI!]!
+              aisConnection(after: String, first: Int, sort: [AISort!], where: AIWhere): AisConnection!
+              directors(limit: Int, offset: Int, sort: [DirectorSort!], where: DirectorWhere): [Director!]!
+              directorsConnection(after: String, first: Int, sort: [DirectorSort!], where: DirectorWhere): DirectorsConnection!
+              dogs(limit: Int, offset: Int, sort: [DogSort!], where: DogWhere): [Dog!]!
+              dogsConnection(after: String, first: Int, sort: [DogSort!], where: DogWhere): DogsConnection!
+              movies(limit: Int, offset: Int, sort: [MovieSort!], where: MovieWhere): [Movie!]!
+              moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
+              people(limit: Int, offset: Int, sort: [PersonSort!], where: PersonWhere): [Person!]!
+              peopleConnection(after: String, first: Int, sort: [PersonSort!], where: PersonWhere): PeopleConnection!
+            }
+
+            \\"\\"\\"An enum for sorting in either ascending or descending order.\\"\\"\\"
+            enum SortDirection {
+              \\"\\"\\"Sort by field values in ascending order.\\"\\"\\"
+              ASC
+              \\"\\"\\"Sort by field values in descending order.\\"\\"\\"
+              DESC
+            }
+
+            type StringAggregateSelection {
+              longest: String
+              shortest: String
+            }
+
+            \\"\\"\\"Filters for an aggregation of a string field\\"\\"\\"
+            input StringScalarAggregationFilters {
+              averageLength: FloatScalarFilters
+              longestLength: IntScalarFilters
+              shortestLength: IntScalarFilters
+            }
+
+            \\"\\"\\"String filters\\"\\"\\"
+            input StringScalarFilters {
+              contains: String
+              endsWith: String
+              eq: String
+              in: [String!]
+              startsWith: String
+            }
+
+            \\"\\"\\"String mutations\\"\\"\\"
+            input StringScalarMutations {
+              set: String
+            }
+
+            type UpdateAisMutationResponse {
+              ais: [AI!]!
+              info: UpdateInfo!
+            }
+
+            type UpdateDogsMutationResponse {
+              dogs: [Dog!]!
+              info: UpdateInfo!
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships created and deleted during an update mutation
+            \\"\\"\\"
+            type UpdateInfo {
+              nodesCreated: Int!
+              nodesDeleted: Int!
+              relationshipsCreated: Int!
+              relationshipsDeleted: Int!
+            }
+
+            type UpdateMoviesMutationResponse {
+              info: UpdateInfo!
+              movies: [Movie!]!
+            }
+
+            type UpdatePeopleMutationResponse {
+              info: UpdateInfo!
+              people: [Person!]!
+            }"
+        `);
+    });
+
+    test("1-* relationship with edge properties", async () => {
+        const typeDefs = gql`
+            interface Actor {
+                name: String!
+            }
+            interface Director {
+                years: Int!
+            }
+
+            type Movie @node {
+                title: String!
+                actor: [Actor!]! @relationship(type: "ACTED_IN", direction: IN, properties: "ActedIn")
+                director: Director! @relationship(type: "DIRECTED", direction: IN, properties: "Directed")
+            }
+
+            type Dog implements Actor @node {
+                name: String!
+                actedIn: Movie! @relationship(type: "ACTED_IN", direction: OUT, properties: "ActedIn")
+            }
+
+            type Person implements Actor & Director @node {
+                name: String!
+                years: Int!
+                actedIn: Movie! @relationship(type: "ACTED_IN", direction: OUT, properties: "ActedIn")
+            }
+
+            type AI implements Director @node {
+                model: String!
+                years: Int!
+                directed: [Movie!]! @relationship(type: "DIRECTED", direction: OUT, properties: "Directed")
+            }
+
+            type ActedIn @relationshipProperties {
+                scenes: Int!
+            }
+            type Directed @relationshipProperties {
+                year: Int!
+            }
+        `;
+        const neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            features: {
+                excludeDeprecatedFields: {
+                    mutationOperations: true,
+                    aggregationFilters: true,
+                    aggregationFiltersOutsideConnection: true,
+                    relationshipFilters: true,
+                    attributeFilters: true,
+                },
+            },
+        });
+        const printedSchema = printSchemaWithDirectives(lexicographicSortSchema(await neoSchema.getSchema()));
+
+        expect(printedSchema).toMatchInlineSnapshot(`
+            "schema {
+              query: Query
+              mutation: Mutation
+            }
+
+            type AI implements Director {
+              directed(limit: Int, offset: Int, sort: [MovieSort!], where: MovieWhere): [Movie!]!
+              directedConnection(after: String, first: Int, sort: [AIDirectedConnectionSort!], where: AIDirectedConnectionWhere): AIDirectedConnection!
+              model: String!
+              years: Int!
+            }
+
+            type AIAggregate {
+              count: Count!
+              node: AIAggregateNode!
+            }
+
+            type AIAggregateNode {
+              model: StringAggregateSelection!
+              years: IntAggregateSelection!
+            }
+
+            input AICreateInput {
+              directed: AIDirectedFieldInput
+              model: String!
+              years: Int!
+            }
+
+            input AIDeleteInput {
+              directed: [AIDirectedDeleteFieldInput!]
+            }
+
+            input AIDirectedConnectFieldInput {
+              connect: [MovieConnectInput!]
+              where: MovieConnectWhere
+            }
+
+            type AIDirectedConnection {
+              aggregate: AIMovieDirectedAggregateSelection!
+              edges: [AIDirectedRelationship!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            input AIDirectedConnectionAggregateInput {
+              AND: [AIDirectedConnectionAggregateInput!]
+              NOT: AIDirectedConnectionAggregateInput
+              OR: [AIDirectedConnectionAggregateInput!]
+              count: ConnectionAggregationCountFilterInput
+              node: AIDirectedNodeAggregationWhereInput
+            }
+
+            input AIDirectedConnectionFilters {
+              \\"\\"\\"Filter AIS by aggregating results on related AIDirectedConnections\\"\\"\\"
+              aggregate: AIDirectedConnectionAggregateInput
+              \\"\\"\\"
+              Return AIS where all of the related AIDirectedConnections match this filter
+              \\"\\"\\"
+              all: AIDirectedConnectionWhere
+              \\"\\"\\"
+              Return AIS where none of the related AIDirectedConnections match this filter
+              \\"\\"\\"
+              none: AIDirectedConnectionWhere
+              \\"\\"\\"
+              Return AIS where one of the related AIDirectedConnections match this filter
+              \\"\\"\\"
+              single: AIDirectedConnectionWhere
+              \\"\\"\\"
+              Return AIS where some of the related AIDirectedConnections match this filter
+              \\"\\"\\"
+              some: AIDirectedConnectionWhere
+            }
+
+            input AIDirectedConnectionSort {
+              node: MovieSort
+            }
+
+            input AIDirectedConnectionWhere {
+              AND: [AIDirectedConnectionWhere!]
+              NOT: AIDirectedConnectionWhere
+              OR: [AIDirectedConnectionWhere!]
+              node: MovieWhere
+            }
+
+            input AIDirectedCreateFieldInput {
+              node: MovieCreateInput!
+            }
+
+            input AIDirectedDeleteFieldInput {
+              delete: MovieDeleteInput
+              where: AIDirectedConnectionWhere
+            }
+
+            input AIDirectedDisconnectFieldInput {
+              disconnect: MovieDisconnectInput
+              where: AIDirectedConnectionWhere
+            }
+
+            input AIDirectedFieldInput {
+              connect: [AIDirectedConnectFieldInput!]
+              create: [AIDirectedCreateFieldInput!]
+            }
+
+            input AIDirectedNodeAggregationWhereInput {
+              AND: [AIDirectedNodeAggregationWhereInput!]
+              NOT: AIDirectedNodeAggregationWhereInput
+              OR: [AIDirectedNodeAggregationWhereInput!]
+              title: StringScalarAggregationFilters
+            }
+
+            type AIDirectedRelationship {
+              cursor: String!
+              node: Movie!
+            }
+
+            input AIDirectedUpdateConnectionInput {
+              node: MovieUpdateInput
+              where: AIDirectedConnectionWhere
+            }
+
+            input AIDirectedUpdateFieldInput {
+              connect: [AIDirectedConnectFieldInput!]
+              create: [AIDirectedCreateFieldInput!]
+              delete: [AIDirectedDeleteFieldInput!]
+              disconnect: [AIDirectedDisconnectFieldInput!]
+              update: AIDirectedUpdateConnectionInput
+            }
+
+            type AIEdge {
+              cursor: String!
+              node: AI!
+            }
+
+            type AIMovieDirectedAggregateSelection {
+              count: CountConnection!
+              node: AIMovieDirectedNodeAggregateSelection
+            }
+
+            type AIMovieDirectedNodeAggregateSelection {
+              title: StringAggregateSelection!
+            }
+
+            \\"\\"\\"
+            Fields to sort Ais by. The order in which sorts are applied is not guaranteed when specifying many fields in one AISort object.
+            \\"\\"\\"
+            input AISort {
+              model: SortDirection
+              years: SortDirection
+            }
+
+            input AIUpdateInput {
+              directed: [AIDirectedUpdateFieldInput!]
+              model: StringScalarMutations
+              years: IntScalarMutations
+            }
+
+            input AIWhere {
+              AND: [AIWhere!]
+              NOT: AIWhere
+              OR: [AIWhere!]
+              directed: MovieRelationshipFilters
+              directedConnection: AIDirectedConnectionFilters
+              model: StringScalarFilters
+              years: IntScalarFilters
+            }
+
+            interface Actor {
+              name: String!
+            }
+
+            type ActorAggregate {
+              count: Count!
+              node: ActorAggregateNode!
+            }
+
+            type ActorAggregateNode {
+              name: StringAggregateSelection!
+            }
+
+            input ActorConnectWhere {
+              node: ActorWhere!
+            }
+
+            input ActorCreateInput {
+              Dog: DogCreateInput
+              Person: PersonCreateInput
+            }
+
+            type ActorEdge {
+              cursor: String!
+              node: Actor!
+            }
+
+            enum ActorImplementation {
+              Dog
+              Person
+            }
+
+            input ActorRelationshipFilters {
+              \\"\\"\\"Filter type where all of the related Actors match this filter\\"\\"\\"
+              all: ActorWhere
+              \\"\\"\\"Filter type where none of the related Actors match this filter\\"\\"\\"
+              none: ActorWhere
+              \\"\\"\\"Filter type where one of the related Actors match this filter\\"\\"\\"
+              single: ActorWhere
+              \\"\\"\\"Filter type where some of the related Actors match this filter\\"\\"\\"
+              some: ActorWhere
+            }
+
+            \\"\\"\\"
+            Fields to sort Actors by. The order in which sorts are applied is not guaranteed when specifying many fields in one ActorSort object.
+            \\"\\"\\"
+            input ActorSort {
+              name: SortDirection
+            }
+
+            input ActorUpdateInput {
+              name: StringScalarMutations
+            }
+
+            input ActorWhere {
+              AND: [ActorWhere!]
+              NOT: ActorWhere
+              OR: [ActorWhere!]
+              name: StringScalarFilters
+              typename: [ActorImplementation!]
+            }
+
+            type ActorsConnection {
+              aggregate: ActorAggregate!
+              edges: [ActorEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type AisConnection {
+              aggregate: AIAggregate!
+              edges: [AIEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            input ConnectionAggregationCountFilterInput {
+              edges: IntScalarFilters
+              nodes: IntScalarFilters
+            }
+
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
+            type CreateAisMutationResponse {
+              ais: [AI!]!
+              info: CreateInfo!
+            }
+
+            type CreateDogsMutationResponse {
+              dogs: [Dog!]!
+              info: CreateInfo!
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships created during a create mutation
+            \\"\\"\\"
+            type CreateInfo {
+              nodesCreated: Int!
+              relationshipsCreated: Int!
+            }
+
+            type CreateMoviesMutationResponse {
+              info: CreateInfo!
+              movies: [Movie!]!
+            }
+
+            type CreatePeopleMutationResponse {
+              info: CreateInfo!
+              people: [Person!]!
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships deleted during a delete mutation
+            \\"\\"\\"
+            type DeleteInfo {
+              nodesDeleted: Int!
+              relationshipsDeleted: Int!
+            }
+
+            interface Director {
+              years: Int!
+            }
+
+            type DirectorAggregate {
+              count: Count!
+              node: DirectorAggregateNode!
+            }
+
+            type DirectorAggregateNode {
+              years: IntAggregateSelection!
+            }
+
+            type DirectorEdge {
+              cursor: String!
+              node: Director!
+            }
+
+            enum DirectorImplementation {
+              AI
+              Person
+            }
+
+            \\"\\"\\"
+            Fields to sort Directors by. The order in which sorts are applied is not guaranteed when specifying many fields in one DirectorSort object.
+            \\"\\"\\"
+            input DirectorSort {
+              years: SortDirection
+            }
+
+            input DirectorWhere {
+              AND: [DirectorWhere!]
+              NOT: DirectorWhere
+              OR: [DirectorWhere!]
+              typename: [DirectorImplementation!]
+              years: IntScalarFilters
+            }
+
+            type DirectorsConnection {
+              aggregate: DirectorAggregate!
+              edges: [DirectorEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type Dog implements Actor {
+              actedIn: Movie!
+              actedInConnection: DogActedInConnection!
+              name: String!
+            }
+
+            type DogActedInConnection {
+              edges: [DogActedInRelationship!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            input DogActedInConnectionWhere {
+              AND: [DogActedInConnectionWhere!]
+              NOT: DogActedInConnectionWhere
+              OR: [DogActedInConnectionWhere!]
+              node: MovieWhere
+            }
+
+            type DogActedInRelationship {
+              cursor: String!
+              node: Movie!
+            }
+
+            type DogAggregate {
+              count: Count!
+              node: DogAggregateNode!
+            }
+
+            type DogAggregateNode {
+              name: StringAggregateSelection!
+            }
+
+            input DogCreateInput {
+              name: String!
+            }
+
+            type DogEdge {
+              cursor: String!
+              node: Dog!
+            }
+
+            \\"\\"\\"
+            Fields to sort Dogs by. The order in which sorts are applied is not guaranteed when specifying many fields in one DogSort object.
+            \\"\\"\\"
+            input DogSort {
+              name: SortDirection
+            }
+
+            input DogUpdateInput {
+              name: StringScalarMutations
+            }
+
+            input DogWhere {
+              AND: [DogWhere!]
+              NOT: DogWhere
+              OR: [DogWhere!]
+              actedIn: MovieWhere
+              actedInConnection: DogActedInConnectionWhere
+              name: StringScalarFilters
+            }
+
+            type DogsConnection {
+              aggregate: DogAggregate!
+              edges: [DogEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            \\"\\"\\"Float filters\\"\\"\\"
+            input FloatScalarFilters {
+              eq: Float
+              gt: Float
+              gte: Float
+              in: [Float!]
+              lt: Float
+              lte: Float
+            }
+
+            type IntAggregateSelection {
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
+            }
+
+            \\"\\"\\"Int filters\\"\\"\\"
+            input IntScalarFilters {
+              eq: Int
+              gt: Int
+              gte: Int
+              in: [Int!]
+              lt: Int
+              lte: Int
+            }
+
+            \\"\\"\\"Int mutations\\"\\"\\"
+            input IntScalarMutations {
+              add: Int
+              set: Int
+              subtract: Int
+            }
+
+            type Movie {
+              actor(limit: Int, offset: Int, sort: [ActorSort!], where: ActorWhere): [Actor!]!
+              actorConnection(after: String, first: Int, sort: [MovieActorConnectionSort!], where: MovieActorConnectionWhere): MovieActorConnection!
+              director: Director!
+              directorConnection: MovieDirectorConnection!
+              title: String!
+            }
+
+            type MovieActorActorAggregateSelection {
+              count: CountConnection!
+              node: MovieActorActorNodeAggregateSelection
+            }
+
+            type MovieActorActorNodeAggregateSelection {
+              name: StringAggregateSelection!
+            }
+
+            input MovieActorConnectFieldInput {
+              where: ActorConnectWhere
+            }
+
+            type MovieActorConnection {
+              aggregate: MovieActorActorAggregateSelection!
+              edges: [MovieActorRelationship!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            input MovieActorConnectionAggregateInput {
+              AND: [MovieActorConnectionAggregateInput!]
+              NOT: MovieActorConnectionAggregateInput
+              OR: [MovieActorConnectionAggregateInput!]
+              count: ConnectionAggregationCountFilterInput
+              node: MovieActorNodeAggregationWhereInput
+            }
+
+            input MovieActorConnectionFilters {
+              \\"\\"\\"Filter Movies by aggregating results on related MovieActorConnections\\"\\"\\"
+              aggregate: MovieActorConnectionAggregateInput
+              \\"\\"\\"
+              Return Movies where all of the related MovieActorConnections match this filter
+              \\"\\"\\"
+              all: MovieActorConnectionWhere
+              \\"\\"\\"
+              Return Movies where none of the related MovieActorConnections match this filter
+              \\"\\"\\"
+              none: MovieActorConnectionWhere
+              \\"\\"\\"
+              Return Movies where one of the related MovieActorConnections match this filter
+              \\"\\"\\"
+              single: MovieActorConnectionWhere
+              \\"\\"\\"
+              Return Movies where some of the related MovieActorConnections match this filter
+              \\"\\"\\"
+              some: MovieActorConnectionWhere
+            }
+
+            input MovieActorConnectionSort {
+              node: ActorSort
+            }
+
+            input MovieActorConnectionWhere {
+              AND: [MovieActorConnectionWhere!]
+              NOT: MovieActorConnectionWhere
+              OR: [MovieActorConnectionWhere!]
+              node: ActorWhere
+            }
+
+            input MovieActorCreateFieldInput {
+              node: ActorCreateInput!
+            }
+
+            input MovieActorDeleteFieldInput {
+              where: MovieActorConnectionWhere
+            }
+
+            input MovieActorDisconnectFieldInput {
+              where: MovieActorConnectionWhere
+            }
+
+            input MovieActorFieldInput {
+              connect: [MovieActorConnectFieldInput!]
+              create: [MovieActorCreateFieldInput!]
+            }
+
+            input MovieActorNodeAggregationWhereInput {
+              AND: [MovieActorNodeAggregationWhereInput!]
+              NOT: MovieActorNodeAggregationWhereInput
+              OR: [MovieActorNodeAggregationWhereInput!]
+              name: StringScalarAggregationFilters
+            }
+
+            type MovieActorRelationship {
+              cursor: String!
+              node: Actor!
+            }
+
+            input MovieActorUpdateConnectionInput {
+              node: ActorUpdateInput
+              where: MovieActorConnectionWhere
+            }
+
+            input MovieActorUpdateFieldInput {
+              connect: [MovieActorConnectFieldInput!]
+              create: [MovieActorCreateFieldInput!]
+              delete: [MovieActorDeleteFieldInput!]
+              disconnect: [MovieActorDisconnectFieldInput!]
+              update: MovieActorUpdateConnectionInput
+            }
+
+            type MovieAggregate {
+              count: Count!
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              title: StringAggregateSelection!
+            }
+
+            input MovieConnectInput {
+              actor: [MovieActorConnectFieldInput!]
+            }
+
+            input MovieConnectWhere {
+              node: MovieWhere!
+            }
+
+            input MovieCreateInput {
+              actor: MovieActorFieldInput
+              title: String!
+            }
+
+            input MovieDeleteInput {
+              actor: [MovieActorDeleteFieldInput!]
+            }
+
+            type MovieDirectorConnection {
+              edges: [MovieDirectorRelationship!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            input MovieDirectorConnectionWhere {
+              AND: [MovieDirectorConnectionWhere!]
+              NOT: MovieDirectorConnectionWhere
+              OR: [MovieDirectorConnectionWhere!]
+              node: DirectorWhere
+            }
+
+            type MovieDirectorRelationship {
+              cursor: String!
+              node: Director!
+            }
+
+            input MovieDisconnectInput {
+              actor: [MovieActorDisconnectFieldInput!]
+            }
+
+            type MovieEdge {
+              cursor: String!
+              node: Movie!
+            }
+
+            input MovieRelationshipFilters {
+              \\"\\"\\"Filter type where all of the related Movies match this filter\\"\\"\\"
+              all: MovieWhere
+              \\"\\"\\"Filter type where none of the related Movies match this filter\\"\\"\\"
+              none: MovieWhere
+              \\"\\"\\"Filter type where one of the related Movies match this filter\\"\\"\\"
+              single: MovieWhere
+              \\"\\"\\"Filter type where some of the related Movies match this filter\\"\\"\\"
+              some: MovieWhere
+            }
+
+            \\"\\"\\"
+            Fields to sort Movies by. The order in which sorts are applied is not guaranteed when specifying many fields in one MovieSort object.
+            \\"\\"\\"
+            input MovieSort {
+              title: SortDirection
+            }
+
+            input MovieUpdateInput {
+              actor: [MovieActorUpdateFieldInput!]
+              title: StringScalarMutations
+            }
+
+            input MovieWhere {
+              AND: [MovieWhere!]
+              NOT: MovieWhere
+              OR: [MovieWhere!]
+              actor: ActorRelationshipFilters
+              actorConnection: MovieActorConnectionFilters
+              director: DirectorWhere
+              directorConnection: MovieDirectorConnectionWhere
+              title: StringScalarFilters
+            }
+
+            type MoviesConnection {
+              aggregate: MovieAggregate!
+              edges: [MovieEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type Mutation {
+              createAis(input: [AICreateInput!]!): CreateAisMutationResponse!
+              createDogs(input: [DogCreateInput!]!): CreateDogsMutationResponse!
+              createMovies(input: [MovieCreateInput!]!): CreateMoviesMutationResponse!
+              createPeople(input: [PersonCreateInput!]!): CreatePeopleMutationResponse!
+              deleteAis(delete: AIDeleteInput, where: AIWhere): DeleteInfo!
+              deleteDogs(where: DogWhere): DeleteInfo!
+              deleteMovies(delete: MovieDeleteInput, where: MovieWhere): DeleteInfo!
+              deletePeople(where: PersonWhere): DeleteInfo!
+              updateAis(update: AIUpdateInput, where: AIWhere): UpdateAisMutationResponse!
+              updateDogs(update: DogUpdateInput, where: DogWhere): UpdateDogsMutationResponse!
+              updateMovies(update: MovieUpdateInput, where: MovieWhere): UpdateMoviesMutationResponse!
+              updatePeople(update: PersonUpdateInput, where: PersonWhere): UpdatePeopleMutationResponse!
+            }
+
+            \\"\\"\\"Pagination information (Relay)\\"\\"\\"
+            type PageInfo {
+              endCursor: String
+              hasNextPage: Boolean!
+              hasPreviousPage: Boolean!
+              startCursor: String
+            }
+
+            type PeopleConnection {
+              aggregate: PersonAggregate!
+              edges: [PersonEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type Person implements Actor & Director {
+              actedIn: Movie!
+              actedInConnection: PersonActedInConnection!
+              name: String!
+              years: Int!
+            }
+
+            type PersonActedInConnection {
+              edges: [PersonActedInRelationship!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            input PersonActedInConnectionWhere {
+              AND: [PersonActedInConnectionWhere!]
+              NOT: PersonActedInConnectionWhere
+              OR: [PersonActedInConnectionWhere!]
+              node: MovieWhere
+            }
+
+            type PersonActedInRelationship {
+              cursor: String!
+              node: Movie!
+            }
+
+            type PersonAggregate {
+              count: Count!
+              node: PersonAggregateNode!
+            }
+
+            type PersonAggregateNode {
+              name: StringAggregateSelection!
+              years: IntAggregateSelection!
+            }
+
+            input PersonCreateInput {
+              name: String!
+              years: Int!
+            }
+
+            type PersonEdge {
+              cursor: String!
+              node: Person!
+            }
+
+            \\"\\"\\"
+            Fields to sort People by. The order in which sorts are applied is not guaranteed when specifying many fields in one PersonSort object.
+            \\"\\"\\"
+            input PersonSort {
+              name: SortDirection
+              years: SortDirection
+            }
+
+            input PersonUpdateInput {
+              name: StringScalarMutations
+              years: IntScalarMutations
+            }
+
+            input PersonWhere {
+              AND: [PersonWhere!]
+              NOT: PersonWhere
+              OR: [PersonWhere!]
+              actedIn: MovieWhere
+              actedInConnection: PersonActedInConnectionWhere
               name: StringScalarFilters
               years: IntScalarFilters
             }

--- a/packages/graphql/tests/schema/relationship/single-element-relationship-to-union.test.ts
+++ b/packages/graphql/tests/schema/relationship/single-element-relationship-to-union.test.ts
@@ -228,6 +228,25 @@ describe("single item relationships to an Union type", () => {
               totalCount: Int!
             }
 
+            input MovieActorConnectionWhere {
+              Dog: MovieActorDogConnectionWhere
+              Person: MovieActorPersonConnectionWhere
+            }
+
+            input MovieActorDogConnectionWhere {
+              AND: [MovieActorDogConnectionWhere!]
+              NOT: MovieActorDogConnectionWhere
+              OR: [MovieActorDogConnectionWhere!]
+              node: DogWhere
+            }
+
+            input MovieActorPersonConnectionWhere {
+              AND: [MovieActorPersonConnectionWhere!]
+              NOT: MovieActorPersonConnectionWhere
+              OR: [MovieActorPersonConnectionWhere!]
+              node: PersonWhere
+            }
+
             type MovieActorRelationship {
               cursor: String!
               node: Actor!
@@ -246,10 +265,29 @@ describe("single item relationships to an Union type", () => {
               title: String!
             }
 
+            input MovieDirectorAIConnectionWhere {
+              AND: [MovieDirectorAIConnectionWhere!]
+              NOT: MovieDirectorAIConnectionWhere
+              OR: [MovieDirectorAIConnectionWhere!]
+              node: AIWhere
+            }
+
             type MovieDirectorConnection {
               edges: [MovieDirectorRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
+            }
+
+            input MovieDirectorConnectionWhere {
+              AI: MovieDirectorAIConnectionWhere
+              Person: MovieDirectorPersonConnectionWhere
+            }
+
+            input MovieDirectorPersonConnectionWhere {
+              AND: [MovieDirectorPersonConnectionWhere!]
+              NOT: MovieDirectorPersonConnectionWhere
+              OR: [MovieDirectorPersonConnectionWhere!]
+              node: PersonWhere
             }
 
             type MovieDirectorRelationship {
@@ -277,6 +315,10 @@ describe("single item relationships to an Union type", () => {
               AND: [MovieWhere!]
               NOT: MovieWhere
               OR: [MovieWhere!]
+              actor: ActorWhere
+              actorConnection: MovieActorConnectionWhere
+              director: DirectorWhere
+              directorConnection: MovieDirectorConnectionWhere
               title: StringScalarFilters
             }
 
@@ -724,6 +766,13 @@ describe("single item relationships to an Union type", () => {
               totalCount: Int!
             }
 
+            input DogActedInConnectionWhere {
+              AND: [DogActedInConnectionWhere!]
+              NOT: DogActedInConnectionWhere
+              OR: [DogActedInConnectionWhere!]
+              node: MovieWhere
+            }
+
             type DogActedInRelationship {
               cursor: String!
               node: Movie!
@@ -766,6 +815,8 @@ describe("single item relationships to an Union type", () => {
               AND: [DogWhere!]
               NOT: DogWhere
               OR: [DogWhere!]
+              actedIn: MovieWhere
+              actedInConnection: DogActedInConnectionWhere
               nickName: StringScalarFilters
             }
 
@@ -975,10 +1026,29 @@ describe("single item relationships to an Union type", () => {
               actor: MovieActorDeleteInput
             }
 
+            input MovieDirectorAIConnectionWhere {
+              AND: [MovieDirectorAIConnectionWhere!]
+              NOT: MovieDirectorAIConnectionWhere
+              OR: [MovieDirectorAIConnectionWhere!]
+              node: AIWhere
+            }
+
             type MovieDirectorConnection {
               edges: [MovieDirectorRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
+            }
+
+            input MovieDirectorConnectionWhere {
+              AI: MovieDirectorAIConnectionWhere
+              Person: MovieDirectorPersonConnectionWhere
+            }
+
+            input MovieDirectorPersonConnectionWhere {
+              AND: [MovieDirectorPersonConnectionWhere!]
+              NOT: MovieDirectorPersonConnectionWhere
+              OR: [MovieDirectorPersonConnectionWhere!]
+              node: PersonWhere
             }
 
             type MovieDirectorRelationship {
@@ -1024,6 +1094,8 @@ describe("single item relationships to an Union type", () => {
               OR: [MovieWhere!]
               actor: ActorRelationshipFilters
               actorConnection: MovieActorConnectionFilters
+              director: DirectorWhere
+              directorConnection: MovieDirectorConnectionWhere
               title: StringScalarFilters
             }
 
@@ -1076,6 +1148,13 @@ describe("single item relationships to an Union type", () => {
               edges: [PersonActedInRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
+            }
+
+            input PersonActedInConnectionWhere {
+              AND: [PersonActedInConnectionWhere!]
+              NOT: PersonActedInConnectionWhere
+              OR: [PersonActedInConnectionWhere!]
+              node: MovieWhere
             }
 
             type PersonActedInRelationship {
@@ -1241,6 +1320,951 @@ describe("single item relationships to an Union type", () => {
               AND: [PersonWhere!]
               NOT: PersonWhere
               OR: [PersonWhere!]
+              actedIn: MovieWhere
+              actedInConnection: PersonActedInConnectionWhere
+              directed: MovieRelationshipFilters
+              directedConnection: PersonDirectedConnectionFilters
+              name: StringScalarFilters
+            }
+
+            type Query {
+              actors(limit: Int, offset: Int, where: ActorWhere): [Actor!]!
+              ais(limit: Int, offset: Int, sort: [AISort!], where: AIWhere): [AI!]!
+              aisConnection(after: String, first: Int, sort: [AISort!], where: AIWhere): AisConnection!
+              directors(limit: Int, offset: Int, where: DirectorWhere): [Director!]!
+              dogs(limit: Int, offset: Int, sort: [DogSort!], where: DogWhere): [Dog!]!
+              dogsConnection(after: String, first: Int, sort: [DogSort!], where: DogWhere): DogsConnection!
+              movies(limit: Int, offset: Int, sort: [MovieSort!], where: MovieWhere): [Movie!]!
+              moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
+              people(limit: Int, offset: Int, sort: [PersonSort!], where: PersonWhere): [Person!]!
+              peopleConnection(after: String, first: Int, sort: [PersonSort!], where: PersonWhere): PeopleConnection!
+            }
+
+            \\"\\"\\"An enum for sorting in either ascending or descending order.\\"\\"\\"
+            enum SortDirection {
+              \\"\\"\\"Sort by field values in ascending order.\\"\\"\\"
+              ASC
+              \\"\\"\\"Sort by field values in descending order.\\"\\"\\"
+              DESC
+            }
+
+            type StringAggregateSelection {
+              longest: String
+              shortest: String
+            }
+
+            \\"\\"\\"Filters for an aggregation of a string field\\"\\"\\"
+            input StringScalarAggregationFilters {
+              averageLength: FloatScalarFilters
+              longestLength: IntScalarFilters
+              shortestLength: IntScalarFilters
+            }
+
+            \\"\\"\\"String filters\\"\\"\\"
+            input StringScalarFilters {
+              contains: String
+              endsWith: String
+              eq: String
+              in: [String!]
+              startsWith: String
+            }
+
+            \\"\\"\\"String mutations\\"\\"\\"
+            input StringScalarMutations {
+              set: String
+            }
+
+            type UpdateAisMutationResponse {
+              ais: [AI!]!
+              info: UpdateInfo!
+            }
+
+            type UpdateDogsMutationResponse {
+              dogs: [Dog!]!
+              info: UpdateInfo!
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships created and deleted during an update mutation
+            \\"\\"\\"
+            type UpdateInfo {
+              nodesCreated: Int!
+              nodesDeleted: Int!
+              relationshipsCreated: Int!
+              relationshipsDeleted: Int!
+            }
+
+            type UpdateMoviesMutationResponse {
+              info: UpdateInfo!
+              movies: [Movie!]!
+            }
+
+            type UpdatePeopleMutationResponse {
+              info: UpdateInfo!
+              people: [Person!]!
+            }"
+        `);
+    });
+    test("1-* relationship with edge properties", async () => {
+        const typeDefs = gql`
+            union Actor = Dog | Person
+            union Director = Person | AI
+
+            type Movie @node {
+                title: String!
+                actor: [Actor!]! @relationship(type: "ACTED_IN", direction: IN, properties: "ActedIn")
+                director: Director! @relationship(type: "DIRECTED", direction: IN, properties: "Directed")
+            }
+
+            type Person @node {
+                name: String!
+                actedIn: Movie! @relationship(type: "ACTED_IN", direction: OUT, properties: "ActedIn")
+                directed: [Movie!]! @relationship(type: "DIRECTED", direction: OUT, properties: "Directed")
+            }
+
+            type Dog @node {
+                nickName: String!
+                actedIn: Movie! @relationship(type: "ACTED_IN", direction: OUT, properties: "ActedIn")
+            }
+
+            type AI @node {
+                model: String!
+                directed: [Movie!]! @relationship(type: "DIRECTED", direction: OUT, properties: "Directed")
+            }
+
+            type ActedIn @relationshipProperties {
+                scenes: Int!
+            }
+
+            type Directed @relationshipProperties {
+                year: Int!
+            }
+        `;
+        const neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            features: {
+                excludeDeprecatedFields: {
+                    mutationOperations: true,
+                    aggregationFilters: true,
+                    aggregationFiltersOutsideConnection: true,
+                    relationshipFilters: true,
+                    attributeFilters: true,
+                },
+            },
+        });
+        const printedSchema = printSchemaWithDirectives(lexicographicSortSchema(await neoSchema.getSchema()));
+
+        expect(printedSchema).toMatchInlineSnapshot(`
+            "schema {
+              query: Query
+              mutation: Mutation
+            }
+
+            type AI {
+              directed(limit: Int, offset: Int, sort: [MovieSort!], where: MovieWhere): [Movie!]!
+              directedConnection(after: String, first: Int, sort: [AIDirectedConnectionSort!], where: AIDirectedConnectionWhere): AIDirectedConnection!
+              model: String!
+            }
+
+            type AIAggregate {
+              count: Count!
+              node: AIAggregateNode!
+            }
+
+            type AIAggregateNode {
+              model: StringAggregateSelection!
+            }
+
+            input AICreateInput {
+              directed: AIDirectedFieldInput
+              model: String!
+            }
+
+            input AIDeleteInput {
+              directed: [AIDirectedDeleteFieldInput!]
+            }
+
+            input AIDirectedConnectFieldInput {
+              connect: [MovieConnectInput!]
+              where: MovieConnectWhere
+            }
+
+            type AIDirectedConnection {
+              aggregate: AIMovieDirectedAggregateSelection!
+              edges: [AIDirectedRelationship!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            input AIDirectedConnectionAggregateInput {
+              AND: [AIDirectedConnectionAggregateInput!]
+              NOT: AIDirectedConnectionAggregateInput
+              OR: [AIDirectedConnectionAggregateInput!]
+              count: ConnectionAggregationCountFilterInput
+              node: AIDirectedNodeAggregationWhereInput
+            }
+
+            input AIDirectedConnectionFilters {
+              \\"\\"\\"Filter AIS by aggregating results on related AIDirectedConnections\\"\\"\\"
+              aggregate: AIDirectedConnectionAggregateInput
+              \\"\\"\\"
+              Return AIS where all of the related AIDirectedConnections match this filter
+              \\"\\"\\"
+              all: AIDirectedConnectionWhere
+              \\"\\"\\"
+              Return AIS where none of the related AIDirectedConnections match this filter
+              \\"\\"\\"
+              none: AIDirectedConnectionWhere
+              \\"\\"\\"
+              Return AIS where one of the related AIDirectedConnections match this filter
+              \\"\\"\\"
+              single: AIDirectedConnectionWhere
+              \\"\\"\\"
+              Return AIS where some of the related AIDirectedConnections match this filter
+              \\"\\"\\"
+              some: AIDirectedConnectionWhere
+            }
+
+            input AIDirectedConnectionSort {
+              node: MovieSort
+            }
+
+            input AIDirectedConnectionWhere {
+              AND: [AIDirectedConnectionWhere!]
+              NOT: AIDirectedConnectionWhere
+              OR: [AIDirectedConnectionWhere!]
+              node: MovieWhere
+            }
+
+            input AIDirectedCreateFieldInput {
+              node: MovieCreateInput!
+            }
+
+            input AIDirectedDeleteFieldInput {
+              delete: MovieDeleteInput
+              where: AIDirectedConnectionWhere
+            }
+
+            input AIDirectedDisconnectFieldInput {
+              disconnect: MovieDisconnectInput
+              where: AIDirectedConnectionWhere
+            }
+
+            input AIDirectedFieldInput {
+              connect: [AIDirectedConnectFieldInput!]
+              create: [AIDirectedCreateFieldInput!]
+            }
+
+            input AIDirectedNodeAggregationWhereInput {
+              AND: [AIDirectedNodeAggregationWhereInput!]
+              NOT: AIDirectedNodeAggregationWhereInput
+              OR: [AIDirectedNodeAggregationWhereInput!]
+              title: StringScalarAggregationFilters
+            }
+
+            type AIDirectedRelationship {
+              cursor: String!
+              node: Movie!
+            }
+
+            input AIDirectedUpdateConnectionInput {
+              node: MovieUpdateInput
+              where: AIDirectedConnectionWhere
+            }
+
+            input AIDirectedUpdateFieldInput {
+              connect: [AIDirectedConnectFieldInput!]
+              create: [AIDirectedCreateFieldInput!]
+              delete: [AIDirectedDeleteFieldInput!]
+              disconnect: [AIDirectedDisconnectFieldInput!]
+              update: AIDirectedUpdateConnectionInput
+            }
+
+            type AIEdge {
+              cursor: String!
+              node: AI!
+            }
+
+            type AIMovieDirectedAggregateSelection {
+              count: CountConnection!
+              node: AIMovieDirectedNodeAggregateSelection
+            }
+
+            type AIMovieDirectedNodeAggregateSelection {
+              title: StringAggregateSelection!
+            }
+
+            \\"\\"\\"
+            Fields to sort Ais by. The order in which sorts are applied is not guaranteed when specifying many fields in one AISort object.
+            \\"\\"\\"
+            input AISort {
+              model: SortDirection
+            }
+
+            input AIUpdateInput {
+              directed: [AIDirectedUpdateFieldInput!]
+              model: StringScalarMutations
+            }
+
+            input AIWhere {
+              AND: [AIWhere!]
+              NOT: AIWhere
+              OR: [AIWhere!]
+              directed: MovieRelationshipFilters
+              directedConnection: AIDirectedConnectionFilters
+              model: StringScalarFilters
+            }
+
+            union Actor = Dog | Person
+
+            input ActorRelationshipFilters {
+              \\"\\"\\"Filter type where all of the related Actors match this filter\\"\\"\\"
+              all: ActorWhere
+              \\"\\"\\"Filter type where none of the related Actors match this filter\\"\\"\\"
+              none: ActorWhere
+              \\"\\"\\"Filter type where one of the related Actors match this filter\\"\\"\\"
+              single: ActorWhere
+              \\"\\"\\"Filter type where some of the related Actors match this filter\\"\\"\\"
+              some: ActorWhere
+            }
+
+            input ActorWhere {
+              Dog: DogWhere
+              Person: PersonWhere
+            }
+
+            type AisConnection {
+              aggregate: AIAggregate!
+              edges: [AIEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            input ConnectionAggregationCountFilterInput {
+              edges: IntScalarFilters
+              nodes: IntScalarFilters
+            }
+
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
+            type CreateAisMutationResponse {
+              ais: [AI!]!
+              info: CreateInfo!
+            }
+
+            type CreateDogsMutationResponse {
+              dogs: [Dog!]!
+              info: CreateInfo!
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships created during a create mutation
+            \\"\\"\\"
+            type CreateInfo {
+              nodesCreated: Int!
+              relationshipsCreated: Int!
+            }
+
+            type CreateMoviesMutationResponse {
+              info: CreateInfo!
+              movies: [Movie!]!
+            }
+
+            type CreatePeopleMutationResponse {
+              info: CreateInfo!
+              people: [Person!]!
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships deleted during a delete mutation
+            \\"\\"\\"
+            type DeleteInfo {
+              nodesDeleted: Int!
+              relationshipsDeleted: Int!
+            }
+
+            union Director = AI | Person
+
+            input DirectorWhere {
+              AI: AIWhere
+              Person: PersonWhere
+            }
+
+            type Dog {
+              actedIn: Movie!
+              actedInConnection: DogActedInConnection!
+              nickName: String!
+            }
+
+            type DogActedInConnection {
+              edges: [DogActedInRelationship!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            input DogActedInConnectionWhere {
+              AND: [DogActedInConnectionWhere!]
+              NOT: DogActedInConnectionWhere
+              OR: [DogActedInConnectionWhere!]
+              node: MovieWhere
+            }
+
+            type DogActedInRelationship {
+              cursor: String!
+              node: Movie!
+            }
+
+            type DogAggregate {
+              count: Count!
+              node: DogAggregateNode!
+            }
+
+            type DogAggregateNode {
+              nickName: StringAggregateSelection!
+            }
+
+            input DogConnectWhere {
+              node: DogWhere!
+            }
+
+            input DogCreateInput {
+              nickName: String!
+            }
+
+            type DogEdge {
+              cursor: String!
+              node: Dog!
+            }
+
+            \\"\\"\\"
+            Fields to sort Dogs by. The order in which sorts are applied is not guaranteed when specifying many fields in one DogSort object.
+            \\"\\"\\"
+            input DogSort {
+              nickName: SortDirection
+            }
+
+            input DogUpdateInput {
+              nickName: StringScalarMutations
+            }
+
+            input DogWhere {
+              AND: [DogWhere!]
+              NOT: DogWhere
+              OR: [DogWhere!]
+              actedIn: MovieWhere
+              actedInConnection: DogActedInConnectionWhere
+              nickName: StringScalarFilters
+            }
+
+            type DogsConnection {
+              aggregate: DogAggregate!
+              edges: [DogEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            \\"\\"\\"Float filters\\"\\"\\"
+            input FloatScalarFilters {
+              eq: Float
+              gt: Float
+              gte: Float
+              in: [Float!]
+              lt: Float
+              lte: Float
+            }
+
+            \\"\\"\\"Int filters\\"\\"\\"
+            input IntScalarFilters {
+              eq: Int
+              gt: Int
+              gte: Int
+              in: [Int!]
+              lt: Int
+              lte: Int
+            }
+
+            type Movie {
+              actor(limit: Int, offset: Int, where: ActorWhere): [Actor!]!
+              actorConnection(after: String, first: Int, where: MovieActorConnectionWhere): MovieActorConnection!
+              director: Director!
+              directorConnection: MovieDirectorConnection!
+              title: String!
+            }
+
+            input MovieActorConnectInput {
+              Dog: [MovieActorDogConnectFieldInput!]
+              Person: [MovieActorPersonConnectFieldInput!]
+            }
+
+            type MovieActorConnection {
+              edges: [MovieActorRelationship!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            input MovieActorConnectionFilters {
+              \\"\\"\\"
+              Return Movies where all of the related MovieActorConnections match this filter
+              \\"\\"\\"
+              all: MovieActorConnectionWhere
+              \\"\\"\\"
+              Return Movies where none of the related MovieActorConnections match this filter
+              \\"\\"\\"
+              none: MovieActorConnectionWhere
+              \\"\\"\\"
+              Return Movies where one of the related MovieActorConnections match this filter
+              \\"\\"\\"
+              single: MovieActorConnectionWhere
+              \\"\\"\\"
+              Return Movies where some of the related MovieActorConnections match this filter
+              \\"\\"\\"
+              some: MovieActorConnectionWhere
+            }
+
+            input MovieActorConnectionWhere {
+              Dog: MovieActorDogConnectionWhere
+              Person: MovieActorPersonConnectionWhere
+            }
+
+            input MovieActorCreateInput {
+              Dog: MovieActorDogFieldInput
+              Person: MovieActorPersonFieldInput
+            }
+
+            input MovieActorDeleteInput {
+              Dog: [MovieActorDogDeleteFieldInput!]
+              Person: [MovieActorPersonDeleteFieldInput!]
+            }
+
+            input MovieActorDisconnectInput {
+              Dog: [MovieActorDogDisconnectFieldInput!]
+              Person: [MovieActorPersonDisconnectFieldInput!]
+            }
+
+            input MovieActorDogConnectFieldInput {
+              where: DogConnectWhere
+            }
+
+            input MovieActorDogConnectionWhere {
+              AND: [MovieActorDogConnectionWhere!]
+              NOT: MovieActorDogConnectionWhere
+              OR: [MovieActorDogConnectionWhere!]
+              node: DogWhere
+            }
+
+            input MovieActorDogCreateFieldInput {
+              node: DogCreateInput!
+            }
+
+            input MovieActorDogDeleteFieldInput {
+              where: MovieActorDogConnectionWhere
+            }
+
+            input MovieActorDogDisconnectFieldInput {
+              where: MovieActorDogConnectionWhere
+            }
+
+            input MovieActorDogFieldInput {
+              connect: [MovieActorDogConnectFieldInput!]
+              create: [MovieActorDogCreateFieldInput!]
+            }
+
+            input MovieActorDogUpdateConnectionInput {
+              node: DogUpdateInput
+              where: MovieActorDogConnectionWhere
+            }
+
+            input MovieActorDogUpdateFieldInput {
+              connect: [MovieActorDogConnectFieldInput!]
+              create: [MovieActorDogCreateFieldInput!]
+              delete: [MovieActorDogDeleteFieldInput!]
+              disconnect: [MovieActorDogDisconnectFieldInput!]
+              update: MovieActorDogUpdateConnectionInput
+            }
+
+            input MovieActorPersonConnectFieldInput {
+              connect: [PersonConnectInput!]
+              where: PersonConnectWhere
+            }
+
+            input MovieActorPersonConnectionWhere {
+              AND: [MovieActorPersonConnectionWhere!]
+              NOT: MovieActorPersonConnectionWhere
+              OR: [MovieActorPersonConnectionWhere!]
+              node: PersonWhere
+            }
+
+            input MovieActorPersonCreateFieldInput {
+              node: PersonCreateInput!
+            }
+
+            input MovieActorPersonDeleteFieldInput {
+              delete: PersonDeleteInput
+              where: MovieActorPersonConnectionWhere
+            }
+
+            input MovieActorPersonDisconnectFieldInput {
+              disconnect: PersonDisconnectInput
+              where: MovieActorPersonConnectionWhere
+            }
+
+            input MovieActorPersonFieldInput {
+              connect: [MovieActorPersonConnectFieldInput!]
+              create: [MovieActorPersonCreateFieldInput!]
+            }
+
+            input MovieActorPersonUpdateConnectionInput {
+              node: PersonUpdateInput
+              where: MovieActorPersonConnectionWhere
+            }
+
+            input MovieActorPersonUpdateFieldInput {
+              connect: [MovieActorPersonConnectFieldInput!]
+              create: [MovieActorPersonCreateFieldInput!]
+              delete: [MovieActorPersonDeleteFieldInput!]
+              disconnect: [MovieActorPersonDisconnectFieldInput!]
+              update: MovieActorPersonUpdateConnectionInput
+            }
+
+            type MovieActorRelationship {
+              cursor: String!
+              node: Actor!
+            }
+
+            input MovieActorUpdateInput {
+              Dog: [MovieActorDogUpdateFieldInput!]
+              Person: [MovieActorPersonUpdateFieldInput!]
+            }
+
+            type MovieAggregate {
+              count: Count!
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              title: StringAggregateSelection!
+            }
+
+            input MovieConnectInput {
+              actor: MovieActorConnectInput
+            }
+
+            input MovieConnectWhere {
+              node: MovieWhere!
+            }
+
+            input MovieCreateInput {
+              actor: MovieActorCreateInput
+              title: String!
+            }
+
+            input MovieDeleteInput {
+              actor: MovieActorDeleteInput
+            }
+
+            input MovieDirectorAIConnectionWhere {
+              AND: [MovieDirectorAIConnectionWhere!]
+              NOT: MovieDirectorAIConnectionWhere
+              OR: [MovieDirectorAIConnectionWhere!]
+              node: AIWhere
+            }
+
+            type MovieDirectorConnection {
+              edges: [MovieDirectorRelationship!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            input MovieDirectorConnectionWhere {
+              AI: MovieDirectorAIConnectionWhere
+              Person: MovieDirectorPersonConnectionWhere
+            }
+
+            input MovieDirectorPersonConnectionWhere {
+              AND: [MovieDirectorPersonConnectionWhere!]
+              NOT: MovieDirectorPersonConnectionWhere
+              OR: [MovieDirectorPersonConnectionWhere!]
+              node: PersonWhere
+            }
+
+            type MovieDirectorRelationship {
+              cursor: String!
+              node: Director!
+            }
+
+            input MovieDisconnectInput {
+              actor: MovieActorDisconnectInput
+            }
+
+            type MovieEdge {
+              cursor: String!
+              node: Movie!
+            }
+
+            input MovieRelationshipFilters {
+              \\"\\"\\"Filter type where all of the related Movies match this filter\\"\\"\\"
+              all: MovieWhere
+              \\"\\"\\"Filter type where none of the related Movies match this filter\\"\\"\\"
+              none: MovieWhere
+              \\"\\"\\"Filter type where one of the related Movies match this filter\\"\\"\\"
+              single: MovieWhere
+              \\"\\"\\"Filter type where some of the related Movies match this filter\\"\\"\\"
+              some: MovieWhere
+            }
+
+            \\"\\"\\"
+            Fields to sort Movies by. The order in which sorts are applied is not guaranteed when specifying many fields in one MovieSort object.
+            \\"\\"\\"
+            input MovieSort {
+              title: SortDirection
+            }
+
+            input MovieUpdateInput {
+              actor: MovieActorUpdateInput
+              title: StringScalarMutations
+            }
+
+            input MovieWhere {
+              AND: [MovieWhere!]
+              NOT: MovieWhere
+              OR: [MovieWhere!]
+              actor: ActorRelationshipFilters
+              actorConnection: MovieActorConnectionFilters
+              director: DirectorWhere
+              directorConnection: MovieDirectorConnectionWhere
+              title: StringScalarFilters
+            }
+
+            type MoviesConnection {
+              aggregate: MovieAggregate!
+              edges: [MovieEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type Mutation {
+              createAis(input: [AICreateInput!]!): CreateAisMutationResponse!
+              createDogs(input: [DogCreateInput!]!): CreateDogsMutationResponse!
+              createMovies(input: [MovieCreateInput!]!): CreateMoviesMutationResponse!
+              createPeople(input: [PersonCreateInput!]!): CreatePeopleMutationResponse!
+              deleteAis(delete: AIDeleteInput, where: AIWhere): DeleteInfo!
+              deleteDogs(where: DogWhere): DeleteInfo!
+              deleteMovies(delete: MovieDeleteInput, where: MovieWhere): DeleteInfo!
+              deletePeople(delete: PersonDeleteInput, where: PersonWhere): DeleteInfo!
+              updateAis(update: AIUpdateInput, where: AIWhere): UpdateAisMutationResponse!
+              updateDogs(update: DogUpdateInput, where: DogWhere): UpdateDogsMutationResponse!
+              updateMovies(update: MovieUpdateInput, where: MovieWhere): UpdateMoviesMutationResponse!
+              updatePeople(update: PersonUpdateInput, where: PersonWhere): UpdatePeopleMutationResponse!
+            }
+
+            \\"\\"\\"Pagination information (Relay)\\"\\"\\"
+            type PageInfo {
+              endCursor: String
+              hasNextPage: Boolean!
+              hasPreviousPage: Boolean!
+              startCursor: String
+            }
+
+            type PeopleConnection {
+              aggregate: PersonAggregate!
+              edges: [PersonEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type Person {
+              actedIn: Movie!
+              actedInConnection: PersonActedInConnection!
+              directed(limit: Int, offset: Int, sort: [MovieSort!], where: MovieWhere): [Movie!]!
+              directedConnection(after: String, first: Int, sort: [PersonDirectedConnectionSort!], where: PersonDirectedConnectionWhere): PersonDirectedConnection!
+              name: String!
+            }
+
+            type PersonActedInConnection {
+              edges: [PersonActedInRelationship!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            input PersonActedInConnectionWhere {
+              AND: [PersonActedInConnectionWhere!]
+              NOT: PersonActedInConnectionWhere
+              OR: [PersonActedInConnectionWhere!]
+              node: MovieWhere
+            }
+
+            type PersonActedInRelationship {
+              cursor: String!
+              node: Movie!
+            }
+
+            type PersonAggregate {
+              count: Count!
+              node: PersonAggregateNode!
+            }
+
+            type PersonAggregateNode {
+              name: StringAggregateSelection!
+            }
+
+            input PersonConnectInput {
+              directed: [PersonDirectedConnectFieldInput!]
+            }
+
+            input PersonConnectWhere {
+              node: PersonWhere!
+            }
+
+            input PersonCreateInput {
+              directed: PersonDirectedFieldInput
+              name: String!
+            }
+
+            input PersonDeleteInput {
+              directed: [PersonDirectedDeleteFieldInput!]
+            }
+
+            input PersonDirectedConnectFieldInput {
+              connect: [MovieConnectInput!]
+              where: MovieConnectWhere
+            }
+
+            type PersonDirectedConnection {
+              aggregate: PersonMovieDirectedAggregateSelection!
+              edges: [PersonDirectedRelationship!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            input PersonDirectedConnectionAggregateInput {
+              AND: [PersonDirectedConnectionAggregateInput!]
+              NOT: PersonDirectedConnectionAggregateInput
+              OR: [PersonDirectedConnectionAggregateInput!]
+              count: ConnectionAggregationCountFilterInput
+              node: PersonDirectedNodeAggregationWhereInput
+            }
+
+            input PersonDirectedConnectionFilters {
+              \\"\\"\\"
+              Filter People by aggregating results on related PersonDirectedConnections
+              \\"\\"\\"
+              aggregate: PersonDirectedConnectionAggregateInput
+              \\"\\"\\"
+              Return People where all of the related PersonDirectedConnections match this filter
+              \\"\\"\\"
+              all: PersonDirectedConnectionWhere
+              \\"\\"\\"
+              Return People where none of the related PersonDirectedConnections match this filter
+              \\"\\"\\"
+              none: PersonDirectedConnectionWhere
+              \\"\\"\\"
+              Return People where one of the related PersonDirectedConnections match this filter
+              \\"\\"\\"
+              single: PersonDirectedConnectionWhere
+              \\"\\"\\"
+              Return People where some of the related PersonDirectedConnections match this filter
+              \\"\\"\\"
+              some: PersonDirectedConnectionWhere
+            }
+
+            input PersonDirectedConnectionSort {
+              node: MovieSort
+            }
+
+            input PersonDirectedConnectionWhere {
+              AND: [PersonDirectedConnectionWhere!]
+              NOT: PersonDirectedConnectionWhere
+              OR: [PersonDirectedConnectionWhere!]
+              node: MovieWhere
+            }
+
+            input PersonDirectedCreateFieldInput {
+              node: MovieCreateInput!
+            }
+
+            input PersonDirectedDeleteFieldInput {
+              delete: MovieDeleteInput
+              where: PersonDirectedConnectionWhere
+            }
+
+            input PersonDirectedDisconnectFieldInput {
+              disconnect: MovieDisconnectInput
+              where: PersonDirectedConnectionWhere
+            }
+
+            input PersonDirectedFieldInput {
+              connect: [PersonDirectedConnectFieldInput!]
+              create: [PersonDirectedCreateFieldInput!]
+            }
+
+            input PersonDirectedNodeAggregationWhereInput {
+              AND: [PersonDirectedNodeAggregationWhereInput!]
+              NOT: PersonDirectedNodeAggregationWhereInput
+              OR: [PersonDirectedNodeAggregationWhereInput!]
+              title: StringScalarAggregationFilters
+            }
+
+            type PersonDirectedRelationship {
+              cursor: String!
+              node: Movie!
+            }
+
+            input PersonDirectedUpdateConnectionInput {
+              node: MovieUpdateInput
+              where: PersonDirectedConnectionWhere
+            }
+
+            input PersonDirectedUpdateFieldInput {
+              connect: [PersonDirectedConnectFieldInput!]
+              create: [PersonDirectedCreateFieldInput!]
+              delete: [PersonDirectedDeleteFieldInput!]
+              disconnect: [PersonDirectedDisconnectFieldInput!]
+              update: PersonDirectedUpdateConnectionInput
+            }
+
+            input PersonDisconnectInput {
+              directed: [PersonDirectedDisconnectFieldInput!]
+            }
+
+            type PersonEdge {
+              cursor: String!
+              node: Person!
+            }
+
+            type PersonMovieDirectedAggregateSelection {
+              count: CountConnection!
+              node: PersonMovieDirectedNodeAggregateSelection
+            }
+
+            type PersonMovieDirectedNodeAggregateSelection {
+              title: StringAggregateSelection!
+            }
+
+            \\"\\"\\"
+            Fields to sort People by. The order in which sorts are applied is not guaranteed when specifying many fields in one PersonSort object.
+            \\"\\"\\"
+            input PersonSort {
+              name: SortDirection
+            }
+
+            input PersonUpdateInput {
+              directed: [PersonDirectedUpdateFieldInput!]
+              name: StringScalarMutations
+            }
+
+            input PersonWhere {
+              AND: [PersonWhere!]
+              NOT: PersonWhere
+              OR: [PersonWhere!]
+              actedIn: MovieWhere
+              actedInConnection: PersonActedInConnectionWhere
               directed: MovieRelationshipFilters
               directedConnection: PersonDirectedConnectionFilters
               name: StringScalarFilters

--- a/packages/graphql/tests/schema/relationship/single-element-relationship-to-union.test.ts
+++ b/packages/graphql/tests/schema/relationship/single-element-relationship-to-union.test.ts
@@ -1486,6 +1486,7 @@ describe("single item relationships to an Union type", () => {
 
             input AIDirectedConnectFieldInput {
               connect: [MovieConnectInput!]
+              edge: DirectedCreateInput!
               where: MovieConnectWhere
             }
 
@@ -1501,6 +1502,7 @@ describe("single item relationships to an Union type", () => {
               NOT: AIDirectedConnectionAggregateInput
               OR: [AIDirectedConnectionAggregateInput!]
               count: ConnectionAggregationCountFilterInput
+              edge: DirectedAggregationWhereInput
               node: AIDirectedNodeAggregationWhereInput
             }
 
@@ -1526,6 +1528,7 @@ describe("single item relationships to an Union type", () => {
             }
 
             input AIDirectedConnectionSort {
+              edge: DirectedSort
               node: MovieSort
             }
 
@@ -1533,10 +1536,12 @@ describe("single item relationships to an Union type", () => {
               AND: [AIDirectedConnectionWhere!]
               NOT: AIDirectedConnectionWhere
               OR: [AIDirectedConnectionWhere!]
+              edge: DirectedWhere
               node: MovieWhere
             }
 
             input AIDirectedCreateFieldInput {
+              edge: DirectedCreateInput!
               node: MovieCreateInput!
             }
 
@@ -1565,9 +1570,11 @@ describe("single item relationships to an Union type", () => {
             type AIDirectedRelationship {
               cursor: String!
               node: Movie!
+              properties: Directed!
             }
 
             input AIDirectedUpdateConnectionInput {
+              edge: DirectedUpdateInput
               node: MovieUpdateInput
               where: AIDirectedConnectionWhere
             }
@@ -1587,7 +1594,12 @@ describe("single item relationships to an Union type", () => {
 
             type AIMovieDirectedAggregateSelection {
               count: CountConnection!
+              edge: AIMovieDirectedEdgeAggregateSelection
               node: AIMovieDirectedNodeAggregateSelection
+            }
+
+            type AIMovieDirectedEdgeAggregateSelection {
+              year: IntAggregateSelection!
             }
 
             type AIMovieDirectedNodeAggregateSelection {
@@ -1613,6 +1625,35 @@ describe("single item relationships to an Union type", () => {
               directed: MovieRelationshipFilters
               directedConnection: AIDirectedConnectionFilters
               model: StringScalarFilters
+            }
+
+            \\"\\"\\"
+            The edge properties for the following fields:
+            * Movie.actor
+            * Person.actedIn
+            * Dog.actedIn
+            \\"\\"\\"
+            type ActedIn {
+              scenes: Int!
+            }
+
+            input ActedInCreateInput {
+              scenes: Int!
+            }
+
+            input ActedInSort {
+              scenes: SortDirection
+            }
+
+            input ActedInUpdateInput {
+              scenes: IntScalarMutations
+            }
+
+            input ActedInWhere {
+              AND: [ActedInWhere!]
+              NOT: ActedInWhere
+              OR: [ActedInWhere!]
+              scenes: IntScalarFilters
             }
 
             union Actor = Dog | Person
@@ -1690,6 +1731,42 @@ describe("single item relationships to an Union type", () => {
               relationshipsDeleted: Int!
             }
 
+            \\"\\"\\"
+            The edge properties for the following fields:
+            * Movie.director
+            * Person.directed
+            * AI.directed
+            \\"\\"\\"
+            type Directed {
+              year: Int!
+            }
+
+            input DirectedAggregationWhereInput {
+              AND: [DirectedAggregationWhereInput!]
+              NOT: DirectedAggregationWhereInput
+              OR: [DirectedAggregationWhereInput!]
+              year: IntScalarAggregationFilters
+            }
+
+            input DirectedCreateInput {
+              year: Int!
+            }
+
+            input DirectedSort {
+              year: SortDirection
+            }
+
+            input DirectedUpdateInput {
+              year: IntScalarMutations
+            }
+
+            input DirectedWhere {
+              AND: [DirectedWhere!]
+              NOT: DirectedWhere
+              OR: [DirectedWhere!]
+              year: IntScalarFilters
+            }
+
             union Director = AI | Person
 
             input DirectorWhere {
@@ -1713,12 +1790,14 @@ describe("single item relationships to an Union type", () => {
               AND: [DogActedInConnectionWhere!]
               NOT: DogActedInConnectionWhere
               OR: [DogActedInConnectionWhere!]
+              edge: ActedInWhere
               node: MovieWhere
             }
 
             type DogActedInRelationship {
               cursor: String!
               node: Movie!
+              properties: ActedIn!
             }
 
             type DogAggregate {
@@ -1780,6 +1859,21 @@ describe("single item relationships to an Union type", () => {
               lte: Float
             }
 
+            type IntAggregateSelection {
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
+            }
+
+            \\"\\"\\"Filters for an aggregation of an int field\\"\\"\\"
+            input IntScalarAggregationFilters {
+              average: FloatScalarFilters
+              max: IntScalarFilters
+              min: IntScalarFilters
+              sum: IntScalarFilters
+            }
+
             \\"\\"\\"Int filters\\"\\"\\"
             input IntScalarFilters {
               eq: Int
@@ -1790,9 +1884,16 @@ describe("single item relationships to an Union type", () => {
               lte: Int
             }
 
+            \\"\\"\\"Int mutations\\"\\"\\"
+            input IntScalarMutations {
+              add: Int
+              set: Int
+              subtract: Int
+            }
+
             type Movie {
               actor(limit: Int, offset: Int, where: ActorWhere): [Actor!]!
-              actorConnection(after: String, first: Int, where: MovieActorConnectionWhere): MovieActorConnection!
+              actorConnection(after: String, first: Int, sort: [MovieActorConnectionSort!], where: MovieActorConnectionWhere): MovieActorConnection!
               director: Director!
               directorConnection: MovieDirectorConnection!
               title: String!
@@ -1828,6 +1929,10 @@ describe("single item relationships to an Union type", () => {
               some: MovieActorConnectionWhere
             }
 
+            input MovieActorConnectionSort {
+              edge: ActedInSort
+            }
+
             input MovieActorConnectionWhere {
               Dog: MovieActorDogConnectionWhere
               Person: MovieActorPersonConnectionWhere
@@ -1849,6 +1954,7 @@ describe("single item relationships to an Union type", () => {
             }
 
             input MovieActorDogConnectFieldInput {
+              edge: ActedInCreateInput!
               where: DogConnectWhere
             }
 
@@ -1856,10 +1962,12 @@ describe("single item relationships to an Union type", () => {
               AND: [MovieActorDogConnectionWhere!]
               NOT: MovieActorDogConnectionWhere
               OR: [MovieActorDogConnectionWhere!]
+              edge: ActedInWhere
               node: DogWhere
             }
 
             input MovieActorDogCreateFieldInput {
+              edge: ActedInCreateInput!
               node: DogCreateInput!
             }
 
@@ -1877,6 +1985,7 @@ describe("single item relationships to an Union type", () => {
             }
 
             input MovieActorDogUpdateConnectionInput {
+              edge: ActedInUpdateInput
               node: DogUpdateInput
               where: MovieActorDogConnectionWhere
             }
@@ -1891,6 +2000,7 @@ describe("single item relationships to an Union type", () => {
 
             input MovieActorPersonConnectFieldInput {
               connect: [PersonConnectInput!]
+              edge: ActedInCreateInput!
               where: PersonConnectWhere
             }
 
@@ -1898,10 +2008,12 @@ describe("single item relationships to an Union type", () => {
               AND: [MovieActorPersonConnectionWhere!]
               NOT: MovieActorPersonConnectionWhere
               OR: [MovieActorPersonConnectionWhere!]
+              edge: ActedInWhere
               node: PersonWhere
             }
 
             input MovieActorPersonCreateFieldInput {
+              edge: ActedInCreateInput!
               node: PersonCreateInput!
             }
 
@@ -1921,6 +2033,7 @@ describe("single item relationships to an Union type", () => {
             }
 
             input MovieActorPersonUpdateConnectionInput {
+              edge: ActedInUpdateInput
               node: PersonUpdateInput
               where: MovieActorPersonConnectionWhere
             }
@@ -1936,6 +2049,7 @@ describe("single item relationships to an Union type", () => {
             type MovieActorRelationship {
               cursor: String!
               node: Actor!
+              properties: ActedIn!
             }
 
             input MovieActorUpdateInput {
@@ -1973,6 +2087,7 @@ describe("single item relationships to an Union type", () => {
               AND: [MovieDirectorAIConnectionWhere!]
               NOT: MovieDirectorAIConnectionWhere
               OR: [MovieDirectorAIConnectionWhere!]
+              edge: DirectedWhere
               node: AIWhere
             }
 
@@ -1991,12 +2106,14 @@ describe("single item relationships to an Union type", () => {
               AND: [MovieDirectorPersonConnectionWhere!]
               NOT: MovieDirectorPersonConnectionWhere
               OR: [MovieDirectorPersonConnectionWhere!]
+              edge: DirectedWhere
               node: PersonWhere
             }
 
             type MovieDirectorRelationship {
               cursor: String!
               node: Director!
+              properties: Directed!
             }
 
             input MovieDisconnectInput {
@@ -2097,12 +2214,14 @@ describe("single item relationships to an Union type", () => {
               AND: [PersonActedInConnectionWhere!]
               NOT: PersonActedInConnectionWhere
               OR: [PersonActedInConnectionWhere!]
+              edge: ActedInWhere
               node: MovieWhere
             }
 
             type PersonActedInRelationship {
               cursor: String!
               node: Movie!
+              properties: ActedIn!
             }
 
             type PersonAggregate {
@@ -2133,6 +2252,7 @@ describe("single item relationships to an Union type", () => {
 
             input PersonDirectedConnectFieldInput {
               connect: [MovieConnectInput!]
+              edge: DirectedCreateInput!
               where: MovieConnectWhere
             }
 
@@ -2148,6 +2268,7 @@ describe("single item relationships to an Union type", () => {
               NOT: PersonDirectedConnectionAggregateInput
               OR: [PersonDirectedConnectionAggregateInput!]
               count: ConnectionAggregationCountFilterInput
+              edge: DirectedAggregationWhereInput
               node: PersonDirectedNodeAggregationWhereInput
             }
 
@@ -2175,6 +2296,7 @@ describe("single item relationships to an Union type", () => {
             }
 
             input PersonDirectedConnectionSort {
+              edge: DirectedSort
               node: MovieSort
             }
 
@@ -2182,10 +2304,12 @@ describe("single item relationships to an Union type", () => {
               AND: [PersonDirectedConnectionWhere!]
               NOT: PersonDirectedConnectionWhere
               OR: [PersonDirectedConnectionWhere!]
+              edge: DirectedWhere
               node: MovieWhere
             }
 
             input PersonDirectedCreateFieldInput {
+              edge: DirectedCreateInput!
               node: MovieCreateInput!
             }
 
@@ -2214,9 +2338,11 @@ describe("single item relationships to an Union type", () => {
             type PersonDirectedRelationship {
               cursor: String!
               node: Movie!
+              properties: Directed!
             }
 
             input PersonDirectedUpdateConnectionInput {
+              edge: DirectedUpdateInput
               node: MovieUpdateInput
               where: PersonDirectedConnectionWhere
             }
@@ -2240,7 +2366,12 @@ describe("single item relationships to an Union type", () => {
 
             type PersonMovieDirectedAggregateSelection {
               count: CountConnection!
+              edge: PersonMovieDirectedEdgeAggregateSelection
               node: PersonMovieDirectedNodeAggregateSelection
+            }
+
+            type PersonMovieDirectedEdgeAggregateSelection {
+              year: IntAggregateSelection!
             }
 
             type PersonMovieDirectedNodeAggregateSelection {

--- a/packages/graphql/tests/schema/relationship/single-element-relationship.test.ts
+++ b/packages/graphql/tests/schema/relationship/single-element-relationship.test.ts
@@ -99,6 +99,13 @@ describe("single item relationships", () => {
               totalCount: Int!
             }
 
+            input MovieActorConnectionWhere {
+              AND: [MovieActorConnectionWhere!]
+              NOT: MovieActorConnectionWhere
+              OR: [MovieActorConnectionWhere!]
+              node: PersonWhere
+            }
+
             type MovieActorRelationship {
               cursor: String!
               node: Person!
@@ -121,6 +128,13 @@ describe("single item relationships", () => {
               edges: [MovieDirectorRelationship!]!
               pageInfo: PageInfo!
               totalCount: Int!
+            }
+
+            input MovieDirectorConnectionWhere {
+              AND: [MovieDirectorConnectionWhere!]
+              NOT: MovieDirectorConnectionWhere
+              OR: [MovieDirectorConnectionWhere!]
+              node: PersonWhere
             }
 
             type MovieDirectorRelationship {
@@ -148,6 +162,10 @@ describe("single item relationships", () => {
               AND: [MovieWhere!]
               NOT: MovieWhere
               OR: [MovieWhere!]
+              actor: PersonWhere
+              actorConnection: MovieActorConnectionWhere
+              director: PersonWhere
+              directorConnection: MovieDirectorConnectionWhere
               title: StringScalarFilters
             }
 
@@ -398,6 +416,13 @@ describe("single item relationships", () => {
               totalCount: Int!
             }
 
+            input MovieDirectorConnectionWhere {
+              AND: [MovieDirectorConnectionWhere!]
+              NOT: MovieDirectorConnectionWhere
+              OR: [MovieDirectorConnectionWhere!]
+              node: PersonWhere
+            }
+
             type MovieDirectorRelationship {
               cursor: String!
               node: Person!
@@ -434,6 +459,8 @@ describe("single item relationships", () => {
               AND: [MovieWhere!]
               NOT: MovieWhere
               OR: [MovieWhere!]
+              director: PersonWhere
+              directorConnection: MovieDirectorConnectionWhere
               title: StringScalarFilters
             }
 
@@ -595,6 +622,498 @@ describe("single item relationships", () => {
             type PersonMovieDirectedAggregateSelection {
               count: CountConnection!
               node: PersonMovieDirectedNodeAggregateSelection
+            }
+
+            type PersonMovieDirectedNodeAggregateSelection {
+              title: StringAggregateSelection!
+            }
+
+            \\"\\"\\"
+            Fields to sort People by. The order in which sorts are applied is not guaranteed when specifying many fields in one PersonSort object.
+            \\"\\"\\"
+            input PersonSort {
+              name: SortDirection
+            }
+
+            input PersonUpdateInput {
+              directed: [PersonDirectedUpdateFieldInput!]
+              name: StringScalarMutations
+            }
+
+            input PersonWhere {
+              AND: [PersonWhere!]
+              NOT: PersonWhere
+              OR: [PersonWhere!]
+              directed: MovieRelationshipFilters
+              directedConnection: PersonDirectedConnectionFilters
+              name: StringScalarFilters
+            }
+
+            type Query {
+              movies(limit: Int, offset: Int, sort: [MovieSort!], where: MovieWhere): [Movie!]!
+              moviesConnection(after: String, first: Int, sort: [MovieSort!], where: MovieWhere): MoviesConnection!
+              people(limit: Int, offset: Int, sort: [PersonSort!], where: PersonWhere): [Person!]!
+              peopleConnection(after: String, first: Int, sort: [PersonSort!], where: PersonWhere): PeopleConnection!
+            }
+
+            \\"\\"\\"An enum for sorting in either ascending or descending order.\\"\\"\\"
+            enum SortDirection {
+              \\"\\"\\"Sort by field values in ascending order.\\"\\"\\"
+              ASC
+              \\"\\"\\"Sort by field values in descending order.\\"\\"\\"
+              DESC
+            }
+
+            type StringAggregateSelection {
+              longest: String
+              shortest: String
+            }
+
+            \\"\\"\\"Filters for an aggregation of a string field\\"\\"\\"
+            input StringScalarAggregationFilters {
+              averageLength: FloatScalarFilters
+              longestLength: IntScalarFilters
+              shortestLength: IntScalarFilters
+            }
+
+            \\"\\"\\"String filters\\"\\"\\"
+            input StringScalarFilters {
+              contains: String
+              endsWith: String
+              eq: String
+              in: [String!]
+              startsWith: String
+            }
+
+            \\"\\"\\"String mutations\\"\\"\\"
+            input StringScalarMutations {
+              set: String
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships created and deleted during an update mutation
+            \\"\\"\\"
+            type UpdateInfo {
+              nodesCreated: Int!
+              nodesDeleted: Int!
+              relationshipsCreated: Int!
+              relationshipsDeleted: Int!
+            }
+
+            type UpdateMoviesMutationResponse {
+              info: UpdateInfo!
+              movies: [Movie!]!
+            }
+
+            type UpdatePeopleMutationResponse {
+              info: UpdateInfo!
+              people: [Person!]!
+            }"
+        `);
+    });
+
+    test("1-* relationship with edge properties", async () => {
+        const typeDefs = gql`
+            type Movie @node {
+                title: String!
+                director: Person! @relationship(type: "DIRECTED", direction: IN, properties: "DirectedProps")
+            }
+
+            type Person @node {
+                name: String!
+                directed: [Movie!]! @relationship(type: "DIRECTED", direction: OUT, properties: "DirectedProps")
+            }
+
+            type DirectedProps @relationshipProperties {
+                year: Int!
+            }
+        `;
+        const neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            features: {
+                excludeDeprecatedFields: {
+                    mutationOperations: true,
+                    aggregationFilters: true,
+                    aggregationFiltersOutsideConnection: true,
+                    relationshipFilters: true,
+                    attributeFilters: true,
+                },
+            },
+        });
+        const printedSchema = printSchemaWithDirectives(lexicographicSortSchema(await neoSchema.getSchema()));
+
+        expect(printedSchema).toMatchInlineSnapshot(`
+            "schema {
+              query: Query
+              mutation: Mutation
+            }
+
+            input ConnectionAggregationCountFilterInput {
+              edges: IntScalarFilters
+              nodes: IntScalarFilters
+            }
+
+            type Count {
+              nodes: Int!
+            }
+
+            type CountConnection {
+              edges: Int!
+              nodes: Int!
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships created during a create mutation
+            \\"\\"\\"
+            type CreateInfo {
+              nodesCreated: Int!
+              relationshipsCreated: Int!
+            }
+
+            type CreateMoviesMutationResponse {
+              info: CreateInfo!
+              movies: [Movie!]!
+            }
+
+            type CreatePeopleMutationResponse {
+              info: CreateInfo!
+              people: [Person!]!
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships deleted during a delete mutation
+            \\"\\"\\"
+            type DeleteInfo {
+              nodesDeleted: Int!
+              relationshipsDeleted: Int!
+            }
+
+            \\"\\"\\"
+            The edge properties for the following fields:
+            * Movie.director
+            * Person.directed
+            \\"\\"\\"
+            type DirectedProps {
+              year: Int!
+            }
+
+            input DirectedPropsAggregationWhereInput {
+              AND: [DirectedPropsAggregationWhereInput!]
+              NOT: DirectedPropsAggregationWhereInput
+              OR: [DirectedPropsAggregationWhereInput!]
+              year: IntScalarAggregationFilters
+            }
+
+            input DirectedPropsCreateInput {
+              year: Int!
+            }
+
+            input DirectedPropsSort {
+              year: SortDirection
+            }
+
+            input DirectedPropsUpdateInput {
+              year: IntScalarMutations
+            }
+
+            input DirectedPropsWhere {
+              AND: [DirectedPropsWhere!]
+              NOT: DirectedPropsWhere
+              OR: [DirectedPropsWhere!]
+              year: IntScalarFilters
+            }
+
+            \\"\\"\\"Float filters\\"\\"\\"
+            input FloatScalarFilters {
+              eq: Float
+              gt: Float
+              gte: Float
+              in: [Float!]
+              lt: Float
+              lte: Float
+            }
+
+            type IntAggregateSelection {
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
+            }
+
+            \\"\\"\\"Filters for an aggregation of an int field\\"\\"\\"
+            input IntScalarAggregationFilters {
+              average: FloatScalarFilters
+              max: IntScalarFilters
+              min: IntScalarFilters
+              sum: IntScalarFilters
+            }
+
+            \\"\\"\\"Int filters\\"\\"\\"
+            input IntScalarFilters {
+              eq: Int
+              gt: Int
+              gte: Int
+              in: [Int!]
+              lt: Int
+              lte: Int
+            }
+
+            \\"\\"\\"Int mutations\\"\\"\\"
+            input IntScalarMutations {
+              add: Int
+              set: Int
+              subtract: Int
+            }
+
+            type Movie {
+              director: Person!
+              directorConnection: MovieDirectorConnection!
+              title: String!
+            }
+
+            type MovieAggregate {
+              count: Count!
+              node: MovieAggregateNode!
+            }
+
+            type MovieAggregateNode {
+              title: StringAggregateSelection!
+            }
+
+            input MovieConnectWhere {
+              node: MovieWhere!
+            }
+
+            input MovieCreateInput {
+              title: String!
+            }
+
+            type MovieDirectorConnection {
+              edges: [MovieDirectorRelationship!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            input MovieDirectorConnectionWhere {
+              AND: [MovieDirectorConnectionWhere!]
+              NOT: MovieDirectorConnectionWhere
+              OR: [MovieDirectorConnectionWhere!]
+              edge: DirectedPropsWhere
+              node: PersonWhere
+            }
+
+            type MovieDirectorRelationship {
+              cursor: String!
+              node: Person!
+              properties: DirectedProps!
+            }
+
+            type MovieEdge {
+              cursor: String!
+              node: Movie!
+            }
+
+            input MovieRelationshipFilters {
+              \\"\\"\\"Filter type where all of the related Movies match this filter\\"\\"\\"
+              all: MovieWhere
+              \\"\\"\\"Filter type where none of the related Movies match this filter\\"\\"\\"
+              none: MovieWhere
+              \\"\\"\\"Filter type where one of the related Movies match this filter\\"\\"\\"
+              single: MovieWhere
+              \\"\\"\\"Filter type where some of the related Movies match this filter\\"\\"\\"
+              some: MovieWhere
+            }
+
+            \\"\\"\\"
+            Fields to sort Movies by. The order in which sorts are applied is not guaranteed when specifying many fields in one MovieSort object.
+            \\"\\"\\"
+            input MovieSort {
+              title: SortDirection
+            }
+
+            input MovieUpdateInput {
+              title: StringScalarMutations
+            }
+
+            input MovieWhere {
+              AND: [MovieWhere!]
+              NOT: MovieWhere
+              OR: [MovieWhere!]
+              director: PersonWhere
+              directorConnection: MovieDirectorConnectionWhere
+              title: StringScalarFilters
+            }
+
+            type MoviesConnection {
+              aggregate: MovieAggregate!
+              edges: [MovieEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type Mutation {
+              createMovies(input: [MovieCreateInput!]!): CreateMoviesMutationResponse!
+              createPeople(input: [PersonCreateInput!]!): CreatePeopleMutationResponse!
+              deleteMovies(where: MovieWhere): DeleteInfo!
+              deletePeople(delete: PersonDeleteInput, where: PersonWhere): DeleteInfo!
+              updateMovies(update: MovieUpdateInput, where: MovieWhere): UpdateMoviesMutationResponse!
+              updatePeople(update: PersonUpdateInput, where: PersonWhere): UpdatePeopleMutationResponse!
+            }
+
+            \\"\\"\\"Pagination information (Relay)\\"\\"\\"
+            type PageInfo {
+              endCursor: String
+              hasNextPage: Boolean!
+              hasPreviousPage: Boolean!
+              startCursor: String
+            }
+
+            type PeopleConnection {
+              aggregate: PersonAggregate!
+              edges: [PersonEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type Person {
+              directed(limit: Int, offset: Int, sort: [MovieSort!], where: MovieWhere): [Movie!]!
+              directedConnection(after: String, first: Int, sort: [PersonDirectedConnectionSort!], where: PersonDirectedConnectionWhere): PersonDirectedConnection!
+              name: String!
+            }
+
+            type PersonAggregate {
+              count: Count!
+              node: PersonAggregateNode!
+            }
+
+            type PersonAggregateNode {
+              name: StringAggregateSelection!
+            }
+
+            input PersonCreateInput {
+              directed: PersonDirectedFieldInput
+              name: String!
+            }
+
+            input PersonDeleteInput {
+              directed: [PersonDirectedDeleteFieldInput!]
+            }
+
+            input PersonDirectedConnectFieldInput {
+              edge: DirectedPropsCreateInput!
+              where: MovieConnectWhere
+            }
+
+            type PersonDirectedConnection {
+              aggregate: PersonMovieDirectedAggregateSelection!
+              edges: [PersonDirectedRelationship!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            input PersonDirectedConnectionAggregateInput {
+              AND: [PersonDirectedConnectionAggregateInput!]
+              NOT: PersonDirectedConnectionAggregateInput
+              OR: [PersonDirectedConnectionAggregateInput!]
+              count: ConnectionAggregationCountFilterInput
+              edge: DirectedPropsAggregationWhereInput
+              node: PersonDirectedNodeAggregationWhereInput
+            }
+
+            input PersonDirectedConnectionFilters {
+              \\"\\"\\"
+              Filter People by aggregating results on related PersonDirectedConnections
+              \\"\\"\\"
+              aggregate: PersonDirectedConnectionAggregateInput
+              \\"\\"\\"
+              Return People where all of the related PersonDirectedConnections match this filter
+              \\"\\"\\"
+              all: PersonDirectedConnectionWhere
+              \\"\\"\\"
+              Return People where none of the related PersonDirectedConnections match this filter
+              \\"\\"\\"
+              none: PersonDirectedConnectionWhere
+              \\"\\"\\"
+              Return People where one of the related PersonDirectedConnections match this filter
+              \\"\\"\\"
+              single: PersonDirectedConnectionWhere
+              \\"\\"\\"
+              Return People where some of the related PersonDirectedConnections match this filter
+              \\"\\"\\"
+              some: PersonDirectedConnectionWhere
+            }
+
+            input PersonDirectedConnectionSort {
+              edge: DirectedPropsSort
+              node: MovieSort
+            }
+
+            input PersonDirectedConnectionWhere {
+              AND: [PersonDirectedConnectionWhere!]
+              NOT: PersonDirectedConnectionWhere
+              OR: [PersonDirectedConnectionWhere!]
+              edge: DirectedPropsWhere
+              node: MovieWhere
+            }
+
+            input PersonDirectedCreateFieldInput {
+              edge: DirectedPropsCreateInput!
+              node: MovieCreateInput!
+            }
+
+            input PersonDirectedDeleteFieldInput {
+              where: PersonDirectedConnectionWhere
+            }
+
+            input PersonDirectedDisconnectFieldInput {
+              where: PersonDirectedConnectionWhere
+            }
+
+            input PersonDirectedFieldInput {
+              connect: [PersonDirectedConnectFieldInput!]
+              create: [PersonDirectedCreateFieldInput!]
+            }
+
+            input PersonDirectedNodeAggregationWhereInput {
+              AND: [PersonDirectedNodeAggregationWhereInput!]
+              NOT: PersonDirectedNodeAggregationWhereInput
+              OR: [PersonDirectedNodeAggregationWhereInput!]
+              title: StringScalarAggregationFilters
+            }
+
+            type PersonDirectedRelationship {
+              cursor: String!
+              node: Movie!
+              properties: DirectedProps!
+            }
+
+            input PersonDirectedUpdateConnectionInput {
+              edge: DirectedPropsUpdateInput
+              node: MovieUpdateInput
+              where: PersonDirectedConnectionWhere
+            }
+
+            input PersonDirectedUpdateFieldInput {
+              connect: [PersonDirectedConnectFieldInput!]
+              create: [PersonDirectedCreateFieldInput!]
+              delete: [PersonDirectedDeleteFieldInput!]
+              disconnect: [PersonDirectedDisconnectFieldInput!]
+              update: PersonDirectedUpdateConnectionInput
+            }
+
+            type PersonEdge {
+              cursor: String!
+              node: Person!
+            }
+
+            type PersonMovieDirectedAggregateSelection {
+              count: CountConnection!
+              edge: PersonMovieDirectedEdgeAggregateSelection
+              node: PersonMovieDirectedNodeAggregateSelection
+            }
+
+            type PersonMovieDirectedEdgeAggregateSelection {
+              year: IntAggregateSelection!
             }
 
             type PersonMovieDirectedNodeAggregateSelection {

--- a/packages/graphql/tests/schema/relationship/single-element-relationship.test.ts
+++ b/packages/graphql/tests/schema/relationship/single-element-relationship.test.ts
@@ -711,7 +711,6 @@ describe("single item relationships", () => {
             }"
         `);
     });
-
     test("1-* relationship with edge properties", async () => {
         const typeDefs = gql`
             type Movie @node {

--- a/packages/graphql/tests/tck/directives/relationship.test.ts
+++ b/packages/graphql/tests/tck/directives/relationship.test.ts
@@ -20,6 +20,7 @@
 import { Neo4jGraphQL } from "../../../src";
 import { formatCypher, formatParams, translateQuery } from "../utils/tck-test-utils";
 
+// TODO: add some
 describe("Cypher relationship", () => {
     let typeDefs: string;
     let neoSchema: Neo4jGraphQL;

--- a/packages/graphql/tests/tck/directives/relationship/1-many-declareRelationship.test.ts
+++ b/packages/graphql/tests/tck/directives/relationship/1-many-declareRelationship.test.ts
@@ -1,0 +1,707 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Neo4jGraphQL } from "../../../../src";
+import { formatCypher, formatParams, translateQuery } from "../../utils/tck-test-utils";
+
+describe("1-many relationships with Interfaces and declared relationships", () => {
+    let typeDefs: string;
+    let neoSchema: Neo4jGraphQL;
+
+    beforeAll(() => {
+        typeDefs = /* GraphQL */ `
+            interface Actor {
+                name: String!
+                actedIn: Production! @declareRelationship
+                directed: [Production!]! @declareRelationship
+            }
+            interface Production {
+                title: String!
+                actor: [Actor!]! @declareRelationship
+                director: Person! @declareRelationship
+            }
+
+            type Movie implements Production @node {
+                title: String!
+                actor: [Actor!]! @relationship(type: "ACTED_IN", direction: IN, properties: "ActedInMovie")
+                director: Person! @relationship(type: "DIRECTED", direction: IN, properties: "Directed")
+            }
+
+            type Series implements Production @node {
+                title: String!
+                actor: [Actor!]! @relationship(type: "ACTED_IN", direction: IN, properties: "ActedInSeries")
+                director: Person! @relationship(type: "DIRECTED", direction: IN, properties: "Directed")
+            }
+
+            type Dog implements Actor @node {
+                name: String!
+                actedIn: Production! @relationship(type: "ACTED_IN", direction: OUT, properties: "ActedInMovie")
+                directed: [Production!]! @relationship(type: "DIRECTED", direction: OUT, properties: "Directed")
+            }
+
+            type Person implements Actor @node {
+                name: String!
+                actedIn: Production! @relationship(type: "ACTED_IN", direction: OUT, properties: "ActedInSeries")
+                directed: [Production!]! @relationship(type: "DIRECTED", direction: OUT, properties: "Directed")
+            }
+
+            type ActedInMovie @relationshipProperties {
+                screenTime: Int
+            }
+
+            type ActedInSeries @relationshipProperties {
+                episodes: Int
+            }
+
+            type Directed @relationshipProperties {
+                year: Int
+            }
+        `;
+
+        neoSchema = new Neo4jGraphQL({
+            typeDefs,
+        });
+    });
+
+    test("returns all fields", async () => {
+        const query = `
+            query {
+              productions {
+                    actor {
+                        name
+                        actedIn {
+                            title
+                        }
+                    }
+                    director {
+                       name
+                       directed {
+                            title
+                       }
+                    }
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "CYPHER 5
+            CALL (*) {
+                MATCH (this0:Movie)
+                CALL (this0) {
+                    CALL (*) {
+                        WITH *
+                        MATCH (this0)<-[this1:ACTED_IN]-(this2:Dog)
+                        CALL (this2) {
+                            CALL (*) {
+                                WITH *
+                                MATCH (this2)-[this3:ACTED_IN]->(this4:Movie)
+                                WITH this4 { .title, __resolveType: \\"Movie\\", __id: id(this4) } AS var5
+                                RETURN var5
+                                UNION
+                                WITH *
+                                MATCH (this2)-[this6:ACTED_IN]->(this7:Series)
+                                WITH this7 { .title, __resolveType: \\"Series\\", __id: id(this7) } AS var5
+                                RETURN var5
+                            }
+                            WITH var5
+                            RETURN head(collect(var5)) AS var5
+                        }
+                        WITH this2 { .name, actedIn: var5, __resolveType: \\"Dog\\", __id: id(this2) } AS var8
+                        RETURN var8
+                        UNION
+                        WITH *
+                        MATCH (this0)<-[this9:ACTED_IN]-(this10:Person)
+                        CALL (this10) {
+                            CALL (*) {
+                                WITH *
+                                MATCH (this10)-[this11:ACTED_IN]->(this12:Movie)
+                                WITH this12 { .title, __resolveType: \\"Movie\\", __id: id(this12) } AS var13
+                                RETURN var13
+                                UNION
+                                WITH *
+                                MATCH (this10)-[this14:ACTED_IN]->(this15:Series)
+                                WITH this15 { .title, __resolveType: \\"Series\\", __id: id(this15) } AS var13
+                                RETURN var13
+                            }
+                            WITH var13
+                            RETURN head(collect(var13)) AS var13
+                        }
+                        WITH this10 { .name, actedIn: var13, __resolveType: \\"Person\\", __id: id(this10) } AS var8
+                        RETURN var8
+                    }
+                    WITH var8
+                    RETURN collect(var8) AS var8
+                }
+                CALL (this0) {
+                    MATCH (this0)<-[this16:DIRECTED]-(this17:Person)
+                    WITH DISTINCT this17
+                    CALL (this17) {
+                        CALL (*) {
+                            WITH *
+                            MATCH (this17)-[this18:DIRECTED]->(this19:Movie)
+                            WITH this19 { .title, __resolveType: \\"Movie\\", __id: id(this19) } AS var20
+                            RETURN var20
+                            UNION
+                            WITH *
+                            MATCH (this17)-[this21:DIRECTED]->(this22:Series)
+                            WITH this22 { .title, __resolveType: \\"Series\\", __id: id(this22) } AS var20
+                            RETURN var20
+                        }
+                        WITH var20
+                        RETURN collect(var20) AS var20
+                    }
+                    WITH this17 { .name, directed: var20 } AS this17
+                    RETURN head(collect(this17)) AS var23
+                }
+                WITH this0 { actor: var8, director: var23, __resolveType: \\"Movie\\", __id: id(this0) } AS this
+                RETURN this
+                UNION
+                MATCH (this24:Series)
+                CALL (this24) {
+                    CALL (*) {
+                        WITH *
+                        MATCH (this24)<-[this25:ACTED_IN]-(this26:Dog)
+                        CALL (this26) {
+                            CALL (*) {
+                                WITH *
+                                MATCH (this26)-[this27:ACTED_IN]->(this28:Movie)
+                                WITH this28 { .title, __resolveType: \\"Movie\\", __id: id(this28) } AS var29
+                                RETURN var29
+                                UNION
+                                WITH *
+                                MATCH (this26)-[this30:ACTED_IN]->(this31:Series)
+                                WITH this31 { .title, __resolveType: \\"Series\\", __id: id(this31) } AS var29
+                                RETURN var29
+                            }
+                            WITH var29
+                            RETURN head(collect(var29)) AS var29
+                        }
+                        WITH this26 { .name, actedIn: var29, __resolveType: \\"Dog\\", __id: id(this26) } AS var32
+                        RETURN var32
+                        UNION
+                        WITH *
+                        MATCH (this24)<-[this33:ACTED_IN]-(this34:Person)
+                        CALL (this34) {
+                            CALL (*) {
+                                WITH *
+                                MATCH (this34)-[this35:ACTED_IN]->(this36:Movie)
+                                WITH this36 { .title, __resolveType: \\"Movie\\", __id: id(this36) } AS var37
+                                RETURN var37
+                                UNION
+                                WITH *
+                                MATCH (this34)-[this38:ACTED_IN]->(this39:Series)
+                                WITH this39 { .title, __resolveType: \\"Series\\", __id: id(this39) } AS var37
+                                RETURN var37
+                            }
+                            WITH var37
+                            RETURN head(collect(var37)) AS var37
+                        }
+                        WITH this34 { .name, actedIn: var37, __resolveType: \\"Person\\", __id: id(this34) } AS var32
+                        RETURN var32
+                    }
+                    WITH var32
+                    RETURN collect(var32) AS var32
+                }
+                CALL (this24) {
+                    MATCH (this24)<-[this40:DIRECTED]-(this41:Person)
+                    WITH DISTINCT this41
+                    CALL (this41) {
+                        CALL (*) {
+                            WITH *
+                            MATCH (this41)-[this42:DIRECTED]->(this43:Movie)
+                            WITH this43 { .title, __resolveType: \\"Movie\\", __id: id(this43) } AS var44
+                            RETURN var44
+                            UNION
+                            WITH *
+                            MATCH (this41)-[this45:DIRECTED]->(this46:Series)
+                            WITH this46 { .title, __resolveType: \\"Series\\", __id: id(this46) } AS var44
+                            RETURN var44
+                        }
+                        WITH var44
+                        RETURN collect(var44) AS var44
+                    }
+                    WITH this41 { .name, directed: var44 } AS this41
+                    RETURN head(collect(this41)) AS var47
+                }
+                WITH this24 { actor: var32, director: var47, __resolveType: \\"Series\\", __id: id(this24) } AS this
+                RETURN this
+            }
+            WITH this
+            RETURN this AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
+    });
+
+    test("returns filtered fields", async () => {
+        const query = `
+            query {
+              productions {
+                    actor(where: { name: { eq: "Hachiko" }}) {
+                        name
+                        actedIn {
+                            title
+                        }
+                    }
+                    director {
+                       name
+                       directed(where: { title: { eq: "The Office"} }) {
+                            title
+                       }
+                    }
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "CYPHER 5
+            CALL (*) {
+                MATCH (this0:Movie)
+                CALL (this0) {
+                    CALL (*) {
+                        WITH *
+                        MATCH (this0)<-[this1:ACTED_IN]-(this2:Dog)
+                        WHERE this2.name = $param0
+                        CALL (this2) {
+                            CALL (*) {
+                                WITH *
+                                MATCH (this2)-[this3:ACTED_IN]->(this4:Movie)
+                                WITH this4 { .title, __resolveType: \\"Movie\\", __id: id(this4) } AS var5
+                                RETURN var5
+                                UNION
+                                WITH *
+                                MATCH (this2)-[this6:ACTED_IN]->(this7:Series)
+                                WITH this7 { .title, __resolveType: \\"Series\\", __id: id(this7) } AS var5
+                                RETURN var5
+                            }
+                            WITH var5
+                            RETURN head(collect(var5)) AS var5
+                        }
+                        WITH this2 { .name, actedIn: var5, __resolveType: \\"Dog\\", __id: id(this2) } AS var8
+                        RETURN var8
+                        UNION
+                        WITH *
+                        MATCH (this0)<-[this9:ACTED_IN]-(this10:Person)
+                        WHERE this10.name = $param1
+                        CALL (this10) {
+                            CALL (*) {
+                                WITH *
+                                MATCH (this10)-[this11:ACTED_IN]->(this12:Movie)
+                                WITH this12 { .title, __resolveType: \\"Movie\\", __id: id(this12) } AS var13
+                                RETURN var13
+                                UNION
+                                WITH *
+                                MATCH (this10)-[this14:ACTED_IN]->(this15:Series)
+                                WITH this15 { .title, __resolveType: \\"Series\\", __id: id(this15) } AS var13
+                                RETURN var13
+                            }
+                            WITH var13
+                            RETURN head(collect(var13)) AS var13
+                        }
+                        WITH this10 { .name, actedIn: var13, __resolveType: \\"Person\\", __id: id(this10) } AS var8
+                        RETURN var8
+                    }
+                    WITH var8
+                    RETURN collect(var8) AS var8
+                }
+                CALL (this0) {
+                    MATCH (this0)<-[this16:DIRECTED]-(this17:Person)
+                    WITH DISTINCT this17
+                    CALL (this17) {
+                        CALL (*) {
+                            WITH *
+                            MATCH (this17)-[this18:DIRECTED]->(this19:Movie)
+                            WHERE this19.title = $param2
+                            WITH this19 { .title, __resolveType: \\"Movie\\", __id: id(this19) } AS var20
+                            RETURN var20
+                            UNION
+                            WITH *
+                            MATCH (this17)-[this21:DIRECTED]->(this22:Series)
+                            WHERE this22.title = $param3
+                            WITH this22 { .title, __resolveType: \\"Series\\", __id: id(this22) } AS var20
+                            RETURN var20
+                        }
+                        WITH var20
+                        RETURN collect(var20) AS var20
+                    }
+                    WITH this17 { .name, directed: var20 } AS this17
+                    RETURN head(collect(this17)) AS var23
+                }
+                WITH this0 { actor: var8, director: var23, __resolveType: \\"Movie\\", __id: id(this0) } AS this
+                RETURN this
+                UNION
+                MATCH (this24:Series)
+                CALL (this24) {
+                    CALL (*) {
+                        WITH *
+                        MATCH (this24)<-[this25:ACTED_IN]-(this26:Dog)
+                        WHERE this26.name = $param4
+                        CALL (this26) {
+                            CALL (*) {
+                                WITH *
+                                MATCH (this26)-[this27:ACTED_IN]->(this28:Movie)
+                                WITH this28 { .title, __resolveType: \\"Movie\\", __id: id(this28) } AS var29
+                                RETURN var29
+                                UNION
+                                WITH *
+                                MATCH (this26)-[this30:ACTED_IN]->(this31:Series)
+                                WITH this31 { .title, __resolveType: \\"Series\\", __id: id(this31) } AS var29
+                                RETURN var29
+                            }
+                            WITH var29
+                            RETURN head(collect(var29)) AS var29
+                        }
+                        WITH this26 { .name, actedIn: var29, __resolveType: \\"Dog\\", __id: id(this26) } AS var32
+                        RETURN var32
+                        UNION
+                        WITH *
+                        MATCH (this24)<-[this33:ACTED_IN]-(this34:Person)
+                        WHERE this34.name = $param5
+                        CALL (this34) {
+                            CALL (*) {
+                                WITH *
+                                MATCH (this34)-[this35:ACTED_IN]->(this36:Movie)
+                                WITH this36 { .title, __resolveType: \\"Movie\\", __id: id(this36) } AS var37
+                                RETURN var37
+                                UNION
+                                WITH *
+                                MATCH (this34)-[this38:ACTED_IN]->(this39:Series)
+                                WITH this39 { .title, __resolveType: \\"Series\\", __id: id(this39) } AS var37
+                                RETURN var37
+                            }
+                            WITH var37
+                            RETURN head(collect(var37)) AS var37
+                        }
+                        WITH this34 { .name, actedIn: var37, __resolveType: \\"Person\\", __id: id(this34) } AS var32
+                        RETURN var32
+                    }
+                    WITH var32
+                    RETURN collect(var32) AS var32
+                }
+                CALL (this24) {
+                    MATCH (this24)<-[this40:DIRECTED]-(this41:Person)
+                    WITH DISTINCT this41
+                    CALL (this41) {
+                        CALL (*) {
+                            WITH *
+                            MATCH (this41)-[this42:DIRECTED]->(this43:Movie)
+                            WHERE this43.title = $param6
+                            WITH this43 { .title, __resolveType: \\"Movie\\", __id: id(this43) } AS var44
+                            RETURN var44
+                            UNION
+                            WITH *
+                            MATCH (this41)-[this45:DIRECTED]->(this46:Series)
+                            WHERE this46.title = $param7
+                            WITH this46 { .title, __resolveType: \\"Series\\", __id: id(this46) } AS var44
+                            RETURN var44
+                        }
+                        WITH var44
+                        RETURN collect(var44) AS var44
+                    }
+                    WITH this41 { .name, directed: var44 } AS this41
+                    RETURN head(collect(this41)) AS var47
+                }
+                WITH this24 { actor: var32, director: var47, __resolveType: \\"Series\\", __id: id(this24) } AS this
+                RETURN this
+            }
+            WITH this
+            RETURN this AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"Hachiko\\",
+                \\"param1\\": \\"Hachiko\\",
+                \\"param2\\": \\"The Office\\",
+                \\"param3\\": \\"The Office\\",
+                \\"param4\\": \\"Hachiko\\",
+                \\"param5\\": \\"Hachiko\\",
+                \\"param6\\": \\"The Office\\",
+                \\"param7\\": \\"The Office\\"
+            }"
+        `);
+    });
+
+    test("nested filter", async () => {
+        const query = `
+            query {
+               productions(where: { director: { name: { eq: "Director" } } }) {
+                    title
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "CYPHER 5
+            CALL (*) {
+                MATCH (this0:Movie)
+                WHERE EXISTS {
+                    MATCH (this0)<-[:DIRECTED]-(this1:Person)
+                    WHERE this1.name = $param0
+                }
+                WITH this0 { .title, __resolveType: \\"Movie\\", __id: id(this0) } AS this
+                RETURN this
+                UNION
+                MATCH (this2:Series)
+                WHERE EXISTS {
+                    MATCH (this2)<-[:DIRECTED]-(this3:Person)
+                    WHERE this3.name = $param1
+                }
+                WITH this2 { .title, __resolveType: \\"Series\\", __id: id(this2) } AS this
+                RETURN this
+            }
+            WITH this
+            RETURN this AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"Director\\",
+                \\"param1\\": \\"Director\\"
+            }"
+        `);
+    });
+
+    test("double nested filter", async () => {
+        const query = `
+            query {
+                actors(where: { actedIn: { director: { name: { eq: "Director" } } } }) {
+                    name
+                    actedIn {
+                        title
+                    }
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "CYPHER 5
+            CALL (*) {
+                MATCH (this0:Dog)
+                WHERE (EXISTS {
+                    MATCH (this0)-[:ACTED_IN]->(this1:Movie)
+                    WHERE EXISTS {
+                        MATCH (this1)<-[:DIRECTED]-(this2:Person)
+                        WHERE this2.name = $param0
+                    }
+                } OR EXISTS {
+                    MATCH (this0)-[:ACTED_IN]->(this3:Series)
+                    WHERE EXISTS {
+                        MATCH (this3)<-[:DIRECTED]-(this4:Person)
+                        WHERE this4.name = $param1
+                    }
+                })
+                CALL (this0) {
+                    CALL (*) {
+                        WITH *
+                        MATCH (this0)-[this5:ACTED_IN]->(this6:Movie)
+                        WITH this6 { .title, __resolveType: \\"Movie\\", __id: id(this6) } AS var7
+                        RETURN var7
+                        UNION
+                        WITH *
+                        MATCH (this0)-[this8:ACTED_IN]->(this9:Series)
+                        WITH this9 { .title, __resolveType: \\"Series\\", __id: id(this9) } AS var7
+                        RETURN var7
+                    }
+                    WITH var7
+                    RETURN head(collect(var7)) AS var7
+                }
+                WITH this0 { .name, actedIn: var7, __resolveType: \\"Dog\\", __id: id(this0) } AS this
+                RETURN this
+                UNION
+                MATCH (this10:Person)
+                WHERE (EXISTS {
+                    MATCH (this10)-[:ACTED_IN]->(this11:Movie)
+                    WHERE EXISTS {
+                        MATCH (this11)<-[:DIRECTED]-(this12:Person)
+                        WHERE this12.name = $param2
+                    }
+                } OR EXISTS {
+                    MATCH (this10)-[:ACTED_IN]->(this13:Series)
+                    WHERE EXISTS {
+                        MATCH (this13)<-[:DIRECTED]-(this14:Person)
+                        WHERE this14.name = $param3
+                    }
+                })
+                CALL (this10) {
+                    CALL (*) {
+                        WITH *
+                        MATCH (this10)-[this15:ACTED_IN]->(this16:Movie)
+                        WITH this16 { .title, __resolveType: \\"Movie\\", __id: id(this16) } AS var17
+                        RETURN var17
+                        UNION
+                        WITH *
+                        MATCH (this10)-[this18:ACTED_IN]->(this19:Series)
+                        WITH this19 { .title, __resolveType: \\"Series\\", __id: id(this19) } AS var17
+                        RETURN var17
+                    }
+                    WITH var17
+                    RETURN head(collect(var17)) AS var17
+                }
+                WITH this10 { .name, actedIn: var17, __resolveType: \\"Person\\", __id: id(this10) } AS this
+                RETURN this
+            }
+            WITH this
+            RETURN this AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"Director\\",
+                \\"param1\\": \\"Director\\",
+                \\"param2\\": \\"Director\\",
+                \\"param3\\": \\"Director\\"
+            }"
+        `);
+    });
+
+    test("nested filter with edge properties", async () => {
+        const query = `
+            query {
+               productions(where: { directorConnection: { edge: { Directed: { year: { gt: 1992 } } } } }) {
+                    title
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "CYPHER 5
+            CALL (*) {
+                MATCH (this0:Movie)
+                WHERE EXISTS {
+                    MATCH (this0)<-[this1:DIRECTED]-(this2:Person)
+                    WHERE this1.year > $param0
+                }
+                WITH this0 { .title, __resolveType: \\"Movie\\", __id: id(this0) } AS this
+                RETURN this
+                UNION
+                MATCH (this3:Series)
+                WHERE EXISTS {
+                    MATCH (this3)<-[this4:DIRECTED]-(this5:Person)
+                    WHERE this4.year > $param1
+                }
+                WITH this3 { .title, __resolveType: \\"Series\\", __id: id(this3) } AS this
+                RETURN this
+            }
+            WITH this
+            RETURN this AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": {
+                    \\"low\\": 1992,
+                    \\"high\\": 0
+                },
+                \\"param1\\": {
+                    \\"low\\": 1992,
+                    \\"high\\": 0
+                }
+            }"
+        `);
+    });
+
+    test("double nested filter with edge properties", async () => {
+        const query = `
+            query {
+               actors(where: { actedInConnection: { node: { directorConnection: { OR: [{ edge: { Directed: { year: { gt: 1996 } } } }, { node: { name: { eq: "Director" } } }] } } }  }) {
+                    name
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "CYPHER 5
+            CALL (*) {
+                MATCH (this0:Dog)
+                WHERE (EXISTS {
+                    MATCH (this0)-[this1:ACTED_IN]->(this2:Movie)
+                    WHERE EXISTS {
+                        MATCH (this2)<-[this3:DIRECTED]-(this4:Person)
+                        WHERE (this3.year > $param0 OR this4.name = $param1)
+                    }
+                } OR EXISTS {
+                    MATCH (this0)-[this5:ACTED_IN]->(this6:Series)
+                    WHERE EXISTS {
+                        MATCH (this6)<-[this7:DIRECTED]-(this8:Person)
+                        WHERE (this7.year > $param2 OR this8.name = $param3)
+                    }
+                })
+                WITH this0 { .name, __resolveType: \\"Dog\\", __id: id(this0) } AS this
+                RETURN this
+                UNION
+                MATCH (this9:Person)
+                WHERE (EXISTS {
+                    MATCH (this9)-[this10:ACTED_IN]->(this11:Movie)
+                    WHERE EXISTS {
+                        MATCH (this11)<-[this12:DIRECTED]-(this13:Person)
+                        WHERE (this12.year > $param4 OR this13.name = $param5)
+                    }
+                } OR EXISTS {
+                    MATCH (this9)-[this14:ACTED_IN]->(this15:Series)
+                    WHERE EXISTS {
+                        MATCH (this15)<-[this16:DIRECTED]-(this17:Person)
+                        WHERE (this16.year > $param6 OR this17.name = $param7)
+                    }
+                })
+                WITH this9 { .name, __resolveType: \\"Person\\", __id: id(this9) } AS this
+                RETURN this
+            }
+            WITH this
+            RETURN this AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": {
+                    \\"low\\": 1996,
+                    \\"high\\": 0
+                },
+                \\"param1\\": \\"Director\\",
+                \\"param2\\": {
+                    \\"low\\": 1996,
+                    \\"high\\": 0
+                },
+                \\"param3\\": \\"Director\\",
+                \\"param4\\": {
+                    \\"low\\": 1996,
+                    \\"high\\": 0
+                },
+                \\"param5\\": \\"Director\\",
+                \\"param6\\": {
+                    \\"low\\": 1996,
+                    \\"high\\": 0
+                },
+                \\"param7\\": \\"Director\\"
+            }"
+        `);
+    });
+});

--- a/packages/graphql/tests/tck/directives/relationship/1-many-relationship.test.ts
+++ b/packages/graphql/tests/tck/directives/relationship/1-many-relationship.test.ts
@@ -1,0 +1,281 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Neo4jGraphQL } from "../../../../src";
+import { formatCypher, formatParams, translateQuery } from "../../utils/tck-test-utils";
+
+describe("1-to-many relationships on object types", () => {
+    let typeDefs: string;
+    let neoSchema: Neo4jGraphQL;
+
+    beforeAll(() => {
+        typeDefs = /* GraphQL */ `
+            type Movie @node {
+                title: String!
+                director: Person! @relationship(type: "DIRECTED", direction: IN, properties: "Directed")
+            }
+
+            type Person @node {
+                name: String!
+                directed: [Movie!]! @relationship(type: "DIRECTED", direction: OUT, properties: "Directed")
+            }
+
+            type Directed @relationshipProperties {
+                year: Int
+            }
+        `;
+
+        neoSchema = new Neo4jGraphQL({
+            typeDefs,
+        });
+    });
+
+    test("returns all relationships", async () => {
+        const query = `
+            query {
+               people {
+                    directed {
+                        title
+                    }
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "CYPHER 5
+            MATCH (this:Person)
+            CALL (this) {
+                MATCH (this)-[this0:DIRECTED]->(this1:Movie)
+                WITH DISTINCT this1
+                WITH this1 { .title } AS this1
+                RETURN collect(this1) AS var2
+            }
+            RETURN this { directed: var2 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
+    });
+
+    test("nested filter", async () => {
+        const query = `
+            query {
+               movies(where: { director: { name: { eq: "Keanu" } } }) {
+                    director {
+                        name
+                    }
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "CYPHER 5
+            MATCH (this:Movie)
+            WHERE EXISTS {
+                MATCH (this)<-[:DIRECTED]-(this0:Person)
+                WHERE this0.name = $param0
+            }
+            CALL (this) {
+                MATCH (this)<-[this1:DIRECTED]-(this2:Person)
+                WITH DISTINCT this2
+                WITH this2 { .name } AS this2
+                RETURN head(collect(this2)) AS var3
+            }
+            RETURN this { director: var3 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"Keanu\\"
+            }"
+        `);
+    });
+
+    test("double nested filter", async () => {
+        const query = `
+            query {
+               people(where: { directed: { some: { director: { name: { eq: "Keanu" } } } } }) {
+                    directed {
+                        title
+                        director {
+                            name
+                        }
+                    }
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "CYPHER 5
+            MATCH (this:Person)
+            WHERE EXISTS {
+                MATCH (this)-[:DIRECTED]->(this0:Movie)
+                WHERE EXISTS {
+                    MATCH (this0)<-[:DIRECTED]-(this1:Person)
+                    WHERE this1.name = $param0
+                }
+            }
+            CALL (this) {
+                MATCH (this)-[this2:DIRECTED]->(this3:Movie)
+                WITH DISTINCT this3
+                CALL (this3) {
+                    MATCH (this3)<-[this4:DIRECTED]-(this5:Person)
+                    WITH DISTINCT this5
+                    WITH this5 { .name } AS this5
+                    RETURN head(collect(this5)) AS var6
+                }
+                WITH this3 { .title, director: var6 } AS this3
+                RETURN collect(this3) AS var7
+            }
+            RETURN this { directed: var7 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"Keanu\\"
+            }"
+        `);
+    });
+
+    test("nested filter with edge properties", async () => {
+        const query = `
+            query {
+               movies(where: { directorConnection: { edge: { year: { eq: 1999 } } } }) {
+                    directorConnection {
+                        edges {
+                            node {
+                                name
+                            }
+                            properties {
+                                year
+                            }
+                        }
+                    }
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "CYPHER 5
+            MATCH (this:Movie)
+            WHERE EXISTS {
+                MATCH (this)<-[this0:DIRECTED]-(this1:Person)
+                WHERE this0.year = $param0
+            }
+            CALL (this) {
+                MATCH (this)<-[this2:DIRECTED]-(this3:Person)
+                WITH collect({ node: this3, relationship: this2 }) AS edges
+                CALL (edges) {
+                    UNWIND edges AS edge
+                    WITH edge.node AS this3, edge.relationship AS this2
+                    RETURN collect({ properties: { year: this2.year, __resolveType: \\"Directed\\" }, node: { name: this3.name, __resolveType: \\"Person\\" } }) AS var4
+                }
+                RETURN { edges: var4 } AS var5
+            }
+            RETURN this { directorConnection: var5 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": {
+                    \\"low\\": 1999,
+                    \\"high\\": 0
+                }
+            }"
+        `);
+    });
+
+    test("double nested filter with edge properties", async () => {
+        const query = `
+            query {
+               people(where: { directedConnection: { some: { node: { directorConnection: { OR: [{ edge: { year: { gt: 2000 } } }, { node: { name: { startsWith: "K" } } }] } } } } }) {
+                    directedConnection {
+                        edges {
+                            node {
+                                title
+                                directorConnection {
+                                    edges {
+                                        node {
+                                            name
+                                        }
+                                    }
+                                }
+                            }
+                            properties {
+                                year
+                            }
+                        }
+                    }
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "CYPHER 5
+            MATCH (this:Person)
+            WHERE EXISTS {
+                MATCH (this)-[this0:DIRECTED]->(this1:Movie)
+                WHERE EXISTS {
+                    MATCH (this1)<-[this2:DIRECTED]-(this3:Person)
+                    WHERE (this2.year > $param0 OR this3.name STARTS WITH $param1)
+                }
+            }
+            CALL (this) {
+                MATCH (this)-[this4:DIRECTED]->(this5:Movie)
+                WITH collect({ node: this5, relationship: this4 }) AS edges
+                CALL (edges) {
+                    UNWIND edges AS edge
+                    WITH edge.node AS this5, edge.relationship AS this4
+                    CALL (this5) {
+                        MATCH (this5)<-[this6:DIRECTED]-(this7:Person)
+                        WITH collect({ node: this7, relationship: this6 }) AS edges
+                        CALL (edges) {
+                            UNWIND edges AS edge
+                            WITH edge.node AS this7, edge.relationship AS this6
+                            RETURN collect({ node: { name: this7.name, __resolveType: \\"Person\\" } }) AS var8
+                        }
+                        RETURN { edges: var8 } AS var9
+                    }
+                    RETURN collect({ properties: { year: this4.year, __resolveType: \\"Directed\\" }, node: { title: this5.title, directorConnection: var9, __resolveType: \\"Movie\\" } }) AS var10
+                }
+                RETURN { edges: var10 } AS var11
+            }
+            RETURN this { directedConnection: var11 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": {
+                    \\"low\\": 2000,
+                    \\"high\\": 0
+                },
+                \\"param1\\": \\"K\\"
+            }"
+        `);
+    });
+});

--- a/packages/graphql/tests/tck/directives/relationship/many-to-many-relationship.test.ts
+++ b/packages/graphql/tests/tck/directives/relationship/many-to-many-relationship.test.ts
@@ -17,11 +17,10 @@
  * limitations under the License.
  */
 
-import { Neo4jGraphQL } from "../../../src";
-import { formatCypher, formatParams, translateQuery } from "../utils/tck-test-utils";
+import { Neo4jGraphQL } from "../../../../src";
+import { formatCypher, formatParams, translateQuery } from "../../utils/tck-test-utils";
 
-// TODO: add some
-describe("Cypher relationship", () => {
+describe("many-to-many relationships", () => {
     let typeDefs: string;
     let neoSchema: Neo4jGraphQL;
 


### PR DESCRIPTION
# Description

Eq:
```gql
type Movie @node {
    actor: Actor @relationship()
}

query {
    movies(where: { actor: { name: { eq: ""} } })
}
query {
    movies(where: { actorConnection: { edge: { eq: ""} } })
}
```
Note: Relationship filters (some, none, etc…) are not applicable to 1-1 filters

## Complexity

Complexity: Low

# Issue

> **Note**
>
>  Please link to the GitHub issue(s) in which the proposal for this work was discussed
>  
>  To link to multiple issues, use full syntax for each, for example `Closes #1, closes #2, closes #3`

Closes 

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
