### PR TITLE
Migrate cypher builder to v3

### DIFF
--- a/packages/graphql/jest.config.js
+++ b/packages/graphql/jest.config.js
@@ -8,8 +8,16 @@ module.exports = {
     setupFilesAfterEnv: ["jest-extended/all"],
     roots: ["<rootDir>/packages/graphql/src/", "<rootDir>/packages/graphql/tests/"],
     coverageDirectory: "<rootDir>/packages/graphql/coverage/",
+    // @neo4j/cypher-builder is ESM-only; allow Jest to transform it to CJS
+    transformIgnorePatterns: ["/node_modules/(?!@neo4j/cypher-builder)"],
     transform: {
         "^.+\\.ts$": [
+            "ts-jest",
+            {
+                tsconfig: "<rootDir>/packages/graphql/tsconfig.json",
+            },
+        ],
+        "node_modules/@neo4j/cypher-builder/.+\\.js$": [
             "ts-jest",
             {
                 tsconfig: "<rootDir>/packages/graphql/tsconfig.json",

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -85,7 +85,7 @@
         "@graphql-tools/resolvers-composition": "^7.0.0",
         "@graphql-tools/schema": "^10.0.0",
         "@graphql-tools/utils": "11.0.0",
-        "@neo4j/cypher-builder": "file:./neo4j-cypher-builder-3.0.0.tgz",
+        "@neo4j/cypher-builder": "3.0.0",
         "camelcase": "^6.3.0",
         "debug": "^4.3.4",
         "dot-prop": "^6.0.1",

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -85,7 +85,7 @@
         "@graphql-tools/resolvers-composition": "^7.0.0",
         "@graphql-tools/schema": "^10.0.0",
         "@graphql-tools/utils": "11.0.0",
-        "@neo4j/cypher-builder": "2.12.0",
+        "@neo4j/cypher-builder": "file:./neo4j-cypher-builder-3.0.0.tgz",
         "camelcase": "^6.3.0",
         "debug": "^4.3.4",
         "dot-prop": "^6.0.1",

--- a/packages/graphql/src/translate/create-relationship-validation-clauses.ts
+++ b/packages/graphql/src/translate/create-relationship-validation-clauses.ts
@@ -26,6 +26,7 @@ import { filterTruthy } from "../utils/utils";
 import { getEntityLabels } from "./queryAST/utils/create-node-from-entity";
 import { isInterfaceEntity } from "./queryAST/utils/is-interface-entity";
 import { isUnionEntity } from "./queryAST/utils/is-union-entity";
+import { apocWrapper } from "./utils/apoc-wrapper";
 
 /**
  * Generate cardinality validation as the legacy method create-relationship-validation-string.ts but it uses CypherBuilder and the Schema Model
@@ -70,7 +71,7 @@ export function createRelationshipValidationClauses({
                     .to({ labels: getEntityLabels(target, context) })
             )
                 .with([Cypher.count(relVarnameCypher), cVariable])
-                .where(Cypher.apoc.util.validatePredicate(predicateCypher, errorMsg))
+                .where(apocWrapper.validatePredicate(predicateCypher, errorMsg))
                 .return([returnVar, new Cypher.Variable()]);
             return new Cypher.Call(match, [varName]);
         })

--- a/packages/graphql/src/translate/queryAST/ast/fields/aggregation-fields/AggregationAttributeField.ts
+++ b/packages/graphql/src/translate/queryAST/ast/fields/aggregation-fields/AggregationAttributeField.ts
@@ -20,6 +20,7 @@
 import Cypher from "@neo4j/cypher-builder";
 import type { AttributeAdapter } from "../../../../../schema-model/attribute/model-adapters/AttributeAdapter";
 import { filterFields, renameFields } from "../../../../../utils/utils";
+import { apocWrapper } from "../../../../utils/apoc-wrapper";
 import type { QueryASTNode } from "../../QueryASTNode";
 import { AggregationField } from "./AggregationField";
 
@@ -129,6 +130,6 @@ export class AggregationAttributeField extends AggregationField {
     }
 
     private createDatetimeProjection(expr: Cypher.Expr) {
-        return Cypher.apoc.date.convertFormat(expr, "iso_zoned_date_time", "iso_offset_date_time");
+        return apocWrapper.convertFormat(expr, "iso_zoned_date_time", "iso_offset_date_time");
     }
 }

--- a/packages/graphql/src/translate/queryAST/ast/fields/aggregation-fields/DeprecatedAggregationAttributeField.ts
+++ b/packages/graphql/src/translate/queryAST/ast/fields/aggregation-fields/DeprecatedAggregationAttributeField.ts
@@ -20,6 +20,7 @@
 import Cypher from "@neo4j/cypher-builder";
 import type { AttributeAdapter } from "../../../../../schema-model/attribute/model-adapters/AttributeAdapter";
 import { filterFields, renameFields } from "../../../../../utils/utils";
+import { apocWrapper } from "../../../../utils/apoc-wrapper";
 import type { QueryASTNode } from "../../QueryASTNode";
 import { AggregationField } from "./AggregationField";
 
@@ -128,6 +129,6 @@ export class DeprecatedAggregationAttributeField extends AggregationField {
     }
 
     private createDatetimeProjection(expr: Cypher.Expr) {
-        return Cypher.apoc.date.convertFormat(expr, "iso_zoned_date_time", "iso_offset_date_time");
+        return apocWrapper.convertFormat(expr, "iso_zoned_date_time", "iso_offset_date_time");
     }
 }

--- a/packages/graphql/src/translate/queryAST/ast/fields/attribute-fields/DateTimeField.ts
+++ b/packages/graphql/src/translate/queryAST/ast/fields/attribute-fields/DateTimeField.ts
@@ -18,6 +18,7 @@
  */
 
 import Cypher from "@neo4j/cypher-builder";
+import { apocWrapper } from "../../../../utils/apoc-wrapper";
 import { coalesceValueIfNeeded } from "../../filters/utils/coalesce-if-needed";
 import { AttributeField } from "./AttributeField";
 
@@ -49,6 +50,6 @@ export class DateTimeField extends AttributeField {
     }
 
     private createApocConvertFormat(variableOrProperty: Cypher.Variable | Cypher.Property): Cypher.Function {
-        return Cypher.apoc.date.convertFormat(variableOrProperty, "iso_zoned_date_time", "iso_offset_date_time");
+        return apocWrapper.convertFormat(variableOrProperty, "iso_zoned_date_time", "iso_offset_date_time");
     }
 }

--- a/packages/graphql/src/translate/queryAST/ast/filters/authorization-filters/AuthorizationFilters.ts
+++ b/packages/graphql/src/translate/queryAST/ast/filters/authorization-filters/AuthorizationFilters.ts
@@ -20,6 +20,7 @@
 import Cypher from "@neo4j/cypher-builder";
 import { AUTH_FORBIDDEN_ERROR } from "../../../../../constants";
 import type { ValidateWhen } from "../../../../../schema-model/annotation/AuthorizationAnnotation";
+import { apocWrapper } from "../../../../utils/apoc-wrapper";
 import type { QueryASTContext } from "../../QueryASTContext";
 import { QueryASTNode } from "../../QueryASTNode";
 import type { AuthorizationRuleFilter } from "./AuthorizationRuleFilter";
@@ -56,7 +57,7 @@ export class AuthorizationFilters extends QueryASTNode {
             const predicate = this.conditionForEvaluation
                 ? Cypher.and(this.conditionForEvaluation, Cypher.not(validationPredicate))
                 : Cypher.not(validationPredicate);
-            return Cypher.apoc.util.validate(predicate, AUTH_FORBIDDEN_ERROR);
+            return apocWrapper.validate(predicate, AUTH_FORBIDDEN_ERROR);
         }
 
         return;

--- a/packages/graphql/src/translate/queryAST/ast/filters/authorization-filters/AuthorizationFiltersDeprecated.ts
+++ b/packages/graphql/src/translate/queryAST/ast/filters/authorization-filters/AuthorizationFiltersDeprecated.ts
@@ -19,6 +19,7 @@
 
 import Cypher from "@neo4j/cypher-builder";
 import { AUTH_FORBIDDEN_ERROR } from "../../../../../constants";
+import { apocWrapper } from "../../../../utils/apoc-wrapper";
 import type { QueryASTContext } from "../../QueryASTContext";
 import type { QueryASTNode } from "../../QueryASTNode";
 import { Filter } from "../Filter";
@@ -57,7 +58,7 @@ export class AuthorizationFiltersDeprecated extends Filter {
             const predicate = this.conditionForEvaluation
                 ? Cypher.and(this.conditionForEvaluation, Cypher.not(validateInnerPredicate))
                 : Cypher.not(validateInnerPredicate);
-            validatePredicate = Cypher.apoc.util.validatePredicate(predicate, AUTH_FORBIDDEN_ERROR);
+            validatePredicate = apocWrapper.validatePredicate(predicate, AUTH_FORBIDDEN_ERROR);
         }
 
         return Cypher.and(wherePredicate, validatePredicate);

--- a/packages/graphql/src/translate/queryAST/ast/filters/utils/create-date-time-operation.ts
+++ b/packages/graphql/src/translate/queryAST/ast/filters/utils/create-date-time-operation.ts
@@ -67,5 +67,5 @@ function createDateTimeListComprehension(
 ): Cypher.ListComprehension {
     const comprehensionVar = new Cypher.Variable();
     const mapDateTime = Cypher.datetime(comprehensionVar);
-    return new Cypher.ListComprehension(comprehensionVar, param).map(mapDateTime);
+    return new Cypher.ListComprehension(comprehensionVar).in(param).map(mapDateTime);
 }

--- a/packages/graphql/src/translate/queryAST/ast/filters/utils/create-point-operation.ts
+++ b/packages/graphql/src/translate/queryAST/ast/filters/utils/create-point-operation.ts
@@ -70,7 +70,7 @@ function createPointListComprehension(
 ): Cypher.ListComprehension {
     const comprehensionVar = new Cypher.Variable();
     const mapPoint = Cypher.point(comprehensionVar);
-    return new Cypher.ListComprehension(comprehensionVar, param).map(mapPoint);
+    return new Cypher.ListComprehension(comprehensionVar).in(param).map(mapPoint);
 }
 
 function createPointDistanceExpression(

--- a/packages/graphql/src/translate/queryAST/ast/filters/utils/create-time-operation.ts
+++ b/packages/graphql/src/translate/queryAST/ast/filters/utils/create-time-operation.ts
@@ -67,5 +67,5 @@ function createTimeListComprehension(
 ): Cypher.ListComprehension {
     const comprehensionVar = new Cypher.Variable();
     const mapTime = Cypher.time(comprehensionVar);
-    return new Cypher.ListComprehension(comprehensionVar, param).map(mapTime);
+    return new Cypher.ListComprehension(comprehensionVar).in(param).map(mapTime);
 }

--- a/packages/graphql/src/translate/queryAST/ast/input-fields/PropertyInputField.ts
+++ b/packages/graphql/src/translate/queryAST/ast/input-fields/PropertyInputField.ts
@@ -81,7 +81,7 @@ export class PropertyInputField extends InputField {
             }
             const comprehensionVar = new Cypher.Variable();
             const mapPoint = Cypher.point(comprehensionVar);
-            return new Cypher.ListComprehension(comprehensionVar, variable).map(mapPoint);
+            return new Cypher.ListComprehension(comprehensionVar).in(variable).map(mapPoint);
         }
 
         if (this.attribute.typeHelper.isDateTime()) {
@@ -90,7 +90,7 @@ export class PropertyInputField extends InputField {
             }
             const comprehensionVar = new Cypher.Variable();
             const mapDateTime = Cypher.datetime(comprehensionVar);
-            return new Cypher.ListComprehension(comprehensionVar, variable).map(mapDateTime);
+            return new Cypher.ListComprehension(comprehensionVar).in(variable).map(mapDateTime);
         }
 
         if (this.attribute.typeHelper.isTime()) {
@@ -99,7 +99,7 @@ export class PropertyInputField extends InputField {
             }
             const comprehensionVar = new Cypher.Variable();
             const mapTime = Cypher.time(comprehensionVar);
-            return new Cypher.ListComprehension(comprehensionVar, variable).map(mapTime);
+            return new Cypher.ListComprehension(comprehensionVar).in(variable).map(mapTime);
         }
 
         return variable;

--- a/packages/graphql/src/translate/queryAST/ast/input-fields/operators/MathInputField.ts
+++ b/packages/graphql/src/translate/queryAST/ast/input-fields/operators/MathInputField.ts
@@ -19,6 +19,7 @@
 
 import Cypher from "@neo4j/cypher-builder";
 import type { AttributeAdapter } from "../../../../../schema-model/attribute/model-adapters/AttributeAdapter";
+import { apocWrapper } from "../../../../utils/apoc-wrapper";
 import { type QueryASTContext } from "../../QueryASTContext";
 import { ParamInputField } from "../ParamInputField";
 
@@ -63,12 +64,12 @@ export class MathInputField extends ParamInputField {
 
         return [
             Cypher.utils.concat(
-                Cypher.apoc.util.validate(
+                apocWrapper.validate(
                     Cypher.isNull(prop),
                     "Cannot %s %s to Nan",
                     new Cypher.List([new Cypher.Literal(this.operation), this.getParam()])
                 ),
-                Cypher.apoc.util.validate(
+                apocWrapper.validate(
                     Cypher.gt(rightExpr, maxBit),
                     "Overflow: Value returned from operator %s is larger than %s bit",
                     new Cypher.List([new Cypher.Literal(this.operation), new Cypher.Literal(bitSize)])

--- a/packages/graphql/src/translate/queryAST/ast/input-fields/operators/PopInputField.ts
+++ b/packages/graphql/src/translate/queryAST/ast/input-fields/operators/PopInputField.ts
@@ -19,6 +19,7 @@
 
 import Cypher from "@neo4j/cypher-builder";
 import type { AttributeAdapter } from "../../../../../schema-model/attribute/model-adapters/AttributeAdapter";
+import { apocWrapper } from "../../../../utils/apoc-wrapper";
 import { type QueryASTContext } from "../../QueryASTContext";
 import { ParamInputField } from "../ParamInputField";
 
@@ -37,10 +38,7 @@ export class PopInputField extends ParamInputField {
 
     public getPredicate(queryASTContext: QueryASTContext<Cypher.Node>): Cypher.Predicate | undefined {
         const expr = this.getLeftExpression(queryASTContext);
-        return Cypher.apoc.util.validatePredicate(
-            Cypher.isNull(expr),
-            `Property ${this.attribute.name} cannot be NULL`
-        );
+        return apocWrapper.validatePredicate(Cypher.isNull(expr), `Property ${this.attribute.name} cannot be NULL`);
     }
 
     protected getRightExpression(

--- a/packages/graphql/src/translate/queryAST/ast/input-fields/operators/PushInputField.ts
+++ b/packages/graphql/src/translate/queryAST/ast/input-fields/operators/PushInputField.ts
@@ -19,6 +19,7 @@
 
 import Cypher from "@neo4j/cypher-builder";
 import type { AttributeAdapter } from "../../../../../schema-model/attribute/model-adapters/AttributeAdapter";
+import { apocWrapper } from "../../../../utils/apoc-wrapper";
 import { type QueryASTContext } from "../../QueryASTContext";
 import { ParamInputField } from "../ParamInputField";
 
@@ -37,10 +38,7 @@ export class PushInputField extends ParamInputField {
 
     public getPredicate(queryASTContext: QueryASTContext<Cypher.Node>): Cypher.Predicate | undefined {
         const expr = this.getLeftExpression(queryASTContext);
-        return Cypher.apoc.util.validatePredicate(
-            Cypher.isNull(expr),
-            `Property ${this.attribute.name} cannot be NULL`
-        );
+        return apocWrapper.validatePredicate(Cypher.isNull(expr), `Property ${this.attribute.name} cannot be NULL`);
     }
 
     protected getRightExpression(

--- a/packages/graphql/src/translate/queryAST/ast/operations/ConnectionReadOperation.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/ConnectionReadOperation.ts
@@ -336,7 +336,7 @@ export class ConnectionReadOperation extends Operation {
         const projectionMap = this.generateProjectionMapForFields(this.nodeFields, context.target);
         if (projectionMap.size === 0) {
             projectionMap.set({
-                __id: Cypher.id(context.target),
+                __id: Cypher.elementId(context.target),
             });
         }
         projectionMap.set({

--- a/packages/graphql/src/translate/queryAST/ast/operations/composite/CompositeConnectionPartial.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/composite/CompositeConnectionPartial.ts
@@ -70,7 +70,7 @@ export class CompositeConnectionPartial extends ConnectionReadOperation {
         const targetNodeName = this.target.name;
         nodeProjectionMap.set({
             __resolveType: new Cypher.Literal(targetNodeName),
-            __id: Cypher.id(nestedContext.target),
+            __id: Cypher.elementId(nestedContext.target),
         });
 
         const nodeProjectionFields = this.nodeFields.map((f) => f.getProjectionField(nestedContext.target));

--- a/packages/graphql/src/translate/queryAST/ast/operations/composite/CompositeReadPartial.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/composite/CompositeReadPartial.ts
@@ -146,7 +146,7 @@ export class CompositeReadPartial extends ReadOperation {
         const targetNodeName = this.target.name;
         projection.set({
             __resolveType: new Cypher.Literal(targetNodeName),
-            __id: Cypher.id(context.target),
+            __id: Cypher.elementId(context.target),
         });
 
         const withClause = new Cypher.With([projection, returnVariable]);

--- a/packages/graphql/src/translate/utils/apoc-wrapper.ts
+++ b/packages/graphql/src/translate/utils/apoc-wrapper.ts
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import Cypher from "@neo4j/cypher-builder";
 
 export const apocWrapper = {

--- a/packages/graphql/src/translate/utils/apoc-wrapper.ts
+++ b/packages/graphql/src/translate/utils/apoc-wrapper.ts
@@ -1,0 +1,25 @@
+import Cypher from "@neo4j/cypher-builder";
+
+export const apocWrapper = {
+    validatePredicate(predicate: Cypher.Predicate, message: string): Cypher.Function {
+        return new Cypher.Function("apoc.util.validatePredicate", [
+            predicate,
+            new Cypher.Literal(message),
+            new Cypher.Literal([0]),
+        ]);
+    },
+    validate(
+        predicate: Cypher.Predicate,
+        message: string,
+        params: Cypher.List | Cypher.Literal | Cypher.Map = new Cypher.Map()
+    ): Cypher.VoidProcedure {
+        return new Cypher.VoidProcedure("apoc.util.validate", [predicate, new Cypher.Literal(message), params]);
+    },
+    convertFormat(temporalParam: Cypher.Expr, currentFormat: string, convertTo = "yyyy-MM-dd"): Cypher.Function {
+        return new Cypher.Function("apoc.date.convertFormat", [
+            Cypher.toString(temporalParam), // NOTE: should this be `toString` by default?
+            new Cypher.Literal(currentFormat),
+            new Cypher.Literal(convertTo),
+        ]);
+    },
+};

--- a/packages/graphql/src/translate/utils/apoc-wrapper.ts
+++ b/packages/graphql/src/translate/utils/apoc-wrapper.ts
@@ -11,7 +11,7 @@ export const apocWrapper = {
     validate(
         predicate: Cypher.Predicate,
         message: string,
-        params: Cypher.List | Cypher.Literal | Cypher.Map = new Cypher.Map()
+        params: Cypher.List | Cypher.Literal | Cypher.Map = new Cypher.List([])
     ): Cypher.VoidProcedure {
         return new Cypher.VoidProcedure("apoc.util.validate", [predicate, new Cypher.Literal(message), params]);
     },

--- a/packages/graphql/tests/tck/advanced-filtering.test.ts
+++ b/packages/graphql/tests/tck/advanced-filtering.test.ts
@@ -573,8 +573,8 @@ describe("Cypher Advanced Filtering", () => {
                 "CYPHER 5
                 MATCH (this:Movie)
                 WHERE EXISTS {
-                    MATCH (this)-[:IN_GENRE]->(this0:Genre)
-                    WHERE this0.name = $param0
+                  MATCH (this)-[:IN_GENRE]->(this0:Genre)
+                  WHERE this0.name = $param0
                 }
                 RETURN this { .actorCount } AS this"
             `);
@@ -606,11 +606,11 @@ describe("Cypher Advanced Filtering", () => {
                     "CYPHER 5
                     MATCH (this:Movie)
                     WHERE (EXISTS {
-                        MATCH (this)-[:IN_GENRE]->(this0:Genre)
-                        WHERE this0.name = $param0
+                      MATCH (this)-[:IN_GENRE]->(this0:Genre)
+                      WHERE this0.name = $param0
                     } AND NOT (EXISTS {
-                        MATCH (this)-[:IN_GENRE]->(this0:Genre)
-                        WHERE NOT (this0.name = $param0)
+                      MATCH (this)-[:IN_GENRE]->(this0:Genre)
+                      WHERE NOT (this0.name = $param0)
                     }))
                     RETURN this { .actorCount } AS this"
                 `);
@@ -630,8 +630,8 @@ describe("Cypher Advanced Filtering", () => {
                     "CYPHER 5
                     MATCH (this:Movie)
                     WHERE NOT (EXISTS {
-                        MATCH (this)-[:IN_GENRE]->(this0:Genre)
-                        WHERE this0.name = $param0
+                      MATCH (this)-[:IN_GENRE]->(this0:Genre)
+                      WHERE this0.name = $param0
                     })
                     RETURN this { .actorCount } AS this"
                 `);
@@ -668,8 +668,8 @@ describe("Cypher Advanced Filtering", () => {
                     "CYPHER 5
                     MATCH (this:Movie)
                     WHERE EXISTS {
-                        MATCH (this)-[:IN_GENRE]->(this0:Genre)
-                        WHERE this0.name = $param0
+                      MATCH (this)-[:IN_GENRE]->(this0:Genre)
+                      WHERE this0.name = $param0
                     }
                     RETURN this { .actorCount } AS this"
                 `);
@@ -698,8 +698,8 @@ describe("Cypher Advanced Filtering", () => {
                 "CYPHER 5
                 MATCH (this:Movie)
                 WHERE EXISTS {
-                    MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
-                    WHERE this1.name = $param0
+                  MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
+                  WHERE this1.name = $param0
                 }
                 RETURN this { .actorCount } AS this"
             `);
@@ -726,8 +726,8 @@ describe("Cypher Advanced Filtering", () => {
                 "CYPHER 5
                 MATCH (this:Movie)
                 WHERE NOT (EXISTS {
-                    MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
-                    WHERE this1.name = $param0
+                  MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
+                  WHERE this1.name = $param0
                 })
                 RETURN this { .actorCount } AS this"
             `);
@@ -759,11 +759,11 @@ describe("Cypher Advanced Filtering", () => {
                     "CYPHER 5
                     MATCH (this:Movie)
                     WHERE (EXISTS {
-                        MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
-                        WHERE this1.name = $param0
+                      MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
+                      WHERE this1.name = $param0
                     } AND NOT (EXISTS {
-                        MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
-                        WHERE NOT (this1.name = $param0)
+                      MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
+                      WHERE NOT (this1.name = $param0)
                     }))
                     RETURN this { .actorCount } AS this"
                 `);
@@ -782,8 +782,8 @@ describe("Cypher Advanced Filtering", () => {
                     "CYPHER 5
                     MATCH (this:Movie)
                     WHERE NOT (EXISTS {
-                        MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
-                        WHERE this1.name = $param0
+                      MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
+                      WHERE this1.name = $param0
                     })
                     RETURN this { .actorCount } AS this"
                 `);
@@ -819,8 +819,8 @@ describe("Cypher Advanced Filtering", () => {
                     "CYPHER 5
                     MATCH (this:Movie)
                     WHERE EXISTS {
-                        MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
-                        WHERE this1.name = $param0
+                      MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
+                      WHERE this1.name = $param0
                     }
                     RETURN this { .actorCount } AS this"
                 `);

--- a/packages/graphql/tests/tck/aggregations/alias-directive.test.ts
+++ b/packages/graphql/tests/tck/aggregations/alias-directive.test.ts
@@ -69,23 +69,23 @@ describe("Cypher Aggregations Many with Alias directive", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:Movie)
-                WITH DISTINCT this
-                ORDER BY size(this._title) DESC
-                WITH collect(this._title) AS list
-                RETURN { longest: head(list), shortest: last(list) } AS var0
+              MATCH (this:Movie)
+              WITH DISTINCT this
+              ORDER BY size(this._title) DESC
+              WITH collect(this._title) AS list
+              RETURN {longest: head(list), shortest: last(list)} AS var0
             }
             CALL {
-                MATCH (this:Movie)
-                WITH DISTINCT this
-                RETURN { min: min(this.\`_imdb Rating\`), max: max(this.\`_imdb Rating\`), average: avg(this.\`_imdb Rating\`) } AS var1
+              MATCH (this:Movie)
+              WITH DISTINCT this
+              RETURN {min: min(this.\`_imdb Rating\`), max: max(this.\`_imdb Rating\`), average: avg(this.\`_imdb Rating\`)} AS var1
             }
             CALL {
-                MATCH (this:Movie)
-                WITH DISTINCT this
-                RETURN { min: apoc.date.convertFormat(toString(min(this._createdAt)), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\"), max: apoc.date.convertFormat(toString(max(this._createdAt)), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\") } AS var2
+              MATCH (this:Movie)
+              WITH DISTINCT this
+              RETURN {min: apoc.date.convertFormat(toString(min(this._createdAt)), 'iso_zoned_date_time', 'iso_offset_date_time'), max: apoc.date.convertFormat(toString(max(this._createdAt)), 'iso_zoned_date_time', 'iso_offset_date_time')} AS var2
             }
-            RETURN { aggregate: { node: { title: var0, imdbRating: var1, createdAt: var2 } } } AS this"
+            RETURN {aggregate: {node: {title: var0, imdbRating: var1, createdAt: var2}}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);

--- a/packages/graphql/tests/tck/aggregations/alias.test.ts
+++ b/packages/graphql/tests/tck/aggregations/alias.test.ts
@@ -72,27 +72,27 @@ describe("Cypher Aggregations Many while Alias fields", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:Movie)
-                RETURN { nodes: count(DISTINCT this) } AS var0
+              MATCH (this:Movie)
+              RETURN {nodes: count(DISTINCT this)} AS var0
             }
             CALL {
-                MATCH (this:Movie)
-                WITH DISTINCT this
-                ORDER BY size(this.title) DESC
-                WITH collect(this.title) AS list
-                RETURN { _longest: head(list), _shortest: last(list) } AS var1
+              MATCH (this:Movie)
+              WITH DISTINCT this
+              ORDER BY size(this.title) DESC
+              WITH collect(this.title) AS list
+              RETURN {_longest: head(list), _shortest: last(list)} AS var1
             }
             CALL {
-                MATCH (this:Movie)
-                WITH DISTINCT this
-                RETURN { _min: min(this.imdbRating), _max: max(this.imdbRating), _average: avg(this.imdbRating) } AS var2
+              MATCH (this:Movie)
+              WITH DISTINCT this
+              RETURN {_min: min(this.imdbRating), _max: max(this.imdbRating), _average: avg(this.imdbRating)} AS var2
             }
             CALL {
-                MATCH (this:Movie)
-                WITH DISTINCT this
-                RETURN { _min: apoc.date.convertFormat(toString(min(this.createdAt)), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\"), _max: apoc.date.convertFormat(toString(max(this.createdAt)), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\") } AS var3
+              MATCH (this:Movie)
+              WITH DISTINCT this
+              RETURN {_min: apoc.date.convertFormat(toString(min(this.createdAt)), 'iso_zoned_date_time', 'iso_offset_date_time'), _max: apoc.date.convertFormat(toString(max(this.createdAt)), 'iso_zoned_date_time', 'iso_offset_date_time')} AS var3
             }
-            RETURN { aggregate: { _count: var0, node: { _title: var1, _imdbRating: var2, _createdAt: var3 } } } AS this"
+            RETURN {aggregate: {_count: var0, node: {_title: var1, _imdbRating: var2, _createdAt: var3}}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);

--- a/packages/graphql/tests/tck/aggregations/auth.test.ts
+++ b/packages/graphql/tests/tck/aggregations/auth.test.ts
@@ -87,12 +87,12 @@ describe("Cypher Aggregations with Auth", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:User)
-                WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
-                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                RETURN { nodes: count(DISTINCT this) } AS var0
+              MATCH (this:User)
+              WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
+              RETURN {nodes: count(DISTINCT this)} AS var0
             }
-            RETURN { aggregate: { count: var0 } } AS this"
+            RETURN {aggregate: {count: var0}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -125,12 +125,12 @@ describe("Cypher Aggregations with Auth", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:User)
-                WHERE (this.name = $param0 AND ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)))
-                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                RETURN { nodes: count(DISTINCT this) } AS var0
+              MATCH (this:User)
+              WHERE (this.name = $param0 AND ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)))
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
+              RETURN {nodes: count(DISTINCT this)} AS var0
             }
-            RETURN { aggregate: { count: var0 } } AS this"
+            RETURN {aggregate: {count: var0}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -167,13 +167,13 @@ describe("Cypher Aggregations with Auth", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:User)
-                WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
-                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                WITH DISTINCT this
-                RETURN { min: min(this.imdbRatingInt), max: max(this.imdbRatingInt) } AS var0
+              MATCH (this:User)
+              WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
+              WITH DISTINCT this
+              RETURN {min: min(this.imdbRatingInt), max: max(this.imdbRatingInt)} AS var0
             }
-            RETURN { aggregate: { node: { imdbRatingInt: var0 } } } AS this"
+            RETURN {aggregate: {node: {imdbRatingInt: var0}}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -209,13 +209,13 @@ describe("Cypher Aggregations with Auth", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:User)
-                WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
-                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                WITH DISTINCT this
-                RETURN { min: min(this.imdbRatingFloat), max: max(this.imdbRatingFloat) } AS var0
+              MATCH (this:User)
+              WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
+              WITH DISTINCT this
+              RETURN {min: min(this.imdbRatingFloat), max: max(this.imdbRatingFloat)} AS var0
             }
-            RETURN { aggregate: { node: { imdbRatingFloat: var0 } } } AS this"
+            RETURN {aggregate: {node: {imdbRatingFloat: var0}}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -251,13 +251,13 @@ describe("Cypher Aggregations with Auth", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:User)
-                WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
-                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                WITH DISTINCT this
-                RETURN { min: min(this.imdbRatingBigInt), max: max(this.imdbRatingBigInt) } AS var0
+              MATCH (this:User)
+              WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
+              WITH DISTINCT this
+              RETURN {min: min(this.imdbRatingBigInt), max: max(this.imdbRatingBigInt)} AS var0
             }
-            RETURN { aggregate: { node: { imdbRatingBigInt: var0 } } } AS this"
+            RETURN {aggregate: {node: {imdbRatingBigInt: var0}}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -293,15 +293,15 @@ describe("Cypher Aggregations with Auth", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:User)
-                WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
-                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                WITH DISTINCT this
-                ORDER BY size(this.name) DESC
-                WITH collect(this.name) AS list
-                RETURN { longest: head(list), shortest: last(list) } AS var0
+              MATCH (this:User)
+              WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
+              WITH DISTINCT this
+              ORDER BY size(this.name) DESC
+              WITH collect(this.name) AS list
+              RETURN {longest: head(list), shortest: last(list)} AS var0
             }
-            RETURN { aggregate: { node: { name: var0 } } } AS this"
+            RETURN {aggregate: {node: {name: var0}}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -337,13 +337,13 @@ describe("Cypher Aggregations with Auth", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:User)
-                WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
-                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                WITH DISTINCT this
-                RETURN { min: apoc.date.convertFormat(toString(min(this.createdAt)), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\"), max: apoc.date.convertFormat(toString(max(this.createdAt)), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\") } AS var0
+              MATCH (this:User)
+              WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
+              WITH DISTINCT this
+              RETURN {min: apoc.date.convertFormat(toString(min(this.createdAt)), 'iso_zoned_date_time', 'iso_offset_date_time'), max: apoc.date.convertFormat(toString(max(this.createdAt)), 'iso_zoned_date_time', 'iso_offset_date_time')} AS var0
             }
-            RETURN { aggregate: { node: { createdAt: var0 } } } AS this"
+            RETURN {aggregate: {node: {createdAt: var0}}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/aggregations/bigint.test.ts
+++ b/packages/graphql/tests/tck/aggregations/bigint.test.ts
@@ -56,11 +56,11 @@ describe("Cypher Aggregations BigInt", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:File)
-                WITH DISTINCT this
-                RETURN { min: min(this.size) } AS var0
+              MATCH (this:File)
+              WITH DISTINCT this
+              RETURN {min: min(this.size)} AS var0
             }
-            RETURN { aggregate: { node: { size: var0 } } } AS this"
+            RETURN {aggregate: {node: {size: var0}}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -86,11 +86,11 @@ describe("Cypher Aggregations BigInt", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:File)
-                WITH DISTINCT this
-                RETURN { max: max(this.size) } AS var0
+              MATCH (this:File)
+              WITH DISTINCT this
+              RETURN {max: max(this.size)} AS var0
             }
-            RETURN { aggregate: { node: { size: var0 } } } AS this"
+            RETURN {aggregate: {node: {size: var0}}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -116,11 +116,11 @@ describe("Cypher Aggregations BigInt", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:File)
-                WITH DISTINCT this
-                RETURN { average: avg(this.size) } AS var0
+              MATCH (this:File)
+              WITH DISTINCT this
+              RETURN {average: avg(this.size)} AS var0
             }
-            RETURN { aggregate: { node: { size: var0 } } } AS this"
+            RETURN {aggregate: {node: {size: var0}}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -146,11 +146,11 @@ describe("Cypher Aggregations BigInt", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:File)
-                WITH DISTINCT this
-                RETURN { sum: sum(this.size) } AS var0
+              MATCH (this:File)
+              WITH DISTINCT this
+              RETURN {sum: sum(this.size)} AS var0
             }
-            RETURN { aggregate: { node: { size: var0 } } } AS this"
+            RETURN {aggregate: {node: {size: var0}}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -179,11 +179,11 @@ describe("Cypher Aggregations BigInt", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:File)
-                WITH DISTINCT this
-                RETURN { min: min(this.size), max: max(this.size), average: avg(this.size), sum: sum(this.size) } AS var0
+              MATCH (this:File)
+              WITH DISTINCT this
+              RETURN {min: min(this.size), max: max(this.size), average: avg(this.size), sum: sum(this.size)} AS var0
             }
-            RETURN { aggregate: { node: { size: var0 } } } AS this"
+            RETURN {aggregate: {node: {size: var0}}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);

--- a/packages/graphql/tests/tck/aggregations/count.test.ts
+++ b/packages/graphql/tests/tck/aggregations/count.test.ts
@@ -54,10 +54,10 @@ describe("Cypher Aggregations Count", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:Movie)
-                RETURN { nodes: count(DISTINCT this) } AS var0
+              MATCH (this:Movie)
+              RETURN {nodes: count(DISTINCT this)} AS var0
             }
-            RETURN { aggregate: { count: var0 } } AS this"
+            RETURN {aggregate: {count: var0}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -81,11 +81,11 @@ describe("Cypher Aggregations Count", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:Movie)
-                WHERE this.title = $param0
-                RETURN { nodes: count(DISTINCT this) } AS var0
+              MATCH (this:Movie)
+              WHERE this.title = $param0
+              RETURN {nodes: count(DISTINCT this)} AS var0
             }
-            RETURN { aggregate: { count: var0 } } AS this"
+            RETURN {aggregate: {count: var0}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/aggregations/datetime.test.ts
+++ b/packages/graphql/tests/tck/aggregations/datetime.test.ts
@@ -56,11 +56,11 @@ describe("Cypher Aggregations DateTime", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:Movie)
-                WITH DISTINCT this
-                RETURN { min: apoc.date.convertFormat(toString(min(this.createdAt)), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\") } AS var0
+              MATCH (this:Movie)
+              WITH DISTINCT this
+              RETURN {min: apoc.date.convertFormat(toString(min(this.createdAt)), 'iso_zoned_date_time', 'iso_offset_date_time')} AS var0
             }
-            RETURN { aggregate: { node: { createdAt: var0 } } } AS this"
+            RETURN {aggregate: {node: {createdAt: var0}}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -86,11 +86,11 @@ describe("Cypher Aggregations DateTime", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:Movie)
-                WITH DISTINCT this
-                RETURN { max: apoc.date.convertFormat(toString(max(this.createdAt)), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\") } AS var0
+              MATCH (this:Movie)
+              WITH DISTINCT this
+              RETURN {max: apoc.date.convertFormat(toString(max(this.createdAt)), 'iso_zoned_date_time', 'iso_offset_date_time')} AS var0
             }
-            RETURN { aggregate: { node: { createdAt: var0 } } } AS this"
+            RETURN {aggregate: {node: {createdAt: var0}}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -117,11 +117,11 @@ describe("Cypher Aggregations DateTime", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:Movie)
-                WITH DISTINCT this
-                RETURN { min: apoc.date.convertFormat(toString(min(this.createdAt)), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\"), max: apoc.date.convertFormat(toString(max(this.createdAt)), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\") } AS var0
+              MATCH (this:Movie)
+              WITH DISTINCT this
+              RETURN {min: apoc.date.convertFormat(toString(min(this.createdAt)), 'iso_zoned_date_time', 'iso_offset_date_time'), max: apoc.date.convertFormat(toString(max(this.createdAt)), 'iso_zoned_date_time', 'iso_offset_date_time')} AS var0
             }
-            RETURN { aggregate: { node: { createdAt: var0 } } } AS this"
+            RETURN {aggregate: {node: {createdAt: var0}}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);

--- a/packages/graphql/tests/tck/aggregations/duration.test.ts
+++ b/packages/graphql/tests/tck/aggregations/duration.test.ts
@@ -56,11 +56,11 @@ describe("Cypher Aggregations Duration", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:Movie)
-                WITH DISTINCT this
-                RETURN { min: min(this.screenTime) } AS var0
+              MATCH (this:Movie)
+              WITH DISTINCT this
+              RETURN {min: min(this.screenTime)} AS var0
             }
-            RETURN { aggregate: { node: { screenTime: var0 } } } AS this"
+            RETURN {aggregate: {node: {screenTime: var0}}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -86,11 +86,11 @@ describe("Cypher Aggregations Duration", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:Movie)
-                WITH DISTINCT this
-                RETURN { max: max(this.screenTime) } AS var0
+              MATCH (this:Movie)
+              WITH DISTINCT this
+              RETURN {max: max(this.screenTime)} AS var0
             }
-            RETURN { aggregate: { node: { screenTime: var0 } } } AS this"
+            RETURN {aggregate: {node: {screenTime: var0}}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -117,11 +117,11 @@ describe("Cypher Aggregations Duration", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:Movie)
-                WITH DISTINCT this
-                RETURN { min: min(this.screenTime), max: max(this.screenTime) } AS var0
+              MATCH (this:Movie)
+              WITH DISTINCT this
+              RETURN {min: min(this.screenTime), max: max(this.screenTime)} AS var0
             }
-            RETURN { aggregate: { node: { screenTime: var0 } } } AS this"
+            RETURN {aggregate: {node: {screenTime: var0}}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);

--- a/packages/graphql/tests/tck/aggregations/field-level-aggregations/field-level-aggregations-alias.test.ts
+++ b/packages/graphql/tests/tck/aggregations/field-level-aggregations/field-level-aggregations-alias.test.ts
@@ -70,14 +70,14 @@ describe("Field Level Aggregations Alias", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                    WITH DISTINCT this1
-                    ORDER BY size(this1.name) DESC
-                    WITH collect(this1.name) AS list
-                    RETURN { shortest: last(list) } AS var2
-                }
-                RETURN { aggregate: { node: { myName: var2 } } } AS var3
+              CALL (this) {
+                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+                WITH DISTINCT this1
+                ORDER BY size(this1.name) DESC
+                WITH collect(this1.name) AS list
+                RETURN {shortest: last(list)} AS var2
+              }
+              RETURN {aggregate: {node: {myName: var2}}} AS var3
             }
             RETURN this { actorsConnection: var3 } AS this"
         `);
@@ -108,12 +108,12 @@ describe("Field Level Aggregations Alias", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                    WITH DISTINCT this0
-                    RETURN { max: max(this0.screentime) } AS var2
-                }
-                RETURN { aggregate: { edge: { time: var2 } } } AS var3
+              CALL (this) {
+                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+                WITH DISTINCT this0
+                RETURN {max: max(this0.screentime)} AS var2
+              }
+              RETURN {aggregate: {edge: {time: var2}}} AS var3
             }
             RETURN this { actorsConnection: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/aggregations/field-level-aggregations/field-level-aggregations-edge.test.ts
+++ b/packages/graphql/tests/tck/aggregations/field-level-aggregations/field-level-aggregations-edge.test.ts
@@ -73,12 +73,12 @@ describe("Field Level Aggregations", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                    WITH DISTINCT this0
-                    RETURN { min: min(this0.screentime), max: max(this0.screentime), average: avg(this0.screentime), sum: sum(this0.screentime) } AS var2
-                }
-                RETURN { aggregate: { edge: { screentime: var2 } } } AS var3
+              CALL (this) {
+                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+                WITH DISTINCT this0
+                RETURN {min: min(this0.screentime), max: max(this0.screentime), average: avg(this0.screentime), sum: sum(this0.screentime)} AS var2
+              }
+              RETURN {aggregate: {edge: {screentime: var2}}} AS var3
             }
             RETURN this { actorsConnection: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/aggregations/field-level-aggregations/field-level-aggregations-labels.test.ts
+++ b/packages/graphql/tests/tck/aggregations/field-level-aggregations/field-level-aggregations-labels.test.ts
@@ -70,14 +70,14 @@ describe("Field Level Aggregations Alias", () => {
             "CYPHER 5
             MATCH (this:Film)
             CALL (this) {
-                CALL (this) {
-                    MATCH (this)<-[this0:ACTED_IN]-(this1:Person)
-                    WITH DISTINCT this1
-                    ORDER BY size(this1.name) DESC
-                    WITH collect(this1.name) AS list
-                    RETURN { shortest: last(list) } AS var2
-                }
-                RETURN { aggregate: { node: { name: var2 } } } AS var3
+              CALL (this) {
+                MATCH (this)<-[this0:ACTED_IN]-(this1:Person)
+                WITH DISTINCT this1
+                ORDER BY size(this1.name) DESC
+                WITH collect(this1.name) AS list
+                RETURN {shortest: last(list)} AS var2
+              }
+              RETURN {aggregate: {node: {name: var2}}} AS var3
             }
             RETURN this { actorsConnection: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/aggregations/field-level-aggregations/field-level-aggregations-where.test.ts
+++ b/packages/graphql/tests/tck/aggregations/field-level-aggregations/field-level-aggregations-where.test.ts
@@ -67,12 +67,12 @@ describe("Field Level Aggregations Where", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    MATCH (this)<-[this0:ACTED_IN]-(this1:Person)
-                    WHERE this1.age > $param0
-                    RETURN { nodes: count(DISTINCT this1) } AS var2
-                }
-                RETURN { aggregate: { count: var2 } } AS var3
+              CALL (this) {
+                MATCH (this)<-[this0:ACTED_IN]-(this1:Person)
+                WHERE this1.age > $param0
+                RETURN {nodes: count(DISTINCT this1)} AS var2
+              }
+              RETURN {aggregate: {count: var2}} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -116,20 +116,20 @@ describe("Field Level Aggregations Where", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    MATCH (this)<-[this0:ACTED_IN]-(this1:Person)
-                    WHERE this1.name CONTAINS $param0
-                    RETURN { nodes: count(DISTINCT this1) } AS var2
-                }
-                RETURN { aggregate: { count: var2 } } AS var3
+              CALL (this) {
+                MATCH (this)<-[this0:ACTED_IN]-(this1:Person)
+                WHERE this1.name CONTAINS $param0
+                RETURN {nodes: count(DISTINCT this1)} AS var2
+              }
+              RETURN {aggregate: {count: var2}} AS var3
             }
             CALL (this) {
-                CALL (this) {
-                    MATCH (this)<-[this4:DIRECTED]-(this5:Person)
-                    WHERE this5.name CONTAINS $param1
-                    RETURN { nodes: count(DISTINCT this5) } AS var6
-                }
-                RETURN { aggregate: { count: var6 } } AS var7
+              CALL (this) {
+                MATCH (this)<-[this4:DIRECTED]-(this5:Person)
+                WHERE this5.name CONTAINS $param1
+                RETURN {nodes: count(DISTINCT this5)} AS var6
+              }
+              RETURN {aggregate: {count: var6}} AS var7
             }
             RETURN this { .title, actorsConnection: var3, directorsConnection: var7 } AS this"
         `);

--- a/packages/graphql/tests/tck/aggregations/field-level-aggregations/field-level-aggregations.test.ts
+++ b/packages/graphql/tests/tck/aggregations/field-level-aggregations/field-level-aggregations.test.ts
@@ -67,11 +67,11 @@ describe("Field Level Aggregations", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                    RETURN { nodes: count(DISTINCT this1), edges: count(DISTINCT this0) } AS var2
-                }
-                RETURN { aggregate: { count: var2 } } AS var3
+              CALL (this) {
+                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+                RETURN {nodes: count(DISTINCT this1), edges: count(DISTINCT this0)} AS var2
+              }
+              RETURN {aggregate: {count: var2}} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -106,18 +106,18 @@ describe("Field Level Aggregations", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                    RETURN { nodes: count(DISTINCT this1) } AS var2
-                }
-                CALL (this) {
-                    MATCH (this)<-[this3:ACTED_IN]-(this4:Actor)
-                    WITH DISTINCT this4
-                    ORDER BY size(this4.name) DESC
-                    WITH collect(this4.name) AS list
-                    RETURN { longest: head(list), shortest: last(list) } AS var5
-                }
-                RETURN { aggregate: { count: var2, node: { name: var5 } } } AS var6
+              CALL (this) {
+                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+                RETURN {nodes: count(DISTINCT this1)} AS var2
+              }
+              CALL (this) {
+                MATCH (this)<-[this3:ACTED_IN]-(this4:Actor)
+                WITH DISTINCT this4
+                ORDER BY size(this4.name) DESC
+                WITH collect(this4.name) AS list
+                RETURN {longest: head(list), shortest: last(list)} AS var5
+              }
+              RETURN {aggregate: {count: var2, node: {name: var5}}} AS var6
             }
             RETURN this { actorsConnection: var6 } AS this"
         `);
@@ -151,12 +151,12 @@ describe("Field Level Aggregations", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                    WITH DISTINCT this1
-                    RETURN { min: min(this1.age), max: max(this1.age), average: avg(this1.age), sum: sum(this1.age) } AS var2
-                }
-                RETURN { aggregate: { node: { age: var2 } } } AS var3
+              CALL (this) {
+                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+                WITH DISTINCT this1
+                RETURN {min: min(this1.age), max: max(this1.age), average: avg(this1.age), sum: sum(this1.age)} AS var2
+              }
+              RETURN {aggregate: {node: {age: var2}}} AS var3
             }
             RETURN this { actorsConnection: var3 } AS this"
         `);
@@ -189,14 +189,14 @@ describe("Field Level Aggregations", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                    WITH DISTINCT this1
-                    ORDER BY size(this1.name) DESC
-                    WITH collect(this1.name) AS list
-                    RETURN { longest: head(list), shortest: last(list) } AS var2
-                }
-                RETURN { aggregate: { node: { name: var2 } } } AS var3
+              CALL (this) {
+                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+                WITH DISTINCT this1
+                ORDER BY size(this1.name) DESC
+                WITH collect(this1.name) AS list
+                RETURN {longest: head(list), shortest: last(list)} AS var2
+              }
+              RETURN {aggregate: {node: {name: var2}}} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -227,12 +227,12 @@ describe("Field Level Aggregations", () => {
             "CYPHER 5
             MATCH (this:Actor)
             CALL (this) {
-                CALL (this) {
-                    MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                    WITH DISTINCT this1
-                    RETURN { min: apoc.date.convertFormat(toString(min(this1.released)), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\") } AS var2
-                }
-                RETURN { aggregate: { node: { released: var2 } } } AS var3
+              CALL (this) {
+                MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+                WITH DISTINCT this1
+                RETURN {min: apoc.date.convertFormat(toString(min(this1.released)), 'iso_zoned_date_time', 'iso_offset_date_time')} AS var2
+              }
+              RETURN {aggregate: {node: {released: var2}}} AS var3
             }
             RETURN this { moviesConnection: var3 } AS this"
         `);
@@ -270,19 +270,19 @@ describe("Field Level Aggregations", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                    WITH DISTINCT this1
-                    ORDER BY size(this1.name) DESC
-                    WITH collect(this1.name) AS list
-                    RETURN { longest: head(list), shortest: last(list) } AS var2
-                }
-                CALL (this) {
-                    MATCH (this)<-[this3:ACTED_IN]-(this4:Actor)
-                    WITH DISTINCT this4
-                    RETURN { min: min(this4.age), max: max(this4.age), average: avg(this4.age), sum: sum(this4.age) } AS var5
-                }
-                RETURN { aggregate: { node: { name: var2, age: var5 } } } AS var6
+              CALL (this) {
+                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+                WITH DISTINCT this1
+                ORDER BY size(this1.name) DESC
+                WITH collect(this1.name) AS list
+                RETURN {longest: head(list), shortest: last(list)} AS var2
+              }
+              CALL (this) {
+                MATCH (this)<-[this3:ACTED_IN]-(this4:Actor)
+                WITH DISTINCT this4
+                RETURN {min: min(this4.age), max: max(this4.age), average: avg(this4.age), sum: sum(this4.age)} AS var5
+              }
+              RETURN {aggregate: {node: {name: var2, age: var5}}} AS var6
             }
             RETURN this { actorsConnection: var6 } AS this"
         `);

--- a/packages/graphql/tests/tck/aggregations/float.test.ts
+++ b/packages/graphql/tests/tck/aggregations/float.test.ts
@@ -56,11 +56,11 @@ describe("Cypher Aggregations Float", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:Movie)
-                WITH DISTINCT this
-                RETURN { min: min(this.actorCount) } AS var0
+              MATCH (this:Movie)
+              WITH DISTINCT this
+              RETURN {min: min(this.actorCount)} AS var0
             }
-            RETURN { aggregate: { node: { actorCount: var0 } } } AS this"
+            RETURN {aggregate: {node: {actorCount: var0}}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -86,11 +86,11 @@ describe("Cypher Aggregations Float", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:Movie)
-                WITH DISTINCT this
-                RETURN { max: max(this.actorCount) } AS var0
+              MATCH (this:Movie)
+              WITH DISTINCT this
+              RETURN {max: max(this.actorCount)} AS var0
             }
-            RETURN { aggregate: { node: { actorCount: var0 } } } AS this"
+            RETURN {aggregate: {node: {actorCount: var0}}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -116,11 +116,11 @@ describe("Cypher Aggregations Float", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:Movie)
-                WITH DISTINCT this
-                RETURN { average: avg(this.actorCount) } AS var0
+              MATCH (this:Movie)
+              WITH DISTINCT this
+              RETURN {average: avg(this.actorCount)} AS var0
             }
-            RETURN { aggregate: { node: { actorCount: var0 } } } AS this"
+            RETURN {aggregate: {node: {actorCount: var0}}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -146,11 +146,11 @@ describe("Cypher Aggregations Float", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:Movie)
-                WITH DISTINCT this
-                RETURN { sum: sum(this.actorCount) } AS var0
+              MATCH (this:Movie)
+              WITH DISTINCT this
+              RETURN {sum: sum(this.actorCount)} AS var0
             }
-            RETURN { aggregate: { node: { actorCount: var0 } } } AS this"
+            RETURN {aggregate: {node: {actorCount: var0}}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -179,11 +179,11 @@ describe("Cypher Aggregations Float", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:Movie)
-                WITH DISTINCT this
-                RETURN { min: min(this.actorCount), max: max(this.actorCount), average: avg(this.actorCount), sum: sum(this.actorCount) } AS var0
+              MATCH (this:Movie)
+              WITH DISTINCT this
+              RETURN {min: min(this.actorCount), max: max(this.actorCount), average: avg(this.actorCount), sum: sum(this.actorCount)} AS var0
             }
-            RETURN { aggregate: { node: { actorCount: var0 } } } AS this"
+            RETURN {aggregate: {node: {actorCount: var0}}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -215,15 +215,15 @@ describe("Cypher Aggregations Float", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:Movie)
-                RETURN { nodes: count(DISTINCT this) } AS var0
+              MATCH (this:Movie)
+              RETURN {nodes: count(DISTINCT this)} AS var0
             }
             CALL {
-                MATCH (this:Movie)
-                WITH DISTINCT this
-                RETURN { min: min(this.actorCount), max: max(this.actorCount), average: avg(this.actorCount), sum: sum(this.actorCount) } AS var1
+              MATCH (this:Movie)
+              WITH DISTINCT this
+              RETURN {min: min(this.actorCount), max: max(this.actorCount), average: avg(this.actorCount), sum: sum(this.actorCount)} AS var1
             }
-            RETURN { aggregate: { count: var0, node: { actorCount: var1 } } } AS this"
+            RETURN {aggregate: {count: var0, node: {actorCount: var1}}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);

--- a/packages/graphql/tests/tck/aggregations/int.test.ts
+++ b/packages/graphql/tests/tck/aggregations/int.test.ts
@@ -56,11 +56,11 @@ describe("Cypher Aggregations Int", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:Movie)
-                WITH DISTINCT this
-                RETURN { min: min(this.imdbRating) } AS var0
+              MATCH (this:Movie)
+              WITH DISTINCT this
+              RETURN {min: min(this.imdbRating)} AS var0
             }
-            RETURN { aggregate: { node: { imdbRating: var0 } } } AS this"
+            RETURN {aggregate: {node: {imdbRating: var0}}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -86,11 +86,11 @@ describe("Cypher Aggregations Int", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:Movie)
-                WITH DISTINCT this
-                RETURN { max: max(this.imdbRating) } AS var0
+              MATCH (this:Movie)
+              WITH DISTINCT this
+              RETURN {max: max(this.imdbRating)} AS var0
             }
-            RETURN { aggregate: { node: { imdbRating: var0 } } } AS this"
+            RETURN {aggregate: {node: {imdbRating: var0}}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -116,11 +116,11 @@ describe("Cypher Aggregations Int", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:Movie)
-                WITH DISTINCT this
-                RETURN { average: avg(this.imdbRating) } AS var0
+              MATCH (this:Movie)
+              WITH DISTINCT this
+              RETURN {average: avg(this.imdbRating)} AS var0
             }
-            RETURN { aggregate: { node: { imdbRating: var0 } } } AS this"
+            RETURN {aggregate: {node: {imdbRating: var0}}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -146,11 +146,11 @@ describe("Cypher Aggregations Int", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:Movie)
-                WITH DISTINCT this
-                RETURN { sum: sum(this.imdbRating) } AS var0
+              MATCH (this:Movie)
+              WITH DISTINCT this
+              RETURN {sum: sum(this.imdbRating)} AS var0
             }
-            RETURN { aggregate: { node: { imdbRating: var0 } } } AS this"
+            RETURN {aggregate: {node: {imdbRating: var0}}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -179,11 +179,11 @@ describe("Cypher Aggregations Int", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:Movie)
-                WITH DISTINCT this
-                RETURN { min: min(this.imdbRating), max: max(this.imdbRating), average: avg(this.imdbRating), sum: sum(this.imdbRating) } AS var0
+              MATCH (this:Movie)
+              WITH DISTINCT this
+              RETURN {min: min(this.imdbRating), max: max(this.imdbRating), average: avg(this.imdbRating), sum: sum(this.imdbRating)} AS var0
             }
-            RETURN { aggregate: { node: { imdbRating: var0 } } } AS this"
+            RETURN {aggregate: {node: {imdbRating: var0}}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);

--- a/packages/graphql/tests/tck/aggregations/label.test.ts
+++ b/packages/graphql/tests/tck/aggregations/label.test.ts
@@ -76,23 +76,23 @@ describe("Cypher Aggregations Many while Alias fields", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:Film)
-                WITH DISTINCT this
-                ORDER BY size(this.title) DESC
-                WITH collect(this.title) AS list
-                RETURN { _longest: head(list), _shortest: last(list) } AS var0
+              MATCH (this:Film)
+              WITH DISTINCT this
+              ORDER BY size(this.title) DESC
+              WITH collect(this.title) AS list
+              RETURN {_longest: head(list), _shortest: last(list)} AS var0
             }
             CALL {
-                MATCH (this:Film)
-                WITH DISTINCT this
-                RETURN { _min: min(this.imdbRating), _max: max(this.imdbRating), _average: avg(this.imdbRating) } AS var1
+              MATCH (this:Film)
+              WITH DISTINCT this
+              RETURN {_min: min(this.imdbRating), _max: max(this.imdbRating), _average: avg(this.imdbRating)} AS var1
             }
             CALL {
-                MATCH (this:Film)
-                WITH DISTINCT this
-                RETURN { _min: apoc.date.convertFormat(toString(min(this.createdAt)), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\"), _max: apoc.date.convertFormat(toString(max(this.createdAt)), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\") } AS var2
+              MATCH (this:Film)
+              WITH DISTINCT this
+              RETURN {_min: apoc.date.convertFormat(toString(min(this.createdAt)), 'iso_zoned_date_time', 'iso_offset_date_time'), _max: apoc.date.convertFormat(toString(max(this.createdAt)), 'iso_zoned_date_time', 'iso_offset_date_time')} AS var2
             }
-            RETURN { aggregate: { node: { _title: var0, _imdbRating: var1, _createdAt: var2 } } } AS this"
+            RETURN {aggregate: {node: {_title: var0, _imdbRating: var1, _createdAt: var2}}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -128,23 +128,23 @@ describe("Cypher Aggregations Many while Alias fields", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:Actor:Person:Alien)
-                WITH DISTINCT this
-                ORDER BY size(this.name) DESC
-                WITH collect(this.name) AS list
-                RETURN { _longest: head(list), _shortest: last(list) } AS var0
+              MATCH (this:Actor&Person&Alien)
+              WITH DISTINCT this
+              ORDER BY size(this.name) DESC
+              WITH collect(this.name) AS list
+              RETURN {_longest: head(list), _shortest: last(list)} AS var0
             }
             CALL {
-                MATCH (this:Actor:Person:Alien)
-                WITH DISTINCT this
-                RETURN { _min: min(this.imdbRating), _max: max(this.imdbRating), _average: avg(this.imdbRating) } AS var1
+              MATCH (this:Actor&Person&Alien)
+              WITH DISTINCT this
+              RETURN {_min: min(this.imdbRating), _max: max(this.imdbRating), _average: avg(this.imdbRating)} AS var1
             }
             CALL {
-                MATCH (this:Actor:Person:Alien)
-                WITH DISTINCT this
-                RETURN { _min: apoc.date.convertFormat(toString(min(this.createdAt)), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\"), _max: apoc.date.convertFormat(toString(max(this.createdAt)), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\") } AS var2
+              MATCH (this:Actor&Person&Alien)
+              WITH DISTINCT this
+              RETURN {_min: apoc.date.convertFormat(toString(min(this.createdAt)), 'iso_zoned_date_time', 'iso_offset_date_time'), _max: apoc.date.convertFormat(toString(max(this.createdAt)), 'iso_zoned_date_time', 'iso_offset_date_time')} AS var2
             }
-            RETURN { aggregate: { node: { _name: var0, _imdbRating: var1, _createdAt: var2 } } } AS this"
+            RETURN {aggregate: {node: {_name: var0, _imdbRating: var1, _createdAt: var2}}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);

--- a/packages/graphql/tests/tck/aggregations/localdatetime.test.ts
+++ b/packages/graphql/tests/tck/aggregations/localdatetime.test.ts
@@ -56,11 +56,11 @@ describe("Cypher Aggregations LocalDateTime", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:Movie)
-                WITH DISTINCT this
-                RETURN { min: min(this.createdAt) } AS var0
+              MATCH (this:Movie)
+              WITH DISTINCT this
+              RETURN {min: min(this.createdAt)} AS var0
             }
-            RETURN { aggregate: { node: { createdAt: var0 } } } AS this"
+            RETURN {aggregate: {node: {createdAt: var0}}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -86,11 +86,11 @@ describe("Cypher Aggregations LocalDateTime", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:Movie)
-                WITH DISTINCT this
-                RETURN { max: max(this.createdAt) } AS var0
+              MATCH (this:Movie)
+              WITH DISTINCT this
+              RETURN {max: max(this.createdAt)} AS var0
             }
-            RETURN { aggregate: { node: { createdAt: var0 } } } AS this"
+            RETURN {aggregate: {node: {createdAt: var0}}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -117,11 +117,11 @@ describe("Cypher Aggregations LocalDateTime", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:Movie)
-                WITH DISTINCT this
-                RETURN { min: min(this.createdAt), max: max(this.createdAt) } AS var0
+              MATCH (this:Movie)
+              WITH DISTINCT this
+              RETURN {min: min(this.createdAt), max: max(this.createdAt)} AS var0
             }
-            RETURN { aggregate: { node: { createdAt: var0 } } } AS this"
+            RETURN {aggregate: {node: {createdAt: var0}}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);

--- a/packages/graphql/tests/tck/aggregations/localtime.test.ts
+++ b/packages/graphql/tests/tck/aggregations/localtime.test.ts
@@ -56,11 +56,11 @@ describe("Cypher Aggregations LocalTime", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:Movie)
-                WITH DISTINCT this
-                RETURN { min: min(this.createdAt) } AS var0
+              MATCH (this:Movie)
+              WITH DISTINCT this
+              RETURN {min: min(this.createdAt)} AS var0
             }
-            RETURN { aggregate: { node: { createdAt: var0 } } } AS this"
+            RETURN {aggregate: {node: {createdAt: var0}}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -86,11 +86,11 @@ describe("Cypher Aggregations LocalTime", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:Movie)
-                WITH DISTINCT this
-                RETURN { max: max(this.createdAt) } AS var0
+              MATCH (this:Movie)
+              WITH DISTINCT this
+              RETURN {max: max(this.createdAt)} AS var0
             }
-            RETURN { aggregate: { node: { createdAt: var0 } } } AS this"
+            RETURN {aggregate: {node: {createdAt: var0}}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -117,11 +117,11 @@ describe("Cypher Aggregations LocalTime", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:Movie)
-                WITH DISTINCT this
-                RETURN { min: min(this.createdAt), max: max(this.createdAt) } AS var0
+              MATCH (this:Movie)
+              WITH DISTINCT this
+              RETURN {min: min(this.createdAt), max: max(this.createdAt)} AS var0
             }
-            RETURN { aggregate: { node: { createdAt: var0 } } } AS this"
+            RETURN {aggregate: {node: {createdAt: var0}}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);

--- a/packages/graphql/tests/tck/aggregations/many.test.ts
+++ b/packages/graphql/tests/tck/aggregations/many.test.ts
@@ -69,23 +69,23 @@ describe("Cypher Aggregations Many", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:Movie)
-                WITH DISTINCT this
-                ORDER BY size(this.title) DESC
-                WITH collect(this.title) AS list
-                RETURN { longest: head(list), shortest: last(list) } AS var0
+              MATCH (this:Movie)
+              WITH DISTINCT this
+              ORDER BY size(this.title) DESC
+              WITH collect(this.title) AS list
+              RETURN {longest: head(list), shortest: last(list)} AS var0
             }
             CALL {
-                MATCH (this:Movie)
-                WITH DISTINCT this
-                RETURN { min: min(this.imdbRating), max: max(this.imdbRating), average: avg(this.imdbRating) } AS var1
+              MATCH (this:Movie)
+              WITH DISTINCT this
+              RETURN {min: min(this.imdbRating), max: max(this.imdbRating), average: avg(this.imdbRating)} AS var1
             }
             CALL {
-                MATCH (this:Movie)
-                WITH DISTINCT this
-                RETURN { min: apoc.date.convertFormat(toString(min(this.createdAt)), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\"), max: apoc.date.convertFormat(toString(max(this.createdAt)), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\") } AS var2
+              MATCH (this:Movie)
+              WITH DISTINCT this
+              RETURN {min: apoc.date.convertFormat(toString(min(this.createdAt)), 'iso_zoned_date_time', 'iso_offset_date_time'), max: apoc.date.convertFormat(toString(max(this.createdAt)), 'iso_zoned_date_time', 'iso_offset_date_time')} AS var2
             }
-            RETURN { aggregate: { node: { title: var0, imdbRating: var1, createdAt: var2 } } } AS this"
+            RETURN {aggregate: {node: {title: var0, imdbRating: var1, createdAt: var2}}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);

--- a/packages/graphql/tests/tck/aggregations/string.test.ts
+++ b/packages/graphql/tests/tck/aggregations/string.test.ts
@@ -57,13 +57,13 @@ describe("Cypher Aggregations String", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:Movie)
-                WITH DISTINCT this
-                ORDER BY size(this.title) DESC
-                WITH collect(this.title) AS list
-                RETURN { shortest: last(list) } AS var0
+              MATCH (this:Movie)
+              WITH DISTINCT this
+              ORDER BY size(this.title) DESC
+              WITH collect(this.title) AS list
+              RETURN {shortest: last(list)} AS var0
             }
-            RETURN { aggregate: { node: { title: var0 } } } AS this"
+            RETURN {aggregate: {node: {title: var0}}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -89,13 +89,13 @@ describe("Cypher Aggregations String", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:Movie)
-                WITH DISTINCT this
-                ORDER BY size(this.title) DESC
-                WITH collect(this.title) AS list
-                RETURN { longest: head(list) } AS var0
+              MATCH (this:Movie)
+              WITH DISTINCT this
+              ORDER BY size(this.title) DESC
+              WITH collect(this.title) AS list
+              RETURN {longest: head(list)} AS var0
             }
-            RETURN { aggregate: { node: { title: var0 } } } AS this"
+            RETURN {aggregate: {node: {title: var0}}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -122,13 +122,13 @@ describe("Cypher Aggregations String", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:Movie)
-                WITH DISTINCT this
-                ORDER BY size(this.title) DESC
-                WITH collect(this.title) AS list
-                RETURN { longest: head(list), shortest: last(list) } AS var0
+              MATCH (this:Movie)
+              WITH DISTINCT this
+              ORDER BY size(this.title) DESC
+              WITH collect(this.title) AS list
+              RETURN {longest: head(list), shortest: last(list)} AS var0
             }
-            RETURN { aggregate: { node: { title: var0 } } } AS this"
+            RETURN {aggregate: {node: {title: var0}}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -154,14 +154,14 @@ describe("Cypher Aggregations String", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:Movie)
-                WHERE this.testId = $param0
-                WITH DISTINCT this
-                ORDER BY size(this.title) DESC
-                WITH collect(this.title) AS list
-                RETURN { shortest: last(list) } AS var0
+              MATCH (this:Movie)
+              WHERE this.testId = $param0
+              WITH DISTINCT this
+              ORDER BY size(this.title) DESC
+              WITH collect(this.title) AS list
+              RETURN {shortest: last(list)} AS var0
             }
-            RETURN { aggregate: { node: { title: var0 } } } AS this"
+            RETURN {aggregate: {node: {title: var0}}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/aggregations/time.test.ts
+++ b/packages/graphql/tests/tck/aggregations/time.test.ts
@@ -56,11 +56,11 @@ describe("Cypher Aggregations Time", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:Movie)
-                WITH DISTINCT this
-                RETURN { min: min(this.createdAt) } AS var0
+              MATCH (this:Movie)
+              WITH DISTINCT this
+              RETURN {min: min(this.createdAt)} AS var0
             }
-            RETURN { aggregate: { node: { createdAt: var0 } } } AS this"
+            RETURN {aggregate: {node: {createdAt: var0}}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -86,11 +86,11 @@ describe("Cypher Aggregations Time", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:Movie)
-                WITH DISTINCT this
-                RETURN { max: max(this.createdAt) } AS var0
+              MATCH (this:Movie)
+              WITH DISTINCT this
+              RETURN {max: max(this.createdAt)} AS var0
             }
-            RETURN { aggregate: { node: { createdAt: var0 } } } AS this"
+            RETURN {aggregate: {node: {createdAt: var0}}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -117,11 +117,11 @@ describe("Cypher Aggregations Time", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:Movie)
-                WITH DISTINCT this
-                RETURN { min: min(this.createdAt), max: max(this.createdAt) } AS var0
+              MATCH (this:Movie)
+              WITH DISTINCT this
+              RETURN {min: min(this.createdAt), max: max(this.createdAt)} AS var0
             }
-            RETURN { aggregate: { node: { createdAt: var0 } } } AS this"
+            RETURN {aggregate: {node: {createdAt: var0}}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);

--- a/packages/graphql/tests/tck/aggregations/where/authorization-with-aggregation-filter.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/authorization-with-aggregation-filter.test.ts
@@ -60,9 +60,9 @@ describe("Authorization with aggregation filter rule", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                WITH DISTINCT this1
-                RETURN count(this1) = $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              WITH DISTINCT this1
+              RETURN count(this1) = $param0 AS var2
             }
             WITH *
             WHERE ($isAuthenticated = true AND var2 = true)
@@ -96,19 +96,19 @@ describe("Authorization with aggregation filter rule", () => {
             "CYPHER 5
             MATCH (this0:Post)
             CALL (this0) {
-                MATCH (this0)<-[this1:LIKES]-(this2:User)
-                WITH DISTINCT this2
-                RETURN count(this2) = $param0 AS var3
+              MATCH (this0)<-[this1:LIKES]-(this2:User)
+              WITH DISTINCT this2
+              RETURN count(this2) = $param0 AS var3
             }
             WITH *
             WHERE ($isAuthenticated = true AND var3 = true)
-            WITH collect({ node: this0 }) AS edges
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                RETURN collect({ node: { content: this0.content, __resolveType: \\"Post\\" } }) AS var4
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              RETURN collect({node: {content: this0.content, __resolveType: 'Post'}}) AS var4
             }
-            RETURN { edges: var4 } AS this"
+            RETURN {edges: var4} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/aggregations/where/connection-filters-with-aggregations.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/connection-filters-with-aggregations.test.ts
@@ -79,15 +79,15 @@ describe("Field Level Aggregations Edge Filters", () => {
             "CYPHER 5
             MATCH (this:Actor)
             CALL (this) {
-                CALL (this) {
-                    MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                    WHERE (this1.title = $param0 AND this0.screentime = $param1)
-                    WITH DISTINCT this1
-                    ORDER BY size(this1.title) DESC
-                    WITH collect(this1.title) AS list
-                    RETURN { longest: head(list) } AS var2
-                }
-                RETURN { aggregate: { node: { title: var2 } } } AS var3
+              CALL (this) {
+                MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+                WHERE (this1.title = $param0 AND this0.screentime = $param1)
+                WITH DISTINCT this1
+                ORDER BY size(this1.title) DESC
+                WITH collect(this1.title) AS list
+                RETURN {longest: head(list)} AS var2
+              }
+              RETURN {aggregate: {node: {title: var2}}} AS var3
             }
             RETURN this { moviesConnection: var3 } AS this"
         `);
@@ -126,42 +126,42 @@ describe("Field Level Aggregations Edge Filters", () => {
             "CYPHER 5
             MATCH (this:Actor)
             CALL (this) {
+              CALL (this) {
                 CALL (this) {
-                    CALL (this) {
-                        WITH this
-                        MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                        WHERE (this1.title = $param0 AND this0.screentime = $param1)
-                        WITH { node: { __resolveType: \\"Movie\\", __id: id(this1) } } AS edge
-                        RETURN edge
-                        UNION
-                        WITH this
-                        MATCH (this)-[this2:ACTED_IN]->(this3:Series)
-                        WHERE (this3.title = $param2 AND this2.screentime = $param3)
-                        WITH { node: { __resolveType: \\"Series\\", __id: id(this3) } } AS edge
-                        RETURN edge
-                    }
-                    RETURN collect(edge) AS edges
+                  WITH this
+                  MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+                  WHERE (this1.title = $param0 AND this0.screentime = $param1)
+                  WITH {node: {__resolveType: 'Movie', __id: elementId(this1)}} AS edge
+                  RETURN edge
+                  UNION
+                  WITH this
+                  MATCH (this)-[this2:ACTED_IN]->(this3:Series)
+                  WHERE (this3.title = $param2 AND this2.screentime = $param3)
+                  WITH {node: {__resolveType: 'Series', __id: elementId(this3)}} AS edge
+                  RETURN edge
                 }
-                CALL (this) {
-                    CALL {
-                        WITH this
-                        MATCH (this)-[this4:ACTED_IN]->(this5:Movie)
-                        RETURN this5 AS node, this4 AS edge
-                        UNION
-                        WITH this
-                        MATCH (this)-[this6:ACTED_IN]->(this7:Series)
-                        RETURN this7 AS node, this6 AS edge
-                    }
-                    WITH *
-                    WHERE (node.title = $param4 AND edge.screentime = $param5)
-                    WITH DISTINCT node
-                    ORDER BY size(node.title) DESC
-                    WITH collect(node.title) AS list
-                    RETURN { longest: head(list) } AS this8
+                RETURN collect(edge) AS edges
+              }
+              CALL (this) {
+                CALL {
+                  WITH this
+                  MATCH (this)-[this4:ACTED_IN]->(this5:Movie)
+                  RETURN this5 AS node, this4 AS edge
+                  UNION
+                  WITH this
+                  MATCH (this)-[this6:ACTED_IN]->(this7:Series)
+                  RETURN this7 AS node, this6 AS edge
                 }
-                WITH edges, { node: { title: this8 } } AS var9
-                WITH edges, size(edges) AS totalCount, var9
-                RETURN { edges: edges, totalCount: totalCount, aggregate: var9 } AS var10
+                WITH *
+                WHERE (node.title = $param4 AND edge.screentime = $param5)
+                WITH DISTINCT node
+                ORDER BY size(node.title) DESC
+                WITH collect(node.title) AS list
+                RETURN {longest: head(list)} AS this8
+              }
+              WITH edges, {node: {title: this8}} AS var9
+              WITH edges, size(edges) AS totalCount, var9
+              RETURN {edges: edges, totalCount: totalCount, aggregate: var9} AS var10
             }
             RETURN this { actedInConnection: var10 } AS this"
         `);

--- a/packages/graphql/tests/tck/aggregations/where/count-edges.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/count-edges.test.ts
@@ -56,8 +56,8 @@ describe("Cypher Aggregations where with count edges", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)-[this0:LIKES]->(this1:User)
-                RETURN count(this0) = $param0 AS var2
+              MATCH (this)-[this0:LIKES]->(this1:User)
+              RETURN count(this0) = $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -89,8 +89,8 @@ describe("Cypher Aggregations where with count edges", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)-[this0:LIKES]->(this1:User)
-                RETURN count(this0) < $param0 AS var2
+              MATCH (this)-[this0:LIKES]->(this1:User)
+              RETURN count(this0) < $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -122,13 +122,13 @@ describe("Cypher Aggregations where with count edges", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)-[this0:LIKES]->(this1:User)
-                WITH DISTINCT this1
-                RETURN count(this1) = $param0 AS var2
+              MATCH (this)-[this0:LIKES]->(this1:User)
+              WITH DISTINCT this1
+              RETURN count(this1) = $param0 AS var2
             }
             CALL (this) {
-                MATCH (this)-[this3:LIKES]->(this4:User)
-                RETURN count(this3) = $param1 AS var5
+              MATCH (this)-[this3:LIKES]->(this4:User)
+              RETURN count(this3) = $param1 AS var5
             }
             WITH *
             WHERE (var2 = true AND var5 = true)

--- a/packages/graphql/tests/tck/aggregations/where/count-nested.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/count-nested.test.ts
@@ -60,17 +60,17 @@ describe("Cypher Aggregations where with count", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                WITH DISTINCT this1
-                CALL (this1) {
-                    MATCH (this1)-[this2:HAS_POST]->(this3:Post)
-                    WITH DISTINCT this3
-                    RETURN count(this3) = $param0 AS var4
-                }
-                WITH *
-                WHERE var4 = true
-                WITH this1 { .name } AS this1
-                RETURN collect(this1) AS var5
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              WITH DISTINCT this1
+              CALL (this1) {
+                MATCH (this1)-[this2:HAS_POST]->(this3:Post)
+                WITH DISTINCT this3
+                RETURN count(this3) = $param0 AS var4
+              }
+              WITH *
+              WHERE var4 = true
+              WITH this1 { .name } AS this1
+              RETURN collect(this1) AS var5
             }
             RETURN this { .content, likes: var5 } AS this"
         `);
@@ -103,17 +103,17 @@ describe("Cypher Aggregations where with count", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                WITH DISTINCT this1
-                CALL (this1) {
-                    MATCH (this1)-[this2:HAS_POST]->(this3:Post)
-                    WITH DISTINCT this3
-                    RETURN count(this3) < $param0 AS var4
-                }
-                WITH *
-                WHERE var4 = true
-                WITH this1 { .name } AS this1
-                RETURN collect(this1) AS var5
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              WITH DISTINCT this1
+              CALL (this1) {
+                MATCH (this1)-[this2:HAS_POST]->(this3:Post)
+                WITH DISTINCT this3
+                RETURN count(this3) < $param0 AS var4
+              }
+              WITH *
+              WHERE var4 = true
+              WITH this1 { .name } AS this1
+              RETURN collect(this1) AS var5
             }
             RETURN this { .content, likes: var5 } AS this"
         `);
@@ -146,17 +146,17 @@ describe("Cypher Aggregations where with count", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                WITH DISTINCT this1
-                CALL (this1) {
-                    MATCH (this1)-[this2:HAS_POST]->(this3:Post)
-                    WITH DISTINCT this3
-                    RETURN count(this3) <= $param0 AS var4
-                }
-                WITH *
-                WHERE var4 = true
-                WITH this1 { .name } AS this1
-                RETURN collect(this1) AS var5
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              WITH DISTINCT this1
+              CALL (this1) {
+                MATCH (this1)-[this2:HAS_POST]->(this3:Post)
+                WITH DISTINCT this3
+                RETURN count(this3) <= $param0 AS var4
+              }
+              WITH *
+              WHERE var4 = true
+              WITH this1 { .name } AS this1
+              RETURN collect(this1) AS var5
             }
             RETURN this { .content, likes: var5 } AS this"
         `);
@@ -189,17 +189,17 @@ describe("Cypher Aggregations where with count", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                WITH DISTINCT this1
-                CALL (this1) {
-                    MATCH (this1)-[this2:HAS_POST]->(this3:Post)
-                    WITH DISTINCT this3
-                    RETURN count(this3) > $param0 AS var4
-                }
-                WITH *
-                WHERE var4 = true
-                WITH this1 { .name } AS this1
-                RETURN collect(this1) AS var5
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              WITH DISTINCT this1
+              CALL (this1) {
+                MATCH (this1)-[this2:HAS_POST]->(this3:Post)
+                WITH DISTINCT this3
+                RETURN count(this3) > $param0 AS var4
+              }
+              WITH *
+              WHERE var4 = true
+              WITH this1 { .name } AS this1
+              RETURN collect(this1) AS var5
             }
             RETURN this { .content, likes: var5 } AS this"
         `);
@@ -232,17 +232,17 @@ describe("Cypher Aggregations where with count", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                WITH DISTINCT this1
-                CALL (this1) {
-                    MATCH (this1)-[this2:HAS_POST]->(this3:Post)
-                    WITH DISTINCT this3
-                    RETURN count(this3) >= $param0 AS var4
-                }
-                WITH *
-                WHERE var4 = true
-                WITH this1 { .name } AS this1
-                RETURN collect(this1) AS var5
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              WITH DISTINCT this1
+              CALL (this1) {
+                MATCH (this1)-[this2:HAS_POST]->(this3:Post)
+                WITH DISTINCT this3
+                RETURN count(this3) >= $param0 AS var4
+              }
+              WITH *
+              WHERE var4 = true
+              WITH this1 { .name } AS this1
+              RETURN collect(this1) AS var5
             }
             RETURN this { .content, likes: var5 } AS this"
         `);
@@ -275,17 +275,17 @@ describe("Cypher Aggregations where with count", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                WITH DISTINCT this1
-                CALL (this1) {
-                    MATCH (this1)-[this2:HAS_POST]->(this3:Post)
-                    WITH DISTINCT this3
-                    RETURN count(this3) IN $param0 AS var4
-                }
-                WITH *
-                WHERE var4 = true
-                WITH this1 { .name } AS this1
-                RETURN collect(this1) AS var5
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              WITH DISTINCT this1
+              CALL (this1) {
+                MATCH (this1)-[this2:HAS_POST]->(this3:Post)
+                WITH DISTINCT this3
+                RETURN count(this3) IN $param0 AS var4
+              }
+              WITH *
+              WHERE var4 = true
+              WITH this1 { .name } AS this1
+              RETURN collect(this1) AS var5
             }
             RETURN this { .content, likes: var5 } AS this"
         `);

--- a/packages/graphql/tests/tck/aggregations/where/count.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/count.test.ts
@@ -56,9 +56,9 @@ describe("Cypher Aggregations where with count", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                WITH DISTINCT this1
-                RETURN count(this1) = $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              WITH DISTINCT this1
+              RETURN count(this1) = $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -90,9 +90,9 @@ describe("Cypher Aggregations where with count", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                WITH DISTINCT this1
-                RETURN count(this1) < $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              WITH DISTINCT this1
+              RETURN count(this1) < $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -124,9 +124,9 @@ describe("Cypher Aggregations where with count", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                WITH DISTINCT this1
-                RETURN count(this1) <= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              WITH DISTINCT this1
+              RETURN count(this1) <= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -158,9 +158,9 @@ describe("Cypher Aggregations where with count", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                WITH DISTINCT this1
-                RETURN count(this1) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              WITH DISTINCT this1
+              RETURN count(this1) > $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -192,9 +192,9 @@ describe("Cypher Aggregations where with count", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                WITH DISTINCT this1
-                RETURN count(this1) >= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              WITH DISTINCT this1
+              RETURN count(this1) >= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -226,9 +226,9 @@ describe("Cypher Aggregations where with count", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                WITH DISTINCT this1
-                RETURN count(this1) IN $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              WITH DISTINCT this1
+              RETURN count(this1) IN $param0 AS var2
             }
             WITH *
             WHERE var2 = true

--- a/packages/graphql/tests/tck/aggregations/where/edge/bigint.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/edge/bigint.test.ts
@@ -61,8 +61,8 @@ describe("Cypher Aggregations where edge with BigInt", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN avg(this0.someBigInt) = $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN avg(this0.someBigInt) = $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -94,8 +94,8 @@ describe("Cypher Aggregations where edge with BigInt", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN avg(this0.someBigInt) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN avg(this0.someBigInt) > $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -127,8 +127,8 @@ describe("Cypher Aggregations where edge with BigInt", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN avg(this0.someBigInt) >= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN avg(this0.someBigInt) >= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -160,8 +160,8 @@ describe("Cypher Aggregations where edge with BigInt", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN avg(this0.someBigInt) < $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN avg(this0.someBigInt) < $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -193,8 +193,8 @@ describe("Cypher Aggregations where edge with BigInt", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN avg(this0.someBigInt) <= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN avg(this0.someBigInt) <= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -226,8 +226,8 @@ describe("Cypher Aggregations where edge with BigInt", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN sum(this0.someBigInt) = $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN sum(this0.someBigInt) = $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -259,8 +259,8 @@ describe("Cypher Aggregations where edge with BigInt", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN sum(this0.someBigInt) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN sum(this0.someBigInt) > $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -292,8 +292,8 @@ describe("Cypher Aggregations where edge with BigInt", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN sum(this0.someBigInt) >= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN sum(this0.someBigInt) >= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -325,8 +325,8 @@ describe("Cypher Aggregations where edge with BigInt", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN sum(this0.someBigInt) < $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN sum(this0.someBigInt) < $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -358,8 +358,8 @@ describe("Cypher Aggregations where edge with BigInt", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN sum(this0.someBigInt) <= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN sum(this0.someBigInt) <= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -391,8 +391,8 @@ describe("Cypher Aggregations where edge with BigInt", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this0.someBigInt) = $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this0.someBigInt) = $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -424,8 +424,8 @@ describe("Cypher Aggregations where edge with BigInt", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this0.someBigInt) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this0.someBigInt) > $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -457,8 +457,8 @@ describe("Cypher Aggregations where edge with BigInt", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this0.someBigInt) >= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this0.someBigInt) >= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -490,8 +490,8 @@ describe("Cypher Aggregations where edge with BigInt", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this0.someBigInt) < $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this0.someBigInt) < $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -523,8 +523,8 @@ describe("Cypher Aggregations where edge with BigInt", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this0.someBigInt) <= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this0.someBigInt) <= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -556,8 +556,8 @@ describe("Cypher Aggregations where edge with BigInt", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this0.someBigInt) = $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this0.someBigInt) = $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -589,8 +589,8 @@ describe("Cypher Aggregations where edge with BigInt", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this0.someBigInt) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this0.someBigInt) > $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -622,8 +622,8 @@ describe("Cypher Aggregations where edge with BigInt", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this0.someBigInt) >= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this0.someBigInt) >= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -655,8 +655,8 @@ describe("Cypher Aggregations where edge with BigInt", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this0.someBigInt) < $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this0.someBigInt) < $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -688,8 +688,8 @@ describe("Cypher Aggregations where edge with BigInt", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this0.someBigInt) <= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this0.someBigInt) <= $param0 AS var2
             }
             WITH *
             WHERE var2 = true

--- a/packages/graphql/tests/tck/aggregations/where/edge/datetime.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/edge/datetime.test.ts
@@ -63,8 +63,8 @@ describe("Cypher Aggregations where edge with DateTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this0.someDateTime) = datetime($param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this0.someDateTime) = datetime($param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -95,8 +95,8 @@ describe("Cypher Aggregations where edge with DateTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this0.someDateTime) > datetime($param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this0.someDateTime) > datetime($param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -127,8 +127,8 @@ describe("Cypher Aggregations where edge with DateTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this0.someDateTime) >= datetime($param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this0.someDateTime) >= datetime($param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -159,8 +159,8 @@ describe("Cypher Aggregations where edge with DateTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this0.someDateTime) < datetime($param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this0.someDateTime) < datetime($param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -191,8 +191,8 @@ describe("Cypher Aggregations where edge with DateTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this0.someDateTime) <= datetime($param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this0.someDateTime) <= datetime($param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -223,8 +223,8 @@ describe("Cypher Aggregations where edge with DateTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this0.someDateTime) = datetime($param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this0.someDateTime) = datetime($param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -255,8 +255,8 @@ describe("Cypher Aggregations where edge with DateTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this0.someDateTime) > datetime($param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this0.someDateTime) > datetime($param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -287,8 +287,8 @@ describe("Cypher Aggregations where edge with DateTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this0.someDateTime) >= datetime($param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this0.someDateTime) >= datetime($param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -319,8 +319,8 @@ describe("Cypher Aggregations where edge with DateTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this0.someDateTime) < datetime($param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this0.someDateTime) < datetime($param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -351,8 +351,8 @@ describe("Cypher Aggregations where edge with DateTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this0.someDateTime) <= datetime($param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this0.someDateTime) <= datetime($param0) AS var2
             }
             WITH *
             WHERE var2 = true

--- a/packages/graphql/tests/tck/aggregations/where/edge/duration.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/edge/duration.test.ts
@@ -61,8 +61,8 @@ describe("Cypher Aggregations where edge with Duration", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN (datetime() + avg(this0.someDuration)) = (datetime() + $param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN (datetime() + avg(this0.someDuration)) = (datetime() + $param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -96,8 +96,8 @@ describe("Cypher Aggregations where edge with Duration", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN (datetime() + avg(this0.someDuration)) > (datetime() + $param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN (datetime() + avg(this0.someDuration)) > (datetime() + $param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -131,8 +131,8 @@ describe("Cypher Aggregations where edge with Duration", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN (datetime() + avg(this0.someDuration)) >= (datetime() + $param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN (datetime() + avg(this0.someDuration)) >= (datetime() + $param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -166,8 +166,8 @@ describe("Cypher Aggregations where edge with Duration", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN (datetime() + avg(this0.someDuration)) < (datetime() + $param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN (datetime() + avg(this0.someDuration)) < (datetime() + $param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -201,8 +201,8 @@ describe("Cypher Aggregations where edge with Duration", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN (datetime() + avg(this0.someDuration)) <= (datetime() + $param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN (datetime() + avg(this0.someDuration)) <= (datetime() + $param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -236,8 +236,8 @@ describe("Cypher Aggregations where edge with Duration", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN (datetime() + min(this0.someDuration)) = (datetime() + $param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN (datetime() + min(this0.someDuration)) = (datetime() + $param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -271,8 +271,8 @@ describe("Cypher Aggregations where edge with Duration", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN (datetime() + min(this0.someDuration)) > (datetime() + $param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN (datetime() + min(this0.someDuration)) > (datetime() + $param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -306,8 +306,8 @@ describe("Cypher Aggregations where edge with Duration", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN (datetime() + min(this0.someDuration)) >= (datetime() + $param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN (datetime() + min(this0.someDuration)) >= (datetime() + $param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -341,8 +341,8 @@ describe("Cypher Aggregations where edge with Duration", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN (datetime() + min(this0.someDuration)) < (datetime() + $param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN (datetime() + min(this0.someDuration)) < (datetime() + $param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -376,8 +376,8 @@ describe("Cypher Aggregations where edge with Duration", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN (datetime() + min(this0.someDuration)) <= (datetime() + $param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN (datetime() + min(this0.someDuration)) <= (datetime() + $param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -411,8 +411,8 @@ describe("Cypher Aggregations where edge with Duration", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN (datetime() + max(this0.someDuration)) = (datetime() + $param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN (datetime() + max(this0.someDuration)) = (datetime() + $param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -446,8 +446,8 @@ describe("Cypher Aggregations where edge with Duration", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN (datetime() + max(this0.someDuration)) > (datetime() + $param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN (datetime() + max(this0.someDuration)) > (datetime() + $param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -481,8 +481,8 @@ describe("Cypher Aggregations where edge with Duration", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN (datetime() + max(this0.someDuration)) >= (datetime() + $param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN (datetime() + max(this0.someDuration)) >= (datetime() + $param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -516,8 +516,8 @@ describe("Cypher Aggregations where edge with Duration", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN (datetime() + max(this0.someDuration)) < (datetime() + $param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN (datetime() + max(this0.someDuration)) < (datetime() + $param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -551,8 +551,8 @@ describe("Cypher Aggregations where edge with Duration", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN (datetime() + max(this0.someDuration)) <= (datetime() + $param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN (datetime() + max(this0.someDuration)) <= (datetime() + $param0) AS var2
             }
             WITH *
             WHERE var2 = true

--- a/packages/graphql/tests/tck/aggregations/where/edge/float.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/edge/float.test.ts
@@ -61,8 +61,8 @@ describe("Cypher Aggregations where edge with Float", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN avg(this0.someFloat) = $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN avg(this0.someFloat) = $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -91,8 +91,8 @@ describe("Cypher Aggregations where edge with Float", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN avg(this0.someFloat) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN avg(this0.someFloat) > $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -121,8 +121,8 @@ describe("Cypher Aggregations where edge with Float", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN avg(this0.someFloat) >= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN avg(this0.someFloat) >= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -151,8 +151,8 @@ describe("Cypher Aggregations where edge with Float", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN avg(this0.someFloat) < $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN avg(this0.someFloat) < $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -181,8 +181,8 @@ describe("Cypher Aggregations where edge with Float", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN avg(this0.someFloat) <= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN avg(this0.someFloat) <= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -211,8 +211,8 @@ describe("Cypher Aggregations where edge with Float", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN sum(this0.someFloat) = $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN sum(this0.someFloat) = $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -241,8 +241,8 @@ describe("Cypher Aggregations where edge with Float", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN sum(this0.someFloat) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN sum(this0.someFloat) > $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -271,8 +271,8 @@ describe("Cypher Aggregations where edge with Float", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN sum(this0.someFloat) >= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN sum(this0.someFloat) >= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -301,8 +301,8 @@ describe("Cypher Aggregations where edge with Float", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN sum(this0.someFloat) < $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN sum(this0.someFloat) < $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -331,8 +331,8 @@ describe("Cypher Aggregations where edge with Float", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN sum(this0.someFloat) <= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN sum(this0.someFloat) <= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -361,8 +361,8 @@ describe("Cypher Aggregations where edge with Float", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this0.someFloat) = $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this0.someFloat) = $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -391,8 +391,8 @@ describe("Cypher Aggregations where edge with Float", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this0.someFloat) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this0.someFloat) > $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -421,8 +421,8 @@ describe("Cypher Aggregations where edge with Float", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this0.someFloat) >= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this0.someFloat) >= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -451,8 +451,8 @@ describe("Cypher Aggregations where edge with Float", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this0.someFloat) < $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this0.someFloat) < $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -481,8 +481,8 @@ describe("Cypher Aggregations where edge with Float", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this0.someFloat) <= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this0.someFloat) <= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -511,8 +511,8 @@ describe("Cypher Aggregations where edge with Float", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this0.someFloat) = $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this0.someFloat) = $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -541,8 +541,8 @@ describe("Cypher Aggregations where edge with Float", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this0.someFloat) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this0.someFloat) > $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -571,8 +571,8 @@ describe("Cypher Aggregations where edge with Float", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this0.someFloat) >= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this0.someFloat) >= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -601,8 +601,8 @@ describe("Cypher Aggregations where edge with Float", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this0.someFloat) < $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this0.someFloat) < $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -631,8 +631,8 @@ describe("Cypher Aggregations where edge with Float", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this0.someFloat) <= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this0.someFloat) <= $param0 AS var2
             }
             WITH *
             WHERE var2 = true

--- a/packages/graphql/tests/tck/aggregations/where/edge/int.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/edge/int.test.ts
@@ -61,8 +61,8 @@ describe("Cypher Aggregations where edge with Int", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN avg(this0.someInt) = $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN avg(this0.someInt) = $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -91,8 +91,8 @@ describe("Cypher Aggregations where edge with Int", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN avg(this0.someInt) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN avg(this0.someInt) > $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -121,8 +121,8 @@ describe("Cypher Aggregations where edge with Int", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN avg(this0.someInt) >= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN avg(this0.someInt) >= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -151,8 +151,8 @@ describe("Cypher Aggregations where edge with Int", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN avg(this0.someInt) < $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN avg(this0.someInt) < $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -181,8 +181,8 @@ describe("Cypher Aggregations where edge with Int", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN avg(this0.someInt) <= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN avg(this0.someInt) <= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -211,8 +211,8 @@ describe("Cypher Aggregations where edge with Int", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN sum(this0.someInt) = $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN sum(this0.someInt) = $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -244,8 +244,8 @@ describe("Cypher Aggregations where edge with Int", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN sum(this0.someInt) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN sum(this0.someInt) > $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -277,8 +277,8 @@ describe("Cypher Aggregations where edge with Int", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN sum(this0.someInt) >= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN sum(this0.someInt) >= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -310,8 +310,8 @@ describe("Cypher Aggregations where edge with Int", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN sum(this0.someInt) < $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN sum(this0.someInt) < $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -343,8 +343,8 @@ describe("Cypher Aggregations where edge with Int", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN sum(this0.someInt) <= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN sum(this0.someInt) <= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -376,8 +376,8 @@ describe("Cypher Aggregations where edge with Int", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this0.someInt) = $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this0.someInt) = $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -409,8 +409,8 @@ describe("Cypher Aggregations where edge with Int", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this0.someInt) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this0.someInt) > $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -442,8 +442,8 @@ describe("Cypher Aggregations where edge with Int", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this0.someInt) >= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this0.someInt) >= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -475,8 +475,8 @@ describe("Cypher Aggregations where edge with Int", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this0.someInt) < $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this0.someInt) < $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -508,8 +508,8 @@ describe("Cypher Aggregations where edge with Int", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this0.someInt) <= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this0.someInt) <= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -541,8 +541,8 @@ describe("Cypher Aggregations where edge with Int", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this0.someInt) = $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this0.someInt) = $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -574,8 +574,8 @@ describe("Cypher Aggregations where edge with Int", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this0.someInt) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this0.someInt) > $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -607,8 +607,8 @@ describe("Cypher Aggregations where edge with Int", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this0.someInt) >= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this0.someInt) >= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -640,8 +640,8 @@ describe("Cypher Aggregations where edge with Int", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this0.someInt) < $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this0.someInt) < $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -673,8 +673,8 @@ describe("Cypher Aggregations where edge with Int", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this0.someInt) <= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this0.someInt) <= $param0 AS var2
             }
             WITH *
             WHERE var2 = true

--- a/packages/graphql/tests/tck/aggregations/where/edge/interface-relationship.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/edge/interface-relationship.test.ts
@@ -82,9 +82,9 @@ describe("Cypher Aggregations where edge with String", () => {
             "CYPHER 5
             MATCH (this:Actor)
             CALL (this) {
-                MATCH (this)-[this0:ACTED_IN]->(this1)
-                WHERE (this1:Movie OR this1:Series)
-                RETURN count(this1) < $param0 AS var2
+              MATCH (this)-[this0:ACTED_IN]->(this1)
+              WHERE (this1:Movie OR this1:Series)
+              RETURN count(this1) < $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -121,27 +121,27 @@ describe("Cypher Aggregations where edge with String", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL (*) {
-                MATCH (this0:Actor)
-                CALL (this0) {
-                    MATCH (this0)-[this1:ACTED_IN]->(this2)
-                    WHERE (this2:Movie OR this2:Series)
-                    RETURN avg(size(this1.role)) < $param0 AS var3
-                }
-                WITH *
-                WHERE var3 = true
-                WITH this0 { .name, __resolveType: \\"Actor\\", __id: id(this0) } AS this
-                RETURN this
-                UNION
-                MATCH (this4:Cameo)
-                CALL (this4) {
-                    MATCH (this4)-[this5:APPEARED_IN]->(this6)
-                    WHERE (this6:Movie OR this6:Series)
-                    RETURN min(size(this5.role)) < $param1 AS var7
-                }
-                WITH *
-                WHERE var7 = true
-                WITH this4 { .name, __resolveType: \\"Cameo\\", __id: id(this4) } AS this
-                RETURN this
+              MATCH (this0:Actor)
+              CALL (this0) {
+                MATCH (this0)-[this1:ACTED_IN]->(this2)
+                WHERE (this2:Movie OR this2:Series)
+                RETURN avg(size(this1.role)) < $param0 AS var3
+              }
+              WITH *
+              WHERE var3 = true
+              WITH this0 { .name, __resolveType: 'Actor', __id: elementId(this0) } AS this
+              RETURN this
+              UNION
+              MATCH (this4:Cameo)
+              CALL (this4) {
+                MATCH (this4)-[this5:APPEARED_IN]->(this6)
+                WHERE (this6:Movie OR this6:Series)
+                RETURN min(size(this5.role)) < $param1 AS var7
+              }
+              WITH *
+              WHERE var7 = true
+              WITH this4 { .name, __resolveType: 'Cameo', __id: elementId(this4) } AS this
+              RETURN this
             }
             WITH this
             RETURN this AS this"
@@ -174,32 +174,32 @@ describe("Cypher Aggregations where edge with String", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL (*) {
-                MATCH (this0:Actor)
-                CALL (this0) {
-                    MATCH (this0)-[this1:ACTED_IN]->(this2)
-                    WHERE (this2:Movie OR this2:Series)
-                    RETURN count(this2) <= $param0 AS var3
-                }
-                CALL (this0) {
-                    MATCH (this0)-[this4:ACTED_IN]->(this5)
-                    WHERE (this5:Movie OR this5:Series)
-                    RETURN avg(size(this4.role)) < $param1 AS var6
-                }
-                WITH *
-                WHERE (var3 = true AND var6 = true)
-                WITH this0 { .name, __resolveType: \\"Actor\\", __id: id(this0) } AS this
-                RETURN this
-                UNION
-                MATCH (this7:Cameo)
-                CALL (this7) {
-                    MATCH (this7)-[this8:APPEARED_IN]->(this9)
-                    WHERE (this9:Movie OR this9:Series)
-                    RETURN count(this9) <= $param2 AS var10
-                }
-                WITH *
-                WHERE var10 = true
-                WITH this7 { .name, __resolveType: \\"Cameo\\", __id: id(this7) } AS this
-                RETURN this
+              MATCH (this0:Actor)
+              CALL (this0) {
+                MATCH (this0)-[this1:ACTED_IN]->(this2)
+                WHERE (this2:Movie OR this2:Series)
+                RETURN count(this2) <= $param0 AS var3
+              }
+              CALL (this0) {
+                MATCH (this0)-[this4:ACTED_IN]->(this5)
+                WHERE (this5:Movie OR this5:Series)
+                RETURN avg(size(this4.role)) < $param1 AS var6
+              }
+              WITH *
+              WHERE (var3 = true AND var6 = true)
+              WITH this0 { .name, __resolveType: 'Actor', __id: elementId(this0) } AS this
+              RETURN this
+              UNION
+              MATCH (this7:Cameo)
+              CALL (this7) {
+                MATCH (this7)-[this8:APPEARED_IN]->(this9)
+                WHERE (this9:Movie OR this9:Series)
+                RETURN count(this9) <= $param2 AS var10
+              }
+              WITH *
+              WHERE var10 = true
+              WITH this7 { .name, __resolveType: 'Cameo', __id: elementId(this7) } AS this
+              RETURN this
             }
             WITH this
             RETURN this AS this"

--- a/packages/graphql/tests/tck/aggregations/where/edge/localdatetime.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/edge/localdatetime.test.ts
@@ -63,8 +63,8 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this0.someLocalDateTime) = $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this0.someLocalDateTime) = $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -103,8 +103,8 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this0.someLocalDateTime) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this0.someLocalDateTime) > $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -143,8 +143,8 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this0.someLocalDateTime) >= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this0.someLocalDateTime) >= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -183,8 +183,8 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this0.someLocalDateTime) < $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this0.someLocalDateTime) < $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -223,8 +223,8 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this0.someLocalDateTime) <= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this0.someLocalDateTime) <= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -263,8 +263,8 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this0.someLocalDateTime) = $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this0.someLocalDateTime) = $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -303,8 +303,8 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this0.someLocalDateTime) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this0.someLocalDateTime) > $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -343,8 +343,8 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this0.someLocalDateTime) >= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this0.someLocalDateTime) >= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -383,8 +383,8 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this0.someLocalDateTime) < $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this0.someLocalDateTime) < $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -423,8 +423,8 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this0.someLocalDateTime) <= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this0.someLocalDateTime) <= $param0 AS var2
             }
             WITH *
             WHERE var2 = true

--- a/packages/graphql/tests/tck/aggregations/where/edge/localtime.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/edge/localtime.test.ts
@@ -61,8 +61,8 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this0.someLocalTime) = $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this0.someLocalTime) = $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -96,8 +96,8 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this0.someLocalTime) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this0.someLocalTime) > $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -131,8 +131,8 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this0.someLocalTime) >= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this0.someLocalTime) >= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -166,8 +166,8 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this0.someLocalTime) < $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this0.someLocalTime) < $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -201,8 +201,8 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this0.someLocalTime) <= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this0.someLocalTime) <= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -236,8 +236,8 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this0.someLocalTime) = $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this0.someLocalTime) = $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -271,8 +271,8 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this0.someLocalTime) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this0.someLocalTime) > $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -306,8 +306,8 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this0.someLocalTime) >= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this0.someLocalTime) >= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -341,8 +341,8 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this0.someLocalTime) < $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this0.someLocalTime) < $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -376,8 +376,8 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this0.someLocalTime) <= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this0.someLocalTime) <= $param0 AS var2
             }
             WITH *
             WHERE var2 = true

--- a/packages/graphql/tests/tck/aggregations/where/edge/string.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/edge/string.test.ts
@@ -61,8 +61,8 @@ describe("Cypher Aggregations where edge with String", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(size(this0.someString)) = $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(size(this0.someString)) = $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -94,8 +94,8 @@ describe("Cypher Aggregations where edge with String", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(size(this0.someString)) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(size(this0.someString)) > $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -127,8 +127,8 @@ describe("Cypher Aggregations where edge with String", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(size(this0.someString)) >= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(size(this0.someString)) >= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -160,8 +160,8 @@ describe("Cypher Aggregations where edge with String", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(size(this0.someString)) < $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(size(this0.someString)) < $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -193,8 +193,8 @@ describe("Cypher Aggregations where edge with String", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(size(this0.someString)) <= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(size(this0.someString)) <= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -226,8 +226,8 @@ describe("Cypher Aggregations where edge with String", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(size(this0.someString)) = $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(size(this0.someString)) = $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -259,8 +259,8 @@ describe("Cypher Aggregations where edge with String", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(size(this0.someString)) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(size(this0.someString)) > $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -292,8 +292,8 @@ describe("Cypher Aggregations where edge with String", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(size(this0.someString)) >= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(size(this0.someString)) >= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -325,8 +325,8 @@ describe("Cypher Aggregations where edge with String", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(size(this0.someString)) < $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(size(this0.someString)) < $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -358,8 +358,8 @@ describe("Cypher Aggregations where edge with String", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(size(this0.someString)) <= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(size(this0.someString)) <= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -391,8 +391,8 @@ describe("Cypher Aggregations where edge with String", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN avg(size(this0.someString)) = $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN avg(size(this0.someString)) = $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -421,8 +421,8 @@ describe("Cypher Aggregations where edge with String", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN avg(size(this0.someString)) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN avg(size(this0.someString)) > $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -451,8 +451,8 @@ describe("Cypher Aggregations where edge with String", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN avg(size(this0.someString)) >= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN avg(size(this0.someString)) >= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -481,8 +481,8 @@ describe("Cypher Aggregations where edge with String", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN avg(size(this0.someString)) < $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN avg(size(this0.someString)) < $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -511,8 +511,8 @@ describe("Cypher Aggregations where edge with String", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN avg(size(this0.someString)) <= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN avg(size(this0.someString)) <= $param0 AS var2
             }
             WITH *
             WHERE var2 = true

--- a/packages/graphql/tests/tck/aggregations/where/edge/time.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/edge/time.test.ts
@@ -61,8 +61,8 @@ describe("Cypher Aggregations where edge with Time", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this0.someTime) = time($param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this0.someTime) = time($param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -91,8 +91,8 @@ describe("Cypher Aggregations where edge with Time", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this0.someTime) > time($param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this0.someTime) > time($param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -121,8 +121,8 @@ describe("Cypher Aggregations where edge with Time", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this0.someTime) >= time($param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this0.someTime) >= time($param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -151,8 +151,8 @@ describe("Cypher Aggregations where edge with Time", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this0.someTime) < time($param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this0.someTime) < time($param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -181,8 +181,8 @@ describe("Cypher Aggregations where edge with Time", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this0.someTime) <= time($param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this0.someTime) <= time($param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -211,8 +211,8 @@ describe("Cypher Aggregations where edge with Time", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this0.someTime) = time($param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this0.someTime) = time($param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -241,8 +241,8 @@ describe("Cypher Aggregations where edge with Time", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this0.someTime) > time($param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this0.someTime) > time($param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -271,8 +271,8 @@ describe("Cypher Aggregations where edge with Time", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this0.someTime) >= time($param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this0.someTime) >= time($param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -301,8 +301,8 @@ describe("Cypher Aggregations where edge with Time", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this0.someTime) < time($param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this0.someTime) < time($param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -331,8 +331,8 @@ describe("Cypher Aggregations where edge with Time", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this0.someTime) <= time($param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this0.someTime) <= time($param0) AS var2
             }
             WITH *
             WHERE var2 = true

--- a/packages/graphql/tests/tck/aggregations/where/logical.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/logical.test.ts
@@ -62,14 +62,14 @@ describe("Cypher Aggregations where with logical AND plus OR", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                WITH DISTINCT this1
-                RETURN count(this1) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              WITH DISTINCT this1
+              RETURN count(this1) > $param0 AS var2
             }
             CALL (this) {
-                MATCH (this)<-[this3:LIKES]-(this4:User)
-                WITH DISTINCT this4
-                RETURN count(this4) < $param1 AS var5
+              MATCH (this)<-[this3:LIKES]-(this4:User)
+              WITH DISTINCT this4
+              RETURN count(this4) < $param1 AS var5
             }
             WITH *
             WHERE (var2 = true AND var5 = true)
@@ -111,14 +111,14 @@ describe("Cypher Aggregations where with logical AND plus OR", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                WITH DISTINCT this1
-                RETURN count(this1) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              WITH DISTINCT this1
+              RETURN count(this1) > $param0 AS var2
             }
             CALL (this) {
-                MATCH (this)<-[this3:LIKES]-(this4:User)
-                WITH DISTINCT this4
-                RETURN count(this4) < $param1 AS var5
+              MATCH (this)<-[this3:LIKES]-(this4:User)
+              WITH DISTINCT this4
+              RETURN count(this4) < $param1 AS var5
             }
             WITH *
             WHERE (var2 = true OR var5 = true)
@@ -154,9 +154,9 @@ describe("Cypher Aggregations where with logical AND plus OR", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                WITH DISTINCT this1
-                RETURN count(this1) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              WITH DISTINCT this1
+              RETURN count(this1) > $param0 AS var2
             }
             WITH *
             WHERE NOT (var2 = true)
@@ -197,24 +197,24 @@ describe("Cypher Aggregations where with logical AND plus OR", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                WITH DISTINCT this1
-                RETURN count(this1) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              WITH DISTINCT this1
+              RETURN count(this1) > $param0 AS var2
             }
             CALL (this) {
-                MATCH (this)<-[this3:LIKES]-(this4:User)
-                WITH DISTINCT this4
-                RETURN count(this4) < $param1 AS var5
+              MATCH (this)<-[this3:LIKES]-(this4:User)
+              WITH DISTINCT this4
+              RETURN count(this4) < $param1 AS var5
             }
             CALL (this) {
-                MATCH (this)<-[this6:LIKES]-(this7:User)
-                WITH DISTINCT this7
-                RETURN count(this7) > $param2 AS var8
+              MATCH (this)<-[this6:LIKES]-(this7:User)
+              WITH DISTINCT this7
+              RETURN count(this7) > $param2 AS var8
             }
             CALL (this) {
-                MATCH (this)<-[this9:LIKES]-(this10:User)
-                WITH DISTINCT this10
-                RETURN count(this10) < $param3 AS var11
+              MATCH (this)<-[this9:LIKES]-(this10:User)
+              WITH DISTINCT this10
+              RETURN count(this10) < $param3 AS var11
             }
             WITH *
             WHERE ((var2 = true AND var5 = true) AND (var8 = true OR var11 = true))
@@ -271,29 +271,29 @@ describe("Cypher Aggregations where with logical AND plus OR", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                WITH DISTINCT this1
-                RETURN count(this1) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              WITH DISTINCT this1
+              RETURN count(this1) > $param0 AS var2
             }
             CALL (this) {
-                MATCH (this)<-[this3:LIKES]-(this4:User)
-                WITH DISTINCT this4
-                RETURN count(this4) < $param1 AS var5
+              MATCH (this)<-[this3:LIKES]-(this4:User)
+              WITH DISTINCT this4
+              RETURN count(this4) < $param1 AS var5
             }
             CALL (this) {
-                MATCH (this)<-[this6:LIKES]-(this7:User)
-                WITH DISTINCT this7
-                RETURN count(this7) > $param2 AS var8
+              MATCH (this)<-[this6:LIKES]-(this7:User)
+              WITH DISTINCT this7
+              RETURN count(this7) > $param2 AS var8
             }
             CALL (this) {
-                MATCH (this)<-[this9:LIKES]-(this10:User)
-                WITH DISTINCT this10
-                RETURN count(this10) < $param3 AS var11
+              MATCH (this)<-[this9:LIKES]-(this10:User)
+              WITH DISTINCT this10
+              RETURN count(this10) < $param3 AS var11
             }
             CALL (this) {
-                MATCH (this)<-[this12:LIKES]-(this13:User)
-                WITH DISTINCT this13
-                RETURN count(this13) < $param4 AS var14
+              MATCH (this)<-[this12:LIKES]-(this13:User)
+              WITH DISTINCT this13
+              RETURN count(this13) < $param4 AS var14
             }
             WITH *
             WHERE (var2 = true AND var5 = true AND (var8 = true OR var11 = true OR var14 = true))

--- a/packages/graphql/tests/tck/aggregations/where/node/bigint.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/node/bigint.test.ts
@@ -57,8 +57,8 @@ describe("Cypher Aggregations where node with BigInt", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN avg(this1.someBigInt) = $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN avg(this1.someBigInt) = $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -90,8 +90,8 @@ describe("Cypher Aggregations where node with BigInt", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN avg(this1.someBigInt) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN avg(this1.someBigInt) > $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -123,8 +123,8 @@ describe("Cypher Aggregations where node with BigInt", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN avg(this1.someBigInt) >= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN avg(this1.someBigInt) >= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -156,8 +156,8 @@ describe("Cypher Aggregations where node with BigInt", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN avg(this1.someBigInt) < $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN avg(this1.someBigInt) < $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -189,8 +189,8 @@ describe("Cypher Aggregations where node with BigInt", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN avg(this1.someBigInt) <= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN avg(this1.someBigInt) <= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -222,8 +222,8 @@ describe("Cypher Aggregations where node with BigInt", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN sum(this1.someBigInt) = $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN sum(this1.someBigInt) = $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -255,8 +255,8 @@ describe("Cypher Aggregations where node with BigInt", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN sum(this1.someBigInt) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN sum(this1.someBigInt) > $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -288,8 +288,8 @@ describe("Cypher Aggregations where node with BigInt", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN sum(this1.someBigInt) >= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN sum(this1.someBigInt) >= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -321,8 +321,8 @@ describe("Cypher Aggregations where node with BigInt", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN sum(this1.someBigInt) < $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN sum(this1.someBigInt) < $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -354,8 +354,8 @@ describe("Cypher Aggregations where node with BigInt", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN sum(this1.someBigInt) <= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN sum(this1.someBigInt) <= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -387,8 +387,8 @@ describe("Cypher Aggregations where node with BigInt", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this1.someBigInt) = $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this1.someBigInt) = $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -420,8 +420,8 @@ describe("Cypher Aggregations where node with BigInt", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this1.someBigInt) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this1.someBigInt) > $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -453,8 +453,8 @@ describe("Cypher Aggregations where node with BigInt", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this1.someBigInt) >= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this1.someBigInt) >= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -486,8 +486,8 @@ describe("Cypher Aggregations where node with BigInt", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this1.someBigInt) < $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this1.someBigInt) < $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -519,8 +519,8 @@ describe("Cypher Aggregations where node with BigInt", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this1.someBigInt) <= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this1.someBigInt) <= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -552,8 +552,8 @@ describe("Cypher Aggregations where node with BigInt", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this1.someBigInt) = $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this1.someBigInt) = $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -585,8 +585,8 @@ describe("Cypher Aggregations where node with BigInt", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this1.someBigInt) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this1.someBigInt) > $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -618,8 +618,8 @@ describe("Cypher Aggregations where node with BigInt", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this1.someBigInt) >= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this1.someBigInt) >= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -651,8 +651,8 @@ describe("Cypher Aggregations where node with BigInt", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this1.someBigInt) < $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this1.someBigInt) < $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -684,8 +684,8 @@ describe("Cypher Aggregations where node with BigInt", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this1.someBigInt) <= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this1.someBigInt) <= $param0 AS var2
             }
             WITH *
             WHERE var2 = true

--- a/packages/graphql/tests/tck/aggregations/where/node/datetime.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/node/datetime.test.ts
@@ -59,8 +59,8 @@ describe("Cypher Aggregations where node with DateTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this1.someDateTime) = datetime($param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this1.someDateTime) = datetime($param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -91,8 +91,8 @@ describe("Cypher Aggregations where node with DateTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this1.someDateTime) > datetime($param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this1.someDateTime) > datetime($param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -123,8 +123,8 @@ describe("Cypher Aggregations where node with DateTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this1.someDateTime) >= datetime($param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this1.someDateTime) >= datetime($param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -155,8 +155,8 @@ describe("Cypher Aggregations where node with DateTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this1.someDateTime) < datetime($param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this1.someDateTime) < datetime($param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -187,8 +187,8 @@ describe("Cypher Aggregations where node with DateTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this1.someDateTime) <= datetime($param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this1.someDateTime) <= datetime($param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -219,8 +219,8 @@ describe("Cypher Aggregations where node with DateTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this1.someDateTime) = datetime($param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this1.someDateTime) = datetime($param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -251,8 +251,8 @@ describe("Cypher Aggregations where node with DateTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this1.someDateTime) > datetime($param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this1.someDateTime) > datetime($param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -283,8 +283,8 @@ describe("Cypher Aggregations where node with DateTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this1.someDateTime) >= datetime($param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this1.someDateTime) >= datetime($param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -315,8 +315,8 @@ describe("Cypher Aggregations where node with DateTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this1.someDateTime) < datetime($param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this1.someDateTime) < datetime($param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -347,8 +347,8 @@ describe("Cypher Aggregations where node with DateTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this1.someDateTime) <= datetime($param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this1.someDateTime) <= datetime($param0) AS var2
             }
             WITH *
             WHERE var2 = true

--- a/packages/graphql/tests/tck/aggregations/where/node/duration.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/node/duration.test.ts
@@ -57,8 +57,8 @@ describe("Cypher Aggregations where node with Duration", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN (datetime() + avg(this1.someDuration)) = (datetime() + $param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN (datetime() + avg(this1.someDuration)) = (datetime() + $param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -92,8 +92,8 @@ describe("Cypher Aggregations where node with Duration", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN (datetime() + avg(this1.someDuration)) > (datetime() + $param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN (datetime() + avg(this1.someDuration)) > (datetime() + $param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -127,8 +127,8 @@ describe("Cypher Aggregations where node with Duration", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN (datetime() + avg(this1.someDuration)) >= (datetime() + $param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN (datetime() + avg(this1.someDuration)) >= (datetime() + $param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -162,8 +162,8 @@ describe("Cypher Aggregations where node with Duration", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN (datetime() + avg(this1.someDuration)) < (datetime() + $param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN (datetime() + avg(this1.someDuration)) < (datetime() + $param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -197,8 +197,8 @@ describe("Cypher Aggregations where node with Duration", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN (datetime() + avg(this1.someDuration)) <= (datetime() + $param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN (datetime() + avg(this1.someDuration)) <= (datetime() + $param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -232,8 +232,8 @@ describe("Cypher Aggregations where node with Duration", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN (datetime() + min(this1.someDuration)) = (datetime() + $param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN (datetime() + min(this1.someDuration)) = (datetime() + $param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -267,8 +267,8 @@ describe("Cypher Aggregations where node with Duration", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN (datetime() + min(this1.someDuration)) > (datetime() + $param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN (datetime() + min(this1.someDuration)) > (datetime() + $param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -302,8 +302,8 @@ describe("Cypher Aggregations where node with Duration", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN (datetime() + min(this1.someDuration)) >= (datetime() + $param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN (datetime() + min(this1.someDuration)) >= (datetime() + $param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -337,8 +337,8 @@ describe("Cypher Aggregations where node with Duration", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN (datetime() + min(this1.someDuration)) < (datetime() + $param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN (datetime() + min(this1.someDuration)) < (datetime() + $param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -372,8 +372,8 @@ describe("Cypher Aggregations where node with Duration", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN (datetime() + min(this1.someDuration)) <= (datetime() + $param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN (datetime() + min(this1.someDuration)) <= (datetime() + $param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -407,8 +407,8 @@ describe("Cypher Aggregations where node with Duration", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN (datetime() + max(this1.someDuration)) = (datetime() + $param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN (datetime() + max(this1.someDuration)) = (datetime() + $param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -442,8 +442,8 @@ describe("Cypher Aggregations where node with Duration", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN (datetime() + max(this1.someDuration)) > (datetime() + $param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN (datetime() + max(this1.someDuration)) > (datetime() + $param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -477,8 +477,8 @@ describe("Cypher Aggregations where node with Duration", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN (datetime() + max(this1.someDuration)) >= (datetime() + $param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN (datetime() + max(this1.someDuration)) >= (datetime() + $param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -512,8 +512,8 @@ describe("Cypher Aggregations where node with Duration", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN (datetime() + max(this1.someDuration)) < (datetime() + $param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN (datetime() + max(this1.someDuration)) < (datetime() + $param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -547,8 +547,8 @@ describe("Cypher Aggregations where node with Duration", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN (datetime() + max(this1.someDuration)) <= (datetime() + $param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN (datetime() + max(this1.someDuration)) <= (datetime() + $param0) AS var2
             }
             WITH *
             WHERE var2 = true

--- a/packages/graphql/tests/tck/aggregations/where/node/float.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/node/float.test.ts
@@ -57,8 +57,8 @@ describe("Cypher Aggregations where node with Float", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN avg(this1.someFloat) = $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN avg(this1.someFloat) = $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -87,8 +87,8 @@ describe("Cypher Aggregations where node with Float", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN avg(this1.someFloat) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN avg(this1.someFloat) > $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -117,8 +117,8 @@ describe("Cypher Aggregations where node with Float", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN avg(this1.someFloat) >= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN avg(this1.someFloat) >= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -147,8 +147,8 @@ describe("Cypher Aggregations where node with Float", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN avg(this1.someFloat) < $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN avg(this1.someFloat) < $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -177,8 +177,8 @@ describe("Cypher Aggregations where node with Float", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN avg(this1.someFloat) <= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN avg(this1.someFloat) <= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -207,8 +207,8 @@ describe("Cypher Aggregations where node with Float", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN sum(this1.someFloat) = $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN sum(this1.someFloat) = $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -237,8 +237,8 @@ describe("Cypher Aggregations where node with Float", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN sum(this1.someFloat) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN sum(this1.someFloat) > $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -267,8 +267,8 @@ describe("Cypher Aggregations where node with Float", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN sum(this1.someFloat) >= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN sum(this1.someFloat) >= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -297,8 +297,8 @@ describe("Cypher Aggregations where node with Float", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN sum(this1.someFloat) < $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN sum(this1.someFloat) < $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -327,8 +327,8 @@ describe("Cypher Aggregations where node with Float", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN sum(this1.someFloat) <= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN sum(this1.someFloat) <= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -357,8 +357,8 @@ describe("Cypher Aggregations where node with Float", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this1.someFloat) = $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this1.someFloat) = $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -387,8 +387,8 @@ describe("Cypher Aggregations where node with Float", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this1.someFloat) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this1.someFloat) > $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -417,8 +417,8 @@ describe("Cypher Aggregations where node with Float", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this1.someFloat) >= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this1.someFloat) >= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -447,8 +447,8 @@ describe("Cypher Aggregations where node with Float", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this1.someFloat) < $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this1.someFloat) < $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -477,8 +477,8 @@ describe("Cypher Aggregations where node with Float", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this1.someFloat) <= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this1.someFloat) <= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -507,8 +507,8 @@ describe("Cypher Aggregations where node with Float", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this1.someFloat) = $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this1.someFloat) = $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -537,8 +537,8 @@ describe("Cypher Aggregations where node with Float", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this1.someFloat) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this1.someFloat) > $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -567,8 +567,8 @@ describe("Cypher Aggregations where node with Float", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this1.someFloat) >= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this1.someFloat) >= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -597,8 +597,8 @@ describe("Cypher Aggregations where node with Float", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this1.someFloat) < $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this1.someFloat) < $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -627,8 +627,8 @@ describe("Cypher Aggregations where node with Float", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this1.someFloat) <= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this1.someFloat) <= $param0 AS var2
             }
             WITH *
             WHERE var2 = true

--- a/packages/graphql/tests/tck/aggregations/where/node/int.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/node/int.test.ts
@@ -57,9 +57,9 @@ describe("Cypher Aggregations where node with Int", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                WITH DISTINCT this1
-                RETURN avg(this1.someInt) = $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              WITH DISTINCT this1
+              RETURN avg(this1.someInt) = $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -88,9 +88,9 @@ describe("Cypher Aggregations where node with Int", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                WITH DISTINCT this1
-                RETURN avg(this1.someInt) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              WITH DISTINCT this1
+              RETURN avg(this1.someInt) > $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -119,9 +119,9 @@ describe("Cypher Aggregations where node with Int", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                WITH DISTINCT this1
-                RETURN avg(this1.someInt) >= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              WITH DISTINCT this1
+              RETURN avg(this1.someInt) >= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -150,9 +150,9 @@ describe("Cypher Aggregations where node with Int", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                WITH DISTINCT this1
-                RETURN avg(this1.someInt) < $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              WITH DISTINCT this1
+              RETURN avg(this1.someInt) < $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -181,9 +181,9 @@ describe("Cypher Aggregations where node with Int", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                WITH DISTINCT this1
-                RETURN avg(this1.someInt) <= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              WITH DISTINCT this1
+              RETURN avg(this1.someInt) <= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -212,9 +212,9 @@ describe("Cypher Aggregations where node with Int", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                WITH DISTINCT this1
-                RETURN sum(this1.someInt) = $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              WITH DISTINCT this1
+              RETURN sum(this1.someInt) = $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -246,9 +246,9 @@ describe("Cypher Aggregations where node with Int", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                WITH DISTINCT this1
-                RETURN sum(this1.someInt) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              WITH DISTINCT this1
+              RETURN sum(this1.someInt) > $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -280,9 +280,9 @@ describe("Cypher Aggregations where node with Int", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                WITH DISTINCT this1
-                RETURN sum(this1.someInt) >= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              WITH DISTINCT this1
+              RETURN sum(this1.someInt) >= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -314,9 +314,9 @@ describe("Cypher Aggregations where node with Int", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                WITH DISTINCT this1
-                RETURN sum(this1.someInt) < $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              WITH DISTINCT this1
+              RETURN sum(this1.someInt) < $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -348,9 +348,9 @@ describe("Cypher Aggregations where node with Int", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                WITH DISTINCT this1
-                RETURN sum(this1.someInt) <= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              WITH DISTINCT this1
+              RETURN sum(this1.someInt) <= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -382,9 +382,9 @@ describe("Cypher Aggregations where node with Int", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                WITH DISTINCT this1
-                RETURN min(this1.someInt) = $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              WITH DISTINCT this1
+              RETURN min(this1.someInt) = $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -416,9 +416,9 @@ describe("Cypher Aggregations where node with Int", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                WITH DISTINCT this1
-                RETURN min(this1.someInt) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              WITH DISTINCT this1
+              RETURN min(this1.someInt) > $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -450,9 +450,9 @@ describe("Cypher Aggregations where node with Int", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                WITH DISTINCT this1
-                RETURN min(this1.someInt) >= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              WITH DISTINCT this1
+              RETURN min(this1.someInt) >= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -484,9 +484,9 @@ describe("Cypher Aggregations where node with Int", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                WITH DISTINCT this1
-                RETURN min(this1.someInt) < $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              WITH DISTINCT this1
+              RETURN min(this1.someInt) < $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -518,9 +518,9 @@ describe("Cypher Aggregations where node with Int", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                WITH DISTINCT this1
-                RETURN min(this1.someInt) <= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              WITH DISTINCT this1
+              RETURN min(this1.someInt) <= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -552,9 +552,9 @@ describe("Cypher Aggregations where node with Int", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                WITH DISTINCT this1
-                RETURN max(this1.someInt) = $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              WITH DISTINCT this1
+              RETURN max(this1.someInt) = $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -586,9 +586,9 @@ describe("Cypher Aggregations where node with Int", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                WITH DISTINCT this1
-                RETURN max(this1.someInt) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              WITH DISTINCT this1
+              RETURN max(this1.someInt) > $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -620,9 +620,9 @@ describe("Cypher Aggregations where node with Int", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                WITH DISTINCT this1
-                RETURN max(this1.someInt) >= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              WITH DISTINCT this1
+              RETURN max(this1.someInt) >= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -654,9 +654,9 @@ describe("Cypher Aggregations where node with Int", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                WITH DISTINCT this1
-                RETURN max(this1.someInt) < $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              WITH DISTINCT this1
+              RETURN max(this1.someInt) < $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -688,9 +688,9 @@ describe("Cypher Aggregations where node with Int", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                WITH DISTINCT this1
-                RETURN max(this1.someInt) <= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              WITH DISTINCT this1
+              RETURN max(this1.someInt) <= $param0 AS var2
             }
             WITH *
             WHERE var2 = true

--- a/packages/graphql/tests/tck/aggregations/where/node/localdatetime.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/node/localdatetime.test.ts
@@ -59,8 +59,8 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this1.someLocalDateTime) = $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this1.someLocalDateTime) = $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -99,8 +99,8 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this1.someLocalDateTime) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this1.someLocalDateTime) > $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -139,8 +139,8 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this1.someLocalDateTime) >= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this1.someLocalDateTime) >= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -179,8 +179,8 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this1.someLocalDateTime) < $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this1.someLocalDateTime) < $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -219,8 +219,8 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this1.someLocalDateTime) <= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this1.someLocalDateTime) <= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -259,8 +259,8 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this1.someLocalDateTime) = $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this1.someLocalDateTime) = $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -299,8 +299,8 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this1.someLocalDateTime) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this1.someLocalDateTime) > $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -339,8 +339,8 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this1.someLocalDateTime) >= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this1.someLocalDateTime) >= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -379,8 +379,8 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this1.someLocalDateTime) < $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this1.someLocalDateTime) < $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -419,8 +419,8 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this1.someLocalDateTime) <= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this1.someLocalDateTime) <= $param0 AS var2
             }
             WITH *
             WHERE var2 = true

--- a/packages/graphql/tests/tck/aggregations/where/node/localtime.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/node/localtime.test.ts
@@ -57,8 +57,8 @@ describe("Cypher Aggregations where node with LocalTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this1.someLocalTime) = $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this1.someLocalTime) = $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -92,8 +92,8 @@ describe("Cypher Aggregations where node with LocalTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this1.someLocalTime) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this1.someLocalTime) > $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -127,8 +127,8 @@ describe("Cypher Aggregations where node with LocalTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this1.someLocalTime) >= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this1.someLocalTime) >= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -162,8 +162,8 @@ describe("Cypher Aggregations where node with LocalTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this1.someLocalTime) < $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this1.someLocalTime) < $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -197,8 +197,8 @@ describe("Cypher Aggregations where node with LocalTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this1.someLocalTime) <= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this1.someLocalTime) <= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -232,8 +232,8 @@ describe("Cypher Aggregations where node with LocalTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this1.someLocalTime) = $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this1.someLocalTime) = $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -267,8 +267,8 @@ describe("Cypher Aggregations where node with LocalTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this1.someLocalTime) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this1.someLocalTime) > $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -302,8 +302,8 @@ describe("Cypher Aggregations where node with LocalTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this1.someLocalTime) >= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this1.someLocalTime) >= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -337,8 +337,8 @@ describe("Cypher Aggregations where node with LocalTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this1.someLocalTime) < $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this1.someLocalTime) < $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -372,8 +372,8 @@ describe("Cypher Aggregations where node with LocalTime", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this1.someLocalTime) <= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this1.someLocalTime) <= $param0 AS var2
             }
             WITH *
             WHERE var2 = true

--- a/packages/graphql/tests/tck/aggregations/where/node/string.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/node/string.test.ts
@@ -57,8 +57,8 @@ describe("Cypher Aggregations where node with String", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(size(this1.name)) = $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(size(this1.name)) = $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -90,8 +90,8 @@ describe("Cypher Aggregations where node with String", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(size(this1.name)) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(size(this1.name)) > $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -123,8 +123,8 @@ describe("Cypher Aggregations where node with String", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(size(this1.name)) >= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(size(this1.name)) >= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -156,8 +156,8 @@ describe("Cypher Aggregations where node with String", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(size(this1.name)) < $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(size(this1.name)) < $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -189,8 +189,8 @@ describe("Cypher Aggregations where node with String", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(size(this1.name)) <= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(size(this1.name)) <= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -222,8 +222,8 @@ describe("Cypher Aggregations where node with String", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(size(this1.name)) = $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(size(this1.name)) = $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -255,8 +255,8 @@ describe("Cypher Aggregations where node with String", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(size(this1.name)) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(size(this1.name)) > $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -288,8 +288,8 @@ describe("Cypher Aggregations where node with String", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(size(this1.name)) >= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(size(this1.name)) >= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -321,8 +321,8 @@ describe("Cypher Aggregations where node with String", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(size(this1.name)) < $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(size(this1.name)) < $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -354,8 +354,8 @@ describe("Cypher Aggregations where node with String", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(size(this1.name)) <= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(size(this1.name)) <= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -387,8 +387,8 @@ describe("Cypher Aggregations where node with String", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN avg(size(this1.name)) = $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN avg(size(this1.name)) = $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -417,8 +417,8 @@ describe("Cypher Aggregations where node with String", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN avg(size(this1.name)) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN avg(size(this1.name)) > $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -447,8 +447,8 @@ describe("Cypher Aggregations where node with String", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN avg(size(this1.name)) >= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN avg(size(this1.name)) >= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -477,8 +477,8 @@ describe("Cypher Aggregations where node with String", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN avg(size(this1.name)) < $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN avg(size(this1.name)) < $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -507,8 +507,8 @@ describe("Cypher Aggregations where node with String", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN avg(size(this1.name)) <= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN avg(size(this1.name)) <= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -570,9 +570,9 @@ describe("Cypher Aggregations where node with String interface relationships of 
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1)
-                WHERE (this1:User:Employee OR this1:Person)
-                RETURN min(size(this1.name)) = $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1)
+              WHERE (this1:User&Employee OR this1:Person)
+              RETURN min(size(this1.name)) = $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -604,9 +604,9 @@ describe("Cypher Aggregations where node with String interface relationships of 
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1)
-                WHERE (this1:User:Employee OR this1:Person)
-                RETURN min(size(this1.name)) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1)
+              WHERE (this1:User&Employee OR this1:Person)
+              RETURN min(size(this1.name)) > $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -638,9 +638,9 @@ describe("Cypher Aggregations where node with String interface relationships of 
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1)
-                WHERE (this1:User:Employee OR this1:Person)
-                RETURN min(size(this1.name)) >= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1)
+              WHERE (this1:User&Employee OR this1:Person)
+              RETURN min(size(this1.name)) >= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -672,9 +672,9 @@ describe("Cypher Aggregations where node with String interface relationships of 
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1)
-                WHERE (this1:User:Employee OR this1:Person)
-                RETURN min(size(this1.name)) < $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1)
+              WHERE (this1:User&Employee OR this1:Person)
+              RETURN min(size(this1.name)) < $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -706,9 +706,9 @@ describe("Cypher Aggregations where node with String interface relationships of 
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1)
-                WHERE (this1:User:Employee OR this1:Person)
-                RETURN min(size(this1.name)) <= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1)
+              WHERE (this1:User&Employee OR this1:Person)
+              RETURN min(size(this1.name)) <= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -740,9 +740,9 @@ describe("Cypher Aggregations where node with String interface relationships of 
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1)
-                WHERE (this1:User:Employee OR this1:Person)
-                RETURN max(size(this1.name)) = $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1)
+              WHERE (this1:User&Employee OR this1:Person)
+              RETURN max(size(this1.name)) = $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -774,9 +774,9 @@ describe("Cypher Aggregations where node with String interface relationships of 
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1)
-                WHERE (this1:User:Employee OR this1:Person)
-                RETURN max(size(this1.name)) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1)
+              WHERE (this1:User&Employee OR this1:Person)
+              RETURN max(size(this1.name)) > $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -808,9 +808,9 @@ describe("Cypher Aggregations where node with String interface relationships of 
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1)
-                WHERE (this1:User:Employee OR this1:Person)
-                RETURN max(size(this1.name)) >= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1)
+              WHERE (this1:User&Employee OR this1:Person)
+              RETURN max(size(this1.name)) >= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -842,9 +842,9 @@ describe("Cypher Aggregations where node with String interface relationships of 
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1)
-                WHERE (this1:User:Employee OR this1:Person)
-                RETURN max(size(this1.name)) < $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1)
+              WHERE (this1:User&Employee OR this1:Person)
+              RETURN max(size(this1.name)) < $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -876,9 +876,9 @@ describe("Cypher Aggregations where node with String interface relationships of 
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1)
-                WHERE (this1:User:Employee OR this1:Person)
-                RETURN max(size(this1.name)) <= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1)
+              WHERE (this1:User&Employee OR this1:Person)
+              RETURN max(size(this1.name)) <= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -910,9 +910,9 @@ describe("Cypher Aggregations where node with String interface relationships of 
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1)
-                WHERE (this1:User:Employee OR this1:Person)
-                RETURN avg(size(this1.name)) = $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1)
+              WHERE (this1:User&Employee OR this1:Person)
+              RETURN avg(size(this1.name)) = $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -941,9 +941,9 @@ describe("Cypher Aggregations where node with String interface relationships of 
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1)
-                WHERE (this1:User:Employee OR this1:Person)
-                RETURN avg(size(this1.name)) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1)
+              WHERE (this1:User&Employee OR this1:Person)
+              RETURN avg(size(this1.name)) > $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -972,9 +972,9 @@ describe("Cypher Aggregations where node with String interface relationships of 
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1)
-                WHERE (this1:User:Employee OR this1:Person)
-                RETURN avg(size(this1.name)) >= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1)
+              WHERE (this1:User&Employee OR this1:Person)
+              RETURN avg(size(this1.name)) >= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -1003,9 +1003,9 @@ describe("Cypher Aggregations where node with String interface relationships of 
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1)
-                WHERE (this1:User:Employee OR this1:Person)
-                RETURN avg(size(this1.name)) < $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1)
+              WHERE (this1:User&Employee OR this1:Person)
+              RETURN avg(size(this1.name)) < $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -1034,9 +1034,9 @@ describe("Cypher Aggregations where node with String interface relationships of 
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1)
-                WHERE (this1:User:Employee OR this1:Person)
-                RETURN avg(size(this1.name)) <= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1)
+              WHERE (this1:User&Employee OR this1:Person)
+              RETURN avg(size(this1.name)) <= $param0 AS var2
             }
             WITH *
             WHERE var2 = true

--- a/packages/graphql/tests/tck/aggregations/where/node/time.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/node/time.test.ts
@@ -57,9 +57,9 @@ describe("Cypher Aggregations where node with Time", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                WITH DISTINCT this1
-                RETURN min(this1.someTime) = time($param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              WITH DISTINCT this1
+              RETURN min(this1.someTime) = time($param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -88,9 +88,9 @@ describe("Cypher Aggregations where node with Time", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                WITH DISTINCT this1
-                RETURN min(this1.someTime) > time($param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              WITH DISTINCT this1
+              RETURN min(this1.someTime) > time($param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -119,9 +119,9 @@ describe("Cypher Aggregations where node with Time", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                WITH DISTINCT this1
-                RETURN min(this1.someTime) >= time($param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              WITH DISTINCT this1
+              RETURN min(this1.someTime) >= time($param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -150,9 +150,9 @@ describe("Cypher Aggregations where node with Time", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                WITH DISTINCT this1
-                RETURN min(this1.someTime) < time($param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              WITH DISTINCT this1
+              RETURN min(this1.someTime) < time($param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -181,9 +181,9 @@ describe("Cypher Aggregations where node with Time", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                WITH DISTINCT this1
-                RETURN min(this1.someTime) <= time($param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              WITH DISTINCT this1
+              RETURN min(this1.someTime) <= time($param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -212,9 +212,9 @@ describe("Cypher Aggregations where node with Time", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                WITH DISTINCT this1
-                RETURN max(this1.someTime) = time($param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              WITH DISTINCT this1
+              RETURN max(this1.someTime) = time($param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -243,9 +243,9 @@ describe("Cypher Aggregations where node with Time", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                WITH DISTINCT this1
-                RETURN max(this1.someTime) > time($param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              WITH DISTINCT this1
+              RETURN max(this1.someTime) > time($param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -274,9 +274,9 @@ describe("Cypher Aggregations where node with Time", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                WITH DISTINCT this1
-                RETURN max(this1.someTime) >= time($param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              WITH DISTINCT this1
+              RETURN max(this1.someTime) >= time($param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -305,9 +305,9 @@ describe("Cypher Aggregations where node with Time", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                WITH DISTINCT this1
-                RETURN max(this1.someTime) < time($param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              WITH DISTINCT this1
+              RETURN max(this1.someTime) < time($param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -336,9 +336,9 @@ describe("Cypher Aggregations where node with Time", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                WITH DISTINCT this1
-                RETURN max(this1.someTime) <= time($param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              WITH DISTINCT this1
+              RETURN max(this1.someTime) <= time($param0) AS var2
             }
             WITH *
             WHERE var2 = true

--- a/packages/graphql/tests/tck/alias.test.ts
+++ b/packages/graphql/tests/tck/alias.test.ts
@@ -73,20 +73,20 @@ describe("Cypher Alias", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (m:Movie)
-                    RETURN m
-                }
-                WITH m AS this0
-                WITH this0 { aliasCustomId: this0.id } AS this0
-                RETURN collect(this0) AS var1
+              CALL (this) {
+                WITH this AS this
+                MATCH (m:Movie)
+                RETURN m
+              }
+              WITH m AS this0
+              WITH this0 { aliasCustomId: this0.id } AS this0
+              RETURN collect(this0) AS var1
             }
             CALL (this) {
-                MATCH (this)<-[this2:ACTED_IN]-(this3:Actor)
-                WITH DISTINCT this3
-                WITH this3 { aliasActorsName: this3.name } AS this3
-                RETURN collect(this3) AS var4
+              MATCH (this)<-[this2:ACTED_IN]-(this3:Actor)
+              WITH DISTINCT this3
+              WITH this3 { aliasActorsName: this3.name } AS this3
+              RETURN collect(this3) AS var4
             }
             RETURN this { movieId: this.id, actors: var4, custom: var1 } AS this"
         `);

--- a/packages/graphql/tests/tck/array-methods.test.ts
+++ b/packages/graphql/tests/tck/array-methods.test.ts
@@ -51,9 +51,8 @@ describe("Arrays Methods", () => {
             "CYPHER 5
             MATCH (this:Movie)
             WITH *
-            WHERE apoc.util.validatePredicate(this.ratings IS NULL, \\"Property ratings cannot be NULL\\", [0])
-            SET
-                this.ratings = (this.ratings + $param0)
+            WHERE apoc.util.validatePredicate(this.ratings IS NULL, 'Property ratings cannot be NULL', [0])
+            SET this.ratings = (this.ratings + $param0)
             WITH this
             RETURN this { .title, .ratings } AS this"
         `);
@@ -98,10 +97,10 @@ describe("Arrays Methods", () => {
             "CYPHER 5
             MATCH (this:Movie)
             WITH *
-            WHERE (apoc.util.validatePredicate(this.ratings IS NULL, \\"Property ratings cannot be NULL\\", [0]) AND apoc.util.validatePredicate(this.scores IS NULL, \\"Property scores cannot be NULL\\", [0]))
+            WHERE (apoc.util.validatePredicate(this.ratings IS NULL, 'Property ratings cannot be NULL', [0]) AND apoc.util.validatePredicate(this.scores IS NULL, 'Property scores cannot be NULL', [0]))
             SET
-                this.ratings = (this.ratings + $param0),
-                this.scores = (this.scores + $param1)
+              this.ratings = (this.ratings + $param0),
+              this.scores = (this.scores + $param1)
             WITH this
             RETURN this { .title, .ratings, .scores } AS this"
         `);
@@ -159,9 +158,8 @@ describe("Arrays Methods", () => {
             "CYPHER 5
             MATCH (this:Movie)
             WITH *
-            WHERE apoc.util.validatePredicate(this.filmingLocations IS NULL, \\"Property filmingLocations cannot be NULL\\", [0])
-            SET
-                this.filmingLocations = (this.filmingLocations + [var0 IN $param0 | point(var0)])
+            WHERE apoc.util.validatePredicate(this.filmingLocations IS NULL, 'Property filmingLocations cannot be NULL', [0])
+            SET this.filmingLocations = (this.filmingLocations + [var0 IN $param0 | point(var0)])
             WITH this
             RETURN this { .title, .filmingLocations } AS this"
         `);
@@ -218,14 +216,13 @@ describe("Arrays Methods", () => {
             "CYPHER 5
             MATCH (this:Movie)
             WITH *
-            WHERE apoc.util.validatePredicate(this.ratings IS NULL, \\"Property ratings cannot be NULL\\", [0])
+            WHERE apoc.util.validatePredicate(this.ratings IS NULL, 'Property ratings cannot be NULL', [0])
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
             WITH *
-            SET
-                this.ratings = (this.ratings + $param3)
+            SET this.ratings = (this.ratings + $param3)
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
             WITH this
             RETURN this { .title, .ratings } AS this"
         `);
@@ -274,9 +271,8 @@ describe("Arrays Methods", () => {
             "CYPHER 5
             MATCH (this:Movie)
             WITH *
-            WHERE apoc.util.validatePredicate(this.ratings IS NULL, \\"Property ratings cannot be NULL\\", [0])
-            SET
-                this.ratings = this.ratings[0..-$param0]
+            WHERE apoc.util.validatePredicate(this.ratings IS NULL, 'Property ratings cannot be NULL', [0])
+            SET this.ratings = this.ratings[0..-$param0]
             WITH this
             RETURN this { .title, .ratings } AS this"
         `);
@@ -322,10 +318,10 @@ describe("Arrays Methods", () => {
             "CYPHER 5
             MATCH (this:Movie)
             WITH *
-            WHERE (apoc.util.validatePredicate(this.ratings IS NULL, \\"Property ratings cannot be NULL\\", [0]) AND apoc.util.validatePredicate(this.scores IS NULL, \\"Property scores cannot be NULL\\", [0]))
+            WHERE (apoc.util.validatePredicate(this.ratings IS NULL, 'Property ratings cannot be NULL', [0]) AND apoc.util.validatePredicate(this.scores IS NULL, 'Property scores cannot be NULL', [0]))
             SET
-                this.ratings = this.ratings[0..-$param0],
-                this.scores = this.scores[0..-$param1]
+              this.ratings = this.ratings[0..-$param0],
+              this.scores = this.scores[0..-$param1]
             WITH this
             RETURN this { .title, .ratings, .scores } AS this"
         `);
@@ -383,14 +379,13 @@ describe("Arrays Methods", () => {
             "CYPHER 5
             MATCH (this:Movie)
             WITH *
-            WHERE apoc.util.validatePredicate(this.ratings IS NULL, \\"Property ratings cannot be NULL\\", [0])
+            WHERE apoc.util.validatePredicate(this.ratings IS NULL, 'Property ratings cannot be NULL', [0])
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
             WITH *
-            SET
-                this.ratings = this.ratings[0..-$param3]
+            SET this.ratings = this.ratings[0..-$param3]
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
             WITH this
             RETURN this { .title, .ratings } AS this"
         `);
@@ -442,10 +437,10 @@ describe("Arrays Methods", () => {
             "CYPHER 5
             MATCH (this:Movie)
             WITH *
-            WHERE (apoc.util.validatePredicate(this.ratings IS NULL, \\"Property ratings cannot be NULL\\", [0]) AND apoc.util.validatePredicate(this.scores IS NULL, \\"Property scores cannot be NULL\\", [0]))
+            WHERE (apoc.util.validatePredicate(this.ratings IS NULL, 'Property ratings cannot be NULL', [0]) AND apoc.util.validatePredicate(this.scores IS NULL, 'Property scores cannot be NULL', [0]))
             SET
-                this.ratings = (this.ratings + $param0),
-                this.scores = this.scores[0..-$param1]
+              this.ratings = (this.ratings + $param0),
+              this.scores = this.scores[0..-$param1]
             WITH this
             RETURN this { .title, .ratings, .scores } AS this"
         `);
@@ -514,28 +509,27 @@ describe("Arrays Methods", () => {
             WHERE this.id = $param0
             WITH *
             CALL (*) {
-                MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                WITH *
-                WHERE apoc.util.validatePredicate(this0.pay IS NULL, \\"Property pay cannot be NULL\\", [0])
-                SET
-                    this0.pay = (this0.pay + $param1)
+              MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+              WITH *
+              WHERE apoc.util.validatePredicate(this0.pay IS NULL, 'Property pay cannot be NULL', [0])
+              SET this0.pay = (this0.pay + $param1)
             }
             WITH this
             CALL (this) {
-                MATCH (this)-[this2:ACTED_IN]->(this3:Movie)
-                WITH DISTINCT this3
-                WITH this3 { .title } AS this3
-                RETURN collect(this3) AS var4
+              MATCH (this)-[this2:ACTED_IN]->(this3:Movie)
+              WITH DISTINCT this3
+              WITH this3 { .title } AS this3
+              RETURN collect(this3) AS var4
             }
             CALL (this) {
-                MATCH (this)-[this5:ACTED_IN]->(this6:Movie)
-                WITH collect({ node: this6, relationship: this5 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this6, edge.relationship AS this5
-                    RETURN collect({ properties: { pay: this5.pay, __resolveType: \\"ActedIn\\" }, node: { __id: id(this6), __resolveType: \\"Movie\\" } }) AS var7
-                }
-                RETURN { edges: var7 } AS var8
+              MATCH (this)-[this5:ACTED_IN]->(this6:Movie)
+              WITH collect({node: this6, relationship: this5}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this6, edge.relationship AS this5
+                RETURN collect({properties: {pay: this5.pay, __resolveType: 'ActedIn'}, node: {__id: elementId(this6), __resolveType: 'Movie'}}) AS var7
+              }
+              RETURN {edges: var7} AS var8
             }
             RETURN this { .name, actedIn: var4, actedInConnection: var8 } AS this"
         `);
@@ -601,28 +595,27 @@ describe("Arrays Methods", () => {
             WHERE this.id = $param0
             WITH *
             CALL (*) {
-                MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                WITH *
-                WHERE apoc.util.validatePredicate(this0.pay IS NULL, \\"Property pay cannot be NULL\\", [0])
-                SET
-                    this0.pay = this0.pay[0..-$param1]
+              MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+              WITH *
+              WHERE apoc.util.validatePredicate(this0.pay IS NULL, 'Property pay cannot be NULL', [0])
+              SET this0.pay = this0.pay[0..-$param1]
             }
             WITH this
             CALL (this) {
-                MATCH (this)-[this2:ACTED_IN]->(this3:Movie)
-                WITH DISTINCT this3
-                WITH this3 { .title } AS this3
-                RETURN collect(this3) AS var4
+              MATCH (this)-[this2:ACTED_IN]->(this3:Movie)
+              WITH DISTINCT this3
+              WITH this3 { .title } AS this3
+              RETURN collect(this3) AS var4
             }
             CALL (this) {
-                MATCH (this)-[this5:ACTED_IN]->(this6:Movie)
-                WITH collect({ node: this6, relationship: this5 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this6, edge.relationship AS this5
-                    RETURN collect({ properties: { pay: this5.pay, __resolveType: \\"ActedIn\\" }, node: { __id: id(this6), __resolveType: \\"Movie\\" } }) AS var7
-                }
-                RETURN { edges: var7 } AS var8
+              MATCH (this)-[this5:ACTED_IN]->(this6:Movie)
+              WITH collect({node: this6, relationship: this5}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this6, edge.relationship AS this5
+                RETURN collect({properties: {pay: this5.pay, __resolveType: 'ActedIn'}, node: {__id: elementId(this6), __resolveType: 'Movie'}}) AS var7
+              }
+              RETURN {edges: var7} AS var8
             }
             RETURN this { .name, actedIn: var4, actedInConnection: var8 } AS this"
         `);

--- a/packages/graphql/tests/tck/connections/alias.test.ts
+++ b/packages/graphql/tests/tck/connections/alias.test.ts
@@ -63,9 +63,9 @@ describe("Connections Alias", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WITH count(this1) AS totalCount
-                RETURN { totalCount: totalCount } AS var2
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WITH count(this1) AS totalCount
+              RETURN {totalCount: totalCount} AS var2
             }
             RETURN this { actors: var2 } AS this"
         `);
@@ -109,26 +109,26 @@ describe("Connections Alias", () => {
             MATCH (this:Movie)
             WHERE this.title = $param0
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE this1.name = $param1
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE this1.name = $param1
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({properties: {screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {name: this1.name, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             CALL (this) {
-                MATCH (this)<-[this4:ACTED_IN]-(this5:Actor)
-                WHERE this5.name = $param2
-                WITH collect({ node: this5, relationship: this4 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this5, edge.relationship AS this4
-                    RETURN collect({ properties: { screenTime: this4.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this5.name, __resolveType: \\"Actor\\" } }) AS var6
-                }
-                RETURN { edges: var6 } AS var7
+              MATCH (this)<-[this4:ACTED_IN]-(this5:Actor)
+              WHERE this5.name = $param2
+              WITH collect({node: this5, relationship: this4}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this5, edge.relationship AS this4
+                RETURN collect({properties: {screenTime: this4.screenTime, __resolveType: 'ActedIn'}, node: {name: this5.name, __resolveType: 'Actor'}}) AS var6
+              }
+              RETURN {edges: var6} AS var7
             }
             RETURN this { .title, hanks: var3, jenny: var7 } AS this"
         `);

--- a/packages/graphql/tests/tck/connections/filtering/composite.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/composite.test.ts
@@ -79,15 +79,15 @@ describe("Cypher -> Connections -> Filtering -> Composite", () => {
             MATCH (this:Movie)
             WHERE this.title = $param0
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE ((this1.firstName = $param1 AND this1.lastName = $param2) AND (this0.screenTime > $param3 AND this0.screenTime < $param4))
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { firstName: this1.firstName, lastName: this1.lastName, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE ((this1.firstName = $param1 AND this1.lastName = $param2) AND (this0.screenTime > $param3 AND this0.screenTime < $param4))
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({properties: {screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {firstName: this1.firstName, lastName: this1.lastName, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -141,15 +141,15 @@ describe("Cypher -> Connections -> Filtering -> Composite", () => {
             MATCH (this:Movie)
             WHERE this.title = $param0
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE (NOT (this1.firstName = $param1 AND this1.lastName = $param2) AND NOT (this0.screenTime > $param3 AND this0.screenTime < $param4))
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { firstName: this1.firstName, lastName: this1.lastName, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE (NOT (this1.firstName = $param1 AND this1.lastName = $param2) AND NOT (this0.screenTime > $param3 AND this0.screenTime < $param4))
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({properties: {screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {firstName: this1.firstName, lastName: this1.lastName, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -205,15 +205,15 @@ describe("Cypher -> Connections -> Filtering -> Composite", () => {
             MATCH (this:Movie)
             WHERE this.title = $param0
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE ((this1.firstName = $param1 AND this1.lastName = $param2) OR (this0.screenTime > $param3 AND this0.screenTime < $param4))
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { firstName: this1.firstName, lastName: this1.lastName, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE ((this1.firstName = $param1 AND this1.lastName = $param2) OR (this0.screenTime > $param3 AND this0.screenTime < $param4))
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({properties: {screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {firstName: this1.firstName, lastName: this1.lastName, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -271,15 +271,15 @@ describe("Cypher -> Connections -> Filtering -> Composite", () => {
             MATCH (this:Movie)
             WHERE this.title = $param0
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE NOT ((this1.firstName = $param1 AND this1.lastName = $param2) OR (this0.screenTime > $param3 AND this0.screenTime < $param4))
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { firstName: this1.firstName, lastName: this1.lastName, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE NOT ((this1.firstName = $param1 AND this1.lastName = $param2) OR (this0.screenTime > $param3 AND this0.screenTime < $param4))
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({properties: {screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {firstName: this1.firstName, lastName: this1.lastName, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -346,15 +346,15 @@ describe("Cypher -> Connections -> Filtering -> Composite", () => {
             MATCH (this:Movie)
             WHERE this.title = $param0
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE NOT (((this1.firstName = $param1 AND this1.lastName = $param2) OR (this0.screenTime > $param3 AND this0.screenTime < $param4)) AND (this1.firstName = $param5 AND this1.lastName = $param6))
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { firstName: this1.firstName, lastName: this1.lastName, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE NOT (((this1.firstName = $param1 AND this1.lastName = $param2) OR (this0.screenTime > $param3 AND this0.screenTime < $param4)) AND (this1.firstName = $param5 AND this1.lastName = $param6))
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({properties: {screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {firstName: this1.firstName, lastName: this1.lastName, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/connections/filtering/interface-relationships.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/interface-relationships.test.ts
@@ -93,27 +93,27 @@ describe("interface relationships with aliased fields", () => {
             "CYPHER 5
             MATCH (this:Actor)
             WHERE EXISTS {
-                MATCH (this)-[this0:ACTED_IN]->(this1)
-                WHERE (CASE
-                    WHEN this1:Movie THEN this1.movieTitle
-                    WHEN this1:Series THEN this1.seriesTitle
-                    ELSE this1.title
-                END = $param0 AND (this1:Movie OR this1:Series))
+              MATCH (this)-[this0:ACTED_IN]->(this1)
+              WHERE (CASE
+                WHEN this1:Movie THEN this1.movieTitle
+                WHEN this1:Series THEN this1.seriesTitle
+                ELSE this1.title
+              END = $param0 AND (this1:Movie OR this1:Series))
             }
             CALL (this) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this)-[this2:ACTED_IN]->(this3:Movie)
-                    WITH this3 { .runtime, title: this3.movieTitle, __resolveType: \\"Movie\\", __id: id(this3) } AS var4
-                    RETURN var4
-                    UNION
-                    WITH *
-                    MATCH (this)-[this5:ACTED_IN]->(this6:Series)
-                    WITH this6 { .episodes, title: this6.seriesTitle, __resolveType: \\"Series\\", __id: id(this6) } AS var4
-                    RETURN var4
-                }
-                WITH var4
-                RETURN collect(var4) AS var4
+              CALL (*) {
+                WITH *
+                MATCH (this)-[this2:ACTED_IN]->(this3:Movie)
+                WITH this3 { .runtime, title: this3.movieTitle, __resolveType: 'Movie', __id: elementId(this3) } AS var4
+                RETURN var4
+                UNION
+                WITH *
+                MATCH (this)-[this5:ACTED_IN]->(this6:Series)
+                WITH this6 { .episodes, title: this6.seriesTitle, __resolveType: 'Series', __id: elementId(this6) } AS var4
+                RETURN var4
+              }
+              WITH var4
+              RETURN collect(var4) AS var4
             }
             RETURN this { .name, actedIn: var4 } AS this"
         `);
@@ -143,12 +143,12 @@ describe("interface relationships with aliased fields", () => {
             "CYPHER 5
             MATCH (this:Actor)
             WHERE EXISTS {
-                MATCH (this)-[this0:ACTED_IN]->(this1)
-                WHERE (CASE
-                    WHEN this1:Movie THEN this1.movieTitle
-                    WHEN this1:Series THEN this1.seriesTitle
-                    ELSE this1.title
-                END = $param0 AND (this1:Movie OR this1:Series))
+              MATCH (this)-[this0:ACTED_IN]->(this1)
+              WHERE (CASE
+                WHEN this1:Movie THEN this1.movieTitle
+                WHEN this1:Series THEN this1.seriesTitle
+                ELSE this1.title
+              END = $param0 AND (this1:Movie OR this1:Series))
             }
             DETACH DELETE this"
         `);
@@ -185,24 +185,24 @@ describe("interface relationships with aliased fields", () => {
             MATCH (this:ProtectedActor)
             WITH *
             CALL apoc.util.validate(NOT ($isAuthenticated = true AND size([(this)-[this1:ACTED_IN]->(this0) WHERE (($jwt.title IS NOT NULL AND CASE
-                WHEN this0:Movie THEN this0.movieTitle
-                WHEN this0:Series THEN this0.seriesTitle
-                ELSE this0.title
-            END = $jwt.title) AND (this0:Movie OR this0:Series)) | 1]) > 0), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+              WHEN this0:Movie THEN this0.movieTitle
+              WHEN this0:Series THEN this0.seriesTitle
+              ELSE this0.title
+            END = $jwt.title) AND (this0:Movie OR this0:Series)) | 1]) > 0), '@neo4j/graphql/FORBIDDEN', [])
             CALL (this) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this)-[this2:ACTED_IN]->(this3:Movie)
-                    WITH this3 { .runtime, title: this3.movieTitle, __resolveType: \\"Movie\\", __id: id(this3) } AS var4
-                    RETURN var4
-                    UNION
-                    WITH *
-                    MATCH (this)-[this5:ACTED_IN]->(this6:Series)
-                    WITH this6 { .episodes, title: this6.seriesTitle, __resolveType: \\"Series\\", __id: id(this6) } AS var4
-                    RETURN var4
-                }
-                WITH var4
-                RETURN collect(var4) AS var4
+              CALL (*) {
+                WITH *
+                MATCH (this)-[this2:ACTED_IN]->(this3:Movie)
+                WITH this3 { .runtime, title: this3.movieTitle, __resolveType: 'Movie', __id: elementId(this3) } AS var4
+                RETURN var4
+                UNION
+                WITH *
+                MATCH (this)-[this5:ACTED_IN]->(this6:Series)
+                WITH this6 { .episodes, title: this6.seriesTitle, __resolveType: 'Series', __id: elementId(this6) } AS var4
+                RETURN var4
+              }
+              WITH var4
+              RETURN collect(var4) AS var4
             }
             RETURN this { name: this.dbName, actedIn: var4 } AS this"
         `);

--- a/packages/graphql/tests/tck/connections/filtering/node/and.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/node/and.test.ts
@@ -75,15 +75,15 @@ describe("Cypher -> Connections -> Filtering -> Node -> AND", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE (this1.firstName = $param0 AND this1.lastName = $param1)
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { firstName: this1.firstName, lastName: this1.lastName, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE (this1.firstName = $param0 AND this1.lastName = $param1)
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({properties: {screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {firstName: this1.firstName, lastName: this1.lastName, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -122,15 +122,15 @@ describe("Cypher -> Connections -> Filtering -> Node -> AND", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE NOT (this1.firstName = $param0)
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { firstName: this1.firstName, lastName: this1.lastName, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE NOT (this1.firstName = $param0)
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({properties: {screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {firstName: this1.firstName, lastName: this1.lastName, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/connections/filtering/node/arrays.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/node/arrays.test.ts
@@ -72,15 +72,15 @@ describe("Cypher -> Connections -> Filtering -> Node -> Arrays", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE this1.name IN $param0
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE this1.name IN $param0
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({properties: {screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {name: this1.name, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -121,15 +121,15 @@ describe("Cypher -> Connections -> Filtering -> Node -> Arrays", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE $param0 IN this1.favouriteColours
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, favouriteColours: this1.favouriteColours, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE $param0 IN this1.favouriteColours
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({properties: {screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {name: this1.name, favouriteColours: this1.favouriteColours, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/connections/filtering/node/equality.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/node/equality.test.ts
@@ -71,15 +71,15 @@ describe("Cypher -> Connections -> Filtering -> Node -> Equality", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE this1.name = $param0
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE this1.name = $param0
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({properties: {screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {name: this1.name, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -116,15 +116,15 @@ describe("Cypher -> Connections -> Filtering -> Node -> Equality", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE NOT (this1.name = $param0)
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE NOT (this1.name = $param0)
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({properties: {screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {name: this1.name, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/connections/filtering/node/numerical.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/node/numerical.test.ts
@@ -73,15 +73,15 @@ describe("Cypher -> Connections -> Filtering -> Node -> Numerical", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE this1.age < $param0
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, age: this1.age, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE this1.age < $param0
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({properties: {screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {name: this1.name, age: this1.age, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -122,15 +122,15 @@ describe("Cypher -> Connections -> Filtering -> Node -> Numerical", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE this1.age <= $param0
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, age: this1.age, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE this1.age <= $param0
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({properties: {screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {name: this1.name, age: this1.age, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -171,15 +171,15 @@ describe("Cypher -> Connections -> Filtering -> Node -> Numerical", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE this1.age > $param0
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, age: this1.age, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE this1.age > $param0
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({properties: {screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {name: this1.name, age: this1.age, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -220,15 +220,15 @@ describe("Cypher -> Connections -> Filtering -> Node -> Numerical", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE this1.age >= $param0
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, age: this1.age, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE this1.age >= $param0
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({properties: {screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {name: this1.name, age: this1.age, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/connections/filtering/node/or.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/node/or.test.ts
@@ -75,15 +75,15 @@ describe("Cypher -> Connections -> Filtering -> Node -> OR", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE (this1.firstName = $param0 OR this1.lastName = $param1)
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { firstName: this1.firstName, lastName: this1.lastName, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE (this1.firstName = $param0 OR this1.lastName = $param1)
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({properties: {screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {firstName: this1.firstName, lastName: this1.lastName, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/connections/filtering/node/points.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/node/points.test.ts
@@ -89,15 +89,15 @@ describe("Cypher -> Connections -> Filtering -> Node -> Points", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE point.distance(this1.currentLocation, point($param0.point)) = $param0.distance
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, currentLocation: this1.currentLocation, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE point.distance(this1.currentLocation, point($param0.point)) = $param0.distance
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({properties: {screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {name: this1.name, currentLocation: this1.currentLocation, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/connections/filtering/node/relationship.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/node/relationship.test.ts
@@ -64,18 +64,18 @@ describe("Cypher -> Connections -> Filtering -> Node -> Relationship", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE EXISTS {
-                    MATCH (this1)-[:ACTED_IN]->(this2:Movie)
-                    WHERE this2.title = $param0
-                }
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var3
-                }
-                RETURN { edges: var3 } AS var4
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE EXISTS {
+                MATCH (this1)-[:ACTED_IN]->(this2:Movie)
+                WHERE this2.title = $param0
+              }
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({node: {name: this1.name, __resolveType: 'Actor'}}) AS var3
+              }
+              RETURN {edges: var3} AS var4
             }
             RETURN this { .title, actorsConnection: var4 } AS this"
         `);

--- a/packages/graphql/tests/tck/connections/filtering/node/string.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/node/string.test.ts
@@ -79,15 +79,15 @@ describe("Cypher -> Connections -> Filtering -> Node -> String", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE this1.name CONTAINS $param0
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE this1.name CONTAINS $param0
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({properties: {screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {name: this1.name, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -124,15 +124,15 @@ describe("Cypher -> Connections -> Filtering -> Node -> String", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE this1.name STARTS WITH $param0
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE this1.name STARTS WITH $param0
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({properties: {screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {name: this1.name, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -169,15 +169,15 @@ describe("Cypher -> Connections -> Filtering -> Node -> String", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE this1.name ENDS WITH $param0
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE this1.name ENDS WITH $param0
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({properties: {screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {name: this1.name, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -214,15 +214,15 @@ describe("Cypher -> Connections -> Filtering -> Node -> String", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE this1.name =~ $param0
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE this1.name =~ $param0
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({properties: {screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {name: this1.name, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -259,15 +259,15 @@ describe("Cypher -> Connections -> Filtering -> Node -> String", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE toLower(this1.name) CONTAINS toLower($param0)
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE toLower(this1.name) CONTAINS toLower($param0)
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({properties: {screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {name: this1.name, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/connections/filtering/relationship/and.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/relationship/and.test.ts
@@ -75,15 +75,15 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> AND", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE (this0.role ENDS WITH $param0 AND this0.screenTime < $param1)
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ properties: { role: this0.role, screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE (this0.role ENDS WITH $param0 AND this0.screenTime < $param1)
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({properties: {role: this0.role, screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {name: this1.name, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -125,15 +125,15 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> AND", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE NOT (this0.role ENDS WITH $param0)
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ properties: { role: this0.role, screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE NOT (this0.role ENDS WITH $param0)
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({properties: {role: this0.role, screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {name: this1.name, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/connections/filtering/relationship/arrays.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/relationship/arrays.test.ts
@@ -72,15 +72,15 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Arrays", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE this0.screenTime IN $param0
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE this0.screenTime IN $param0
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({properties: {screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {name: this1.name, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -126,15 +126,15 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Arrays", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE $param0 IN this0.quotes
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE $param0 IN this0.quotes
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({properties: {screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {name: this1.name, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/connections/filtering/relationship/equality.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/relationship/equality.test.ts
@@ -71,15 +71,15 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Equality", () =>
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE this0.screenTime = $param0
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE this0.screenTime = $param0
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({properties: {screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {name: this1.name, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -119,15 +119,15 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Equality", () =>
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE NOT (this0.screenTime = $param0)
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE NOT (this0.screenTime = $param0)
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({properties: {screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {name: this1.name, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/connections/filtering/relationship/numerical.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/relationship/numerical.test.ts
@@ -71,15 +71,15 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Numerical", () =
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE this0.screenTime < $param0
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE this0.screenTime < $param0
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({properties: {screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {name: this1.name, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -119,15 +119,15 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Numerical", () =
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE this0.screenTime <= $param0
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE this0.screenTime <= $param0
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({properties: {screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {name: this1.name, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -167,15 +167,15 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Numerical", () =
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE this0.screenTime > $param0
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE this0.screenTime > $param0
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({properties: {screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {name: this1.name, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -215,15 +215,15 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Numerical", () =
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE this0.screenTime >= $param0
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE this0.screenTime >= $param0
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({properties: {screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {name: this1.name, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/connections/filtering/relationship/or.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/relationship/or.test.ts
@@ -75,15 +75,15 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> OR", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE (this0.role ENDS WITH $param0 OR this0.screenTime < $param1)
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ properties: { role: this0.role, screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE (this0.role ENDS WITH $param0 OR this0.screenTime < $param1)
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({properties: {role: this0.role, screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {name: this1.name, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -120,8 +120,8 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> OR", () => {
             "CYPHER 5
             MATCH (this:Movie)
             WHERE EXISTS {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE (this1.name = $param0 OR this0.role = $param1)
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE (this1.name = $param0 OR this0.role = $param1)
             }
             RETURN this { .title } AS this"
         `);

--- a/packages/graphql/tests/tck/connections/filtering/relationship/points.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/relationship/points.test.ts
@@ -87,15 +87,15 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Points", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE point.distance(this0.location, point($param0.point)) = $param0.distance
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ properties: { screenTime: this0.screenTime, location: this0.location, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE point.distance(this0.location, point($param0.point)) = $param0.distance
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({properties: {screenTime: this0.screenTime, location: this0.location, __resolveType: 'ActedIn'}, node: {name: this1.name, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/connections/filtering/relationship/string.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/relationship/string.test.ts
@@ -79,15 +79,15 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> String", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE this0.role CONTAINS $param0
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ properties: { role: this0.role, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE this0.role CONTAINS $param0
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({properties: {role: this0.role, __resolveType: 'ActedIn'}, node: {name: this1.name, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -124,15 +124,15 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> String", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE this0.role STARTS WITH $param0
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ properties: { role: this0.role, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE this0.role STARTS WITH $param0
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({properties: {role: this0.role, __resolveType: 'ActedIn'}, node: {name: this1.name, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -169,15 +169,15 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> String", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE this0.role ENDS WITH $param0
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ properties: { role: this0.role, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE this0.role ENDS WITH $param0
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({properties: {role: this0.role, __resolveType: 'ActedIn'}, node: {name: this1.name, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -214,15 +214,15 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> String", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE this0.role =~ $param0
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ properties: { role: this0.role, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE this0.role =~ $param0
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({properties: {role: this0.role, __resolveType: 'ActedIn'}, node: {name: this1.name, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/connections/filtering/relationship/temporal.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/relationship/temporal.test.ts
@@ -77,15 +77,15 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Temporal", () =>
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE (this0.startDate > $param0 AND this0.endDateTime < datetime($param1))
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ properties: { startDate: this0.startDate, endDateTime: apoc.date.convertFormat(toString(this0.endDateTime), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\"), __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE (this0.startDate > $param0 AND this0.endDateTime < datetime($param1))
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({properties: {startDate: this0.startDate, endDateTime: apoc.date.convertFormat(toString(this0.endDateTime), 'iso_zoned_date_time', 'iso_offset_date_time'), __resolveType: 'ActedIn'}, node: {name: this1.name, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/connections/interfaces.test.ts
+++ b/packages/graphql/tests/tck/connections/interfaces.test.ts
@@ -86,23 +86,23 @@ describe("Cypher -> Connections -> Interfaces", () => {
             "CYPHER 5
             MATCH (this:Actor)
             CALL (this) {
+              CALL (this) {
                 CALL (this) {
-                    CALL (this) {
-                        WITH this
-                        MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                        WITH { properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { __resolveType: \\"Movie\\", __id: id(this1), runtime: this1.runtime, title: this1.title } } AS edge
-                        RETURN edge
-                        UNION
-                        WITH this
-                        MATCH (this)-[this2:ACTED_IN]->(this3:Series)
-                        WITH { properties: { screenTime: this2.screenTime, __resolveType: \\"ActedIn\\" }, node: { __resolveType: \\"Series\\", __id: id(this3), episodes: this3.episodes, title: this3.title } } AS edge
-                        RETURN edge
-                    }
-                    RETURN collect(edge) AS edges
+                  WITH this
+                  MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+                  WITH {properties: {screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {__resolveType: 'Movie', __id: elementId(this1), runtime: this1.runtime, title: this1.title}} AS edge
+                  RETURN edge
+                  UNION
+                  WITH this
+                  MATCH (this)-[this2:ACTED_IN]->(this3:Series)
+                  WITH {properties: {screenTime: this2.screenTime, __resolveType: 'ActedIn'}, node: {__resolveType: 'Series', __id: elementId(this3), episodes: this3.episodes, title: this3.title}} AS edge
+                  RETURN edge
                 }
-                WITH edges
-                WITH edges, size(edges) AS totalCount
-                RETURN { edges: edges, totalCount: totalCount } AS var4
+                RETURN collect(edge) AS edges
+              }
+              WITH edges
+              WITH edges, size(edges) AS totalCount
+              RETURN {edges: edges, totalCount: totalCount} AS var4
             }
             RETURN this { .name, actedInConnection: var4 } AS this"
         `);
@@ -141,25 +141,25 @@ describe("Cypher -> Connections -> Interfaces", () => {
             "CYPHER 5
             MATCH (this:Actor)
             CALL (this) {
+              CALL (this) {
                 CALL (this) {
-                    CALL (this) {
-                        WITH this
-                        MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                        WHERE this1.title STARTS WITH $param0
-                        WITH { properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { __resolveType: \\"Movie\\", __id: id(this1), runtime: this1.runtime, title: this1.title } } AS edge
-                        RETURN edge
-                        UNION
-                        WITH this
-                        MATCH (this)-[this2:ACTED_IN]->(this3:Series)
-                        WHERE this3.title STARTS WITH $param1
-                        WITH { properties: { screenTime: this2.screenTime, __resolveType: \\"ActedIn\\" }, node: { __resolveType: \\"Series\\", __id: id(this3), episodes: this3.episodes, title: this3.title } } AS edge
-                        RETURN edge
-                    }
-                    RETURN collect(edge) AS edges
+                  WITH this
+                  MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+                  WHERE this1.title STARTS WITH $param0
+                  WITH {properties: {screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {__resolveType: 'Movie', __id: elementId(this1), runtime: this1.runtime, title: this1.title}} AS edge
+                  RETURN edge
+                  UNION
+                  WITH this
+                  MATCH (this)-[this2:ACTED_IN]->(this3:Series)
+                  WHERE this3.title STARTS WITH $param1
+                  WITH {properties: {screenTime: this2.screenTime, __resolveType: 'ActedIn'}, node: {__resolveType: 'Series', __id: elementId(this3), episodes: this3.episodes, title: this3.title}} AS edge
+                  RETURN edge
                 }
-                WITH edges
-                WITH edges, size(edges) AS totalCount
-                RETURN { edges: edges, totalCount: totalCount } AS var4
+                RETURN collect(edge) AS edges
+              }
+              WITH edges
+              WITH edges, size(edges) AS totalCount
+              RETURN {edges: edges, totalCount: totalCount} AS var4
             }
             RETURN this { .name, actedInConnection: var4 } AS this"
         `);
@@ -203,25 +203,25 @@ describe("Cypher -> Connections -> Interfaces", () => {
             "CYPHER 5
             MATCH (this:Actor)
             CALL (this) {
+              CALL (this) {
                 CALL (this) {
-                    CALL (this) {
-                        WITH this
-                        MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                        WHERE this0.screenTime > $param0
-                        WITH { properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { __resolveType: \\"Movie\\", __id: id(this1), runtime: this1.runtime, title: this1.title } } AS edge
-                        RETURN edge
-                        UNION
-                        WITH this
-                        MATCH (this)-[this2:ACTED_IN]->(this3:Series)
-                        WHERE this2.screenTime > $param1
-                        WITH { properties: { screenTime: this2.screenTime, __resolveType: \\"ActedIn\\" }, node: { __resolveType: \\"Series\\", __id: id(this3), episodes: this3.episodes, title: this3.title } } AS edge
-                        RETURN edge
-                    }
-                    RETURN collect(edge) AS edges
+                  WITH this
+                  MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+                  WHERE this0.screenTime > $param0
+                  WITH {properties: {screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {__resolveType: 'Movie', __id: elementId(this1), runtime: this1.runtime, title: this1.title}} AS edge
+                  RETURN edge
+                  UNION
+                  WITH this
+                  MATCH (this)-[this2:ACTED_IN]->(this3:Series)
+                  WHERE this2.screenTime > $param1
+                  WITH {properties: {screenTime: this2.screenTime, __resolveType: 'ActedIn'}, node: {__resolveType: 'Series', __id: elementId(this3), episodes: this3.episodes, title: this3.title}} AS edge
+                  RETURN edge
                 }
-                WITH edges
-                WITH edges, size(edges) AS totalCount
-                RETURN { edges: edges, totalCount: totalCount } AS var4
+                RETURN collect(edge) AS edges
+              }
+              WITH edges
+              WITH edges, size(edges) AS totalCount
+              RETURN {edges: edges, totalCount: totalCount} AS var4
             }
             RETURN this { .name, actedInConnection: var4 } AS this"
         `);
@@ -273,29 +273,29 @@ describe("Cypher -> Connections -> Interfaces", () => {
                     "CYPHER 5
                     MATCH (this:Actor)
                     CALL (this) {
+                      CALL (this) {
                         CALL (this) {
-                            CALL (this) {
-                                WITH this
-                                MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                                WITH { properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { __resolveType: \\"Movie\\", __id: id(this1), runtime: this1.runtime, title: this1.title } } AS edge
-                                RETURN edge
-                                UNION
-                                WITH this
-                                MATCH (this)-[this2:ACTED_IN]->(this3:Series)
-                                WITH { properties: { screenTime: this2.screenTime, __resolveType: \\"ActedIn\\" }, node: { __resolveType: \\"Series\\", __id: id(this3), episodes: this3.episodes, title: this3.title } } AS edge
-                                RETURN edge
-                            }
-                            RETURN collect(edge) AS edges
+                          WITH this
+                          MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+                          WITH {properties: {screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {__resolveType: 'Movie', __id: elementId(this1), runtime: this1.runtime, title: this1.title}} AS edge
+                          RETURN edge
+                          UNION
+                          WITH this
+                          MATCH (this)-[this2:ACTED_IN]->(this3:Series)
+                          WITH {properties: {screenTime: this2.screenTime, __resolveType: 'ActedIn'}, node: {__resolveType: 'Series', __id: elementId(this3), episodes: this3.episodes, title: this3.title}} AS edge
+                          RETURN edge
                         }
-                        WITH edges
-                        WITH edges, size(edges) AS totalCount
-                        CALL (edges) {
-                            UNWIND edges AS edge
-                            WITH edge
-                            ORDER BY edge.properties.screenTime ASC
-                            RETURN collect(edge) AS var4
-                        }
-                        RETURN { edges: var4, totalCount: totalCount } AS var5
+                        RETURN collect(edge) AS edges
+                      }
+                      WITH edges
+                      WITH edges, size(edges) AS totalCount
+                      CALL (edges) {
+                        UNWIND edges AS edge
+                        WITH edge
+                        ORDER BY edge.properties.screenTime ASC
+                        RETURN collect(edge) AS var4
+                      }
+                      RETURN {edges: var4, totalCount: totalCount} AS var5
                     }
                     RETURN this { .name, actedInConnection: var5 } AS this"
                 `);
@@ -334,29 +334,29 @@ describe("Cypher -> Connections -> Interfaces", () => {
                     "CYPHER 5
                     MATCH (this:Actor)
                     CALL (this) {
+                      CALL (this) {
                         CALL (this) {
-                            CALL (this) {
-                                WITH this
-                                MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                                WITH { properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { __resolveType: \\"Movie\\", __id: id(this1), runtime: this1.runtime, title: this1.title } } AS edge
-                                RETURN edge
-                                UNION
-                                WITH this
-                                MATCH (this)-[this2:ACTED_IN]->(this3:Series)
-                                WITH { properties: { screenTime: this2.screenTime, __resolveType: \\"ActedIn\\" }, node: { __resolveType: \\"Series\\", __id: id(this3), episodes: this3.episodes, title: this3.title } } AS edge
-                                RETURN edge
-                            }
-                            RETURN collect(edge) AS edges
+                          WITH this
+                          MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+                          WITH {properties: {screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {__resolveType: 'Movie', __id: elementId(this1), runtime: this1.runtime, title: this1.title}} AS edge
+                          RETURN edge
+                          UNION
+                          WITH this
+                          MATCH (this)-[this2:ACTED_IN]->(this3:Series)
+                          WITH {properties: {screenTime: this2.screenTime, __resolveType: 'ActedIn'}, node: {__resolveType: 'Series', __id: elementId(this3), episodes: this3.episodes, title: this3.title}} AS edge
+                          RETURN edge
                         }
-                        WITH edges
-                        WITH edges, size(edges) AS totalCount
-                        CALL (edges) {
-                            UNWIND edges AS edge
-                            WITH edge
-                            ORDER BY edge.node.title ASC
-                            RETURN collect(edge) AS var4
-                        }
-                        RETURN { edges: var4, totalCount: totalCount } AS var5
+                        RETURN collect(edge) AS edges
+                      }
+                      WITH edges
+                      WITH edges, size(edges) AS totalCount
+                      CALL (edges) {
+                        UNWIND edges AS edge
+                        WITH edge
+                        ORDER BY edge.node.title ASC
+                        RETURN collect(edge) AS var4
+                      }
+                      RETURN {edges: var4, totalCount: totalCount} AS var5
                     }
                     RETURN this { .name, actedInConnection: var5 } AS this"
                 `);
@@ -394,29 +394,29 @@ describe("Cypher -> Connections -> Interfaces", () => {
                     "CYPHER 5
                     MATCH (this:Actor)
                     CALL (this) {
+                      CALL (this) {
                         CALL (this) {
-                            CALL (this) {
-                                WITH this
-                                MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                                WITH { properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { __resolveType: \\"Movie\\", __id: id(this1), runtime: this1.runtime, title: this1.title } } AS edge
-                                RETURN edge
-                                UNION
-                                WITH this
-                                MATCH (this)-[this2:ACTED_IN]->(this3:Series)
-                                WITH { properties: { screenTime: this2.screenTime, __resolveType: \\"ActedIn\\" }, node: { __resolveType: \\"Series\\", __id: id(this3), episodes: this3.episodes, title: this3.title } } AS edge
-                                RETURN edge
-                            }
-                            RETURN collect(edge) AS edges
+                          WITH this
+                          MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+                          WITH {properties: {screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {__resolveType: 'Movie', __id: elementId(this1), runtime: this1.runtime, title: this1.title}} AS edge
+                          RETURN edge
+                          UNION
+                          WITH this
+                          MATCH (this)-[this2:ACTED_IN]->(this3:Series)
+                          WITH {properties: {screenTime: this2.screenTime, __resolveType: 'ActedIn'}, node: {__resolveType: 'Series', __id: elementId(this3), episodes: this3.episodes, title: this3.title}} AS edge
+                          RETURN edge
                         }
-                        WITH edges
-                        WITH edges, size(edges) AS totalCount
-                        CALL (edges) {
-                            UNWIND edges AS edge
-                            WITH edge
-                            ORDER BY edge.properties.screenTime ASC
-                            RETURN collect(edge) AS var4
-                        }
-                        RETURN { edges: var4, totalCount: totalCount } AS var5
+                        RETURN collect(edge) AS edges
+                      }
+                      WITH edges
+                      WITH edges, size(edges) AS totalCount
+                      CALL (edges) {
+                        UNWIND edges AS edge
+                        WITH edge
+                        ORDER BY edge.properties.screenTime ASC
+                        RETURN collect(edge) AS var4
+                      }
+                      RETURN {edges: var4, totalCount: totalCount} AS var5
                     }
                     RETURN this { .name, actedInConnection: var5 } AS this"
                 `);
@@ -454,29 +454,29 @@ describe("Cypher -> Connections -> Interfaces", () => {
                     "CYPHER 5
                     MATCH (this:Actor)
                     CALL (this) {
+                      CALL (this) {
                         CALL (this) {
-                            CALL (this) {
-                                WITH this
-                                MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                                WITH { properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { __resolveType: \\"Movie\\", __id: id(this1), runtime: this1.runtime, title: this1.title } } AS edge
-                                RETURN edge
-                                UNION
-                                WITH this
-                                MATCH (this)-[this2:ACTED_IN]->(this3:Series)
-                                WITH { properties: { screenTime: this2.screenTime, __resolveType: \\"ActedIn\\" }, node: { __resolveType: \\"Series\\", __id: id(this3), episodes: this3.episodes, title: this3.title } } AS edge
-                                RETURN edge
-                            }
-                            RETURN collect(edge) AS edges
+                          WITH this
+                          MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+                          WITH {properties: {screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {__resolveType: 'Movie', __id: elementId(this1), runtime: this1.runtime, title: this1.title}} AS edge
+                          RETURN edge
+                          UNION
+                          WITH this
+                          MATCH (this)-[this2:ACTED_IN]->(this3:Series)
+                          WITH {properties: {screenTime: this2.screenTime, __resolveType: 'ActedIn'}, node: {__resolveType: 'Series', __id: elementId(this3), episodes: this3.episodes, title: this3.title}} AS edge
+                          RETURN edge
                         }
-                        WITH edges
-                        WITH edges, size(edges) AS totalCount
-                        CALL (edges) {
-                            UNWIND edges AS edge
-                            WITH edge
-                            ORDER BY edge.node.title ASC
-                            RETURN collect(edge) AS var4
-                        }
-                        RETURN { edges: var4, totalCount: totalCount } AS var5
+                        RETURN collect(edge) AS edges
+                      }
+                      WITH edges
+                      WITH edges, size(edges) AS totalCount
+                      CALL (edges) {
+                        UNWIND edges AS edge
+                        WITH edge
+                        ORDER BY edge.node.title ASC
+                        RETURN collect(edge) AS var4
+                      }
+                      RETURN {edges: var4, totalCount: totalCount} AS var5
                     }
                     RETURN this { .name, actedInConnection: var5 } AS this"
                 `);

--- a/packages/graphql/tests/tck/connections/mixed-nesting.test.ts
+++ b/packages/graphql/tests/tck/connections/mixed-nesting.test.ts
@@ -75,22 +75,22 @@ describe("Mixed nesting", () => {
             MATCH (this:Movie)
             WHERE this.title = $param0
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE this1.name = $param1
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    CALL (this1) {
-                        MATCH (this1)-[this2:ACTED_IN]->(this3:Movie)
-                        WHERE NOT (this3.title = $param2)
-                        WITH DISTINCT this3
-                        WITH this3 { .title } AS this3
-                        RETURN collect(this3) AS var4
-                    }
-                    RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, movies: var4, __resolveType: \\"Actor\\" } }) AS var5
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE this1.name = $param1
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                CALL (this1) {
+                  MATCH (this1)-[this2:ACTED_IN]->(this3:Movie)
+                  WHERE NOT (this3.title = $param2)
+                  WITH DISTINCT this3
+                  WITH this3 { .title } AS this3
+                  RETURN collect(this3) AS var4
                 }
-                RETURN { edges: var5 } AS var6
+                RETURN collect({properties: {screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {name: this1.name, movies: var4, __resolveType: 'Actor'}}) AS var5
+              }
+              RETURN {edges: var5} AS var6
             }
             RETURN this { .title, actorsConnection: var6 } AS this"
         `);
@@ -140,33 +140,33 @@ describe("Mixed nesting", () => {
             MATCH (this:Movie)
             WHERE this.title = $param0
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE this1.name = $param1
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE this1.name = $param1
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                CALL (this1) {
+                  MATCH (this1)-[this2:ACTED_IN]->(this3:Movie)
+                  WHERE NOT (this3.title = $param2)
+                  WITH collect({node: this3, relationship: this2}) AS edges
+                  CALL (edges) {
                     UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    CALL (this1) {
-                        MATCH (this1)-[this2:ACTED_IN]->(this3:Movie)
-                        WHERE NOT (this3.title = $param2)
-                        WITH collect({ node: this3, relationship: this2 }) AS edges
-                        CALL (edges) {
-                            UNWIND edges AS edge
-                            WITH edge.node AS this3, edge.relationship AS this2
-                            CALL (this3) {
-                                MATCH (this3)<-[this4:ACTED_IN]-(this5:Actor)
-                                WHERE NOT (this5.name = $param3)
-                                WITH DISTINCT this5
-                                WITH this5 { .name } AS this5
-                                RETURN collect(this5) AS var6
-                            }
-                            RETURN collect({ node: { title: this3.title, actors: var6, __resolveType: \\"Movie\\" } }) AS var7
-                        }
-                        RETURN { edges: var7 } AS var8
+                    WITH edge.node AS this3, edge.relationship AS this2
+                    CALL (this3) {
+                      MATCH (this3)<-[this4:ACTED_IN]-(this5:Actor)
+                      WHERE NOT (this5.name = $param3)
+                      WITH DISTINCT this5
+                      WITH this5 { .name } AS this5
+                      RETURN collect(this5) AS var6
                     }
-                    RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, moviesConnection: var8, __resolveType: \\"Actor\\" } }) AS var9
+                    RETURN collect({node: {title: this3.title, actors: var6, __resolveType: 'Movie'}}) AS var7
+                  }
+                  RETURN {edges: var7} AS var8
                 }
-                RETURN { edges: var9 } AS var10
+                RETURN collect({properties: {screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {name: this1.name, moviesConnection: var8, __resolveType: 'Actor'}}) AS var9
+              }
+              RETURN {edges: var9} AS var10
             }
             RETURN this { .title, actorsConnection: var10 } AS this"
         `);
@@ -210,22 +210,22 @@ describe("Mixed nesting", () => {
             MATCH (this:Movie)
             WHERE this.title = $param0
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE this1.name = $param1
-                WITH DISTINCT this1
-                CALL (this1) {
-                    MATCH (this1)-[this2:ACTED_IN]->(this3:Movie)
-                    WHERE NOT (this3.title = $param2)
-                    WITH collect({ node: this3, relationship: this2 }) AS edges
-                    CALL (edges) {
-                        UNWIND edges AS edge
-                        WITH edge.node AS this3, edge.relationship AS this2
-                        RETURN collect({ properties: { screenTime: this2.screenTime, __resolveType: \\"ActedIn\\" }, node: { title: this3.title, __resolveType: \\"Movie\\" } }) AS var4
-                    }
-                    RETURN { edges: var4 } AS var5
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE this1.name = $param1
+              WITH DISTINCT this1
+              CALL (this1) {
+                MATCH (this1)-[this2:ACTED_IN]->(this3:Movie)
+                WHERE NOT (this3.title = $param2)
+                WITH collect({node: this3, relationship: this2}) AS edges
+                CALL (edges) {
+                  UNWIND edges AS edge
+                  WITH edge.node AS this3, edge.relationship AS this2
+                  RETURN collect({properties: {screenTime: this2.screenTime, __resolveType: 'ActedIn'}, node: {title: this3.title, __resolveType: 'Movie'}}) AS var4
                 }
-                WITH this1 { .name, moviesConnection: var5 } AS this1
-                RETURN collect(this1) AS var6
+                RETURN {edges: var4} AS var5
+              }
+              WITH this1 { .name, moviesConnection: var5 } AS this1
+              RETURN collect(this1) AS var6
             }
             RETURN this { .title, actors: var6 } AS this"
         `);

--- a/packages/graphql/tests/tck/connections/projections/create.test.ts
+++ b/packages/graphql/tests/tck/connections/projections/create.test.ts
@@ -73,20 +73,19 @@ describe("Cypher -> Connections -> Projections -> Create", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Movie)
-                SET
-                    create_this1.title = create_var0.title
-                RETURN create_this1
+              CREATE (create_this1:Movie)
+              SET create_this1.title = create_var0.title
+              RETURN create_this1
             }
             CALL (create_this1) {
-                MATCH (create_this1)<-[create_this2:ACTED_IN]-(create_this3:Actor)
-                WITH collect({ node: create_this3, relationship: create_this2 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS create_this3, edge.relationship AS create_this2
-                    RETURN collect({ properties: { screenTime: create_this2.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: create_this3.name, __resolveType: \\"Actor\\" } }) AS create_var4
-                }
-                RETURN { edges: create_var4 } AS create_var5
+              MATCH (create_this1)<-[create_this2:ACTED_IN]-(create_this3:Actor)
+              WITH collect({node: create_this3, relationship: create_this2}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS create_this3, edge.relationship AS create_this2
+                RETURN collect({properties: {screenTime: create_this2.screenTime, __resolveType: 'ActedIn'}, node: {name: create_this3.name, __resolveType: 'Actor'}}) AS create_var4
+              }
+              RETURN {edges: create_var4} AS create_var5
             }
             RETURN collect(create_this1 { .title, actorsConnection: create_var5 }) AS data"
         `);
@@ -129,20 +128,19 @@ describe("Cypher -> Connections -> Projections -> Create", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Movie)
-                SET
-                    create_this1.title = create_var0.title
-                RETURN create_this1
+              CREATE (create_this1:Movie)
+              SET create_this1.title = create_var0.title
+              RETURN create_this1
             }
             CALL (create_this1) {
-                MATCH (create_this1)<-[create_this2:ACTED_IN]-(create_this3:Actor)
-                WITH collect({ node: create_this3, relationship: create_this2 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS create_this3, edge.relationship AS create_this2
-                    RETURN collect({ properties: { screenTime: create_this2.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: create_this3.name, __resolveType: \\"Actor\\" } }) AS create_var4
-                }
-                RETURN { edges: create_var4 } AS create_var5
+              MATCH (create_this1)<-[create_this2:ACTED_IN]-(create_this3:Actor)
+              WITH collect({node: create_this3, relationship: create_this2}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS create_this3, edge.relationship AS create_this2
+                RETURN collect({properties: {screenTime: create_this2.screenTime, __resolveType: 'ActedIn'}, node: {name: create_this3.name, __resolveType: 'Actor'}}) AS create_var4
+              }
+              RETURN {edges: create_var4} AS create_var5
             }
             RETURN collect(create_this1 { .title, actorsConnection: create_var5 }) AS data"
         `);
@@ -188,21 +186,20 @@ describe("Cypher -> Connections -> Projections -> Create", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Movie)
-                SET
-                    create_this1.title = create_var0.title
-                RETURN create_this1
+              CREATE (create_this1:Movie)
+              SET create_this1.title = create_var0.title
+              RETURN create_this1
             }
             CALL (create_this1) {
-                MATCH (create_this1)<-[create_this2:ACTED_IN]-(create_this3:Actor)
-                WHERE create_this3.name = $create_param1
-                WITH collect({ node: create_this3, relationship: create_this2 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS create_this3, edge.relationship AS create_this2
-                    RETURN collect({ properties: { screenTime: create_this2.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: create_this3.name, __resolveType: \\"Actor\\" } }) AS create_var4
-                }
-                RETURN { edges: create_var4 } AS create_var5
+              MATCH (create_this1)<-[create_this2:ACTED_IN]-(create_this3:Actor)
+              WHERE create_this3.name = $create_param1
+              WITH collect({node: create_this3, relationship: create_this2}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS create_this3, edge.relationship AS create_this2
+                RETURN collect({properties: {screenTime: create_this2.screenTime, __resolveType: 'ActedIn'}, node: {name: create_this3.name, __resolveType: 'Actor'}}) AS create_var4
+              }
+              RETURN {edges: create_var4} AS create_var5
             }
             RETURN collect(create_this1 { .title, actorsConnection: create_var5 }) AS data"
         `);

--- a/packages/graphql/tests/tck/connections/projections/projections.test.ts
+++ b/packages/graphql/tests/tck/connections/projections/projections.test.ts
@@ -65,7 +65,7 @@ describe("Relay Cursor Connection projections", () => {
             MATCH (this0:Movie)
             WHERE this0.title = $param0
             WITH count(this0) AS totalCount
-            RETURN { totalCount: totalCount } AS this"
+            RETURN {totalCount: totalCount} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -91,7 +91,7 @@ describe("Relay Cursor Connection projections", () => {
             MATCH (this0:Movie)
             WHERE this0.title = $param0
             WITH count(this0) AS totalCount
-            RETURN { totalCount: totalCount } AS this"
+            RETURN {totalCount: totalCount} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -120,9 +120,9 @@ describe("Relay Cursor Connection projections", () => {
             MATCH (this:Movie)
             WHERE this.title = $param0
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WITH count(this1) AS totalCount
-                RETURN { totalCount: totalCount } AS var2
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WITH count(this1) AS totalCount
+              RETURN {totalCount: totalCount} AS var2
             }
             RETURN this { .title, actorsConnection: var2 } AS this"
         `);
@@ -158,14 +158,14 @@ describe("Relay Cursor Connection projections", () => {
             MATCH (this:Movie)
             WHERE this.title = $param0
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WITH collect({ node: this1, relationship: this0 }) AS edges, count(this1) AS totalCount
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ node: { __id: id(this1), __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WITH collect({node: this1, relationship: this0}) AS edges, count(this1) AS totalCount
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({node: {__id: elementId(this1), __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2, totalCount: totalCount} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -196,9 +196,9 @@ describe("Relay Cursor Connection projections", () => {
             MATCH (this:Movie)
             WHERE this.title = $param0
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WITH count(this1) AS totalCount
-                RETURN { totalCount: totalCount } AS var2
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WITH count(this1) AS totalCount
+              RETURN {totalCount: totalCount} AS var2
             }
             RETURN this { .title, actorsConnection: var2 } AS this"
         `);
@@ -229,23 +229,23 @@ describe("Relay Cursor Connection projections", () => {
             MATCH (this:Actor)
             WHERE this.name = $param0
             CALL (this) {
+              CALL (this) {
                 CALL (this) {
-                    CALL (this) {
-                        WITH this
-                        MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                        WITH { node: { __resolveType: \\"Movie\\", __id: id(this1) } } AS edge
-                        RETURN edge
-                        UNION
-                        WITH this
-                        MATCH (this)-[this2:ACTED_IN]->(this3:Series)
-                        WITH { node: { __resolveType: \\"Series\\", __id: id(this3) } } AS edge
-                        RETURN edge
-                    }
-                    RETURN collect(edge) AS edges
+                  WITH this
+                  MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+                  WITH {node: {__resolveType: 'Movie', __id: elementId(this1)}} AS edge
+                  RETURN edge
+                  UNION
+                  WITH this
+                  MATCH (this)-[this2:ACTED_IN]->(this3:Series)
+                  WITH {node: {__resolveType: 'Series', __id: elementId(this3)}} AS edge
+                  RETURN edge
                 }
-                WITH edges
-                WITH edges, size(edges) AS totalCount
-                RETURN { edges: edges, totalCount: totalCount } AS var4
+                RETURN collect(edge) AS edges
+              }
+              WITH edges
+              WITH edges, size(edges) AS totalCount
+              RETURN {edges: edges, totalCount: totalCount} AS var4
             }
             RETURN this { .name, productionsConnection: var4 } AS this"
         `);
@@ -281,23 +281,23 @@ describe("Relay Cursor Connection projections", () => {
             MATCH (this:Actor)
             WHERE this.name = $param0
             CALL (this) {
+              CALL (this) {
                 CALL (this) {
-                    CALL (this) {
-                        WITH this
-                        MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                        WITH { node: { __resolveType: \\"Movie\\", __id: id(this1) } } AS edge
-                        RETURN edge
-                        UNION
-                        WITH this
-                        MATCH (this)-[this2:ACTED_IN]->(this3:Series)
-                        WITH { node: { __resolveType: \\"Series\\", __id: id(this3) } } AS edge
-                        RETURN edge
-                    }
-                    RETURN collect(edge) AS edges
+                  WITH this
+                  MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+                  WITH {node: {__resolveType: 'Movie', __id: elementId(this1)}} AS edge
+                  RETURN edge
+                  UNION
+                  WITH this
+                  MATCH (this)-[this2:ACTED_IN]->(this3:Series)
+                  WITH {node: {__resolveType: 'Series', __id: elementId(this3)}} AS edge
+                  RETURN edge
                 }
-                WITH edges
-                WITH edges, size(edges) AS totalCount
-                RETURN { edges: edges, totalCount: totalCount } AS var4
+                RETURN collect(edge) AS edges
+              }
+              WITH edges
+              WITH edges, size(edges) AS totalCount
+              RETURN {edges: edges, totalCount: totalCount} AS var4
             }
             RETURN this { .name, productionsConnection: var4 } AS this"
         `);
@@ -333,14 +333,14 @@ describe("Relay Cursor Connection projections", () => {
             MATCH (this:Movie)
             WHERE this.title = $param0
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WITH collect({ node: this1, relationship: this0 }) AS edges, count(this1) AS totalCount
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WITH collect({node: this1, relationship: this0}) AS edges, count(this1) AS totalCount
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({node: {name: this1.name, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2, totalCount: totalCount} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -376,16 +376,16 @@ describe("Relay Cursor Connection projections", () => {
             MATCH (this:Movie)
             WHERE this.title = $param0
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WITH collect({ node: this1, relationship: this0 }) AS edges, count(this1) AS totalCount
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    WITH *
-                    LIMIT $param1
-                    RETURN collect({ node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WITH collect({node: this1, relationship: this0}) AS edges, count(this1) AS totalCount
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                WITH *
+                LIMIT $param1
+                RETURN collect({node: {name: this1.name, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2, totalCount: totalCount} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/connections/projections/update.test.ts
+++ b/packages/graphql/tests/tck/connections/projections/update.test.ts
@@ -76,14 +76,14 @@ describe("Cypher -> Connections -> Projections -> Update", () => {
             WHERE this.title = $param0
             WITH this
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({properties: {screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {name: this1.name, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/connections/relationship-properties.test.ts
+++ b/packages/graphql/tests/tck/connections/relationship-properties.test.ts
@@ -73,14 +73,14 @@ describe("Relationship Properties Cypher", () => {
             MATCH (this:Movie)
             WHERE this.title = $param0
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({properties: {screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {name: this1.name, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -118,15 +118,15 @@ describe("Relationship Properties Cypher", () => {
             MATCH (this:Movie)
             WHERE this.title = $param0
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE this1.name = $param1
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE this1.name = $param1
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({properties: {screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {name: this1.name, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -165,16 +165,16 @@ describe("Relationship Properties Cypher", () => {
             MATCH (this:Movie)
             WHERE this.title = $param0
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    WITH *
-                    ORDER BY this0.screenTime DESC
-                    RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                WITH *
+                ORDER BY this0.screenTime DESC
+                RETURN collect({properties: {screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {name: this1.name, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -210,16 +210,16 @@ describe("Relationship Properties Cypher", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    WITH *
-                    ORDER BY this0.year DESC, this1.name ASC
-                    RETURN collect({ properties: { year: this0.year, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                WITH *
+                ORDER BY this0.year DESC, this1.name ASC
+                RETURN collect({properties: {year: this0.year, __resolveType: 'ActedIn'}, node: {name: this1.name, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { actorsConnection: var3 } AS this"
         `);
@@ -250,16 +250,16 @@ describe("Relationship Properties Cypher", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    WITH *
-                    ORDER BY this1.name ASC, this0.year DESC
-                    RETURN collect({ properties: { year: this0.year, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                WITH *
+                ORDER BY this1.name ASC, this0.year DESC
+                RETURN collect({properties: {year: this0.year, __resolveType: 'ActedIn'}, node: {name: this1.name, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { actorsConnection: var3 } AS this"
         `);
@@ -303,24 +303,24 @@ describe("Relationship Properties Cypher", () => {
             MATCH (this:Movie)
             WHERE this.title = $param0
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                CALL (this1) {
+                  MATCH (this1)-[this2:ACTED_IN]->(this3:Movie)
+                  WITH collect({node: this3, relationship: this2}) AS edges
+                  CALL (edges) {
                     UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    CALL (this1) {
-                        MATCH (this1)-[this2:ACTED_IN]->(this3:Movie)
-                        WITH collect({ node: this3, relationship: this2 }) AS edges
-                        CALL (edges) {
-                            UNWIND edges AS edge
-                            WITH edge.node AS this3, edge.relationship AS this2
-                            RETURN collect({ properties: { screenTime: this2.screenTime, __resolveType: \\"ActedIn\\" }, node: { title: this3.title, __resolveType: \\"Movie\\" } }) AS var4
-                        }
-                        RETURN { edges: var4 } AS var5
-                    }
-                    RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, moviesConnection: var5, __resolveType: \\"Actor\\" } }) AS var6
+                    WITH edge.node AS this3, edge.relationship AS this2
+                    RETURN collect({properties: {screenTime: this2.screenTime, __resolveType: 'ActedIn'}, node: {title: this3.title, __resolveType: 'Movie'}}) AS var4
+                  }
+                  RETURN {edges: var4} AS var5
                 }
-                RETURN { edges: var6 } AS var7
+                RETURN collect({properties: {screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {name: this1.name, moviesConnection: var5, __resolveType: 'Actor'}}) AS var6
+              }
+              RETURN {edges: var6} AS var7
             }
             RETURN this { .title, actorsConnection: var7 } AS this"
         `);
@@ -378,34 +378,34 @@ describe("Relationship Properties Cypher", () => {
             MATCH (this:Movie)
             WHERE this.title = $param0
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                CALL (this1) {
+                  MATCH (this1)-[this2:ACTED_IN]->(this3:Movie)
+                  WITH collect({node: this3, relationship: this2}) AS edges
+                  CALL (edges) {
                     UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    CALL (this1) {
-                        MATCH (this1)-[this2:ACTED_IN]->(this3:Movie)
-                        WITH collect({ node: this3, relationship: this2 }) AS edges
-                        CALL (edges) {
-                            UNWIND edges AS edge
-                            WITH edge.node AS this3, edge.relationship AS this2
-                            CALL (this3) {
-                                MATCH (this3)<-[this4:ACTED_IN]-(this5:Actor)
-                                WITH collect({ node: this5, relationship: this4 }) AS edges
-                                CALL (edges) {
-                                    UNWIND edges AS edge
-                                    WITH edge.node AS this5, edge.relationship AS this4
-                                    RETURN collect({ properties: { screenTime: this4.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this5.name, __resolveType: \\"Actor\\" } }) AS var6
-                                }
-                                RETURN { edges: var6 } AS var7
-                            }
-                            RETURN collect({ properties: { screenTime: this2.screenTime, __resolveType: \\"ActedIn\\" }, node: { title: this3.title, actorsConnection: var7, __resolveType: \\"Movie\\" } }) AS var8
-                        }
-                        RETURN { edges: var8 } AS var9
+                    WITH edge.node AS this3, edge.relationship AS this2
+                    CALL (this3) {
+                      MATCH (this3)<-[this4:ACTED_IN]-(this5:Actor)
+                      WITH collect({node: this5, relationship: this4}) AS edges
+                      CALL (edges) {
+                        UNWIND edges AS edge
+                        WITH edge.node AS this5, edge.relationship AS this4
+                        RETURN collect({properties: {screenTime: this4.screenTime, __resolveType: 'ActedIn'}, node: {name: this5.name, __resolveType: 'Actor'}}) AS var6
+                      }
+                      RETURN {edges: var6} AS var7
                     }
-                    RETURN collect({ properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, moviesConnection: var9, __resolveType: \\"Actor\\" } }) AS var10
+                    RETURN collect({properties: {screenTime: this2.screenTime, __resolveType: 'ActedIn'}, node: {title: this3.title, actorsConnection: var7, __resolveType: 'Movie'}}) AS var8
+                  }
+                  RETURN {edges: var8} AS var9
                 }
-                RETURN { edges: var10 } AS var11
+                RETURN collect({properties: {screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {name: this1.name, moviesConnection: var9, __resolveType: 'Actor'}}) AS var10
+              }
+              RETURN {edges: var10} AS var11
             }
             RETURN this { .title, actorsConnection: var11 } AS this"
         `);

--- a/packages/graphql/tests/tck/connections/relationship_properties/connect.test.ts
+++ b/packages/graphql/tests/tck/connections/relationship_properties/connect.test.ts
@@ -72,31 +72,29 @@ describe("Relationship Properties Connect Cypher", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                CREATE (this0:Movie)
-                SET
-                    this0.title = $param0
-                WITH *
-                CALL (this0) {
-                    MATCH (this1:Actor)
-                    CREATE (this0)<-[this2:ACTED_IN]-(this1)
-                    SET
-                        this2.screenTime = $param1
-                }
-                RETURN this0 AS this
+              CREATE (this0:Movie)
+              SET this0.title = $param0
+              WITH *
+              CALL (this0) {
+                MATCH (this1:Actor)
+                CREATE (this0)<-[this2:ACTED_IN]-(this1)
+                SET this2.screenTime = $param1
+              }
+              RETURN this0 AS this
             }
             WITH this
             CALL (this) {
-                CALL (this) {
-                    MATCH (this)<-[this3:ACTED_IN]-(this4:Actor)
-                    WITH collect({ node: this4, relationship: this3 }) AS edges
-                    CALL (edges) {
-                        UNWIND edges AS edge
-                        WITH edge.node AS this4, edge.relationship AS this3
-                        RETURN collect({ properties: { screenTime: this3.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this4.name, __resolveType: \\"Actor\\" } }) AS var5
-                    }
-                    RETURN { edges: var5 } AS var6
+              CALL (this) {
+                MATCH (this)<-[this3:ACTED_IN]-(this4:Actor)
+                WITH collect({node: this4, relationship: this3}) AS edges
+                CALL (edges) {
+                  UNWIND edges AS edge
+                  WITH edge.node AS this4, edge.relationship AS this3
+                  RETURN collect({properties: {screenTime: this3.screenTime, __resolveType: 'ActedIn'}, node: {name: this4.name, __resolveType: 'Actor'}}) AS var5
                 }
-                RETURN this { .title, actorsConnection: var6 } AS var7
+                RETURN {edges: var5} AS var6
+              }
+              RETURN this { .title, actorsConnection: var6 } AS var7
             }
             RETURN collect(var7) AS data"
         `);
@@ -147,32 +145,30 @@ describe("Relationship Properties Connect Cypher", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                CREATE (this0:Movie)
-                SET
-                    this0.title = $param0
-                WITH *
-                CALL (this0) {
-                    MATCH (this1:Actor)
-                    WHERE this1.name = $param1
-                    CREATE (this0)<-[this2:ACTED_IN]-(this1)
-                    SET
-                        this2.screenTime = $param2
-                }
-                RETURN this0 AS this
+              CREATE (this0:Movie)
+              SET this0.title = $param0
+              WITH *
+              CALL (this0) {
+                MATCH (this1:Actor)
+                WHERE this1.name = $param1
+                CREATE (this0)<-[this2:ACTED_IN]-(this1)
+                SET this2.screenTime = $param2
+              }
+              RETURN this0 AS this
             }
             WITH this
             CALL (this) {
-                CALL (this) {
-                    MATCH (this)<-[this3:ACTED_IN]-(this4:Actor)
-                    WITH collect({ node: this4, relationship: this3 }) AS edges
-                    CALL (edges) {
-                        UNWIND edges AS edge
-                        WITH edge.node AS this4, edge.relationship AS this3
-                        RETURN collect({ properties: { screenTime: this3.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this4.name, __resolveType: \\"Actor\\" } }) AS var5
-                    }
-                    RETURN { edges: var5 } AS var6
+              CALL (this) {
+                MATCH (this)<-[this3:ACTED_IN]-(this4:Actor)
+                WITH collect({node: this4, relationship: this3}) AS edges
+                CALL (edges) {
+                  UNWIND edges AS edge
+                  WITH edge.node AS this4, edge.relationship AS this3
+                  RETURN collect({properties: {screenTime: this3.screenTime, __resolveType: 'ActedIn'}, node: {name: this4.name, __resolveType: 'Actor'}}) AS var5
                 }
-                RETURN this { .title, actorsConnection: var6 } AS var7
+                RETURN {edges: var5} AS var6
+              }
+              RETURN this { .title, actorsConnection: var6 } AS var7
             }
             RETURN collect(var7) AS data"
         `);
@@ -222,23 +218,22 @@ describe("Relationship Properties Connect Cypher", () => {
             WHERE this.title = $param0
             WITH *
             CALL (*) {
-                CALL (this) {
-                    MATCH (this0:Actor)
-                    CREATE (this)<-[this1:ACTED_IN]-(this0)
-                    SET
-                        this1.screenTime = $param1
-                }
+              CALL (this) {
+                MATCH (this0:Actor)
+                CREATE (this)<-[this1:ACTED_IN]-(this0)
+                SET this1.screenTime = $param1
+              }
             }
             WITH this
             CALL (this) {
-                MATCH (this)<-[this2:ACTED_IN]-(this3:Actor)
-                WITH collect({ node: this3, relationship: this2 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this3, edge.relationship AS this2
-                    RETURN collect({ properties: { screenTime: this2.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this3.name, __resolveType: \\"Actor\\" } }) AS var4
-                }
-                RETURN { edges: var4 } AS var5
+              MATCH (this)<-[this2:ACTED_IN]-(this3:Actor)
+              WITH collect({node: this3, relationship: this2}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this3, edge.relationship AS this2
+                RETURN collect({properties: {screenTime: this2.screenTime, __resolveType: 'ActedIn'}, node: {name: this3.name, __resolveType: 'Actor'}}) AS var4
+              }
+              RETURN {edges: var4} AS var5
             }
             RETURN this { .title, actorsConnection: var5 } AS this"
         `);
@@ -291,24 +286,23 @@ describe("Relationship Properties Connect Cypher", () => {
             WHERE this.title = $param0
             WITH *
             CALL (*) {
-                CALL (this) {
-                    MATCH (this0:Actor)
-                    WHERE this0.name = $param1
-                    CREATE (this)<-[this1:ACTED_IN]-(this0)
-                    SET
-                        this1.screenTime = $param2
-                }
+              CALL (this) {
+                MATCH (this0:Actor)
+                WHERE this0.name = $param1
+                CREATE (this)<-[this1:ACTED_IN]-(this0)
+                SET this1.screenTime = $param2
+              }
             }
             WITH this
             CALL (this) {
-                MATCH (this)<-[this2:ACTED_IN]-(this3:Actor)
-                WITH collect({ node: this3, relationship: this2 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this3, edge.relationship AS this2
-                    RETURN collect({ properties: { screenTime: this2.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this3.name, __resolveType: \\"Actor\\" } }) AS var4
-                }
-                RETURN { edges: var4 } AS var5
+              MATCH (this)<-[this2:ACTED_IN]-(this3:Actor)
+              WITH collect({node: this3, relationship: this2}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this3, edge.relationship AS this2
+                RETURN collect({properties: {screenTime: this2.screenTime, __resolveType: 'ActedIn'}, node: {name: this3.name, __resolveType: 'Actor'}}) AS var4
+              }
+              RETURN {edges: var4} AS var5
             }
             RETURN this { .title, actorsConnection: var5 } AS this"
         `);

--- a/packages/graphql/tests/tck/connections/relationship_properties/create.test.ts
+++ b/packages/graphql/tests/tck/connections/relationship_properties/create.test.ts
@@ -80,31 +80,28 @@ describe("Relationship Properties Create Cypher", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Movie)
-                SET
-                    create_this1.title = create_var0.title
-                WITH create_this1, create_var0
-                CALL (create_this1, create_var0) {
-                    UNWIND create_var0.actors.create AS create_var2
-                    CREATE (create_this3:Actor)
-                    SET
-                        create_this3.name = create_var2.node.name
-                    MERGE (create_this1)<-[create_this4:ACTED_IN]-(create_this3)
-                    SET
-                        create_this4.screenTime = create_var2.edge.screenTime
-                    RETURN collect(NULL) AS create_var5
-                }
-                RETURN create_this1
+              CREATE (create_this1:Movie)
+              SET create_this1.title = create_var0.title
+              WITH create_this1, create_var0
+              CALL (create_this1, create_var0) {
+                UNWIND create_var0.actors.create AS create_var2
+                CREATE (create_this3:Actor)
+                SET create_this3.name = create_var2.node.name
+                MERGE (create_this1)<-[create_this4:ACTED_IN]-(create_this3)
+                SET create_this4.screenTime = create_var2.edge.screenTime
+                RETURN collect(NULL) AS create_var5
+              }
+              RETURN create_this1
             }
             CALL (create_this1) {
-                MATCH (create_this1)<-[create_this6:ACTED_IN]-(create_this7:Actor)
-                WITH collect({ node: create_this7, relationship: create_this6 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS create_this7, edge.relationship AS create_this6
-                    RETURN collect({ properties: { screenTime: create_this6.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: create_this7.name, __resolveType: \\"Actor\\" } }) AS create_var8
-                }
-                RETURN { edges: create_var8 } AS create_var9
+              MATCH (create_this1)<-[create_this6:ACTED_IN]-(create_this7:Actor)
+              WITH collect({node: create_this7, relationship: create_this6}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS create_this7, edge.relationship AS create_this6
+                RETURN collect({properties: {screenTime: create_this6.screenTime, __resolveType: 'ActedIn'}, node: {name: create_this7.name, __resolveType: 'Actor'}}) AS create_var8
+              }
+              RETURN {edges: create_var8} AS create_var9
             }
             RETURN collect(create_this1 { .title, actorsConnection: create_var9 }) AS data"
         `);

--- a/packages/graphql/tests/tck/connections/relationship_properties/update.test.ts
+++ b/packages/graphql/tests/tck/connections/relationship_properties/update.test.ts
@@ -73,11 +73,10 @@ describe("Cypher -> Connections -> Relationship Properties -> Update", () => {
             WHERE this.title = $param0
             WITH *
             CALL (*) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WITH *
-                WHERE this1.name = $param1
-                SET
-                    this0.screenTime = $param2
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WITH *
+              WHERE this1.name = $param1
+              SET this0.screenTime = $param2
             }
             WITH this
             RETURN this { .title } AS this"
@@ -128,12 +127,12 @@ describe("Cypher -> Connections -> Relationship Properties -> Update", () => {
             WHERE this.title = $param0
             WITH *
             CALL (*) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WITH *
-                WHERE this1.name = $param1
-                SET
-                    this1.name = $param2,
-                    this0.screenTime = $param3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WITH *
+              WHERE this1.name = $param1
+              SET
+                this1.name = $param2,
+                this0.screenTime = $param3
             }
             WITH this
             RETURN this { .title } AS this"

--- a/packages/graphql/tests/tck/connections/sort.test.ts
+++ b/packages/graphql/tests/tck/connections/sort.test.ts
@@ -77,26 +77,26 @@ describe("Relationship Properties Cypher", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             MATCH (this0:Movie)
-            WITH collect({ node: this0 }) AS edges
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                WITH *
-                ORDER BY this0.title ASC
-                LIMIT $param0
-                CALL (this0) {
-                    MATCH (this0)<-[this1:ACTED_IN]-(this2:Actor)
-                    WITH collect({ node: this2, relationship: this1 }) AS edges
-                    CALL (edges) {
-                        UNWIND edges AS edge
-                        WITH edge.node AS this2, edge.relationship AS this1
-                        RETURN collect({ node: { name: this2.name, __resolveType: \\"Actor\\" } }) AS var3
-                    }
-                    RETURN { edges: var3 } AS var4
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              WITH *
+              ORDER BY this0.title ASC
+              LIMIT $param0
+              CALL (this0) {
+                MATCH (this0)<-[this1:ACTED_IN]-(this2:Actor)
+                WITH collect({node: this2, relationship: this1}) AS edges
+                CALL (edges) {
+                  UNWIND edges AS edge
+                  WITH edge.node AS this2, edge.relationship AS this1
+                  RETURN collect({node: {name: this2.name, __resolveType: 'Actor'}}) AS var3
                 }
-                RETURN collect({ node: { title: this0.title, actorsConnection: var4, __resolveType: \\"Movie\\" } }) AS var5
+                RETURN {edges: var3} AS var4
+              }
+              RETURN collect({node: {title: this0.title, actorsConnection: var4, __resolveType: 'Movie'}}) AS var5
             }
-            RETURN { edges: var5 } AS this"
+            RETURN {edges: var5} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -134,34 +134,34 @@ describe("Relationship Properties Cypher", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             MATCH (this0:Movie)
-            WITH collect({ node: this0 }) AS edges
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              CALL (this0) {
                 CALL (this0) {
-                    CALL (this0) {
-                        WITH this0 AS this
-                        MATCH (actor:Actor)-[:ACTED_IN]->(this) RETURN count(actor) as count
-                    }
-                    WITH count AS this1
-                    RETURN this1 AS var2
+                  WITH this0 AS this
+                  MATCH (actor:Actor)-[:ACTED_IN]->(this) RETURN count(actor) as count
                 }
-                WITH *
-                ORDER BY this0.title DESC, var2 ASC
-                LIMIT $param0
-                CALL (this0) {
-                    MATCH (this0)<-[this3:ACTED_IN]-(this4:Actor)
-                    WITH collect({ node: this4, relationship: this3 }) AS edges
-                    CALL (edges) {
-                        UNWIND edges AS edge
-                        WITH edge.node AS this4, edge.relationship AS this3
-                        RETURN collect({ node: { name: this4.name, __resolveType: \\"Actor\\" } }) AS var5
-                    }
-                    RETURN { edges: var5 } AS var6
+                WITH count AS this1
+                RETURN this1 AS var2
+              }
+              WITH *
+              ORDER BY this0.title DESC, var2 ASC
+              LIMIT $param0
+              CALL (this0) {
+                MATCH (this0)<-[this3:ACTED_IN]-(this4:Actor)
+                WITH collect({node: this4, relationship: this3}) AS edges
+                CALL (edges) {
+                  UNWIND edges AS edge
+                  WITH edge.node AS this4, edge.relationship AS this3
+                  RETURN collect({node: {name: this4.name, __resolveType: 'Actor'}}) AS var5
                 }
-                RETURN collect({ node: { title: this0.title, actorsConnection: var6, __resolveType: \\"Movie\\" } }) AS var7
+                RETURN {edges: var5} AS var6
+              }
+              RETURN collect({node: {title: this0.title, actorsConnection: var6, __resolveType: 'Movie'}}) AS var7
             }
-            RETURN { edges: var7 } AS this"
+            RETURN {edges: var7} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/connections/top-level-interfaces.test.ts
+++ b/packages/graphql/tests/tck/connections/top-level-interfaces.test.ts
@@ -80,22 +80,22 @@ describe("Top level interface connections", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL () {
-                CALL () {
-                    MATCH (this0:Movie)
-                    WHERE this0.title = $param0
-                    WITH { node: { __resolveType: \\"Movie\\", __id: id(this0), cost: this0.cost, title: this0.title } } AS edge
-                    RETURN edge
-                    UNION
-                    MATCH (this1:Series)
-                    WHERE this1.title = $param1
-                    WITH { node: { __resolveType: \\"Series\\", __id: id(this1), title: this1.title } } AS edge
-                    RETURN edge
-                }
-                RETURN collect(edge) AS edges
+              CALL () {
+                MATCH (this0:Movie)
+                WHERE this0.title = $param0
+                WITH {node: {__resolveType: 'Movie', __id: elementId(this0), cost: this0.cost, title: this0.title}} AS edge
+                RETURN edge
+                UNION
+                MATCH (this1:Series)
+                WHERE this1.title = $param1
+                WITH {node: {__resolveType: 'Series', __id: elementId(this1), title: this1.title}} AS edge
+                RETURN edge
+              }
+              RETURN collect(edge) AS edges
             }
             WITH edges
             WITH edges, size(edges) AS totalCount
-            RETURN { edges: edges, totalCount: totalCount } AS this"
+            RETURN {edges: edges, totalCount: totalCount} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -126,28 +126,28 @@ describe("Top level interface connections", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL () {
-                CALL () {
-                    MATCH (this0:Movie)
-                    WHERE this0.title = $param0
-                    WITH { node: { __resolveType: \\"Movie\\", __id: id(this0), cost: this0.cost, title: this0.title } } AS edge
-                    RETURN edge
-                    UNION
-                    MATCH (this1:Series)
-                    WHERE this1.title = $param1
-                    WITH { node: { __resolveType: \\"Series\\", __id: id(this1), title: this1.title } } AS edge
-                    RETURN edge
-                }
-                RETURN collect(edge) AS edges
+              CALL () {
+                MATCH (this0:Movie)
+                WHERE this0.title = $param0
+                WITH {node: {__resolveType: 'Movie', __id: elementId(this0), cost: this0.cost, title: this0.title}} AS edge
+                RETURN edge
+                UNION
+                MATCH (this1:Series)
+                WHERE this1.title = $param1
+                WITH {node: {__resolveType: 'Series', __id: elementId(this1), title: this1.title}} AS edge
+                RETURN edge
+              }
+              RETURN collect(edge) AS edges
             }
             WITH edges
             WITH edges, size(edges) AS totalCount
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge
-                LIMIT $param2
-                RETURN collect(edge) AS var2
+              UNWIND edges AS edge
+              WITH edge
+              LIMIT $param2
+              RETURN collect(edge) AS var2
             }
-            RETURN { edges: var2, totalCount: totalCount } AS this"
+            RETURN {edges: var2, totalCount: totalCount} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/connections/unions.test.ts
+++ b/packages/graphql/tests/tck/connections/unions.test.ts
@@ -83,23 +83,23 @@ describe("Cypher -> Connections -> Unions", () => {
             "CYPHER 5
             MATCH (this:Author)
             CALL (this) {
+              CALL (this) {
                 CALL (this) {
-                    CALL (this) {
-                        WITH this
-                        MATCH (this)-[this0:WROTE]->(this1:Book)
-                        WITH { properties: { words: this0.words, __resolveType: \\"Wrote\\" }, node: { __resolveType: \\"Book\\", __id: id(this1), title: this1.title } } AS edge
-                        RETURN edge
-                        UNION
-                        WITH this
-                        MATCH (this)-[this2:WROTE]->(this3:Journal)
-                        WITH { properties: { words: this2.words, __resolveType: \\"Wrote\\" }, node: { __resolveType: \\"Journal\\", __id: id(this3), subject: this3.subject } } AS edge
-                        RETURN edge
-                    }
-                    RETURN collect(edge) AS edges
+                  WITH this
+                  MATCH (this)-[this0:WROTE]->(this1:Book)
+                  WITH {properties: {words: this0.words, __resolveType: 'Wrote'}, node: {__resolveType: 'Book', __id: elementId(this1), title: this1.title}} AS edge
+                  RETURN edge
+                  UNION
+                  WITH this
+                  MATCH (this)-[this2:WROTE]->(this3:Journal)
+                  WITH {properties: {words: this2.words, __resolveType: 'Wrote'}, node: {__resolveType: 'Journal', __id: elementId(this3), subject: this3.subject}} AS edge
+                  RETURN edge
                 }
-                WITH edges
-                WITH edges, size(edges) AS totalCount
-                RETURN { edges: edges, totalCount: totalCount } AS var4
+                RETURN collect(edge) AS edges
+              }
+              WITH edges
+              WITH edges, size(edges) AS totalCount
+              RETURN {edges: edges, totalCount: totalCount} AS var4
             }
             RETURN this { .name, publicationsConnection: var4 } AS this"
         `);
@@ -142,25 +142,25 @@ describe("Cypher -> Connections -> Unions", () => {
             "CYPHER 5
             MATCH (this:Author)
             CALL (this) {
+              CALL (this) {
                 CALL (this) {
-                    CALL (this) {
-                        WITH this
-                        MATCH (this)-[this0:WROTE]->(this1:Book)
-                        WHERE this1.title = $param0
-                        WITH { properties: { words: this0.words, __resolveType: \\"Wrote\\" }, node: { __resolveType: \\"Book\\", __id: id(this1), title: this1.title } } AS edge
-                        RETURN edge
-                        UNION
-                        WITH this
-                        MATCH (this)-[this2:WROTE]->(this3:Journal)
-                        WHERE this3.subject = $param1
-                        WITH { properties: { words: this2.words, __resolveType: \\"Wrote\\" }, node: { __resolveType: \\"Journal\\", __id: id(this3), subject: this3.subject } } AS edge
-                        RETURN edge
-                    }
-                    RETURN collect(edge) AS edges
+                  WITH this
+                  MATCH (this)-[this0:WROTE]->(this1:Book)
+                  WHERE this1.title = $param0
+                  WITH {properties: {words: this0.words, __resolveType: 'Wrote'}, node: {__resolveType: 'Book', __id: elementId(this1), title: this1.title}} AS edge
+                  RETURN edge
+                  UNION
+                  WITH this
+                  MATCH (this)-[this2:WROTE]->(this3:Journal)
+                  WHERE this3.subject = $param1
+                  WITH {properties: {words: this2.words, __resolveType: 'Wrote'}, node: {__resolveType: 'Journal', __id: elementId(this3), subject: this3.subject}} AS edge
+                  RETURN edge
                 }
-                WITH edges
-                WITH edges, size(edges) AS totalCount
-                RETURN { edges: edges, totalCount: totalCount } AS var4
+                RETURN collect(edge) AS edges
+              }
+              WITH edges
+              WITH edges, size(edges) AS totalCount
+              RETURN {edges: edges, totalCount: totalCount} AS var4
             }
             RETURN this { .name, publicationsConnection: var4 } AS this"
         `);
@@ -205,25 +205,25 @@ describe("Cypher -> Connections -> Unions", () => {
             "CYPHER 5
             MATCH (this:Author)
             CALL (this) {
+              CALL (this) {
                 CALL (this) {
-                    CALL (this) {
-                        WITH this
-                        MATCH (this)-[this0:WROTE]->(this1:Book)
-                        WHERE this0.words = $param0
-                        WITH { properties: { words: this0.words, __resolveType: \\"Wrote\\" }, node: { __resolveType: \\"Book\\", __id: id(this1), title: this1.title } } AS edge
-                        RETURN edge
-                        UNION
-                        WITH this
-                        MATCH (this)-[this2:WROTE]->(this3:Journal)
-                        WHERE this2.words = $param1
-                        WITH { properties: { words: this2.words, __resolveType: \\"Wrote\\" }, node: { __resolveType: \\"Journal\\", __id: id(this3), subject: this3.subject } } AS edge
-                        RETURN edge
-                    }
-                    RETURN collect(edge) AS edges
+                  WITH this
+                  MATCH (this)-[this0:WROTE]->(this1:Book)
+                  WHERE this0.words = $param0
+                  WITH {properties: {words: this0.words, __resolveType: 'Wrote'}, node: {__resolveType: 'Book', __id: elementId(this1), title: this1.title}} AS edge
+                  RETURN edge
+                  UNION
+                  WITH this
+                  MATCH (this)-[this2:WROTE]->(this3:Journal)
+                  WHERE this2.words = $param1
+                  WITH {properties: {words: this2.words, __resolveType: 'Wrote'}, node: {__resolveType: 'Journal', __id: elementId(this3), subject: this3.subject}} AS edge
+                  RETURN edge
                 }
-                WITH edges
-                WITH edges, size(edges) AS totalCount
-                RETURN { edges: edges, totalCount: totalCount } AS var4
+                RETURN collect(edge) AS edges
+              }
+              WITH edges
+              WITH edges, size(edges) AS totalCount
+              RETURN {edges: edges, totalCount: totalCount} AS var4
             }
             RETURN this { .name, publicationsConnection: var4 } AS this"
         `);
@@ -277,25 +277,25 @@ describe("Cypher -> Connections -> Unions", () => {
             "CYPHER 5
             MATCH (this:Author)
             CALL (this) {
+              CALL (this) {
                 CALL (this) {
-                    CALL (this) {
-                        WITH this
-                        MATCH (this)-[this0:WROTE]->(this1:Book)
-                        WHERE (this1.title = $param0 AND this0.words = $param1)
-                        WITH { properties: { words: this0.words, __resolveType: \\"Wrote\\" }, node: { __resolveType: \\"Book\\", __id: id(this1), title: this1.title } } AS edge
-                        RETURN edge
-                        UNION
-                        WITH this
-                        MATCH (this)-[this2:WROTE]->(this3:Journal)
-                        WHERE (this3.subject = $param2 AND this2.words = $param3)
-                        WITH { properties: { words: this2.words, __resolveType: \\"Wrote\\" }, node: { __resolveType: \\"Journal\\", __id: id(this3), subject: this3.subject } } AS edge
-                        RETURN edge
-                    }
-                    RETURN collect(edge) AS edges
+                  WITH this
+                  MATCH (this)-[this0:WROTE]->(this1:Book)
+                  WHERE (this1.title = $param0 AND this0.words = $param1)
+                  WITH {properties: {words: this0.words, __resolveType: 'Wrote'}, node: {__resolveType: 'Book', __id: elementId(this1), title: this1.title}} AS edge
+                  RETURN edge
+                  UNION
+                  WITH this
+                  MATCH (this)-[this2:WROTE]->(this3:Journal)
+                  WHERE (this3.subject = $param2 AND this2.words = $param3)
+                  WITH {properties: {words: this2.words, __resolveType: 'Wrote'}, node: {__resolveType: 'Journal', __id: elementId(this3), subject: this3.subject}} AS edge
+                  RETURN edge
                 }
-                WITH edges
-                WITH edges, size(edges) AS totalCount
-                RETURN { edges: edges, totalCount: totalCount } AS var4
+                RETURN collect(edge) AS edges
+              }
+              WITH edges
+              WITH edges, size(edges) AS totalCount
+              RETURN {edges: edges, totalCount: totalCount} AS var4
             }
             RETURN this { .name, publicationsConnection: var4 } AS this"
         `);
@@ -346,29 +346,29 @@ describe("Cypher -> Connections -> Unions", () => {
             "CYPHER 5
             MATCH (this:Author)
             CALL (this) {
+              CALL (this) {
                 CALL (this) {
-                    CALL (this) {
-                        WITH this
-                        MATCH (this)-[this0:WROTE]->(this1:Book)
-                        WITH { properties: { words: this0.words, __resolveType: \\"Wrote\\" }, node: { __resolveType: \\"Book\\", __id: id(this1), title: this1.title } } AS edge
-                        RETURN edge
-                        UNION
-                        WITH this
-                        MATCH (this)-[this2:WROTE]->(this3:Journal)
-                        WITH { properties: { words: this2.words, __resolveType: \\"Wrote\\" }, node: { __resolveType: \\"Journal\\", __id: id(this3), subject: this3.subject } } AS edge
-                        RETURN edge
-                    }
-                    RETURN collect(edge) AS edges
+                  WITH this
+                  MATCH (this)-[this0:WROTE]->(this1:Book)
+                  WITH {properties: {words: this0.words, __resolveType: 'Wrote'}, node: {__resolveType: 'Book', __id: elementId(this1), title: this1.title}} AS edge
+                  RETURN edge
+                  UNION
+                  WITH this
+                  MATCH (this)-[this2:WROTE]->(this3:Journal)
+                  WITH {properties: {words: this2.words, __resolveType: 'Wrote'}, node: {__resolveType: 'Journal', __id: elementId(this3), subject: this3.subject}} AS edge
+                  RETURN edge
                 }
-                WITH edges
-                WITH edges, size(edges) AS totalCount
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge
-                    ORDER BY edge.properties.words ASC
-                    RETURN collect(edge) AS var4
-                }
-                RETURN { edges: var4, totalCount: totalCount } AS var5
+                RETURN collect(edge) AS edges
+              }
+              WITH edges
+              WITH edges, size(edges) AS totalCount
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge
+                ORDER BY edge.properties.words ASC
+                RETURN collect(edge) AS var4
+              }
+              RETURN {edges: var4, totalCount: totalCount} AS var5
             }
             RETURN this { .name, publicationsConnection: var5 } AS this"
         `);

--- a/packages/graphql/tests/tck/deprecated/aggregations/where/node/int-deprecated.test.ts
+++ b/packages/graphql/tests/tck/deprecated/aggregations/where/node/int-deprecated.test.ts
@@ -57,8 +57,8 @@ describe("Cypher Aggregations where node with Int - deprecated", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN avg(this1.someInt) = $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN avg(this1.someInt) = $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -87,8 +87,8 @@ describe("Cypher Aggregations where node with Int - deprecated", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN avg(this1.someInt) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN avg(this1.someInt) > $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -117,8 +117,8 @@ describe("Cypher Aggregations where node with Int - deprecated", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN avg(this1.someInt) >= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN avg(this1.someInt) >= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -147,8 +147,8 @@ describe("Cypher Aggregations where node with Int - deprecated", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN avg(this1.someInt) < $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN avg(this1.someInt) < $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -177,8 +177,8 @@ describe("Cypher Aggregations where node with Int - deprecated", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN avg(this1.someInt) <= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN avg(this1.someInt) <= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -207,8 +207,8 @@ describe("Cypher Aggregations where node with Int - deprecated", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN sum(this1.someInt) = $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN sum(this1.someInt) = $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -240,8 +240,8 @@ describe("Cypher Aggregations where node with Int - deprecated", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN sum(this1.someInt) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN sum(this1.someInt) > $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -273,8 +273,8 @@ describe("Cypher Aggregations where node with Int - deprecated", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN sum(this1.someInt) >= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN sum(this1.someInt) >= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -306,8 +306,8 @@ describe("Cypher Aggregations where node with Int - deprecated", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN sum(this1.someInt) < $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN sum(this1.someInt) < $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -339,8 +339,8 @@ describe("Cypher Aggregations where node with Int - deprecated", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN sum(this1.someInt) <= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN sum(this1.someInt) <= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -372,8 +372,8 @@ describe("Cypher Aggregations where node with Int - deprecated", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this1.someInt) = $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this1.someInt) = $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -405,8 +405,8 @@ describe("Cypher Aggregations where node with Int - deprecated", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this1.someInt) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this1.someInt) > $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -438,8 +438,8 @@ describe("Cypher Aggregations where node with Int - deprecated", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this1.someInt) >= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this1.someInt) >= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -471,8 +471,8 @@ describe("Cypher Aggregations where node with Int - deprecated", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this1.someInt) < $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this1.someInt) < $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -504,8 +504,8 @@ describe("Cypher Aggregations where node with Int - deprecated", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this1.someInt) <= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this1.someInt) <= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -537,8 +537,8 @@ describe("Cypher Aggregations where node with Int - deprecated", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this1.someInt) = $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this1.someInt) = $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -570,8 +570,8 @@ describe("Cypher Aggregations where node with Int - deprecated", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this1.someInt) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this1.someInt) > $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -603,8 +603,8 @@ describe("Cypher Aggregations where node with Int - deprecated", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this1.someInt) >= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this1.someInt) >= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -636,8 +636,8 @@ describe("Cypher Aggregations where node with Int - deprecated", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this1.someInt) < $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this1.someInt) < $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -669,8 +669,8 @@ describe("Cypher Aggregations where node with Int - deprecated", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this1.someInt) <= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this1.someInt) <= $param0 AS var2
             }
             WITH *
             WHERE var2 = true

--- a/packages/graphql/tests/tck/deprecated/aggregations/where/node/time-deprecated.test.ts
+++ b/packages/graphql/tests/tck/deprecated/aggregations/where/node/time-deprecated.test.ts
@@ -57,8 +57,8 @@ describe("Cypher Aggregations where node with Time - deprecated", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this1.someTime) = time($param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this1.someTime) = time($param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -87,8 +87,8 @@ describe("Cypher Aggregations where node with Time - deprecated", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this1.someTime) > time($param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this1.someTime) > time($param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -117,8 +117,8 @@ describe("Cypher Aggregations where node with Time - deprecated", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this1.someTime) >= time($param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this1.someTime) >= time($param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -147,8 +147,8 @@ describe("Cypher Aggregations where node with Time - deprecated", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this1.someTime) < time($param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this1.someTime) < time($param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -177,8 +177,8 @@ describe("Cypher Aggregations where node with Time - deprecated", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN min(this1.someTime) <= time($param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN min(this1.someTime) <= time($param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -207,8 +207,8 @@ describe("Cypher Aggregations where node with Time - deprecated", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this1.someTime) = time($param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this1.someTime) = time($param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -237,8 +237,8 @@ describe("Cypher Aggregations where node with Time - deprecated", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this1.someTime) > time($param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this1.someTime) > time($param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -267,8 +267,8 @@ describe("Cypher Aggregations where node with Time - deprecated", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this1.someTime) >= time($param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this1.someTime) >= time($param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -297,8 +297,8 @@ describe("Cypher Aggregations where node with Time - deprecated", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this1.someTime) < time($param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this1.someTime) < time($param0) AS var2
             }
             WITH *
             WHERE var2 = true
@@ -327,8 +327,8 @@ describe("Cypher Aggregations where node with Time - deprecated", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN max(this1.someTime) <= time($param0) AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN max(this1.someTime) <= time($param0) AS var2
             }
             WITH *
             WHERE var2 = true

--- a/packages/graphql/tests/tck/deprecated/cypher-sort-deprecated.test.ts
+++ b/packages/graphql/tests/tck/deprecated/cypher-sort-deprecated.test.ts
@@ -178,13 +178,13 @@ describe("Cypher sort deprecated", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:HAS_GENRE]->(genre:Genre)
-                    RETURN count(DISTINCT genre) as result
-                }
-                WITH result AS this0
-                RETURN this0 AS var1
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:HAS_GENRE]->(genre:Genre)
+                RETURN count(DISTINCT genre) as result
+              }
+              WITH result AS this0
+              RETURN this0 AS var1
             }
             WITH *
             ORDER BY var1 DESC
@@ -209,13 +209,13 @@ describe("Cypher sort deprecated", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:HAS_GENRE]->(genre:Genre)
-                    RETURN count(DISTINCT genre) as result
-                }
-                WITH result AS this0
-                RETURN this0 AS var1
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:HAS_GENRE]->(genre:Genre)
+                RETURN count(DISTINCT genre) as result
+              }
+              WITH result AS this0
+              RETURN this0 AS var1
             }
             RETURN this { totalGenres: var1 } AS this"
         `);
@@ -238,13 +238,13 @@ describe("Cypher sort deprecated", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:HAS_GENRE]->(genre:Genre)
-                    RETURN count(DISTINCT genre) as result
-                }
-                WITH result AS this0
-                RETURN this0 AS var1
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:HAS_GENRE]->(genre:Genre)
+                RETURN count(DISTINCT genre) as result
+              }
+              WITH result AS this0
+              RETURN this0 AS var1
             }
             WITH *
             ORDER BY var1 DESC
@@ -339,11 +339,11 @@ describe("Cypher sort deprecated", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)-[this0:HAS_GENRE]->(this1:Genre)
-                WITH DISTINCT this1
-                WITH this1 { .name } AS this1
-                ORDER BY this1.name DESC
-                RETURN collect(this1) AS var2
+              MATCH (this)-[this0:HAS_GENRE]->(this1:Genre)
+              WITH DISTINCT this1
+              WITH this1 { .name } AS this1
+              ORDER BY this1.name DESC
+              RETURN collect(this1) AS var2
             }
             RETURN this { genres: var2 } AS this"
         `);
@@ -368,11 +368,11 @@ describe("Cypher sort deprecated", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)-[this0:HAS_GENRE]->(this1:Genre)
-                WITH DISTINCT this1
-                WITH this1 { .name } AS this1
-                ORDER BY this1.name ASC
-                RETURN collect(this1) AS var2
+              MATCH (this)-[this0:HAS_GENRE]->(this1:Genre)
+              WITH DISTINCT this1
+              WITH this1 { .name } AS this1
+              ORDER BY this1.name ASC
+              RETURN collect(this1) AS var2
             }
             RETURN this { genres: var2 } AS this"
         `);
@@ -398,20 +398,20 @@ describe("Cypher sort deprecated", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)-[this0:HAS_GENRE]->(this1:Genre)
-                WITH DISTINCT this1
+              MATCH (this)-[this0:HAS_GENRE]->(this1:Genre)
+              WITH DISTINCT this1
+              CALL (this1) {
                 CALL (this1) {
-                    CALL (this1) {
-                        WITH this1 AS this
-                        MATCH (this)<-[:HAS_GENRE]-(movie:Movie)
-                        RETURN count(DISTINCT movie) as result
-                    }
-                    WITH result AS this2
-                    RETURN this2 AS var3
+                  WITH this1 AS this
+                  MATCH (this)<-[:HAS_GENRE]-(movie:Movie)
+                  RETURN count(DISTINCT movie) as result
                 }
-                WITH this1 { .name, totalMovies: var3 } AS this1
-                ORDER BY var3 ASC
-                RETURN collect(this1) AS var4
+                WITH result AS this2
+                RETURN this2 AS var3
+              }
+              WITH this1 { .name, totalMovies: var3 } AS this1
+              ORDER BY var3 ASC
+              RETURN collect(this1) AS var4
             }
             RETURN this { genres: var4 } AS this"
         `);
@@ -450,43 +450,43 @@ describe("Cypher sort deprecated", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             MATCH (this0:Movie)
-            WITH collect({ node: this0 }) AS edges, count(this0) AS totalCount
+            WITH collect({node: this0}) AS edges, count(this0) AS totalCount
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              CALL (this0) {
                 CALL (this0) {
-                    CALL (this0) {
-                        WITH this0 AS this
-                        MATCH (actor:Actor)-[:ACTED_IN]->(this) RETURN count(actor) as count
-                    }
-                    WITH count AS this1
-                    RETURN this1 AS var2
+                  WITH this0 AS this
+                  MATCH (actor:Actor)-[:ACTED_IN]->(this) RETURN count(actor) as count
                 }
-                WITH *
-                ORDER BY this0.title DESC, var2 ASC
-                LIMIT $param0
-                CALL (this0) {
-                    MATCH (this0)<-[this3:ACTED_IN]-(this4:Actor)
-                    WITH collect({ node: this4, relationship: this3 }) AS edges
-                    CALL (edges) {
-                        UNWIND edges AS edge
-                        WITH edge.node AS this4, edge.relationship AS this3
-                        CALL (this4) {
-                            CALL (this4) {
-                                WITH this4 AS this
-                                MATCH (this)-[r:ACTED_IN]->(:Movie)
-                                RETURN sum(r.screenTime) as sum
-                            }
-                            WITH sum AS this5
-                            RETURN this5 AS var6
-                        }
-                        RETURN collect({ node: { name: this4.name, totalScreenTime: var6, __resolveType: \\"Actor\\" } }) AS var7
+                WITH count AS this1
+                RETURN this1 AS var2
+              }
+              WITH *
+              ORDER BY this0.title DESC, var2 ASC
+              LIMIT $param0
+              CALL (this0) {
+                MATCH (this0)<-[this3:ACTED_IN]-(this4:Actor)
+                WITH collect({node: this4, relationship: this3}) AS edges
+                CALL (edges) {
+                  UNWIND edges AS edge
+                  WITH edge.node AS this4, edge.relationship AS this3
+                  CALL (this4) {
+                    CALL (this4) {
+                      WITH this4 AS this
+                      MATCH (this)-[r:ACTED_IN]->(:Movie)
+                      RETURN sum(r.screenTime) as sum
                     }
-                    RETURN { edges: var7 } AS var8
+                    WITH sum AS this5
+                    RETURN this5 AS var6
+                  }
+                  RETURN collect({node: {name: this4.name, totalScreenTime: var6, __resolveType: 'Actor'}}) AS var7
                 }
-                RETURN collect({ node: { title: this0.title, actorsConnection: var8, __resolveType: \\"Movie\\" } }) AS var9
+                RETURN {edges: var7} AS var8
+              }
+              RETURN collect({node: {title: this0.title, actorsConnection: var8, __resolveType: 'Movie'}}) AS var9
             }
-            RETURN { edges: var9, totalCount: totalCount } AS this"
+            RETURN {edges: var9, totalCount: totalCount} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -533,44 +533,44 @@ describe("Cypher sort deprecated", () => {
             "CYPHER 5
             MATCH (this:Actor)
             CALL (this) {
-                MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                WITH collect({ node: this1, relationship: this0 }) AS edges, count(this1) AS totalCount
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    CALL (this1) {
-                        CALL (this1) {
-                            WITH this1 AS this
-                            MATCH (actor:Actor)-[:ACTED_IN]->(this) RETURN count(actor) as count
-                        }
-                        WITH count AS this2
-                        RETURN this2 AS var3
-                    }
-                    WITH *
-                    ORDER BY this1.title DESC, var3 ASC
-                    LIMIT $param0
-                    CALL (this1) {
-                        MATCH (this1)<-[this4:ACTED_IN]-(this5:Actor)
-                        WITH collect({ node: this5, relationship: this4 }) AS edges
-                        CALL (edges) {
-                            UNWIND edges AS edge
-                            WITH edge.node AS this5, edge.relationship AS this4
-                            CALL (this5) {
-                                CALL (this5) {
-                                    WITH this5 AS this
-                                    MATCH (this)-[r:ACTED_IN]->(:Movie)
-                                    RETURN sum(r.screenTime) as sum
-                                }
-                                WITH sum AS this6
-                                RETURN this6 AS var7
-                            }
-                            RETURN collect({ node: { name: this5.name, totalScreenTime: var7, __resolveType: \\"Actor\\" } }) AS var8
-                        }
-                        RETURN { edges: var8 } AS var9
-                    }
-                    RETURN collect({ node: { title: this1.title, actorsConnection: var9, __resolveType: \\"Movie\\" } }) AS var10
+              MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+              WITH collect({node: this1, relationship: this0}) AS edges, count(this1) AS totalCount
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                CALL (this1) {
+                  CALL (this1) {
+                    WITH this1 AS this
+                    MATCH (actor:Actor)-[:ACTED_IN]->(this) RETURN count(actor) as count
+                  }
+                  WITH count AS this2
+                  RETURN this2 AS var3
                 }
-                RETURN { edges: var10, totalCount: totalCount } AS var11
+                WITH *
+                ORDER BY this1.title DESC, var3 ASC
+                LIMIT $param0
+                CALL (this1) {
+                  MATCH (this1)<-[this4:ACTED_IN]-(this5:Actor)
+                  WITH collect({node: this5, relationship: this4}) AS edges
+                  CALL (edges) {
+                    UNWIND edges AS edge
+                    WITH edge.node AS this5, edge.relationship AS this4
+                    CALL (this5) {
+                      CALL (this5) {
+                        WITH this5 AS this
+                        MATCH (this)-[r:ACTED_IN]->(:Movie)
+                        RETURN sum(r.screenTime) as sum
+                      }
+                      WITH sum AS this6
+                      RETURN this6 AS var7
+                    }
+                    RETURN collect({node: {name: this5.name, totalScreenTime: var7, __resolveType: 'Actor'}}) AS var8
+                  }
+                  RETURN {edges: var8} AS var9
+                }
+                RETURN collect({node: {title: this1.title, actorsConnection: var9, __resolveType: 'Movie'}}) AS var10
+              }
+              RETURN {edges: var10, totalCount: totalCount} AS var11
             }
             RETURN this { moviesConnection: var11 } AS this"
         `);

--- a/packages/graphql/tests/tck/deprecated/generic-filtering/advanced-filtering-deprecated.test.ts
+++ b/packages/graphql/tests/tck/deprecated/generic-filtering/advanced-filtering-deprecated.test.ts
@@ -573,8 +573,8 @@ describe("Cypher Advanced Filtering - deprecated", () => {
                 "CYPHER 5
                 MATCH (this:Movie)
                 WHERE EXISTS {
-                    MATCH (this)-[:IN_GENRE]->(this0:Genre)
-                    WHERE this0.name = $param0
+                  MATCH (this)-[:IN_GENRE]->(this0:Genre)
+                  WHERE this0.name = $param0
                 }
                 RETURN this { .actorCount } AS this"
             `);
@@ -601,8 +601,8 @@ describe("Cypher Advanced Filtering - deprecated", () => {
                 "CYPHER 5
                 MATCH (this:Movie)
                 WHERE NOT (EXISTS {
-                    MATCH (this)-[:IN_GENRE]->(this0:Genre)
-                    WHERE this0.name = $param0
+                  MATCH (this)-[:IN_GENRE]->(this0:Genre)
+                  WHERE this0.name = $param0
                 })
                 RETURN this { .actorCount } AS this"
             `);
@@ -634,11 +634,11 @@ describe("Cypher Advanced Filtering - deprecated", () => {
                     "CYPHER 5
                     MATCH (this:Movie)
                     WHERE (EXISTS {
-                        MATCH (this)-[:IN_GENRE]->(this0:Genre)
-                        WHERE this0.name = $param0
+                      MATCH (this)-[:IN_GENRE]->(this0:Genre)
+                      WHERE this0.name = $param0
                     } AND NOT (EXISTS {
-                        MATCH (this)-[:IN_GENRE]->(this0:Genre)
-                        WHERE NOT (this0.name = $param0)
+                      MATCH (this)-[:IN_GENRE]->(this0:Genre)
+                      WHERE NOT (this0.name = $param0)
                     }))
                     RETURN this { .actorCount } AS this"
                 `);
@@ -657,8 +657,8 @@ describe("Cypher Advanced Filtering - deprecated", () => {
                     "CYPHER 5
                     MATCH (this:Movie)
                     WHERE NOT (EXISTS {
-                        MATCH (this)-[:IN_GENRE]->(this0:Genre)
-                        WHERE this0.name = $param0
+                      MATCH (this)-[:IN_GENRE]->(this0:Genre)
+                      WHERE this0.name = $param0
                     })
                     RETURN this { .actorCount } AS this"
                 `);
@@ -694,8 +694,8 @@ describe("Cypher Advanced Filtering - deprecated", () => {
                     "CYPHER 5
                     MATCH (this:Movie)
                     WHERE EXISTS {
-                        MATCH (this)-[:IN_GENRE]->(this0:Genre)
-                        WHERE this0.name = $param0
+                      MATCH (this)-[:IN_GENRE]->(this0:Genre)
+                      WHERE this0.name = $param0
                     }
                     RETURN this { .actorCount } AS this"
                 `);
@@ -724,8 +724,8 @@ describe("Cypher Advanced Filtering - deprecated", () => {
                 "CYPHER 5
                 MATCH (this:Movie)
                 WHERE EXISTS {
-                    MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
-                    WHERE this1.name = $param0
+                  MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
+                  WHERE this1.name = $param0
                 }
                 RETURN this { .actorCount } AS this"
             `);
@@ -752,8 +752,8 @@ describe("Cypher Advanced Filtering - deprecated", () => {
                 "CYPHER 5
                 MATCH (this:Movie)
                 WHERE NOT (EXISTS {
-                    MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
-                    WHERE this1.name = $param0
+                  MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
+                  WHERE this1.name = $param0
                 })
                 RETURN this { .actorCount } AS this"
             `);
@@ -785,11 +785,11 @@ describe("Cypher Advanced Filtering - deprecated", () => {
                     "CYPHER 5
                     MATCH (this:Movie)
                     WHERE (EXISTS {
-                        MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
-                        WHERE this1.name = $param0
+                      MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
+                      WHERE this1.name = $param0
                     } AND NOT (EXISTS {
-                        MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
-                        WHERE NOT (this1.name = $param0)
+                      MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
+                      WHERE NOT (this1.name = $param0)
                     }))
                     RETURN this { .actorCount } AS this"
                 `);
@@ -808,8 +808,8 @@ describe("Cypher Advanced Filtering - deprecated", () => {
                     "CYPHER 5
                     MATCH (this:Movie)
                     WHERE NOT (EXISTS {
-                        MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
-                        WHERE this1.name = $param0
+                      MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
+                      WHERE this1.name = $param0
                     })
                     RETURN this { .actorCount } AS this"
                 `);
@@ -845,8 +845,8 @@ describe("Cypher Advanced Filtering - deprecated", () => {
                     "CYPHER 5
                     MATCH (this:Movie)
                     WHERE EXISTS {
-                        MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
-                        WHERE this1.name = $param0
+                      MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
+                      WHERE this1.name = $param0
                     }
                     RETURN this { .actorCount } AS this"
                 `);

--- a/packages/graphql/tests/tck/deprecated/generic-filtering/count-deprecated.test.ts
+++ b/packages/graphql/tests/tck/deprecated/generic-filtering/count-deprecated.test.ts
@@ -56,8 +56,8 @@ describe("Cypher Aggregations where with count, deprecated", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN count(this1) = $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN count(this1) = $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -89,8 +89,8 @@ describe("Cypher Aggregations where with count, deprecated", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN count(this1) < $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN count(this1) < $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -122,8 +122,8 @@ describe("Cypher Aggregations where with count, deprecated", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN count(this1) <= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN count(this1) <= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -155,8 +155,8 @@ describe("Cypher Aggregations where with count, deprecated", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN count(this1) > $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN count(this1) > $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -188,8 +188,8 @@ describe("Cypher Aggregations where with count, deprecated", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:LIKES]-(this1:User)
-                RETURN count(this1) >= $param0 AS var2
+              MATCH (this)<-[this0:LIKES]-(this1:User)
+              RETURN count(this1) >= $param0 AS var2
             }
             WITH *
             WHERE var2 = true

--- a/packages/graphql/tests/tck/deprecated/generic-filtering/cypher-filtering-list-deprecated.test.ts
+++ b/packages/graphql/tests/tck/deprecated/generic-filtering/cypher-filtering-list-deprecated.test.ts
@@ -53,13 +53,13 @@ describe("cypher directive filtering - Lists - deprecated", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    RETURN ['a', 'b', 'c'] as list
-                }
-                UNWIND list AS var0
-                WITH var0 AS this1
-                RETURN collect(this1) AS var2
+              CALL (this) {
+                WITH this AS this
+                RETURN ['a', 'b', 'c'] as list
+              }
+              UNWIND list AS var0
+              WITH var0 AS this1
+              RETURN collect(this1) AS var2
             }
             WITH *
             WHERE $param0 IN var2

--- a/packages/graphql/tests/tck/deprecated/generic-filtering/cypher-filtering-one-to-one-relationship-deprecated.test.ts
+++ b/packages/graphql/tests/tck/deprecated/generic-filtering/cypher-filtering-one-to-one-relationship-deprecated.test.ts
@@ -68,13 +68,13 @@ describe("cypher directive filtering - One To One Relationship - deprecated", ()
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:ACTED_IN]->(actor:Actor)
-                    RETURN actor
-                }
-                WITH actor AS this0
-                RETURN head(collect(this0)) AS this1
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:ACTED_IN]->(actor:Actor)
+                RETURN actor
+              }
+              WITH actor AS this0
+              RETURN head(collect(this0)) AS this1
             }
             WITH *
             WHERE this1.name = $param0
@@ -135,13 +135,13 @@ describe("cypher directive filtering - One To One Relationship - deprecated", ()
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:ACTED_IN]->(actor:Actor)
-                    RETURN actor
-                }
-                WITH actor AS this0
-                RETURN head(collect(this0)) AS this1
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:ACTED_IN]->(actor:Actor)
+                RETURN actor
+              }
+              WITH actor AS this0
+              RETURN head(collect(this0)) AS this1
             }
             WITH *
             WHERE (this.released = $param0 AND (this1.name = $param1 AND this1.age > $param2))
@@ -211,25 +211,25 @@ describe("cypher directive filtering - One To One Relationship - deprecated", ()
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)<-[:ACTED_IN]-(actor:Actor)
-                    RETURN actor
-                }
-                WITH actor AS this0
-                RETURN head(collect(this0)) AS this1
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                RETURN actor
+              }
+              WITH actor AS this0
+              RETURN head(collect(this0)) AS this1
             }
             WITH *
             WHERE this1.name = $param0
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)<-[:ACTED_IN]-(actor:Actor)
-                    RETURN actor
-                }
-                WITH actor AS this2
-                WITH this2 { .name } AS this2
-                RETURN head(collect(this2)) AS var3
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                RETURN actor
+              }
+              WITH actor AS this2
+              WITH this2 { .name } AS this2
+              RETURN head(collect(this2)) AS var3
             }
             RETURN this { .title, actor: var3 } AS this"
         `);
@@ -287,13 +287,13 @@ describe("cypher directive filtering - One To One Relationship - deprecated", ()
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)<-[:ACTED_IN]-(actor:Actor)
-                    RETURN actor
-                }
-                WITH actor AS this0
-                RETURN head(collect(this0)) AS this1
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                RETURN actor
+              }
+              WITH actor AS this0
+              RETURN head(collect(this0)) AS this1
             }
             WITH *
             WHERE (this.released = $param0 AND this1 IS NULL)
@@ -356,13 +356,13 @@ describe("cypher directive filtering - One To One Relationship - deprecated", ()
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)<-[:ACTED_IN]-(actor:Actor)
-                    RETURN actor
-                }
-                WITH actor AS this0
-                RETURN head(collect(this0)) AS this1
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                RETURN actor
+              }
+              WITH actor AS this0
+              RETURN head(collect(this0)) AS this1
             }
             WITH *
             WHERE (this.released IN $param0 AND NOT (this1 IS NULL))
@@ -441,46 +441,46 @@ describe("cypher directive filtering - One To One Relationship - deprecated", ()
             "CYPHER 5
             MATCH (this:Person)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:DIRECTED]->(movie:Movie)
-                    RETURN movie
-                }
-                WITH movie AS this0
-                RETURN head(collect(this0)) AS this1
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:DIRECTED]->(movie:Movie)
+                RETURN movie
+              }
+              WITH movie AS this0
+              RETURN head(collect(this0)) AS this1
             }
             WITH *
             WHERE this1.title = $param0
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:DIRECTED]->(movie:Movie)
-                    RETURN movie
-                }
-                WITH movie AS this2
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:DIRECTED]->(movie:Movie)
+                RETURN movie
+              }
+              WITH movie AS this2
+              CALL (this2) {
                 CALL (this2) {
-                    CALL (this2) {
-                        WITH this2 AS this
-                        MATCH (this)<-[:DIRECTED]-(director:Person)
-                        RETURN director
-                    }
-                    WITH director AS this3
-                    WITH this3 { .name } AS this3
-                    RETURN head(collect(this3)) AS var4
+                  WITH this2 AS this
+                  MATCH (this)<-[:DIRECTED]-(director:Person)
+                  RETURN director
                 }
+                WITH director AS this3
+                WITH this3 { .name } AS this3
+                RETURN head(collect(this3)) AS var4
+              }
+              CALL (this2) {
                 CALL (this2) {
-                    CALL (this2) {
-                        WITH this2 AS this
-                        MATCH (this)<-[:DIRECTED]-(director:Person)
-                        RETURN director
-                    }
-                    WITH director AS this5
-                    RETURN head(collect(this5)) AS this6
+                  WITH this2 AS this
+                  MATCH (this)<-[:DIRECTED]-(director:Person)
+                  RETURN director
                 }
-                WITH *
-                WHERE ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND this6.name = $jwt.custom_value))
-                WITH this2 { .title, directed_by: var4 } AS this2
-                RETURN head(collect(this2)) AS var7
+                WITH director AS this5
+                RETURN head(collect(this5)) AS this6
+              }
+              WITH *
+              WHERE ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND this6.name = $jwt.custom_value))
+              WITH this2 { .title, directed_by: var4 } AS this2
+              RETURN head(collect(this2)) AS var7
             }
             RETURN this { directed: var7 } AS this"
         `);
@@ -557,46 +557,46 @@ describe("cypher directive filtering - One To One Relationship - deprecated", ()
             "CYPHER 5
             MATCH (this:Person)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:DIRECTED]->(movie:Movie)
-                    RETURN movie
-                }
-                WITH movie AS this0
-                RETURN head(collect(this0)) AS this1
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:DIRECTED]->(movie:Movie)
+                RETURN movie
+              }
+              WITH movie AS this0
+              RETURN head(collect(this0)) AS this1
             }
             WITH *
             WHERE this1.title = $param0
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:DIRECTED]->(movie:Movie)
-                    RETURN movie
-                }
-                WITH movie AS this2
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:DIRECTED]->(movie:Movie)
+                RETURN movie
+              }
+              WITH movie AS this2
+              CALL (this2) {
                 CALL (this2) {
-                    CALL (this2) {
-                        WITH this2 AS this
-                        MATCH (this)<-[:DIRECTED]-(director:Person)
-                        RETURN director
-                    }
-                    WITH director AS this3
-                    WITH this3 { .name } AS this3
-                    RETURN head(collect(this3)) AS var4
+                  WITH this2 AS this
+                  MATCH (this)<-[:DIRECTED]-(director:Person)
+                  RETURN director
                 }
+                WITH director AS this3
+                WITH this3 { .name } AS this3
+                RETURN head(collect(this3)) AS var4
+              }
+              CALL (this2) {
                 CALL (this2) {
-                    CALL (this2) {
-                        WITH this2 AS this
-                        MATCH (this)<-[:DIRECTED]-(director:Person)
-                        RETURN director
-                    }
-                    WITH director AS this5
-                    RETURN head(collect(this5)) AS this6
+                  WITH this2 AS this
+                  MATCH (this)<-[:DIRECTED]-(director:Person)
+                  RETURN director
                 }
-                WITH *
-                WHERE ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND this6.name = $jwt.custom_value))
-                WITH this2 { .title, directed_by: var4 } AS this2
-                RETURN head(collect(this2)) AS var7
+                WITH director AS this5
+                RETURN head(collect(this5)) AS this6
+              }
+              WITH *
+              WHERE ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND this6.name = $jwt.custom_value))
+              WITH this2 { .title, directed_by: var4 } AS this2
+              RETURN head(collect(this2)) AS var7
             }
             RETURN this { directed: var7 } AS this"
         `);
@@ -672,46 +672,46 @@ describe("cypher directive filtering - One To One Relationship - deprecated", ()
             "CYPHER 5
             MATCH (this:Person)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:DIRECTED]->(movie:Movie)
-                    RETURN movie
-                }
-                WITH movie AS this0
-                RETURN head(collect(this0)) AS this1
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:DIRECTED]->(movie:Movie)
+                RETURN movie
+              }
+              WITH movie AS this0
+              RETURN head(collect(this0)) AS this1
             }
             WITH *
             WHERE this1.title = $param0
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:DIRECTED]->(movie:Movie)
-                    RETURN movie
-                }
-                WITH movie AS this2
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:DIRECTED]->(movie:Movie)
+                RETURN movie
+              }
+              WITH movie AS this2
+              CALL (this2) {
                 CALL (this2) {
-                    CALL (this2) {
-                        WITH this2 AS this
-                        MATCH (this)<-[:DIRECTED]-(director:Person)
-                        RETURN director
-                    }
-                    WITH director AS this3
-                    WITH this3 { .name } AS this3
-                    RETURN head(collect(this3)) AS var4
+                  WITH this2 AS this
+                  MATCH (this)<-[:DIRECTED]-(director:Person)
+                  RETURN director
                 }
+                WITH director AS this3
+                WITH this3 { .name } AS this3
+                RETURN head(collect(this3)) AS var4
+              }
+              CALL (this2) {
                 CALL (this2) {
-                    CALL (this2) {
-                        WITH this2 AS this
-                        MATCH (this)<-[:DIRECTED]-(director:Person)
-                        RETURN director
-                    }
-                    WITH director AS this5
-                    RETURN head(collect(this5)) AS this6
+                  WITH this2 AS this
+                  MATCH (this)<-[:DIRECTED]-(director:Person)
+                  RETURN director
                 }
-                WITH *
-                WHERE ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND this6.name = $jwt.custom_value))
-                WITH this2 { .title, directed_by: var4 } AS this2
-                RETURN head(collect(this2)) AS var7
+                WITH director AS this5
+                RETURN head(collect(this5)) AS this6
+              }
+              WITH *
+              WHERE ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND this6.name = $jwt.custom_value))
+              WITH this2 { .title, directed_by: var4 } AS this2
+              RETURN head(collect(this2)) AS var7
             }
             RETURN this { directed: var7 } AS this"
         `);
@@ -787,46 +787,46 @@ describe("cypher directive filtering - One To One Relationship - deprecated", ()
             "CYPHER 5
             MATCH (this:Person)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:DIRECTED]->(movie:Movie)
-                    RETURN movie
-                }
-                WITH movie AS this0
-                RETURN head(collect(this0)) AS this1
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:DIRECTED]->(movie:Movie)
+                RETURN movie
+              }
+              WITH movie AS this0
+              RETURN head(collect(this0)) AS this1
             }
             WITH *
             WHERE this1.title = $param0
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:DIRECTED]->(movie:Movie)
-                    RETURN movie
-                }
-                WITH movie AS this2
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:DIRECTED]->(movie:Movie)
+                RETURN movie
+              }
+              WITH movie AS this2
+              CALL (this2) {
                 CALL (this2) {
-                    CALL (this2) {
-                        WITH this2 AS this
-                        MATCH (this)<-[:DIRECTED]-(director:Person)
-                        RETURN director
-                    }
-                    WITH director AS this3
-                    WITH this3 { .name } AS this3
-                    RETURN head(collect(this3)) AS var4
+                  WITH this2 AS this
+                  MATCH (this)<-[:DIRECTED]-(director:Person)
+                  RETURN director
                 }
+                WITH director AS this3
+                WITH this3 { .name } AS this3
+                RETURN head(collect(this3)) AS var4
+              }
+              CALL (this2) {
                 CALL (this2) {
-                    CALL (this2) {
-                        WITH this2 AS this
-                        MATCH (this)<-[:DIRECTED]-(director:Person)
-                        RETURN director
-                    }
-                    WITH director AS this5
-                    RETURN head(collect(this5)) AS this6
+                  WITH this2 AS this
+                  MATCH (this)<-[:DIRECTED]-(director:Person)
+                  RETURN director
                 }
-                WITH *
-                WHERE ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND this6.name = $jwt.custom_value))
-                WITH this2 { .title, directed_by: var4 } AS this2
-                RETURN head(collect(this2)) AS var7
+                WITH director AS this5
+                RETURN head(collect(this5)) AS this6
+              }
+              WITH *
+              WHERE ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND this6.name = $jwt.custom_value))
+              WITH this2 { .title, directed_by: var4 } AS this2
+              RETURN head(collect(this2)) AS var7
             }
             RETURN this { directed: var7 } AS this"
         `);
@@ -903,46 +903,46 @@ describe("cypher directive filtering - One To One Relationship - deprecated", ()
             "CYPHER 5
             MATCH (this:Person)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:DIRECTED]->(movie:Movie)
-                    RETURN movie
-                }
-                WITH movie AS this0
-                RETURN head(collect(this0)) AS this1
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:DIRECTED]->(movie:Movie)
+                RETURN movie
+              }
+              WITH movie AS this0
+              RETURN head(collect(this0)) AS this1
             }
             WITH *
             WHERE this1.title = $param0
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:DIRECTED]->(movie:Movie)
-                    RETURN movie
-                }
-                WITH movie AS this2
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:DIRECTED]->(movie:Movie)
+                RETURN movie
+              }
+              WITH movie AS this2
+              CALL (this2) {
                 CALL (this2) {
-                    CALL (this2) {
-                        WITH this2 AS this
-                        MATCH (this)<-[:DIRECTED]-(director:Person)
-                        RETURN director
-                    }
-                    WITH director AS this3
-                    WITH this3 { .name } AS this3
-                    RETURN head(collect(this3)) AS var4
+                  WITH this2 AS this
+                  MATCH (this)<-[:DIRECTED]-(director:Person)
+                  RETURN director
                 }
+                WITH director AS this3
+                WITH this3 { .name } AS this3
+                RETURN head(collect(this3)) AS var4
+              }
+              CALL (this2) {
                 CALL (this2) {
-                    CALL (this2) {
-                        WITH this2 AS this
-                        MATCH (this)<-[:DIRECTED]-(director:Person)
-                        RETURN director
-                    }
-                    WITH director AS this5
-                    RETURN head(collect(this5)) AS this6
+                  WITH this2 AS this
+                  MATCH (this)<-[:DIRECTED]-(director:Person)
+                  RETURN director
                 }
-                WITH *
-                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND this6.name = $jwt.custom_value)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                WITH this2 { .title, directed_by: var4 } AS this2
-                RETURN head(collect(this2)) AS var7
+                WITH director AS this5
+                RETURN head(collect(this5)) AS this6
+              }
+              WITH *
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND this6.name = $jwt.custom_value)), '@neo4j/graphql/FORBIDDEN', [])
+              WITH this2 { .title, directed_by: var4 } AS this2
+              RETURN head(collect(this2)) AS var7
             }
             RETURN this { directed: var7 } AS this"
         `);
@@ -1019,46 +1019,46 @@ describe("cypher directive filtering - One To One Relationship - deprecated", ()
             "CYPHER 5
             MATCH (this:Person)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:DIRECTED]->(movie:Movie)
-                    RETURN movie
-                }
-                WITH movie AS this0
-                RETURN head(collect(this0)) AS this1
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:DIRECTED]->(movie:Movie)
+                RETURN movie
+              }
+              WITH movie AS this0
+              RETURN head(collect(this0)) AS this1
             }
             WITH *
             WHERE this1.title = $param0
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:DIRECTED]->(movie:Movie)
-                    RETURN movie
-                }
-                WITH movie AS this2
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:DIRECTED]->(movie:Movie)
+                RETURN movie
+              }
+              WITH movie AS this2
+              CALL (this2) {
                 CALL (this2) {
-                    CALL (this2) {
-                        WITH this2 AS this
-                        MATCH (this)<-[:DIRECTED]-(director:Person)
-                        RETURN director
-                    }
-                    WITH director AS this3
-                    WITH this3 { .name } AS this3
-                    RETURN head(collect(this3)) AS var4
+                  WITH this2 AS this
+                  MATCH (this)<-[:DIRECTED]-(director:Person)
+                  RETURN director
                 }
+                WITH director AS this3
+                WITH this3 { .name } AS this3
+                RETURN head(collect(this3)) AS var4
+              }
+              CALL (this2) {
                 CALL (this2) {
-                    CALL (this2) {
-                        WITH this2 AS this
-                        MATCH (this)<-[:DIRECTED]-(director:Person)
-                        RETURN director
-                    }
-                    WITH director AS this5
-                    RETURN head(collect(this5)) AS this6
+                  WITH this2 AS this
+                  MATCH (this)<-[:DIRECTED]-(director:Person)
+                  RETURN director
                 }
-                WITH *
-                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND this6.name = $jwt.custom_value)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                WITH this2 { .title, directed_by: var4 } AS this2
-                RETURN head(collect(this2)) AS var7
+                WITH director AS this5
+                RETURN head(collect(this5)) AS this6
+              }
+              WITH *
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND this6.name = $jwt.custom_value)), '@neo4j/graphql/FORBIDDEN', [])
+              WITH this2 { .title, directed_by: var4 } AS this2
+              RETURN head(collect(this2)) AS var7
             }
             RETURN this { directed: var7 } AS this"
         `);
@@ -1134,46 +1134,46 @@ describe("cypher directive filtering - One To One Relationship - deprecated", ()
             "CYPHER 5
             MATCH (this:Person)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:DIRECTED]->(movie:Movie)
-                    RETURN movie
-                }
-                WITH movie AS this0
-                RETURN head(collect(this0)) AS this1
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:DIRECTED]->(movie:Movie)
+                RETURN movie
+              }
+              WITH movie AS this0
+              RETURN head(collect(this0)) AS this1
             }
             WITH *
             WHERE this1.title = $param0
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:DIRECTED]->(movie:Movie)
-                    RETURN movie
-                }
-                WITH movie AS this2
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:DIRECTED]->(movie:Movie)
+                RETURN movie
+              }
+              WITH movie AS this2
+              CALL (this2) {
                 CALL (this2) {
-                    CALL (this2) {
-                        WITH this2 AS this
-                        MATCH (this)<-[:DIRECTED]-(director:Person)
-                        RETURN director
-                    }
-                    WITH director AS this3
-                    WITH this3 { .name } AS this3
-                    RETURN head(collect(this3)) AS var4
+                  WITH this2 AS this
+                  MATCH (this)<-[:DIRECTED]-(director:Person)
+                  RETURN director
                 }
+                WITH director AS this3
+                WITH this3 { .name } AS this3
+                RETURN head(collect(this3)) AS var4
+              }
+              CALL (this2) {
                 CALL (this2) {
-                    CALL (this2) {
-                        WITH this2 AS this
-                        MATCH (this)<-[:DIRECTED]-(director:Person)
-                        RETURN director
-                    }
-                    WITH director AS this5
-                    RETURN head(collect(this5)) AS this6
+                  WITH this2 AS this
+                  MATCH (this)<-[:DIRECTED]-(director:Person)
+                  RETURN director
                 }
-                WITH *
-                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND this6.name = $jwt.custom_value)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                WITH this2 { .title, directed_by: var4 } AS this2
-                RETURN head(collect(this2)) AS var7
+                WITH director AS this5
+                RETURN head(collect(this5)) AS this6
+              }
+              WITH *
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND this6.name = $jwt.custom_value)), '@neo4j/graphql/FORBIDDEN', [])
+              WITH this2 { .title, directed_by: var4 } AS this2
+              RETURN head(collect(this2)) AS var7
             }
             RETURN this { directed: var7 } AS this"
         `);
@@ -1249,46 +1249,46 @@ describe("cypher directive filtering - One To One Relationship - deprecated", ()
             "CYPHER 5
             MATCH (this:Person)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:DIRECTED]->(movie:Movie)
-                    RETURN movie
-                }
-                WITH movie AS this0
-                RETURN head(collect(this0)) AS this1
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:DIRECTED]->(movie:Movie)
+                RETURN movie
+              }
+              WITH movie AS this0
+              RETURN head(collect(this0)) AS this1
             }
             WITH *
             WHERE this1.title = $param0
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:DIRECTED]->(movie:Movie)
-                    RETURN movie
-                }
-                WITH movie AS this2
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:DIRECTED]->(movie:Movie)
+                RETURN movie
+              }
+              WITH movie AS this2
+              CALL (this2) {
                 CALL (this2) {
-                    CALL (this2) {
-                        WITH this2 AS this
-                        MATCH (this)<-[:DIRECTED]-(director:Person)
-                        RETURN director
-                    }
-                    WITH director AS this3
-                    WITH this3 { .name } AS this3
-                    RETURN head(collect(this3)) AS var4
+                  WITH this2 AS this
+                  MATCH (this)<-[:DIRECTED]-(director:Person)
+                  RETURN director
                 }
+                WITH director AS this3
+                WITH this3 { .name } AS this3
+                RETURN head(collect(this3)) AS var4
+              }
+              CALL (this2) {
                 CALL (this2) {
-                    CALL (this2) {
-                        WITH this2 AS this
-                        MATCH (this)<-[:DIRECTED]-(director:Person)
-                        RETURN director
-                    }
-                    WITH director AS this5
-                    RETURN head(collect(this5)) AS this6
+                  WITH this2 AS this
+                  MATCH (this)<-[:DIRECTED]-(director:Person)
+                  RETURN director
                 }
-                WITH *
-                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND this6.name = $jwt.custom_value)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                WITH this2 { .title, directed_by: var4 } AS this2
-                RETURN head(collect(this2)) AS var7
+                WITH director AS this5
+                RETURN head(collect(this5)) AS this6
+              }
+              WITH *
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND this6.name = $jwt.custom_value)), '@neo4j/graphql/FORBIDDEN', [])
+              WITH this2 { .title, directed_by: var4 } AS this2
+              RETURN head(collect(this2)) AS var7
             }
             RETURN this { directed: var7 } AS this"
         `);
@@ -1367,57 +1367,57 @@ describe("cypher directive filtering - One To One Relationship - deprecated", ()
             "CYPHER 5
             MATCH (this:Person)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:DIRECTED]->(movie:Movie)
-                    RETURN movie
-                }
-                WITH movie AS this0
-                RETURN head(collect(this0)) AS this1
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:DIRECTED]->(movie:Movie)
+                RETURN movie
+              }
+              WITH movie AS this0
+              RETURN head(collect(this0)) AS this1
             }
             WITH *
             WHERE this1.title = $param0
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:DIRECTED]->(movie:Movie)
-                    RETURN movie
-                }
-                WITH movie AS this2
-                CALL (this2) {
-                    MATCH (this2)<-[this3:ACTED_IN]-(this4:Person)
-                    WITH DISTINCT this4
-                    CALL (this4) {
-                        MATCH (this4)-[this5:ACTED_IN]->(this6:Movie)
-                        WITH DISTINCT this6
-                        CALL (this6) {
-                            CALL (this6) {
-                                WITH this6 AS this
-                                MATCH (this)<-[:DIRECTED]-(director:Person)
-                                RETURN director
-                            }
-                            WITH director AS this7
-                            WITH this7 { .name } AS this7
-                            RETURN head(collect(this7)) AS var8
-                        }
-                        WITH this6 { .title, directed_by: var8 } AS this6
-                        RETURN collect(this6) AS var9
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:DIRECTED]->(movie:Movie)
+                RETURN movie
+              }
+              WITH movie AS this2
+              CALL (this2) {
+                MATCH (this2)<-[this3:ACTED_IN]-(this4:Person)
+                WITH DISTINCT this4
+                CALL (this4) {
+                  MATCH (this4)-[this5:ACTED_IN]->(this6:Movie)
+                  WITH DISTINCT this6
+                  CALL (this6) {
+                    CALL (this6) {
+                      WITH this6 AS this
+                      MATCH (this)<-[:DIRECTED]-(director:Person)
+                      RETURN director
                     }
-                    WITH this4 { .name, movies: var9 } AS this4
-                    RETURN collect(this4) AS var10
+                    WITH director AS this7
+                    WITH this7 { .name } AS this7
+                    RETURN head(collect(this7)) AS var8
+                  }
+                  WITH this6 { .title, directed_by: var8 } AS this6
+                  RETURN collect(this6) AS var9
                 }
+                WITH this4 { .name, movies: var9 } AS this4
+                RETURN collect(this4) AS var10
+              }
+              CALL (this2) {
                 CALL (this2) {
-                    CALL (this2) {
-                        WITH this2 AS this
-                        MATCH (this)<-[:DIRECTED]-(director:Person)
-                        RETURN director
-                    }
-                    WITH director AS this11
-                    WITH this11 { .name } AS this11
-                    RETURN head(collect(this11)) AS var12
+                  WITH this2 AS this
+                  MATCH (this)<-[:DIRECTED]-(director:Person)
+                  RETURN director
                 }
-                WITH this2 { .title, directed_by: var12, actors: var10 } AS this2
-                RETURN head(collect(this2)) AS var13
+                WITH director AS this11
+                WITH this11 { .name } AS this11
+                RETURN head(collect(this11)) AS var12
+              }
+              WITH this2 { .title, directed_by: var12, actors: var10 } AS this2
+              RETURN head(collect(this2)) AS var13
             }
             RETURN this { directed: var13 } AS this"
         `);
@@ -1484,25 +1484,25 @@ describe("cypher directive filtering - One To One Relationship - deprecated", ()
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)<-[:DIRECTED]-(director:Person)
-                    RETURN director
-                }
-                WITH director AS this0
-                RETURN head(collect(this0)) AS this1
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)<-[:DIRECTED]-(director:Person)
+                RETURN director
+              }
+              WITH director AS this0
+              RETURN head(collect(this0)) AS this1
             }
             WITH *
             WHERE (this.title ENDS WITH $param0 AND this1.name = $param1)
             CALL (this) {
-                MATCH (this)<-[this2:ACTED_IN]-(this3:Person)
-                WITH collect({ node: this3, relationship: this2 }) AS edges, count(this3) AS totalCount
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this3, edge.relationship AS this2
-                    RETURN collect({ node: { name: this3.name, __resolveType: \\"Person\\" } }) AS var4
-                }
-                RETURN { edges: var4, totalCount: totalCount } AS var5
+              MATCH (this)<-[this2:ACTED_IN]-(this3:Person)
+              WITH collect({node: this3, relationship: this2}) AS edges, count(this3) AS totalCount
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this3, edge.relationship AS this2
+                RETURN collect({node: {name: this3.name, __resolveType: 'Person'}}) AS var4
+              }
+              RETURN {edges: var4, totalCount: totalCount} AS var5
             }
             RETURN this { actorsConnection: var5 } AS this"
         `);

--- a/packages/graphql/tests/tck/deprecated/generic-filtering/cypher-filtering-scalar-deprecated.test.ts
+++ b/packages/graphql/tests/tck/deprecated/generic-filtering/cypher-filtering-scalar-deprecated.test.ts
@@ -54,24 +54,24 @@ describe("cypher directive filtering - deprecated", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (m:Movie)
-                    RETURN count(m) as c
-                }
-                WITH c AS this0
-                RETURN this0 AS var1
+              CALL (this) {
+                WITH this AS this
+                MATCH (m:Movie)
+                RETURN count(m) as c
+              }
+              WITH c AS this0
+              RETURN this0 AS var1
             }
             WITH *
             WHERE (this.title = $param0 AND var1 >= $param1)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (m:Movie)
-                    RETURN count(m) as c
-                }
-                WITH c AS this2
-                RETURN this2 AS var3
+              CALL (this) {
+                WITH this AS this
+                MATCH (m:Movie)
+                RETURN count(m) as c
+              }
+              WITH c AS this2
+              RETURN this2 AS var3
             }
             RETURN this { special_count: var3 } AS this"
         `);
@@ -120,24 +120,24 @@ describe("cypher directive filtering - deprecated", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (m:Movie)
-                    RETURN count(m) as c
-                }
-                WITH c AS this0
-                RETURN this0 AS var1
+              CALL (this) {
+                WITH this AS this
+                MATCH (m:Movie)
+                RETURN count(m) as c
+              }
+              WITH c AS this0
+              RETURN this0 AS var1
             }
             WITH *
             WHERE (this.title = $param0 AND var1 >= $param1)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (m:Movie)
-                    RETURN count(m) as c
-                }
-                WITH c AS this2
-                RETURN this2 AS var3
+              CALL (this) {
+                WITH this AS this
+                MATCH (m:Movie)
+                RETURN count(m) as c
+              }
+              WITH c AS this2
+              RETURN this2 AS var3
             }
             RETURN this { special_count: var3 } AS this"
         `);
@@ -186,13 +186,13 @@ describe("cypher directive filtering - deprecated", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (m:Movie)
-                    RETURN count(m) as c
-                }
-                WITH c AS this0
-                RETURN this0 AS var1
+              CALL (this) {
+                WITH this AS this
+                MATCH (m:Movie)
+                RETURN count(m) as c
+              }
+              WITH c AS this0
+              RETURN this0 AS var1
             }
             WITH *
             WHERE var1 >= $param0

--- a/packages/graphql/tests/tck/deprecated/generic-filtering/delete-deprecated.test.ts
+++ b/packages/graphql/tests/tck/deprecated/generic-filtering/delete-deprecated.test.ts
@@ -88,13 +88,13 @@ describe("Cypher Delete - Deprecated", () => {
             WHERE this.id = $param0
             WITH *
             CALL (*) {
-                OPTIONAL MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE this1.name = $param1
-                WITH this0, collect(DISTINCT this1) AS var2
-                CALL (var2) {
-                    UNWIND var2 AS var3
-                    DETACH DELETE var3
-                }
+              OPTIONAL MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE this1.name = $param1
+              WITH this0, collect(DISTINCT this1) AS var2
+              CALL (var2) {
+                UNWIND var2 AS var3
+                DETACH DELETE var3
+              }
             }
             WITH *
             DETACH DELETE this"
@@ -133,22 +133,22 @@ describe("Cypher Delete - Deprecated", () => {
             WHERE this.id = $param0
             WITH *
             CALL (*) {
-                OPTIONAL MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE this1.name = $param1
-                WITH this0, collect(DISTINCT this1) AS var2
-                CALL (var2) {
-                    UNWIND var2 AS var3
-                    DETACH DELETE var3
-                }
+              OPTIONAL MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE this1.name = $param1
+              WITH this0, collect(DISTINCT this1) AS var2
+              CALL (var2) {
+                UNWIND var2 AS var3
+                DETACH DELETE var3
+              }
             }
             CALL (*) {
-                OPTIONAL MATCH (this)<-[this4:ACTED_IN]-(this5:Actor)
-                WHERE this5.name = $param2
-                WITH this4, collect(DISTINCT this5) AS var6
-                CALL (var6) {
-                    UNWIND var6 AS var7
-                    DETACH DELETE var7
-                }
+              OPTIONAL MATCH (this)<-[this4:ACTED_IN]-(this5:Actor)
+              WHERE this5.name = $param2
+              WITH this4, collect(DISTINCT this5) AS var6
+              CALL (var6) {
+                UNWIND var6 AS var7
+                DETACH DELETE var7
+              }
             }
             WITH *
             DETACH DELETE this"
@@ -188,23 +188,23 @@ describe("Cypher Delete - Deprecated", () => {
             WHERE this.id = $param0
             WITH *
             CALL (*) {
-                OPTIONAL MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE this1.name = $param1
-                WITH *
-                CALL (*) {
-                    OPTIONAL MATCH (this1)-[this2:ACTED_IN]->(this3:Movie)
-                    WHERE this3.id = $param2
-                    WITH this2, collect(DISTINCT this3) AS var4
-                    CALL (var4) {
-                        UNWIND var4 AS var5
-                        DETACH DELETE var5
-                    }
+              OPTIONAL MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE this1.name = $param1
+              WITH *
+              CALL (*) {
+                OPTIONAL MATCH (this1)-[this2:ACTED_IN]->(this3:Movie)
+                WHERE this3.id = $param2
+                WITH this2, collect(DISTINCT this3) AS var4
+                CALL (var4) {
+                  UNWIND var4 AS var5
+                  DETACH DELETE var5
                 }
-                WITH this0, collect(DISTINCT this1) AS var6
-                CALL (var6) {
-                    UNWIND var6 AS var7
-                    DETACH DELETE var7
-                }
+              }
+              WITH this0, collect(DISTINCT this1) AS var6
+              CALL (var6) {
+                UNWIND var6 AS var7
+                DETACH DELETE var7
+              }
             }
             WITH *
             DETACH DELETE this"
@@ -249,33 +249,33 @@ describe("Cypher Delete - Deprecated", () => {
             WHERE this.id = $param0
             WITH *
             CALL (*) {
-                OPTIONAL MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE this1.name = $param1
+              OPTIONAL MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE this1.name = $param1
+              WITH *
+              CALL (*) {
+                OPTIONAL MATCH (this1)-[this2:ACTED_IN]->(this3:Movie)
+                WHERE this3.id = $param2
                 WITH *
                 CALL (*) {
-                    OPTIONAL MATCH (this1)-[this2:ACTED_IN]->(this3:Movie)
-                    WHERE this3.id = $param2
-                    WITH *
-                    CALL (*) {
-                        OPTIONAL MATCH (this3)<-[this4:ACTED_IN]-(this5:Actor)
-                        WHERE this5.name = $param3
-                        WITH this4, collect(DISTINCT this5) AS var6
-                        CALL (var6) {
-                            UNWIND var6 AS var7
-                            DETACH DELETE var7
-                        }
-                    }
-                    WITH this2, collect(DISTINCT this3) AS var8
-                    CALL (var8) {
-                        UNWIND var8 AS var9
-                        DETACH DELETE var9
-                    }
+                  OPTIONAL MATCH (this3)<-[this4:ACTED_IN]-(this5:Actor)
+                  WHERE this5.name = $param3
+                  WITH this4, collect(DISTINCT this5) AS var6
+                  CALL (var6) {
+                    UNWIND var6 AS var7
+                    DETACH DELETE var7
+                  }
                 }
-                WITH this0, collect(DISTINCT this1) AS var10
-                CALL (var10) {
-                    UNWIND var10 AS var11
-                    DETACH DELETE var11
+                WITH this2, collect(DISTINCT this3) AS var8
+                CALL (var8) {
+                  UNWIND var8 AS var9
+                  DETACH DELETE var9
                 }
+              }
+              WITH this0, collect(DISTINCT this1) AS var10
+              CALL (var10) {
+                UNWIND var10 AS var11
+                DETACH DELETE var11
+              }
             }
             WITH *
             DETACH DELETE this"

--- a/packages/graphql/tests/tck/deprecated/generic-filtering/delete-interface-deprecated.test.ts
+++ b/packages/graphql/tests/tck/deprecated/generic-filtering/delete-interface-deprecated.test.ts
@@ -122,22 +122,22 @@ describe("Cypher Delete - interface - deprecated", () => {
             WHERE this.name = $param0
             WITH *
             CALL (*) {
-                OPTIONAL MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                WHERE this1.title = $param1
-                WITH this0, collect(DISTINCT this1) AS var2
-                CALL (var2) {
-                    UNWIND var2 AS var3
-                    DETACH DELETE var3
-                }
+              OPTIONAL MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+              WHERE this1.title = $param1
+              WITH this0, collect(DISTINCT this1) AS var2
+              CALL (var2) {
+                UNWIND var2 AS var3
+                DETACH DELETE var3
+              }
             }
             CALL (*) {
-                OPTIONAL MATCH (this)-[this4:ACTED_IN]->(this5:Series)
-                WHERE this5.title = $param2
-                WITH this4, collect(DISTINCT this5) AS var6
-                CALL (var6) {
-                    UNWIND var6 AS var7
-                    DETACH DELETE var7
-                }
+              OPTIONAL MATCH (this)-[this4:ACTED_IN]->(this5:Series)
+              WHERE this5.title = $param2
+              WITH this4, collect(DISTINCT this5) AS var6
+              CALL (var6) {
+                UNWIND var6 AS var7
+                DETACH DELETE var7
+              }
             }
             WITH *
             DETACH DELETE this"
@@ -172,22 +172,22 @@ describe("Cypher Delete - interface - deprecated", () => {
             WHERE this.name = $param0
             WITH *
             CALL (*) {
-                OPTIONAL MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                WHERE (this1.title = $param1 AND this1:Movie)
-                WITH this0, collect(DISTINCT this1) AS var2
-                CALL (var2) {
-                    UNWIND var2 AS var3
-                    DETACH DELETE var3
-                }
+              OPTIONAL MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+              WHERE (this1.title = $param1 AND this1:Movie)
+              WITH this0, collect(DISTINCT this1) AS var2
+              CALL (var2) {
+                UNWIND var2 AS var3
+                DETACH DELETE var3
+              }
             }
             CALL (*) {
-                OPTIONAL MATCH (this)-[this4:ACTED_IN]->(this5:Series)
-                WHERE (this5.title = $param2 AND this5:Movie)
-                WITH this4, collect(DISTINCT this5) AS var6
-                CALL (var6) {
-                    UNWIND var6 AS var7
-                    DETACH DELETE var7
-                }
+              OPTIONAL MATCH (this)-[this4:ACTED_IN]->(this5:Series)
+              WHERE (this5.title = $param2 AND this5:Movie)
+              WITH this4, collect(DISTINCT this5) AS var6
+              CALL (var6) {
+                UNWIND var6 AS var7
+                DETACH DELETE var7
+              }
             }
             WITH *
             DETACH DELETE this"
@@ -224,22 +224,22 @@ describe("Cypher Delete - interface - deprecated", () => {
             WHERE this.name = $param0
             WITH *
             CALL (*) {
-                OPTIONAL MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                WHERE (this1.title = $param1 OR this1.title = $param2)
-                WITH this0, collect(DISTINCT this1) AS var2
-                CALL (var2) {
-                    UNWIND var2 AS var3
-                    DETACH DELETE var3
-                }
+              OPTIONAL MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+              WHERE (this1.title = $param1 OR this1.title = $param2)
+              WITH this0, collect(DISTINCT this1) AS var2
+              CALL (var2) {
+                UNWIND var2 AS var3
+                DETACH DELETE var3
+              }
             }
             CALL (*) {
-                OPTIONAL MATCH (this)-[this4:ACTED_IN]->(this5:Series)
-                WHERE (this5.title = $param3 OR this5.title = $param4)
-                WITH this4, collect(DISTINCT this5) AS var6
-                CALL (var6) {
-                    UNWIND var6 AS var7
-                    DETACH DELETE var7
-                }
+              OPTIONAL MATCH (this)-[this4:ACTED_IN]->(this5:Series)
+              WHERE (this5.title = $param3 OR this5.title = $param4)
+              WITH this4, collect(DISTINCT this5) AS var6
+              CALL (var6) {
+                UNWIND var6 AS var7
+                DETACH DELETE var7
+              }
             }
             WITH *
             DETACH DELETE this"
@@ -281,42 +281,42 @@ describe("Cypher Delete - interface - deprecated", () => {
             WHERE this.name = $param0
             WITH *
             CALL (*) {
-                OPTIONAL MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                WHERE this1.title = $param1
-                WITH *
-                CALL (*) {
-                    OPTIONAL MATCH (this1)<-[this2:ACTED_IN]-(this3:Actor)
-                    WHERE this3.name = $param2
-                    WITH this2, collect(DISTINCT this3) AS var4
-                    CALL (var4) {
-                        UNWIND var4 AS var5
-                        DETACH DELETE var5
-                    }
+              OPTIONAL MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+              WHERE this1.title = $param1
+              WITH *
+              CALL (*) {
+                OPTIONAL MATCH (this1)<-[this2:ACTED_IN]-(this3:Actor)
+                WHERE this3.name = $param2
+                WITH this2, collect(DISTINCT this3) AS var4
+                CALL (var4) {
+                  UNWIND var4 AS var5
+                  DETACH DELETE var5
                 }
-                WITH this0, collect(DISTINCT this1) AS var6
-                CALL (var6) {
-                    UNWIND var6 AS var7
-                    DETACH DELETE var7
-                }
+              }
+              WITH this0, collect(DISTINCT this1) AS var6
+              CALL (var6) {
+                UNWIND var6 AS var7
+                DETACH DELETE var7
+              }
             }
             CALL (*) {
-                OPTIONAL MATCH (this)-[this8:ACTED_IN]->(this9:Series)
-                WHERE this9.title = $param3
-                WITH *
-                CALL (*) {
-                    OPTIONAL MATCH (this9)<-[this10:ACTED_IN]-(this11:Actor)
-                    WHERE this11.name = $param4
-                    WITH this10, collect(DISTINCT this11) AS var12
-                    CALL (var12) {
-                        UNWIND var12 AS var13
-                        DETACH DELETE var13
-                    }
+              OPTIONAL MATCH (this)-[this8:ACTED_IN]->(this9:Series)
+              WHERE this9.title = $param3
+              WITH *
+              CALL (*) {
+                OPTIONAL MATCH (this9)<-[this10:ACTED_IN]-(this11:Actor)
+                WHERE this11.name = $param4
+                WITH this10, collect(DISTINCT this11) AS var12
+                CALL (var12) {
+                  UNWIND var12 AS var13
+                  DETACH DELETE var13
                 }
-                WITH this8, collect(DISTINCT this9) AS var14
-                CALL (var14) {
-                    UNWIND var14 AS var15
-                    DETACH DELETE var15
-                }
+              }
+              WITH this8, collect(DISTINCT this9) AS var14
+              CALL (var14) {
+                UNWIND var14 AS var15
+                DETACH DELETE var15
+              }
             }
             WITH *
             DETACH DELETE this"

--- a/packages/graphql/tests/tck/deprecated/generic-filtering/node-label-interface-deprecated.test.ts
+++ b/packages/graphql/tests/tck/deprecated/generic-filtering/node-label-interface-deprecated.test.ts
@@ -69,23 +69,23 @@ describe("Node directive with interface - deprecated", () => {
             MATCH (this:Film)
             WHERE this.title = $param0
             CALL (this) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this)-[this0:SEARCH]->(this1:Category:ExtraLabel1:ExtraLabel2)
-                    WHERE this1.name = $param1
-                    WITH this1 { .name, __resolveType: \\"Genre\\", __id: id(this1) } AS var2
-                    RETURN var2
-                    UNION
-                    WITH *
-                    MATCH (this)-[this3:SEARCH]->(this4:Film)
-                    WHERE this4.name = $param2
-                    WITH this4 { .title, __resolveType: \\"Movie\\", __id: id(this4) } AS var2
-                    RETURN var2
-                }
-                WITH var2
-                SKIP $param3
-                LIMIT $param4
-                RETURN collect(var2) AS var2
+              CALL (*) {
+                WITH *
+                MATCH (this)-[this0:SEARCH]->(this1:Category&ExtraLabel1&ExtraLabel2)
+                WHERE this1.name = $param1
+                WITH this1 { .name, __resolveType: 'Genre', __id: elementId(this1) } AS var2
+                RETURN var2
+                UNION
+                WITH *
+                MATCH (this)-[this3:SEARCH]->(this4:Film)
+                WHERE this4.name = $param2
+                WITH this4 { .title, __resolveType: 'Movie', __id: elementId(this4) } AS var2
+                RETURN var2
+              }
+              WITH var2
+              SKIP $param3
+              LIMIT $param4
+              RETURN collect(var2) AS var2
             }
             RETURN this { search: var2 } AS this"
         `);

--- a/packages/graphql/tests/tck/deprecated/generic-filtering/projection-deprecated.test.ts
+++ b/packages/graphql/tests/tck/deprecated/generic-filtering/projection-deprecated.test.ts
@@ -69,13 +69,12 @@ describe("Cypher Auth Projection - deprecated", () => {
             MATCH (this:User)
             WITH *
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
             WITH *
-            SET
-                this.id = $param2
+            SET this.id = $param2
             WITH this
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
             RETURN this { .id } AS this"
         `);
 
@@ -113,10 +112,9 @@ describe("Cypher Auth Projection - deprecated", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:User)
-                SET
-                    create_this1.id = create_var0.id
-                RETURN create_this1
+              CREATE (create_this1:User)
+              SET create_this1.id = create_var0.id
+              RETURN create_this1
             }
             RETURN collect(create_this1 { .id }) AS data"
         `);

--- a/packages/graphql/tests/tck/deprecated/generic-filtering/roles-deprecated.test.ts
+++ b/packages/graphql/tests/tck/deprecated/generic-filtering/roles-deprecated.test.ts
@@ -114,7 +114,7 @@ describe("Cypher Auth Roles - deprecated", () => {
             "CYPHER 5
             MATCH (this:User)
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
             RETURN this { .id, .name } AS this"
         `);
 
@@ -152,8 +152,8 @@ describe("Cypher Auth Roles - deprecated", () => {
             "CYPHER 5
             MATCH (this:User)
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
             RETURN this { .id, .name, .password } AS this"
         `);
 
@@ -192,18 +192,18 @@ describe("Cypher Auth Roles - deprecated", () => {
             "CYPHER 5
             MATCH (this:User)
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:HAS_HISTORY]->(h:History) RETURN h
-                }
-                WITH h AS this0
-                WITH *
-                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                WITH this0 { .url } AS this0
-                RETURN collect(this0) AS var1
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:HAS_HISTORY]->(h:History) RETURN h
+              }
+              WITH h AS this0
+              WITH *
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
+              WITH this0 { .url } AS this0
+              RETURN collect(this0) AS var1
             }
             RETURN this { history: var1 } AS this"
         `);
@@ -244,13 +244,12 @@ describe("Cypher Auth Roles - deprecated", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:User)
-                SET
-                    create_this1.id = create_var0.id
-                WITH *
-                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $create_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                CALL apoc.util.validate((create_var0.password IS NOT NULL AND NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $create_param4 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                RETURN create_this1
+              CREATE (create_this1:User)
+              SET create_this1.id = create_var0.id
+              WITH *
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $create_param3 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
+              CALL apoc.util.validate((create_var0.password IS NOT NULL AND NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $create_param4 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
+              RETURN create_this1
             }
             RETURN collect(create_this1 { .id }) AS data"
         `);
@@ -295,14 +294,14 @@ describe("Cypher Auth Roles - deprecated", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:User)
-                SET
-                    create_this1.id = create_var0.id,
-                    create_this1.password = create_var0.password
-                WITH *
-                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $create_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                CALL apoc.util.validate((create_var0.password IS NOT NULL AND NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $create_param4 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                RETURN create_this1
+              CREATE (create_this1:User)
+              SET
+                create_this1.id = create_var0.id,
+                create_this1.password = create_var0.password
+              WITH *
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $create_param3 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
+              CALL apoc.util.validate((create_var0.password IS NOT NULL AND NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $create_param4 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
+              RETURN create_this1
             }
             RETURN collect(create_this1 { .id }) AS data"
         `);
@@ -350,15 +349,14 @@ describe("Cypher Auth Roles - deprecated", () => {
             WITH *
             WHERE this.id = $param0
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
             WITH *
-            SET
-                this.id = $param4
+            SET this.id = $param4
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
             WITH this
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param6 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param6 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
             RETURN this { .id } AS this"
         `);
 
@@ -402,17 +400,16 @@ describe("Cypher Auth Roles - deprecated", () => {
             WITH *
             WHERE this.id = $param0
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
             WITH *
-            SET
-                this.password = $param5
+            SET this.password = $param5
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param6 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param7 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param6 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param7 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
             WITH this
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param8 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param8 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
             RETURN this { .id } AS this"
         `);
 
@@ -458,19 +455,19 @@ describe("Cypher Auth Roles - deprecated", () => {
             WITH *
             WITH *
             CALL (*) {
-                CALL (this) {
-                    MATCH (this0:Post)
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    CREATE (this)-[this1:HAS_POST]->(this0)
-                    WITH *
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    WITH *
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                }
+              CALL (this) {
+                MATCH (this0:Post)
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
+                CREATE (this)-[this1:HAS_POST]->(this0)
+                WITH *
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
+                WITH *
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
+              }
             }
             WITH this
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
             RETURN this { .id } AS this"
         `);
 
@@ -517,21 +514,21 @@ describe("Cypher Auth Roles - deprecated", () => {
             WITH *
             WITH *
             CALL (*) {
-                MATCH (this)<-[this0:HAS_COMMENT]-(this1:Post)
-                WITH *
-                WITH *
-                CALL (*) {
-                    CALL (this1) {
-                        MATCH (this2:User)
-                        WHERE this2.id = $param0
-                        CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                        CREATE (this1)-[this3:HAS_POST]->(this2)
-                        WITH *
-                        CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                        WITH *
-                        CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    }
+              MATCH (this)<-[this0:HAS_COMMENT]-(this1:Post)
+              WITH *
+              WITH *
+              CALL (*) {
+                CALL (this1) {
+                  MATCH (this2:User)
+                  WHERE this2.id = $param0
+                  CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
+                  CREATE (this1)-[this3:HAS_POST]->(this2)
+                  WITH *
+                  CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
+                  WITH *
+                  CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
                 }
+              }
             }
             WITH this
             RETURN this { .content } AS this"
@@ -576,22 +573,22 @@ describe("Cypher Auth Roles - deprecated", () => {
             WITH *
             WITH *
             CALL (*) {
-                CALL (this) {
-                    OPTIONAL MATCH (this)-[this0:HAS_POST]->(this1:Post)
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    WITH *
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    WITH *
-                    DELETE this0
-                    WITH *
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    WITH *
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                }
+              CALL (this) {
+                OPTIONAL MATCH (this)-[this0:HAS_POST]->(this1:Post)
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
+                WITH *
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
+                WITH *
+                DELETE this0
+                WITH *
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
+                WITH *
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
+              }
             }
             WITH this
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param6 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param6 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
             RETURN this { .id } AS this"
         `);
 
@@ -641,24 +638,24 @@ describe("Cypher Auth Roles - deprecated", () => {
             WITH *
             WITH *
             CALL (*) {
-                MATCH (this)<-[this0:HAS_COMMENT]-(this1:Post)
-                WITH *
-                WITH *
-                CALL (*) {
-                    CALL (this1) {
-                        OPTIONAL MATCH (this1)-[this2:HAS_POST]->(this3:User)
-                        WHERE this3.id = $param0
-                        CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                        WITH *
-                        CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                        WITH *
-                        DELETE this2
-                        WITH *
-                        CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                        WITH *
-                        CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param6 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    }
+              MATCH (this)<-[this0:HAS_COMMENT]-(this1:Post)
+              WITH *
+              WITH *
+              CALL (*) {
+                CALL (this1) {
+                  OPTIONAL MATCH (this1)-[this2:HAS_POST]->(this3:User)
+                  WHERE this3.id = $param0
+                  CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
+                  WITH *
+                  CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
+                  WITH *
+                  DELETE this2
+                  WITH *
+                  CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
+                  WITH *
+                  CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param6 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
                 }
+              }
             }
             WITH this
             RETURN this { .content } AS this"
@@ -699,7 +696,7 @@ describe("Cypher Auth Roles - deprecated", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             MATCH (this:User)
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
             WITH *
             DETACH DELETE this"
         `);
@@ -735,16 +732,16 @@ describe("Cypher Auth Roles - deprecated", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             MATCH (this:User)
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
             WITH *
             CALL (*) {
-                OPTIONAL MATCH (this)-[this0:HAS_POST]->(this1:Post)
-                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                WITH this0, collect(DISTINCT this1) AS var2
-                CALL (var2) {
-                    UNWIND var2 AS var3
-                    DETACH DELETE var3
-                }
+              OPTIONAL MATCH (this)-[this0:HAS_POST]->(this1:Post)
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
+              WITH this0, collect(DISTINCT this1) AS var2
+              CALL (var2) {
+                UNWIND var2 AS var3
+                DETACH DELETE var3
+              }
             }
             WITH *
             DETACH DELETE this"

--- a/packages/graphql/tests/tck/deprecated/issues/6005.test.ts
+++ b/packages/graphql/tests/tck/deprecated/issues/6005.test.ts
@@ -62,8 +62,8 @@ describe("https://github.com/neo4j/graphql/issues/6005", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                RETURN count(this1) = $param0 AS var2
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              RETURN count(this1) = $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -96,16 +96,16 @@ describe("https://github.com/neo4j/graphql/issues/6005", () => {
             "CYPHER 5
             MATCH (this:Actor)
             CALL (this) {
-                MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                WITH DISTINCT this1
-                CALL (this1) {
-                    MATCH (this1)<-[this2:ACTED_IN]-(this3:Actor)
-                    RETURN count(this3) = $param0 AS var4
-                }
-                WITH *
-                WHERE var4 = true
-                WITH this1 { .title } AS this1
-                RETURN collect(this1) AS var5
+              MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+              WITH DISTINCT this1
+              CALL (this1) {
+                MATCH (this1)<-[this2:ACTED_IN]-(this3:Actor)
+                RETURN count(this3) = $param0 AS var4
+              }
+              WITH *
+              WHERE var4 = true
+              WITH this1 { .title } AS this1
+              RETURN collect(this1) AS var5
             }
             RETURN this { movies: var5 } AS this"
         `);
@@ -134,14 +134,14 @@ describe("https://github.com/neo4j/graphql/issues/6005", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)<-[:ACTED_IN]-(this0:Actor)
-                CALL (this0) {
-                    MATCH (this0)-[this1:ACTED_IN]->(this2:Movie)
-                    RETURN count(this2) = $param0 AS var3
-                }
-                WITH *
-                WHERE var3 = true
-                RETURN count(this0) > 0 AS var4
+              MATCH (this)<-[:ACTED_IN]-(this0:Actor)
+              CALL (this0) {
+                MATCH (this0)-[this1:ACTED_IN]->(this2:Movie)
+                RETURN count(this2) = $param0 AS var3
+              }
+              WITH *
+              WHERE var3 = true
+              RETURN count(this0) > 0 AS var4
             }
             WITH *
             WHERE var4 = true

--- a/packages/graphql/tests/tck/directives/alias.test.ts
+++ b/packages/graphql/tests/tck/directives/alias.test.ts
@@ -68,10 +68,10 @@ describe("Cypher alias directive", () => {
             "CYPHER 5
             MATCH (this:Actor)
             CALL (this) {
-                MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                WITH DISTINCT this1
-                WITH this1 { .title, rating: this1.ratingPropInDb } AS this1
-                RETURN collect(this1) AS var2
+              MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+              WITH DISTINCT this1
+              WITH this1 { .title, rating: this1.ratingPropInDb } AS this1
+              RETURN collect(this1) AS var2
             }
             RETURN this { .name, city: this.cityPropInDb, actedIn: var2 } AS this"
         `);
@@ -107,14 +107,14 @@ describe("Cypher alias directive", () => {
             "CYPHER 5
             MATCH (this:Actor)
             CALL (this) {
-                MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ properties: { character: this0.characterPropInDb, screenTime: this0.screenTime, __resolveType: \\"ActorActedInProps\\" }, node: { title: this1.title, rating: this1.ratingPropInDb, __resolveType: \\"Movie\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({properties: {character: this0.characterPropInDb, screenTime: this0.screenTime, __resolveType: 'ActorActedInProps'}, node: {title: this1.title, rating: this1.ratingPropInDb, __resolveType: 'Movie'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { .name, city: this.cityPropInDb, actedInConnection: var3 } AS this"
         `);
@@ -169,40 +169,40 @@ describe("Cypher alias directive", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Actor)
+              CREATE (create_this1:Actor)
+              SET
+                create_this1.name = create_var0.name,
+                create_this1.cityPropInDb = create_var0.city
+              WITH create_this1, create_var0
+              CALL (create_this1, create_var0) {
+                UNWIND create_var0.actedIn.create AS create_var2
+                CREATE (create_this3:Movie)
                 SET
-                    create_this1.name = create_var0.name,
-                    create_this1.cityPropInDb = create_var0.city
-                WITH create_this1, create_var0
-                CALL (create_this1, create_var0) {
-                    UNWIND create_var0.actedIn.create AS create_var2
-                    CREATE (create_this3:Movie)
-                    SET
-                        create_this3.title = create_var2.node.title,
-                        create_this3.ratingPropInDb = create_var2.node.rating
-                    MERGE (create_this1)-[create_this4:ACTED_IN]->(create_this3)
-                    SET
-                        create_this4.characterPropInDb = create_var2.edge.character,
-                        create_this4.screenTime = create_var2.edge.screenTime
-                    RETURN collect(NULL) AS create_var5
-                }
-                RETURN create_this1
+                  create_this3.title = create_var2.node.title,
+                  create_this3.ratingPropInDb = create_var2.node.rating
+                MERGE (create_this1)-[create_this4:ACTED_IN]->(create_this3)
+                SET
+                  create_this4.characterPropInDb = create_var2.edge.character,
+                  create_this4.screenTime = create_var2.edge.screenTime
+                RETURN collect(NULL) AS create_var5
+              }
+              RETURN create_this1
             }
             CALL (create_this1) {
-                MATCH (create_this1)-[create_this6:ACTED_IN]->(create_this7:Movie)
-                WITH DISTINCT create_this7
-                WITH create_this7 { .title, rating: create_this7.ratingPropInDb } AS create_this7
-                RETURN collect(create_this7) AS create_var8
+              MATCH (create_this1)-[create_this6:ACTED_IN]->(create_this7:Movie)
+              WITH DISTINCT create_this7
+              WITH create_this7 { .title, rating: create_this7.ratingPropInDb } AS create_this7
+              RETURN collect(create_this7) AS create_var8
             }
             CALL (create_this1) {
-                MATCH (create_this1)-[create_this9:ACTED_IN]->(create_this10:Movie)
-                WITH collect({ node: create_this10, relationship: create_this9 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS create_this10, edge.relationship AS create_this9
-                    RETURN collect({ properties: { character: create_this9.characterPropInDb, screenTime: create_this9.screenTime, __resolveType: \\"ActorActedInProps\\" }, node: { title: create_this10.title, rating: create_this10.ratingPropInDb, __resolveType: \\"Movie\\" } }) AS create_var11
-                }
-                RETURN { edges: create_var11 } AS create_var12
+              MATCH (create_this1)-[create_this9:ACTED_IN]->(create_this10:Movie)
+              WITH collect({node: create_this10, relationship: create_this9}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS create_this10, edge.relationship AS create_this9
+                RETURN collect({properties: {character: create_this9.characterPropInDb, screenTime: create_this9.screenTime, __resolveType: 'ActorActedInProps'}, node: {title: create_this10.title, rating: create_this10.ratingPropInDb, __resolveType: 'Movie'}}) AS create_var11
+              }
+              RETURN {edges: create_var11} AS create_var12
             }
             RETURN collect(create_this1 { .name, city: create_this1.cityPropInDb, actedIn: create_var8, actedInConnection: create_var12 }) AS data"
         `);

--- a/packages/graphql/tests/tck/directives/authorization/arguments/allow/allow.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/allow/allow.test.ts
@@ -123,7 +123,7 @@ describe("Cypher Auth Allow", () => {
             "CYPHER 5
             MATCH (this:User)
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
             RETURN this { .id } AS this"
         `);
 
@@ -158,8 +158,8 @@ describe("Cypher Auth Allow", () => {
             "CYPHER 5
             MATCH (this:User)
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
             RETURN this { .password } AS this"
         `);
 
@@ -197,17 +197,17 @@ describe("Cypher Auth Allow", () => {
             "CYPHER 5
             MATCH (this:User)
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
             CALL (this) {
-                MATCH (this)-[this0:HAS_POST]->(this1:Post)
-                WITH DISTINCT this1
-                WITH *
-                CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                    MATCH (this1)<-[:HAS_POST]-(this2:User)
-                    WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
-                }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                WITH this1 { .content } AS this1
-                RETURN collect(this1) AS var3
+              MATCH (this)-[this0:HAS_POST]->(this1:Post)
+              WITH DISTINCT this1
+              WITH *
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
+                MATCH (this1)<-[:HAS_POST]-(this2:User)
+                WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
+              }), '@neo4j/graphql/FORBIDDEN', [])
+              WITH this1 { .content } AS this1
+              RETURN collect(this1) AS var3
             }
             RETURN this { .id, posts: var3 } AS this"
         `);
@@ -246,17 +246,17 @@ describe("Cypher Auth Allow", () => {
             MATCH (this:Post)
             WITH *
             CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                MATCH (this)<-[:HAS_POST]-(this0:User)
-                WHERE ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)
-            }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+              MATCH (this)<-[:HAS_POST]-(this0:User)
+              WHERE ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)
+            }), '@neo4j/graphql/FORBIDDEN', [])
             CALL (this) {
-                MATCH (this)<-[this1:HAS_POST]-(this2:User)
-                WITH DISTINCT this2
-                WITH *
-                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                WITH this2 { .password } AS this2
-                RETURN collect(this2) AS var3
+              MATCH (this)<-[this1:HAS_POST]-(this2:User)
+              WITH DISTINCT this2
+              WITH *
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
+              WITH this2 { .password } AS this2
+              RETURN collect(this2) AS var3
             }
             RETURN this { creator: var3 } AS this"
         `);
@@ -298,30 +298,30 @@ describe("Cypher Auth Allow", () => {
             MATCH (this:User)
             WITH *
             WHERE this.id = $param0
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
             CALL (this) {
-                MATCH (this)-[this0:HAS_POST]->(this1:Post)
-                WITH DISTINCT this1
+              MATCH (this)-[this0:HAS_POST]->(this1:Post)
+              WITH DISTINCT this1
+              WITH *
+              WHERE this1.id = $param3
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
+                MATCH (this1)<-[:HAS_POST]-(this2:User)
+                WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
+              }), '@neo4j/graphql/FORBIDDEN', [])
+              CALL (this1) {
+                MATCH (this1)-[this3:HAS_COMMENT]->(this4:Comment)
+                WITH DISTINCT this4
                 WITH *
-                WHERE this1.id = $param3
+                WHERE this4.id = $param4
                 CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                    MATCH (this1)<-[:HAS_POST]-(this2:User)
-                    WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
-                }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                CALL (this1) {
-                    MATCH (this1)-[this3:HAS_COMMENT]->(this4:Comment)
-                    WITH DISTINCT this4
-                    WITH *
-                    WHERE this4.id = $param4
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                        MATCH (this4)<-[:HAS_COMMENT]-(this5:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this5.id = $jwt.sub)
-                    }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    WITH this4 { .content } AS this4
-                    RETURN collect(this4) AS var6
-                }
-                WITH this1 { comments: var6 } AS this1
-                RETURN collect(this1) AS var7
+                  MATCH (this4)<-[:HAS_COMMENT]-(this5:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this5.id = $jwt.sub)
+                }), '@neo4j/graphql/FORBIDDEN', [])
+                WITH this4 { .content } AS this4
+                RETURN collect(this4) AS var6
+              }
+              WITH this1 { comments: var6 } AS this1
+              RETURN collect(this1) AS var7
             }
             RETURN this { .id, posts: var7 } AS this"
         `);
@@ -364,13 +364,12 @@ describe("Cypher Auth Allow", () => {
             WITH *
             WHERE this.id = $param0
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
             WITH *
-            SET
-                this.id = $param3
+            SET this.id = $param3
             WITH this
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
             RETURN this { .id } AS this"
         `);
 
@@ -411,14 +410,13 @@ describe("Cypher Auth Allow", () => {
             WITH *
             WHERE this.id = $param0
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
             WITH *
-            SET
-                this.password = $param3
+            SET this.password = $param3
             WITH this
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
             RETURN this { .id } AS this"
         `);
 
@@ -463,20 +461,19 @@ describe("Cypher Auth Allow", () => {
             WHERE this.id = $param0
             WITH *
             CALL (*) {
-                MATCH (this)<-[this0:HAS_POST]-(this1:User)
-                WITH *
-                WITH *
-                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this1.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                WITH *
-                SET
-                    this1.id = $param3
+              MATCH (this)<-[this0:HAS_POST]-(this1:User)
+              WITH *
+              WITH *
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this1.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
+              WITH *
+              SET this1.id = $param3
             }
             WITH this
             WITH *
             CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                MATCH (this)<-[:HAS_POST]-(this2:User)
-                WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
-            }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+              MATCH (this)<-[:HAS_POST]-(this2:User)
+              WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
+            }), '@neo4j/graphql/FORBIDDEN', [])
             RETURN this { .id } AS this"
         `);
 
@@ -521,21 +518,20 @@ describe("Cypher Auth Allow", () => {
             WHERE this.id = $param0
             WITH *
             CALL (*) {
-                MATCH (this)<-[this0:HAS_POST]-(this1:User)
-                WITH *
-                WITH *
-                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this1.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this1.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                WITH *
-                SET
-                    this1.password = $param3
+              MATCH (this)<-[this0:HAS_POST]-(this1:User)
+              WITH *
+              WITH *
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this1.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this1.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
+              WITH *
+              SET this1.password = $param3
             }
             WITH this
             WITH *
             CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                MATCH (this)<-[:HAS_POST]-(this2:User)
-                WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
-            }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+              MATCH (this)<-[:HAS_POST]-(this2:User)
+              WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
+            }), '@neo4j/graphql/FORBIDDEN', [])
             RETURN this { .id } AS this"
         `);
 
@@ -572,7 +568,7 @@ describe("Cypher Auth Allow", () => {
             "CYPHER 5
             MATCH (this:User)
             WHERE this.id = $param0
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
             WITH *
             DETACH DELETE this"
         `);
@@ -612,20 +608,20 @@ describe("Cypher Auth Allow", () => {
             "CYPHER 5
             MATCH (this:User)
             WHERE this.id = $param0
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
             WITH *
             CALL (*) {
-                OPTIONAL MATCH (this)-[this0:HAS_POST]->(this1:Post)
-                WHERE this1.id = $param3
-                CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                    MATCH (this1)<-[:HAS_POST]-(this2:User)
-                    WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
-                }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                WITH this0, collect(DISTINCT this1) AS var3
-                CALL (var3) {
-                    UNWIND var3 AS var4
-                    DETACH DELETE var4
-                }
+              OPTIONAL MATCH (this)-[this0:HAS_POST]->(this1:Post)
+              WHERE this1.id = $param3
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
+                MATCH (this1)<-[:HAS_POST]-(this2:User)
+                WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
+              }), '@neo4j/graphql/FORBIDDEN', [])
+              WITH this0, collect(DISTINCT this1) AS var3
+              CALL (var3) {
+                UNWIND var3 AS var4
+                DETACH DELETE var4
+              }
             }
             WITH *
             DETACH DELETE this"
@@ -672,22 +668,22 @@ describe("Cypher Auth Allow", () => {
             WHERE this.id = $param0
             WITH *
             CALL (*) {
-                CALL (this) {
-                    OPTIONAL MATCH (this)-[this0:HAS_POST]->(this1:Post)
-                    WHERE this1.id = $param1
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                        MATCH (this1)<-[:HAS_POST]-(this2:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
-                    }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    WITH *
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    WITH *
-                    DELETE this0
-                }
+              CALL (this) {
+                OPTIONAL MATCH (this)-[this0:HAS_POST]->(this1:Post)
+                WHERE this1.id = $param1
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
+                  MATCH (this1)<-[:HAS_POST]-(this2:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
+                }), '@neo4j/graphql/FORBIDDEN', [])
+                WITH *
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
+                WITH *
+                DELETE this0
+              }
             }
             WITH this
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
             RETURN this { .id } AS this"
         `);
 
@@ -736,41 +732,41 @@ describe("Cypher Auth Allow", () => {
             WHERE this.id = $param0
             WITH *
             CALL (*) {
-                CALL (this) {
-                    OPTIONAL MATCH (this)<-[this0:HAS_COMMENT]-(this1:Post)
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                        MATCH (this1)<-[:HAS_POST]-(this2:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
-                    }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+              CALL (this) {
+                OPTIONAL MATCH (this)<-[this0:HAS_COMMENT]-(this1:Post)
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
+                  MATCH (this1)<-[:HAS_POST]-(this2:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
+                }), '@neo4j/graphql/FORBIDDEN', [])
+                WITH *
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
+                  MATCH (this)<-[:HAS_COMMENT]-(this3:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
+                }), '@neo4j/graphql/FORBIDDEN', [])
+                CALL (this1) {
+                  CALL (this1) {
+                    OPTIONAL MATCH (this1)<-[this4:HAS_POST]-(this5:User)
+                    WHERE this5.id = $param3
+                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this5.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
                     WITH *
                     CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                        MATCH (this)<-[:HAS_COMMENT]-(this3:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
-                    }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    CALL (this1) {
-                        CALL (this1) {
-                            OPTIONAL MATCH (this1)<-[this4:HAS_POST]-(this5:User)
-                            WHERE this5.id = $param3
-                            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this5.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                            WITH *
-                            CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                                MATCH (this1)<-[:HAS_POST]-(this6:User)
-                                WHERE ($jwt.sub IS NOT NULL AND this6.id = $jwt.sub)
-                            }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                            WITH *
-                            DELETE this4
-                        }
-                    }
+                      MATCH (this1)<-[:HAS_POST]-(this6:User)
+                      WHERE ($jwt.sub IS NOT NULL AND this6.id = $jwt.sub)
+                    }), '@neo4j/graphql/FORBIDDEN', [])
                     WITH *
-                    DELETE this0
+                    DELETE this4
+                  }
                 }
+                WITH *
+                DELETE this0
+              }
             }
             WITH this
             WITH *
             CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                MATCH (this)<-[:HAS_COMMENT]-(this7:User)
-                WHERE ($jwt.sub IS NOT NULL AND this7.id = $jwt.sub)
-            }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+              MATCH (this)<-[:HAS_COMMENT]-(this7:User)
+              WHERE ($jwt.sub IS NOT NULL AND this7.id = $jwt.sub)
+            }), '@neo4j/graphql/FORBIDDEN', [])
             RETURN this { .id } AS this"
         `);
 
@@ -815,19 +811,19 @@ describe("Cypher Auth Allow", () => {
             WHERE this.id = $param0
             WITH *
             CALL (*) {
-                CALL (this) {
-                    MATCH (this0:Post)
-                    WHERE this0.id = $param1
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                        MATCH (this0)<-[:HAS_POST]-(this1:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this1.id = $jwt.sub)
-                    }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    CREATE (this)-[this2:HAS_POST]->(this0)
-                }
+              CALL (this) {
+                MATCH (this0:Post)
+                WHERE this0.id = $param1
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
+                  MATCH (this0)<-[:HAS_POST]-(this1:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this1.id = $jwt.sub)
+                }), '@neo4j/graphql/FORBIDDEN', [])
+                CREATE (this)-[this2:HAS_POST]->(this0)
+              }
             }
             WITH this
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
             RETURN this { .id } AS this"
         `);
 

--- a/packages/graphql/tests/tck/directives/authorization/arguments/allow/interface-relationships/implementation-allow.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/allow/interface-relationships/implementation-allow.test.ts
@@ -97,23 +97,23 @@ describe("@auth allow on specific interface implementation", () => {
             "CYPHER 5
             MATCH (this:User)
             CALL (this) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this)-[this0:HAS_CONTENT]->(this1:Comment)
-                    WITH this1 { .id, .content, __resolveType: \\"Comment\\", __id: id(this1) } AS var2
-                    RETURN var2
-                    UNION
-                    WITH *
-                    MATCH (this)-[this3:HAS_CONTENT]->(this4:Post)
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                        MATCH (this4)<-[:HAS_CONTENT]-(this5:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this5.id = $jwt.sub)
-                    }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    WITH this4 { .id, .content, __resolveType: \\"Post\\", __id: id(this4) } AS var2
-                    RETURN var2
-                }
-                WITH var2
-                RETURN collect(var2) AS var2
+              CALL (*) {
+                WITH *
+                MATCH (this)-[this0:HAS_CONTENT]->(this1:Comment)
+                WITH this1 { .id, .content, __resolveType: 'Comment', __id: elementId(this1) } AS var2
+                RETURN var2
+                UNION
+                WITH *
+                MATCH (this)-[this3:HAS_CONTENT]->(this4:Post)
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
+                  MATCH (this4)<-[:HAS_CONTENT]-(this5:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this5.id = $jwt.sub)
+                }), '@neo4j/graphql/FORBIDDEN', [])
+                WITH this4 { .id, .content, __resolveType: 'Post', __id: elementId(this4) } AS var2
+                RETURN var2
+              }
+              WITH var2
+              RETURN collect(var2) AS var2
             }
             RETURN this { .id, content: var2 } AS this"
         `);
@@ -157,32 +157,32 @@ describe("@auth allow on specific interface implementation", () => {
             MATCH (this:User)
             WHERE this.id = $param0
             CALL (this) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this)-[this0:HAS_CONTENT]->(this1:Comment)
-                    WHERE this1.id = $param1
-                    WITH this1 { __resolveType: \\"Comment\\", __id: id(this1) } AS var2
-                    RETURN var2
-                    UNION
-                    WITH *
-                    MATCH (this)-[this3:HAS_CONTENT]->(this4:Post)
-                    WHERE this4.id = $param2
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                        MATCH (this4)<-[:HAS_CONTENT]-(this5:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this5.id = $jwt.sub)
-                    }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    CALL (this4) {
-                        MATCH (this4)-[this6:HAS_COMMENT]->(this7:Comment)
-                        WHERE this7.id = $param5
-                        WITH DISTINCT this7
-                        WITH this7 { .content } AS this7
-                        RETURN collect(this7) AS var8
-                    }
-                    WITH this4 { comments: var8, __resolveType: \\"Post\\", __id: id(this4) } AS var2
-                    RETURN var2
+              CALL (*) {
+                WITH *
+                MATCH (this)-[this0:HAS_CONTENT]->(this1:Comment)
+                WHERE this1.id = $param1
+                WITH this1 { __resolveType: 'Comment', __id: elementId(this1) } AS var2
+                RETURN var2
+                UNION
+                WITH *
+                MATCH (this)-[this3:HAS_CONTENT]->(this4:Post)
+                WHERE this4.id = $param2
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
+                  MATCH (this4)<-[:HAS_CONTENT]-(this5:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this5.id = $jwt.sub)
+                }), '@neo4j/graphql/FORBIDDEN', [])
+                CALL (this4) {
+                  MATCH (this4)-[this6:HAS_COMMENT]->(this7:Comment)
+                  WHERE this7.id = $param5
+                  WITH DISTINCT this7
+                  WITH this7 { .content } AS this7
+                  RETURN collect(this7) AS var8
                 }
-                WITH var2
-                RETURN collect(var2) AS var2
+                WITH this4 { comments: var8, __resolveType: 'Post', __id: elementId(this4) } AS var2
+                RETURN var2
+              }
+              WITH var2
+              RETURN collect(var2) AS var2
             }
             RETURN this { .id, content: var2 } AS this"
         `);
@@ -233,43 +233,41 @@ describe("@auth allow on specific interface implementation", () => {
             WHERE this.id = $param0
             WITH *
             CALL (*) {
-                MATCH (this)-[this0:HAS_CONTENT]->(this1:Comment)
-                WITH *
-                SET
-                    this1.id = $param1
+              MATCH (this)-[this0:HAS_CONTENT]->(this1:Comment)
+              WITH *
+              SET this1.id = $param1
             }
             WITH *
             CALL (*) {
-                MATCH (this)-[this2:HAS_CONTENT]->(this3:Post)
-                WITH *
-                WITH *
-                CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                    MATCH (this3)<-[:HAS_CONTENT]-(this4:User)
-                    WHERE ($jwt.sub IS NOT NULL AND this4.id = $jwt.sub)
-                }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                WITH *
-                SET
-                    this3.id = $param4
+              MATCH (this)-[this2:HAS_CONTENT]->(this3:Post)
+              WITH *
+              WITH *
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
+                MATCH (this3)<-[:HAS_CONTENT]-(this4:User)
+                WHERE ($jwt.sub IS NOT NULL AND this4.id = $jwt.sub)
+              }), '@neo4j/graphql/FORBIDDEN', [])
+              WITH *
+              SET this3.id = $param4
             }
             WITH this
             CALL (this) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this)-[this5:HAS_CONTENT]->(this6:Comment)
-                    WITH this6 { .id, __resolveType: \\"Comment\\", __id: id(this6) } AS var7
-                    RETURN var7
-                    UNION
-                    WITH *
-                    MATCH (this)-[this8:HAS_CONTENT]->(this9:Post)
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                        MATCH (this9)<-[:HAS_CONTENT]-(this10:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this10.id = $jwt.sub)
-                    }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    WITH this9 { .id, __resolveType: \\"Post\\", __id: id(this9) } AS var7
-                    RETURN var7
-                }
-                WITH var7
-                RETURN collect(var7) AS var7
+              CALL (*) {
+                WITH *
+                MATCH (this)-[this5:HAS_CONTENT]->(this6:Comment)
+                WITH this6 { .id, __resolveType: 'Comment', __id: elementId(this6) } AS var7
+                RETURN var7
+                UNION
+                WITH *
+                MATCH (this)-[this8:HAS_CONTENT]->(this9:Post)
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
+                  MATCH (this9)<-[:HAS_CONTENT]-(this10:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this10.id = $jwt.sub)
+                }), '@neo4j/graphql/FORBIDDEN', [])
+                WITH this9 { .id, __resolveType: 'Post', __id: elementId(this9) } AS var7
+                RETURN var7
+              }
+              WITH var7
+              RETURN collect(var7) AS var7
             }
             RETURN this { .id, content: var7 } AS this"
         `);
@@ -313,26 +311,26 @@ describe("@auth allow on specific interface implementation", () => {
             WHERE this.id = $param0
             WITH *
             CALL (*) {
-                OPTIONAL MATCH (this)-[this0:HAS_CONTENT]->(this1:Comment)
-                WHERE this1.id = $param1
-                WITH this0, collect(DISTINCT this1) AS var2
-                CALL (var2) {
-                    UNWIND var2 AS var3
-                    DETACH DELETE var3
-                }
+              OPTIONAL MATCH (this)-[this0:HAS_CONTENT]->(this1:Comment)
+              WHERE this1.id = $param1
+              WITH this0, collect(DISTINCT this1) AS var2
+              CALL (var2) {
+                UNWIND var2 AS var3
+                DETACH DELETE var3
+              }
             }
             CALL (*) {
-                OPTIONAL MATCH (this)-[this4:HAS_CONTENT]->(this5:Post)
-                WHERE this5.id = $param2
-                CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                    MATCH (this5)<-[:HAS_CONTENT]-(this6:User)
-                    WHERE ($jwt.sub IS NOT NULL AND this6.id = $jwt.sub)
-                }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                WITH this4, collect(DISTINCT this5) AS var7
-                CALL (var7) {
-                    UNWIND var7 AS var8
-                    DETACH DELETE var8
-                }
+              OPTIONAL MATCH (this)-[this4:HAS_CONTENT]->(this5:Post)
+              WHERE this5.id = $param2
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
+                MATCH (this5)<-[:HAS_CONTENT]-(this6:User)
+                WHERE ($jwt.sub IS NOT NULL AND this6.id = $jwt.sub)
+              }), '@neo4j/graphql/FORBIDDEN', [])
+              WITH this4, collect(DISTINCT this5) AS var7
+              CALL (var7) {
+                UNWIND var7 AS var8
+                DETACH DELETE var8
+              }
             }
             WITH *
             DETACH DELETE this"

--- a/packages/graphql/tests/tck/directives/authorization/arguments/is-authenticated/interface-relationships/implementation-is-authenticated.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/is-authenticated/interface-relationships/implementation-is-authenticated.test.ts
@@ -81,11 +81,11 @@ describe("Cypher Auth isAuthenticated", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Post)
-                SET
-                    create_this1.id = create_var0.id,
-                    create_this1.content = create_var0.content
-                RETURN create_this1
+              CREATE (create_this1:Post)
+              SET
+                create_this1.id = create_var0.id,
+                create_this1.content = create_var0.content
+              RETURN create_this1
             }
             RETURN collect(create_this1 { .id }) AS data"
         `);
@@ -122,11 +122,11 @@ describe("Cypher Auth isAuthenticated", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Comment)
-                SET
-                    create_this1.id = create_var0.id,
-                    create_this1.content = create_var0.content
-                RETURN create_this1
+              CREATE (create_this1:Comment)
+              SET
+                create_this1.id = create_var0.id,
+                create_this1.content = create_var0.content
+              RETURN create_this1
             }
             RETURN collect(create_this1 { .id }) AS data"
         `);
@@ -164,8 +164,7 @@ describe("Cypher Auth isAuthenticated", () => {
             MATCH (this:Post)
             WITH *
             WHERE this.id = $param0
-            SET
-                this.id = $param1
+            SET this.id = $param1
             WITH this
             RETURN this { .id } AS this"
         `);
@@ -199,8 +198,7 @@ describe("Cypher Auth isAuthenticated", () => {
             MATCH (this:Comment)
             WITH *
             WHERE this.id = $param0
-            SET
-                this.id = $param1
+            SET this.id = $param1
             WITH this
             RETURN this { .id } AS this"
         `);
@@ -278,20 +276,20 @@ describe("Cypher Auth isAuthenticated", () => {
             MATCH (this:User)
             WITH *
             CALL (*) {
-                OPTIONAL MATCH (this)-[this0:HAS_CONTENT]->(this1:Comment)
-                WITH this0, collect(DISTINCT this1) AS var2
-                CALL (var2) {
-                    UNWIND var2 AS var3
-                    DETACH DELETE var3
-                }
+              OPTIONAL MATCH (this)-[this0:HAS_CONTENT]->(this1:Comment)
+              WITH this0, collect(DISTINCT this1) AS var2
+              CALL (var2) {
+                UNWIND var2 AS var3
+                DETACH DELETE var3
+              }
             }
             CALL (*) {
-                OPTIONAL MATCH (this)-[this4:HAS_CONTENT]->(this5:Post)
-                WITH this4, collect(DISTINCT this5) AS var6
-                CALL (var6) {
-                    UNWIND var6 AS var7
-                    DETACH DELETE var7
-                }
+              OPTIONAL MATCH (this)-[this4:HAS_CONTENT]->(this5:Post)
+              WITH this4, collect(DISTINCT this5) AS var6
+              CALL (var6) {
+                UNWIND var6 AS var7
+                DETACH DELETE var7
+              }
             }
             WITH *
             DETACH DELETE this"

--- a/packages/graphql/tests/tck/directives/authorization/arguments/is-authenticated/is-authenticated.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/is-authenticated/is-authenticated.test.ts
@@ -134,13 +134,13 @@ describe("Cypher Auth isAuthenticated", () => {
             "CYPHER 5
             MATCH (this:User)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:HAS_HISTORY]->(h:History) RETURN h
-                }
-                WITH h AS this0
-                WITH this0 { .url } AS this0
-                RETURN collect(this0) AS var1
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:HAS_HISTORY]->(h:History) RETURN h
+              }
+              WITH h AS this0
+              WITH this0 { .url } AS this0
+              RETURN collect(this0) AS var1
             }
             RETURN this { history: var1 } AS this"
         `);
@@ -168,10 +168,9 @@ describe("Cypher Auth isAuthenticated", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:User)
-                SET
-                    create_this1.id = create_var0.id
-                RETURN create_this1
+              CREATE (create_this1:User)
+              SET create_this1.id = create_var0.id
+              RETURN create_this1
             }
             RETURN collect(create_this1 { .id }) AS data"
         `);
@@ -207,11 +206,11 @@ describe("Cypher Auth isAuthenticated", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:User)
-                SET
-                    create_this1.id = create_var0.id,
-                    create_this1.password = create_var0.password
-                RETURN create_this1
+              CREATE (create_this1:User)
+              SET
+                create_this1.id = create_var0.id,
+                create_this1.password = create_var0.password
+              RETURN create_this1
             }
             RETURN collect(create_this1 { .id }) AS data"
         `);
@@ -249,8 +248,7 @@ describe("Cypher Auth isAuthenticated", () => {
             MATCH (this:User)
             WITH *
             WHERE this.id = $param0
-            SET
-                this.id = $param1
+            SET this.id = $param1
             WITH this
             RETURN this { .id } AS this"
         `);
@@ -284,8 +282,7 @@ describe("Cypher Auth isAuthenticated", () => {
             MATCH (this:User)
             WITH *
             WHERE this.id = $param0
-            SET
-                this.password = $param1
+            SET this.password = $param1
             WITH this
             RETURN this { .id } AS this"
         `);
@@ -340,12 +337,12 @@ describe("Cypher Auth isAuthenticated", () => {
             MATCH (this:User)
             WITH *
             CALL (*) {
-                OPTIONAL MATCH (this)-[this0:HAS_POST]->(this1:Post)
-                WITH this0, collect(DISTINCT this1) AS var2
-                CALL (var2) {
-                    UNWIND var2 AS var3
-                    DETACH DELETE var3
-                }
+              OPTIONAL MATCH (this)-[this0:HAS_POST]->(this1:Post)
+              WITH this0, collect(DISTINCT this1) AS var2
+              CALL (var2) {
+                UNWIND var2 AS var3
+                DETACH DELETE var3
+              }
             }
             WITH *
             DETACH DELETE this"

--- a/packages/graphql/tests/tck/directives/authorization/arguments/roles-where.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/roles-where.test.ts
@@ -107,7 +107,7 @@ describe("Cypher Auth Where with Roles", () => {
             "CYPHER 5
             MATCH (this:User)
             WITH *
-            CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
             RETURN this { .id } AS this"
         `);
 
@@ -145,7 +145,7 @@ describe("Cypher Auth Where with Roles", () => {
             MATCH (this:User)
             WITH *
             WHERE this.name = $param0
-            CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
             RETURN this { .id } AS this"
         `);
 
@@ -186,17 +186,17 @@ describe("Cypher Auth Where with Roles", () => {
             "CYPHER 5
             MATCH (this:User)
             WITH *
-            CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
             CALL (this) {
-                MATCH (this)-[this0:HAS_POST]->(this1:Post)
-                WITH DISTINCT this1
-                WITH *
-                CALL apoc.util.validate(NOT (($isAuthenticated = true AND EXISTS {
-                    MATCH (this1)<-[:HAS_POST]-(this2:User)
-                    WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
-                } AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                WITH this1 { .content } AS this1
-                RETURN collect(this1) AS var3
+              MATCH (this)-[this0:HAS_POST]->(this1:Post)
+              WITH DISTINCT this1
+              WITH *
+              CALL apoc.util.validate(NOT (($isAuthenticated = true AND EXISTS {
+                MATCH (this1)<-[:HAS_POST]-(this2:User)
+                WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
+              } AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
+              WITH this1 { .content } AS this1
+              RETURN collect(this1) AS var3
             }
             RETURN this { .id, posts: var3 } AS this"
         `);
@@ -243,20 +243,20 @@ describe("Cypher Auth Where with Roles", () => {
             "CYPHER 5
             MATCH (this:User)
             WITH *
-            CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
             CALL (this) {
-                MATCH (this)-[this0:HAS_POST]->(this1:Post)
-                CALL apoc.util.validate(NOT (($isAuthenticated = true AND EXISTS {
-                    MATCH (this1)<-[:HAS_POST]-(this2:User)
-                    WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
-                } AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ node: { content: this1.content, __resolveType: \\"Post\\" } }) AS var3
-                }
-                RETURN { edges: var3 } AS var4
+              MATCH (this)-[this0:HAS_POST]->(this1:Post)
+              CALL apoc.util.validate(NOT (($isAuthenticated = true AND EXISTS {
+                MATCH (this1)<-[:HAS_POST]-(this2:User)
+                WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
+              } AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({node: {content: this1.content, __resolveType: 'Post'}}) AS var3
+              }
+              RETURN {edges: var3} AS var4
             }
             RETURN this { .id, postsConnection: var4 } AS this"
         `);
@@ -303,21 +303,21 @@ describe("Cypher Auth Where with Roles", () => {
             "CYPHER 5
             MATCH (this:User)
             WITH *
-            CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
             CALL (this) {
-                MATCH (this)-[this0:HAS_POST]->(this1:Post)
-                WHERE this1.id = $param4
-                CALL apoc.util.validate(NOT (($isAuthenticated = true AND EXISTS {
-                    MATCH (this1)<-[:HAS_POST]-(this2:User)
-                    WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
-                } AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param6 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ node: { content: this1.content, __resolveType: \\"Post\\" } }) AS var3
-                }
-                RETURN { edges: var3 } AS var4
+              MATCH (this)-[this0:HAS_POST]->(this1:Post)
+              WHERE this1.id = $param4
+              CALL apoc.util.validate(NOT (($isAuthenticated = true AND EXISTS {
+                MATCH (this1)<-[:HAS_POST]-(this2:User)
+                WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
+              } AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param6 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({node: {content: this1.content, __resolveType: 'Post'}}) AS var3
+              }
+              RETURN {edges: var3} AS var4
             }
             RETURN this { .id, postsConnection: var4 } AS this"
         `);
@@ -361,18 +361,18 @@ describe("Cypher Auth Where with Roles", () => {
             "CYPHER 5
             MATCH (this:User)
             WITH *
-            CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
             CALL (this) {
-                MATCH (this)-[this0:HAS_POST]->(this1:Post)
-                WITH DISTINCT this1
-                WITH *
-                WHERE this1.content = $param4
-                CALL apoc.util.validate(NOT (($isAuthenticated = true AND EXISTS {
-                    MATCH (this1)<-[:HAS_POST]-(this2:User)
-                    WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
-                } AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param6 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                WITH this1 { .content } AS this1
-                RETURN collect(this1) AS var3
+              MATCH (this)-[this0:HAS_POST]->(this1:Post)
+              WITH DISTINCT this1
+              WITH *
+              WHERE this1.content = $param4
+              CALL apoc.util.validate(NOT (($isAuthenticated = true AND EXISTS {
+                MATCH (this1)<-[:HAS_POST]-(this2:User)
+                WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
+              } AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param6 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
+              WITH this1 { .content } AS this1
+              RETURN collect(this1) AS var3
             }
             RETURN this { .id, posts: var3 } AS this"
         `);
@@ -418,20 +418,20 @@ describe("Cypher Auth Where with Roles", () => {
             "CYPHER 5
             MATCH (this:User)
             WITH *
-            CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
             CALL (this) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this)-[this0:HAS_POST]->(this1:Post)
-                    CALL apoc.util.validate(NOT (($isAuthenticated = true AND EXISTS {
-                        MATCH (this1)<-[:HAS_POST]-(this2:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
-                    } AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    WITH this1 { .id, __resolveType: \\"Post\\", __id: id(this1) } AS var3
-                    RETURN var3
-                }
-                WITH var3
-                RETURN collect(var3) AS var3
+              CALL (*) {
+                WITH *
+                MATCH (this)-[this0:HAS_POST]->(this1:Post)
+                CALL apoc.util.validate(NOT (($isAuthenticated = true AND EXISTS {
+                  MATCH (this1)<-[:HAS_POST]-(this2:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
+                } AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
+                WITH this1 { .id, __resolveType: 'Post', __id: elementId(this1) } AS var3
+                RETURN var3
+              }
+              WITH var3
+              RETURN collect(var3) AS var3
             }
             RETURN this { .id, content: var3 } AS this"
         `);
@@ -480,24 +480,24 @@ describe("Cypher Auth Where with Roles", () => {
             "CYPHER 5
             MATCH (this:User)
             WITH *
-            CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
             CALL (this) {
+              CALL (this) {
                 CALL (this) {
-                    CALL (this) {
-                        WITH this
-                        MATCH (this)-[this0:HAS_POST]->(this1:Post)
-                        CALL apoc.util.validate(NOT (($isAuthenticated = true AND EXISTS {
-                            MATCH (this1)<-[:HAS_POST]-(this2:User)
-                            WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
-                        } AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                        WITH { node: { __resolveType: \\"Post\\", __id: id(this1), id: this1.id } } AS edge
-                        RETURN edge
-                    }
-                    RETURN collect(edge) AS edges
+                  WITH this
+                  MATCH (this)-[this0:HAS_POST]->(this1:Post)
+                  CALL apoc.util.validate(NOT (($isAuthenticated = true AND EXISTS {
+                    MATCH (this1)<-[:HAS_POST]-(this2:User)
+                    WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
+                  } AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
+                  WITH {node: {__resolveType: 'Post', __id: elementId(this1), id: this1.id}} AS edge
+                  RETURN edge
                 }
-                WITH edges
-                WITH edges, size(edges) AS totalCount
-                RETURN { edges: edges, totalCount: totalCount } AS var3
+                RETURN collect(edge) AS edges
+              }
+              WITH edges
+              WITH edges, size(edges) AS totalCount
+              RETURN {edges: edges, totalCount: totalCount} AS var3
             }
             RETURN this { .id, contentConnection: var3 } AS this"
         `);
@@ -546,25 +546,25 @@ describe("Cypher Auth Where with Roles", () => {
             "CYPHER 5
             MATCH (this:User)
             WITH *
-            CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
             CALL (this) {
+              CALL (this) {
                 CALL (this) {
-                    CALL (this) {
-                        WITH this
-                        MATCH (this)-[this0:HAS_POST]->(this1:Post)
-                        WHERE this1.id = $param4
-                        CALL apoc.util.validate(NOT (($isAuthenticated = true AND EXISTS {
-                            MATCH (this1)<-[:HAS_POST]-(this2:User)
-                            WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
-                        } AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param6 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                        WITH { node: { __resolveType: \\"Post\\", __id: id(this1), id: this1.id } } AS edge
-                        RETURN edge
-                    }
-                    RETURN collect(edge) AS edges
+                  WITH this
+                  MATCH (this)-[this0:HAS_POST]->(this1:Post)
+                  WHERE this1.id = $param4
+                  CALL apoc.util.validate(NOT (($isAuthenticated = true AND EXISTS {
+                    MATCH (this1)<-[:HAS_POST]-(this2:User)
+                    WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
+                  } AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param6 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
+                  WITH {node: {__resolveType: 'Post', __id: elementId(this1), id: this1.id}} AS edge
+                  RETURN edge
                 }
-                WITH edges
-                WITH edges, size(edges) AS totalCount
-                RETURN { edges: edges, totalCount: totalCount } AS var3
+                RETURN collect(edge) AS edges
+              }
+              WITH edges
+              WITH edges, size(edges) AS totalCount
+              RETURN {edges: edges, totalCount: totalCount} AS var3
             }
             RETURN this { .id, contentConnection: var3 } AS this"
         `);
@@ -608,15 +608,14 @@ describe("Cypher Auth Where with Roles", () => {
             MATCH (this:User)
             WITH *
             WITH *
-            CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
             WITH *
-            SET
-                this.name = $param4
+            SET this.name = $param4
             WITH *
-            CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param6 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param6 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
             WITH this
             WITH *
-            CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param7 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param8 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param7 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param8 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
             RETURN this { .id } AS this"
         `);
 
@@ -662,15 +661,14 @@ describe("Cypher Auth Where with Roles", () => {
             WITH *
             WHERE this.name = $param0
             WITH *
-            CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
             WITH *
-            SET
-                this.name = $param5
+            SET this.name = $param5
             WITH *
-            CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param6 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param7 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param6 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param7 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
             WITH this
             WITH *
-            CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param8 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param9 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param8 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param9 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
             RETURN this { .id } AS this"
         `);
 
@@ -720,35 +718,34 @@ describe("Cypher Auth Where with Roles", () => {
             WITH *
             WITH *
             CALL (*) {
-                MATCH (this)-[this0:HAS_POST]->(this1:Post)
-                WITH *
-                WITH *
-                CALL apoc.util.validate(NOT (($isAuthenticated = true AND EXISTS {
-                    MATCH (this1)<-[:HAS_POST]-(this2:User)
-                    WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
-                } AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                WITH *
-                SET
-                    this1.id = $param4
-                WITH *
-                CALL apoc.util.validate(NOT (($isAuthenticated = true AND EXISTS {
-                    MATCH (this1)<-[:HAS_POST]-(this3:User)
-                    WHERE ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
-                } AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param6 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+              MATCH (this)-[this0:HAS_POST]->(this1:Post)
+              WITH *
+              WITH *
+              CALL apoc.util.validate(NOT (($isAuthenticated = true AND EXISTS {
+                MATCH (this1)<-[:HAS_POST]-(this2:User)
+                WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
+              } AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
+              WITH *
+              SET this1.id = $param4
+              WITH *
+              CALL apoc.util.validate(NOT (($isAuthenticated = true AND EXISTS {
+                MATCH (this1)<-[:HAS_POST]-(this3:User)
+                WHERE ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
+              } AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param6 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
             }
             WITH this
             WITH *
-            CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param7 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param8 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param7 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param8 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
             CALL (this) {
-                MATCH (this)-[this4:HAS_POST]->(this5:Post)
-                WITH DISTINCT this5
-                WITH *
-                CALL apoc.util.validate(NOT (($isAuthenticated = true AND EXISTS {
-                    MATCH (this5)<-[:HAS_POST]-(this6:User)
-                    WHERE ($jwt.sub IS NOT NULL AND this6.id = $jwt.sub)
-                } AND ($jwt.roles IS NOT NULL AND $param9 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param10 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                WITH this5 { .id } AS this5
-                RETURN collect(this5) AS var7
+              MATCH (this)-[this4:HAS_POST]->(this5:Post)
+              WITH DISTINCT this5
+              WITH *
+              CALL apoc.util.validate(NOT (($isAuthenticated = true AND EXISTS {
+                MATCH (this5)<-[:HAS_POST]-(this6:User)
+                WHERE ($jwt.sub IS NOT NULL AND this6.id = $jwt.sub)
+              } AND ($jwt.roles IS NOT NULL AND $param9 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param10 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
+              WITH this5 { .id } AS this5
+              RETURN collect(this5) AS var7
             }
             RETURN this { .id, posts: var7 } AS this"
         `);
@@ -792,7 +789,7 @@ describe("Cypher Auth Where with Roles", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             MATCH (this:User)
-            CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
             WITH *
             DETACH DELETE this"
         `);
@@ -829,19 +826,19 @@ describe("Cypher Auth Where with Roles", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             MATCH (this:User)
-            CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
             WITH *
             CALL (*) {
-                OPTIONAL MATCH (this)-[this0:HAS_POST]->(this1:Post)
-                CALL apoc.util.validate(NOT (($isAuthenticated = true AND EXISTS {
-                    MATCH (this1)<-[:HAS_POST]-(this2:User)
-                    WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
-                } AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                WITH this0, collect(DISTINCT this1) AS var3
-                CALL (var3) {
-                    UNWIND var3 AS var4
-                    DETACH DELETE var4
-                }
+              OPTIONAL MATCH (this)-[this0:HAS_POST]->(this1:Post)
+              CALL apoc.util.validate(NOT (($isAuthenticated = true AND EXISTS {
+                MATCH (this1)<-[:HAS_POST]-(this2:User)
+                WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
+              } AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
+              WITH this0, collect(DISTINCT this1) AS var3
+              CALL (var3) {
+                UNWIND var3 AS var4
+                DETACH DELETE var4
+              }
             }
             WITH *
             DETACH DELETE this"
@@ -887,36 +884,36 @@ describe("Cypher Auth Where with Roles", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                CREATE (this0:User)
-                SET
-                    this0.id = $param0,
-                    this0.name = $param1,
-                    this0.password = $param2
+              CREATE (this0:User)
+              SET
+                this0.id = $param0,
+                this0.name = $param1,
+                this0.password = $param2
+              WITH *
+              CALL (this0) {
+                MATCH (this1:Post)
+                CALL apoc.util.validate(NOT (($isAuthenticated = true AND EXISTS {
+                  MATCH (this1)<-[:HAS_POST]-(this2:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
+                } AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param6 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
+                CREATE (this0)-[this3:HAS_POST]->(this1)
                 WITH *
-                CALL (this0) {
-                    MATCH (this1:Post)
-                    CALL apoc.util.validate(NOT (($isAuthenticated = true AND EXISTS {
-                        MATCH (this1)<-[:HAS_POST]-(this2:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
-                    } AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param6 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    CREATE (this0)-[this3:HAS_POST]->(this1)
-                    WITH *
-                    CALL apoc.util.validate(NOT (($isAuthenticated = true AND EXISTS {
-                        MATCH (this1)<-[:HAS_POST]-(this4:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this4.id = $jwt.sub)
-                    } AND ($jwt.roles IS NOT NULL AND $param7 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param8 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    WITH *
-                    CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param9 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param10 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                }
+                CALL apoc.util.validate(NOT (($isAuthenticated = true AND EXISTS {
+                  MATCH (this1)<-[:HAS_POST]-(this4:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this4.id = $jwt.sub)
+                } AND ($jwt.roles IS NOT NULL AND $param7 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param8 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
                 WITH *
-                CALL (*) {
-                    CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param11 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param12 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                }
-                RETURN this0 AS this
+                CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param9 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param10 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
+              }
+              WITH *
+              CALL (*) {
+                CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param11 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param12 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
+              }
+              RETURN this0 AS this
             }
             WITH this
             CALL (this) {
-                RETURN this { .id } AS var5
+              RETURN this { .id } AS var5
             }
             RETURN collect(var5) AS data"
         `);
@@ -973,37 +970,37 @@ describe("Cypher Auth Where with Roles", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                CREATE (this0:User)
-                SET
-                    this0.id = $param0,
-                    this0.name = $param1,
-                    this0.password = $param2
+              CREATE (this0:User)
+              SET
+                this0.id = $param0,
+                this0.name = $param1,
+                this0.password = $param2
+              WITH *
+              CALL (this0) {
+                MATCH (this1:Post)
+                WHERE this1.id = $param3
+                CALL apoc.util.validate(NOT (($isAuthenticated = true AND EXISTS {
+                  MATCH (this1)<-[:HAS_POST]-(this2:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
+                } AND ($jwt.roles IS NOT NULL AND $param6 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param7 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
+                CREATE (this0)-[this3:HAS_POST]->(this1)
                 WITH *
-                CALL (this0) {
-                    MATCH (this1:Post)
-                    WHERE this1.id = $param3
-                    CALL apoc.util.validate(NOT (($isAuthenticated = true AND EXISTS {
-                        MATCH (this1)<-[:HAS_POST]-(this2:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
-                    } AND ($jwt.roles IS NOT NULL AND $param6 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param7 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    CREATE (this0)-[this3:HAS_POST]->(this1)
-                    WITH *
-                    CALL apoc.util.validate(NOT (($isAuthenticated = true AND EXISTS {
-                        MATCH (this1)<-[:HAS_POST]-(this4:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this4.id = $jwt.sub)
-                    } AND ($jwt.roles IS NOT NULL AND $param8 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param9 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    WITH *
-                    CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param10 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param11 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                }
+                CALL apoc.util.validate(NOT (($isAuthenticated = true AND EXISTS {
+                  MATCH (this1)<-[:HAS_POST]-(this4:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this4.id = $jwt.sub)
+                } AND ($jwt.roles IS NOT NULL AND $param8 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param9 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
                 WITH *
-                CALL (*) {
-                    CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param12 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param13 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                }
-                RETURN this0 AS this
+                CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param10 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param11 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
+              }
+              WITH *
+              CALL (*) {
+                CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param12 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param13 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
+              }
+              RETURN this0 AS this
             }
             WITH this
             CALL (this) {
-                RETURN this { .id } AS var5
+              RETURN this { .id } AS var5
             }
             RETURN collect(var5) AS data"
         `);
@@ -1055,25 +1052,25 @@ describe("Cypher Auth Where with Roles", () => {
             WITH *
             WITH *
             CALL (*) {
-                CALL (this) {
-                    MATCH (this0:Post)
-                    CALL apoc.util.validate(NOT (($isAuthenticated = true AND EXISTS {
-                        MATCH (this0)<-[:HAS_POST]-(this1:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this1.id = $jwt.sub)
-                    } AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    CREATE (this)-[this2:HAS_POST]->(this0)
-                    WITH *
-                    CALL apoc.util.validate(NOT (($isAuthenticated = true AND EXISTS {
-                        MATCH (this0)<-[:HAS_POST]-(this3:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
-                    } AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    WITH *
-                    CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param6 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param7 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                }
+              CALL (this) {
+                MATCH (this0:Post)
+                CALL apoc.util.validate(NOT (($isAuthenticated = true AND EXISTS {
+                  MATCH (this0)<-[:HAS_POST]-(this1:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this1.id = $jwt.sub)
+                } AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
+                CREATE (this)-[this2:HAS_POST]->(this0)
+                WITH *
+                CALL apoc.util.validate(NOT (($isAuthenticated = true AND EXISTS {
+                  MATCH (this0)<-[:HAS_POST]-(this3:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
+                } AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
+                WITH *
+                CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param6 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param7 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
+              }
             }
             WITH this
             WITH *
-            CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param8 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param9 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param8 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param9 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
             RETURN this { .id } AS this"
         `);
 
@@ -1120,26 +1117,26 @@ describe("Cypher Auth Where with Roles", () => {
             WITH *
             WITH *
             CALL (*) {
-                CALL (this) {
-                    MATCH (this0:Post)
-                    WHERE this0.id = $param0
-                    CALL apoc.util.validate(NOT (($isAuthenticated = true AND EXISTS {
-                        MATCH (this0)<-[:HAS_POST]-(this1:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this1.id = $jwt.sub)
-                    } AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    CREATE (this)-[this2:HAS_POST]->(this0)
-                    WITH *
-                    CALL apoc.util.validate(NOT (($isAuthenticated = true AND EXISTS {
-                        MATCH (this0)<-[:HAS_POST]-(this3:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
-                    } AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param6 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    WITH *
-                    CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param7 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param8 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                }
+              CALL (this) {
+                MATCH (this0:Post)
+                WHERE this0.id = $param0
+                CALL apoc.util.validate(NOT (($isAuthenticated = true AND EXISTS {
+                  MATCH (this0)<-[:HAS_POST]-(this1:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this1.id = $jwt.sub)
+                } AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
+                CREATE (this)-[this2:HAS_POST]->(this0)
+                WITH *
+                CALL apoc.util.validate(NOT (($isAuthenticated = true AND EXISTS {
+                  MATCH (this0)<-[:HAS_POST]-(this3:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
+                } AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param6 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
+                WITH *
+                CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param7 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param8 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
+              }
             }
             WITH this
             WITH *
-            CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param9 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param10 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param9 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param10 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
             RETURN this { .id } AS this"
         `);
 
@@ -1187,28 +1184,28 @@ describe("Cypher Auth Where with Roles", () => {
             WITH *
             WITH *
             CALL (*) {
-                CALL (this) {
-                    OPTIONAL MATCH (this)-[this0:HAS_POST]->(this1:Post)
-                    CALL apoc.util.validate(NOT (($isAuthenticated = true AND EXISTS {
-                        MATCH (this1)<-[:HAS_POST]-(this2:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
-                    } AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    WITH *
-                    CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    WITH *
-                    DELETE this0
-                    WITH *
-                    CALL apoc.util.validate(NOT (($isAuthenticated = true AND EXISTS {
-                        MATCH (this1)<-[:HAS_POST]-(this3:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
-                    } AND ($jwt.roles IS NOT NULL AND $param6 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param7 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    WITH *
-                    CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param8 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param9 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                }
+              CALL (this) {
+                OPTIONAL MATCH (this)-[this0:HAS_POST]->(this1:Post)
+                CALL apoc.util.validate(NOT (($isAuthenticated = true AND EXISTS {
+                  MATCH (this1)<-[:HAS_POST]-(this2:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
+                } AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
+                WITH *
+                CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
+                WITH *
+                DELETE this0
+                WITH *
+                CALL apoc.util.validate(NOT (($isAuthenticated = true AND EXISTS {
+                  MATCH (this1)<-[:HAS_POST]-(this3:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
+                } AND ($jwt.roles IS NOT NULL AND $param6 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param7 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
+                WITH *
+                CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param8 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param9 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
+              }
             }
             WITH this
             WITH *
-            CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param10 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param11 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param10 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param11 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
             RETURN this { .id } AS this"
         `);
 
@@ -1257,29 +1254,29 @@ describe("Cypher Auth Where with Roles", () => {
             WITH *
             WITH *
             CALL (*) {
-                CALL (this) {
-                    OPTIONAL MATCH (this)-[this0:HAS_POST]->(this1:Post)
-                    WHERE this1.id = $param0
-                    CALL apoc.util.validate(NOT (($isAuthenticated = true AND EXISTS {
-                        MATCH (this1)<-[:HAS_POST]-(this2:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
-                    } AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    WITH *
-                    CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param6 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    WITH *
-                    DELETE this0
-                    WITH *
-                    CALL apoc.util.validate(NOT (($isAuthenticated = true AND EXISTS {
-                        MATCH (this1)<-[:HAS_POST]-(this3:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
-                    } AND ($jwt.roles IS NOT NULL AND $param7 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param8 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    WITH *
-                    CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param9 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param10 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                }
+              CALL (this) {
+                OPTIONAL MATCH (this)-[this0:HAS_POST]->(this1:Post)
+                WHERE this1.id = $param0
+                CALL apoc.util.validate(NOT (($isAuthenticated = true AND EXISTS {
+                  MATCH (this1)<-[:HAS_POST]-(this2:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
+                } AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
+                WITH *
+                CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param6 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
+                WITH *
+                DELETE this0
+                WITH *
+                CALL apoc.util.validate(NOT (($isAuthenticated = true AND EXISTS {
+                  MATCH (this1)<-[:HAS_POST]-(this3:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
+                } AND ($jwt.roles IS NOT NULL AND $param7 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param8 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
+                WITH *
+                CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param9 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param10 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
+              }
             }
             WITH this
             WITH *
-            CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param11 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param12 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param11 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param12 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
             RETURN this { .id } AS this"
         `);
 

--- a/packages/graphql/tests/tck/directives/authorization/arguments/roles/roles.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/roles/roles.test.ts
@@ -117,7 +117,7 @@ describe("Cypher Auth Roles", () => {
             "CYPHER 5
             MATCH (this:User)
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
             RETURN this { .id, .name } AS this"
         `);
 
@@ -155,8 +155,8 @@ describe("Cypher Auth Roles", () => {
             "CYPHER 5
             MATCH (this:User)
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
             RETURN this { .id, .name, .password } AS this"
         `);
 
@@ -195,18 +195,18 @@ describe("Cypher Auth Roles", () => {
             "CYPHER 5
             MATCH (this:User)
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:HAS_HISTORY]->(h:History) RETURN h
-                }
-                WITH h AS this0
-                WITH *
-                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                WITH this0 { .url } AS this0
-                RETURN collect(this0) AS var1
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:HAS_HISTORY]->(h:History) RETURN h
+              }
+              WITH h AS this0
+              WITH *
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
+              WITH this0 { .url } AS this0
+              RETURN collect(this0) AS var1
             }
             RETURN this { history: var1 } AS this"
         `);
@@ -247,13 +247,12 @@ describe("Cypher Auth Roles", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:User)
-                SET
-                    create_this1.id = create_var0.id
-                WITH *
-                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $create_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                CALL apoc.util.validate((create_var0.password IS NOT NULL AND NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $create_param4 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                RETURN create_this1
+              CREATE (create_this1:User)
+              SET create_this1.id = create_var0.id
+              WITH *
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $create_param3 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
+              CALL apoc.util.validate((create_var0.password IS NOT NULL AND NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $create_param4 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
+              RETURN create_this1
             }
             RETURN collect(create_this1 { .id }) AS data"
         `);
@@ -298,14 +297,14 @@ describe("Cypher Auth Roles", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:User)
-                SET
-                    create_this1.id = create_var0.id,
-                    create_this1.password = create_var0.password
-                WITH *
-                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $create_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                CALL apoc.util.validate((create_var0.password IS NOT NULL AND NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $create_param4 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                RETURN create_this1
+              CREATE (create_this1:User)
+              SET
+                create_this1.id = create_var0.id,
+                create_this1.password = create_var0.password
+              WITH *
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $create_param3 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
+              CALL apoc.util.validate((create_var0.password IS NOT NULL AND NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $create_param4 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
+              RETURN create_this1
             }
             RETURN collect(create_this1 { .id }) AS data"
         `);
@@ -353,15 +352,14 @@ describe("Cypher Auth Roles", () => {
             WITH *
             WHERE this.id = $param0
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
             WITH *
-            SET
-                this.id = $param4
+            SET this.id = $param4
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
             WITH this
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param6 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param6 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
             RETURN this { .id } AS this"
         `);
 
@@ -405,17 +403,16 @@ describe("Cypher Auth Roles", () => {
             WITH *
             WHERE this.id = $param0
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
             WITH *
-            SET
-                this.password = $param5
+            SET this.password = $param5
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param6 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param7 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param6 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param7 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
             WITH this
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param8 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param8 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
             RETURN this { .id } AS this"
         `);
 
@@ -461,19 +458,19 @@ describe("Cypher Auth Roles", () => {
             WITH *
             WITH *
             CALL (*) {
-                CALL (this) {
-                    MATCH (this0:Post)
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    CREATE (this)-[this1:HAS_POST]->(this0)
-                    WITH *
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    WITH *
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                }
+              CALL (this) {
+                MATCH (this0:Post)
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
+                CREATE (this)-[this1:HAS_POST]->(this0)
+                WITH *
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
+                WITH *
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
+              }
             }
             WITH this
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
             RETURN this { .id } AS this"
         `);
 
@@ -522,21 +519,21 @@ describe("Cypher Auth Roles", () => {
             WITH *
             WITH *
             CALL (*) {
-                MATCH (this)<-[this0:HAS_COMMENT]-(this1:Post)
-                WITH *
-                WITH *
-                CALL (*) {
-                    CALL (this1) {
-                        MATCH (this2:User)
-                        WHERE this2.id = $param0
-                        CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                        CREATE (this1)-[this3:HAS_POST]->(this2)
-                        WITH *
-                        CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                        WITH *
-                        CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    }
+              MATCH (this)<-[this0:HAS_COMMENT]-(this1:Post)
+              WITH *
+              WITH *
+              CALL (*) {
+                CALL (this1) {
+                  MATCH (this2:User)
+                  WHERE this2.id = $param0
+                  CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
+                  CREATE (this1)-[this3:HAS_POST]->(this2)
+                  WITH *
+                  CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
+                  WITH *
+                  CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
                 }
+              }
             }
             WITH this
             RETURN this { .content } AS this"
@@ -581,22 +578,22 @@ describe("Cypher Auth Roles", () => {
             WITH *
             WITH *
             CALL (*) {
-                CALL (this) {
-                    OPTIONAL MATCH (this)-[this0:HAS_POST]->(this1:Post)
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    WITH *
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    WITH *
-                    DELETE this0
-                    WITH *
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    WITH *
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                }
+              CALL (this) {
+                OPTIONAL MATCH (this)-[this0:HAS_POST]->(this1:Post)
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
+                WITH *
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
+                WITH *
+                DELETE this0
+                WITH *
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
+                WITH *
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
+              }
             }
             WITH this
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param6 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param6 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
             RETURN this { .id } AS this"
         `);
 
@@ -648,24 +645,24 @@ describe("Cypher Auth Roles", () => {
             WITH *
             WITH *
             CALL (*) {
-                MATCH (this)<-[this0:HAS_COMMENT]-(this1:Post)
-                WITH *
-                WITH *
-                CALL (*) {
-                    CALL (this1) {
-                        OPTIONAL MATCH (this1)-[this2:HAS_POST]->(this3:User)
-                        WHERE this3.id = $param0
-                        CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                        WITH *
-                        CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                        WITH *
-                        DELETE this2
-                        WITH *
-                        CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                        WITH *
-                        CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param6 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    }
+              MATCH (this)<-[this0:HAS_COMMENT]-(this1:Post)
+              WITH *
+              WITH *
+              CALL (*) {
+                CALL (this1) {
+                  OPTIONAL MATCH (this1)-[this2:HAS_POST]->(this3:User)
+                  WHERE this3.id = $param0
+                  CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
+                  WITH *
+                  CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
+                  WITH *
+                  DELETE this2
+                  WITH *
+                  CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
+                  WITH *
+                  CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param6 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
                 }
+              }
             }
             WITH this
             RETURN this { .content } AS this"
@@ -706,7 +703,7 @@ describe("Cypher Auth Roles", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             MATCH (this:User)
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
             WITH *
             DETACH DELETE this"
         `);
@@ -742,16 +739,16 @@ describe("Cypher Auth Roles", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             MATCH (this:User)
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
             WITH *
             CALL (*) {
-                OPTIONAL MATCH (this)-[this0:HAS_POST]->(this1:Post)
-                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                WITH this0, collect(DISTINCT this1) AS var2
-                CALL (var2) {
-                    UNWIND var2 AS var3
-                    DETACH DELETE var3
-                }
+              OPTIONAL MATCH (this)-[this0:HAS_POST]->(this1:Post)
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
+              WITH this0, collect(DISTINCT this1) AS var2
+              CALL (var2) {
+                UNWIND var2 AS var3
+                DETACH DELETE var3
+              }
             }
             WITH *
             DETACH DELETE this"

--- a/packages/graphql/tests/tck/directives/authorization/arguments/validate/interface-relationships/implementation-bind.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/validate/interface-relationships/implementation-bind.test.ts
@@ -119,38 +119,36 @@ describe("Cypher Auth Allow", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                CREATE (this0:User)
-                SET
-                    this0.id = $param0,
-                    this0.name = $param1
-                WITH *
-                CREATE (this1:Post)
-                WITH *
-                CREATE (this2:User)
-                MERGE (this1)<-[this3:HAS_CONTENT]-(this2)
-                SET
-                    this2.id = $param2
-                MERGE (this0)-[this4:HAS_CONTENT]->(this1)
-                SET
-                    this1.id = $param3
-                WITH *
-                CALL (*) {
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                }
-                CALL (*) {
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                        MATCH (this1)<-[:HAS_CONTENT]-(this5:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this5.id = $jwt.sub)
-                    }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                }
-                CALL (*) {
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                }
-                RETURN this0 AS this
+              CREATE (this0:User)
+              SET
+                this0.id = $param0,
+                this0.name = $param1
+              WITH *
+              CREATE (this1:Post)
+              WITH *
+              CREATE (this2:User)
+              MERGE (this1)<-[this3:HAS_CONTENT]-(this2)
+              SET this2.id = $param2
+              MERGE (this0)-[this4:HAS_CONTENT]->(this1)
+              SET this1.id = $param3
+              WITH *
+              CALL (*) {
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
+              }
+              CALL (*) {
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
+                  MATCH (this1)<-[:HAS_CONTENT]-(this5:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this5.id = $jwt.sub)
+                }), '@neo4j/graphql/FORBIDDEN', [])
+              }
+              CALL (*) {
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
+              }
+              RETURN this0 AS this
             }
             WITH this
             CALL (this) {
-                RETURN this { .id } AS var6
+              RETURN this { .id } AS var6
             }
             RETURN collect(var6) AS data"
         `);
@@ -210,32 +208,30 @@ describe("Cypher Auth Allow", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                CREATE (this0:User)
-                SET
-                    this0.id = $param0,
-                    this0.name = $param1
-                WITH *
-                CREATE (this1:Comment)
-                WITH *
-                CREATE (this2:User)
-                MERGE (this1)<-[this3:HAS_CONTENT]-(this2)
-                SET
-                    this2.id = $param2
-                MERGE (this0)-[this4:HAS_CONTENT]->(this1)
-                SET
-                    this1.id = $param3
-                WITH *
-                CALL (*) {
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                }
-                CALL (*) {
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                }
-                RETURN this0 AS this
+              CREATE (this0:User)
+              SET
+                this0.id = $param0,
+                this0.name = $param1
+              WITH *
+              CREATE (this1:Comment)
+              WITH *
+              CREATE (this2:User)
+              MERGE (this1)<-[this3:HAS_CONTENT]-(this2)
+              SET this2.id = $param2
+              MERGE (this0)-[this4:HAS_CONTENT]->(this1)
+              SET this1.id = $param3
+              WITH *
+              CALL (*) {
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
+              }
+              CALL (*) {
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
+              }
+              RETURN this0 AS this
             }
             WITH this
             CALL (this) {
-                RETURN this { .id } AS var5
+              RETURN this { .id } AS var5
             }
             RETURN collect(var5) AS data"
         `);
@@ -290,38 +286,36 @@ describe("Cypher Auth Allow", () => {
             WHERE this.id = $param0
             WITH *
             CALL (*) {
-                MATCH (this)-[this0:HAS_CONTENT]->(this1:Comment)
+              MATCH (this)-[this0:HAS_CONTENT]->(this1:Comment)
+              WITH *
+              WHERE this1.id = $param1
+              WITH *
+              CALL (*) {
+                MATCH (this1)<-[this2:HAS_CONTENT]-(this3:User)
                 WITH *
-                WHERE this1.id = $param1
+                SET this3.id = $param2
                 WITH *
-                CALL (*) {
-                    MATCH (this1)<-[this2:HAS_CONTENT]-(this3:User)
-                    WITH *
-                    SET
-                        this3.id = $param2
-                    WITH *
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                }
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
+              }
             }
             WITH *
             CALL (*) {
-                MATCH (this)-[this4:HAS_CONTENT]->(this5:Post)
+              MATCH (this)-[this4:HAS_CONTENT]->(this5:Post)
+              WITH *
+              WHERE this5.id = $param5
+              WITH *
+              CALL (*) {
+                MATCH (this5)<-[this6:HAS_CONTENT]-(this7:User)
                 WITH *
-                WHERE this5.id = $param5
+                SET this7.id = $param6
                 WITH *
-                CALL (*) {
-                    MATCH (this5)<-[this6:HAS_CONTENT]-(this7:User)
-                    WITH *
-                    SET
-                        this7.id = $param6
-                    WITH *
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this7.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                }
-                WITH *
-                CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                    MATCH (this5)<-[:HAS_CONTENT]-(this8:User)
-                    WHERE ($jwt.sub IS NOT NULL AND this8.id = $jwt.sub)
-                }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this7.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
+              }
+              WITH *
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
+                MATCH (this5)<-[:HAS_CONTENT]-(this8:User)
+                WHERE ($jwt.sub IS NOT NULL AND this8.id = $jwt.sub)
+              }), '@neo4j/graphql/FORBIDDEN', [])
             }
             WITH this
             RETURN this { .id } AS this"

--- a/packages/graphql/tests/tck/directives/authorization/arguments/validate/validate.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/validate/validate.test.ts
@@ -90,13 +90,13 @@ describe("Cypher Auth Allow", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:User)
-                SET
-                    create_this1.id = create_var0.id,
-                    create_this1.name = create_var0.name
-                WITH *
-                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND create_this1.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                RETURN create_this1
+              CREATE (create_this1:User)
+              SET
+                create_this1.id = create_var0.id,
+                create_this1.name = create_var0.name
+              WITH *
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND create_this1.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
+              RETURN create_this1
             }
             RETURN collect(create_this1 { .id }) AS data"
         `);
@@ -152,38 +152,36 @@ describe("Cypher Auth Allow", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:User)
-                SET
-                    create_this1.id = create_var0.id,
-                    create_this1.name = create_var0.name
-                WITH create_this1, create_var0
-                CALL (create_this1, create_var0) {
-                    UNWIND create_var0.posts.create AS create_var2
-                    CREATE (create_this3:Post)
-                    SET
-                        create_this3.id = create_var2.node.id
-                    MERGE (create_this1)-[create_this4:HAS_POST]->(create_this3)
-                    WITH create_this3, create_var2
-                    CALL (create_this3, create_var2) {
-                        UNWIND create_var2.node.creator.create AS create_var5
-                        CREATE (create_this6:User)
-                        SET
-                            create_this6.id = create_var5.node.id
-                        MERGE (create_this3)<-[create_this7:HAS_POST]-(create_this6)
-                        WITH *
-                        CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND create_this6.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                        RETURN collect(NULL) AS create_var8
-                    }
-                    WITH *
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                        MATCH (create_this3)<-[:HAS_POST]-(create_this9:User)
-                        WHERE ($jwt.sub IS NOT NULL AND create_this9.id = $jwt.sub)
-                    }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    RETURN collect(NULL) AS create_var10
+              CREATE (create_this1:User)
+              SET
+                create_this1.id = create_var0.id,
+                create_this1.name = create_var0.name
+              WITH create_this1, create_var0
+              CALL (create_this1, create_var0) {
+                UNWIND create_var0.posts.create AS create_var2
+                CREATE (create_this3:Post)
+                SET create_this3.id = create_var2.node.id
+                MERGE (create_this1)-[create_this4:HAS_POST]->(create_this3)
+                WITH create_this3, create_var2
+                CALL (create_this3, create_var2) {
+                  UNWIND create_var2.node.creator.create AS create_var5
+                  CREATE (create_this6:User)
+                  SET create_this6.id = create_var5.node.id
+                  MERGE (create_this3)<-[create_this7:HAS_POST]-(create_this6)
+                  WITH *
+                  CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND create_this6.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
+                  RETURN collect(NULL) AS create_var8
                 }
                 WITH *
-                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND create_this1.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                RETURN create_this1
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
+                  MATCH (create_this3)<-[:HAS_POST]-(create_this9:User)
+                  WHERE ($jwt.sub IS NOT NULL AND create_this9.id = $jwt.sub)
+                }), '@neo4j/graphql/FORBIDDEN', [])
+                RETURN collect(NULL) AS create_var10
+              }
+              WITH *
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND create_this1.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
+              RETURN create_this1
             }
             RETURN collect(create_this1 { .id }) AS data"
         `);
@@ -246,10 +244,9 @@ describe("Cypher Auth Allow", () => {
             MATCH (this:User)
             WITH *
             WHERE this.id = $param0
-            SET
-                this.id = $param1
+            SET this.id = $param1
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
             WITH this
             RETURN this { .id } AS this"
         `);
@@ -302,18 +299,17 @@ describe("Cypher Auth Allow", () => {
             WHERE this.id = $param0
             WITH *
             CALL (*) {
-                MATCH (this)-[this0:HAS_POST]->(this1:Post)
+              MATCH (this)-[this0:HAS_POST]->(this1:Post)
+              WITH *
+              WHERE this1.id = $param1
+              WITH *
+              CALL (*) {
+                MATCH (this1)<-[this2:HAS_POST]-(this3:User)
                 WITH *
-                WHERE this1.id = $param1
+                SET this3.id = $param2
                 WITH *
-                CALL (*) {
-                    MATCH (this1)<-[this2:HAS_POST]-(this3:User)
-                    WITH *
-                    SET
-                        this3.id = $param2
-                    WITH *
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                }
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
+              }
             }
             WITH this
             RETURN this { .id } AS this"
@@ -361,18 +357,18 @@ describe("Cypher Auth Allow", () => {
             WHERE this.id = $param0
             WITH *
             CALL (*) {
-                CALL (this) {
-                    MATCH (this0:User)
-                    WHERE this0.id = $param1
-                    CREATE (this)<-[this1:HAS_POST]-(this0)
-                    WITH *
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    WITH *
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                        MATCH (this)<-[:HAS_POST]-(this2:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
-                    }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                }
+              CALL (this) {
+                MATCH (this0:User)
+                WHERE this0.id = $param1
+                CREATE (this)<-[this1:HAS_POST]-(this0)
+                WITH *
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
+                WITH *
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
+                  MATCH (this)<-[:HAS_POST]-(this2:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
+                }), '@neo4j/graphql/FORBIDDEN', [])
+              }
             }
             WITH this
             RETURN this { .id } AS this"
@@ -419,19 +415,19 @@ describe("Cypher Auth Allow", () => {
             WHERE this.id = $param0
             WITH *
             CALL (*) {
-                CALL (this) {
-                    OPTIONAL MATCH (this)<-[this0:HAS_POST]-(this1:User)
-                    WHERE this1.id = $param1
-                    WITH *
-                    DELETE this0
-                    WITH *
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this1.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    WITH *
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                        MATCH (this)<-[:HAS_POST]-(this2:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
-                    }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                }
+              CALL (this) {
+                OPTIONAL MATCH (this)<-[this0:HAS_POST]-(this1:User)
+                WHERE this1.id = $param1
+                WITH *
+                DELETE this0
+                WITH *
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this1.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
+                WITH *
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
+                  MATCH (this)<-[:HAS_POST]-(this2:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
+                }), '@neo4j/graphql/FORBIDDEN', [])
+              }
             }
             WITH this
             RETURN this { .id } AS this"

--- a/packages/graphql/tests/tck/directives/authorization/arguments/where/connection-auth-filter.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/where/connection-auth-filter.test.ts
@@ -98,13 +98,13 @@ describe("Connection auth filter", () => {
             "CYPHER 5
             MATCH (this0:User)
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub))
-            WITH collect({ node: this0 }) AS edges
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                RETURN collect({ node: { id: this0.id, __resolveType: \\"User\\" } }) AS var1
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              RETURN collect({node: {id: this0.id, __resolveType: 'User'}}) AS var1
             }
-            RETURN { edges: var1 } AS this"
+            RETURN {edges: var1} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -142,13 +142,13 @@ describe("Connection auth filter", () => {
             "CYPHER 5
             MATCH (this0:User)
             WHERE (this0.name = $param0 AND ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)))
-            WITH collect({ node: this0 }) AS edges
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                RETURN collect({ node: { id: this0.id, __resolveType: \\"User\\" } }) AS var1
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              RETURN collect({node: {id: this0.id, __resolveType: 'User'}}) AS var1
             }
-            RETURN { edges: var1 } AS this"
+            RETURN {edges: var1} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -190,24 +190,24 @@ describe("Connection auth filter", () => {
             "CYPHER 5
             MATCH (this0:User)
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub))
-            WITH collect({ node: this0 }) AS edges
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                CALL (this0) {
-                    MATCH (this0)-[this1:HAS_POST]->(this2:Post)
-                    WITH DISTINCT this2
-                    WITH *
-                    WHERE ($isAuthenticated = true AND EXISTS {
-                        MATCH (this2)<-[:HAS_POST]-(this3:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
-                    })
-                    WITH this2 { .content } AS this2
-                    RETURN collect(this2) AS var4
-                }
-                RETURN collect({ node: { id: this0.id, posts: var4, __resolveType: \\"User\\" } }) AS var5
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              CALL (this0) {
+                MATCH (this0)-[this1:HAS_POST]->(this2:Post)
+                WITH DISTINCT this2
+                WITH *
+                WHERE ($isAuthenticated = true AND EXISTS {
+                  MATCH (this2)<-[:HAS_POST]-(this3:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
+                })
+                WITH this2 { .content } AS this2
+                RETURN collect(this2) AS var4
+              }
+              RETURN collect({node: {id: this0.id, posts: var4, __resolveType: 'User'}}) AS var5
             }
-            RETURN { edges: var5 } AS this"
+            RETURN {edges: var5} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -252,27 +252,27 @@ describe("Connection auth filter", () => {
             "CYPHER 5
             MATCH (this0:User)
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub))
-            WITH collect({ node: this0 }) AS edges
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                CALL (this0) {
-                    MATCH (this0)-[this1:HAS_POST]->(this2:Post)
-                    WHERE ($isAuthenticated = true AND EXISTS {
-                        MATCH (this2)<-[:HAS_POST]-(this3:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
-                    })
-                    WITH collect({ node: this2, relationship: this1 }) AS edges
-                    CALL (edges) {
-                        UNWIND edges AS edge
-                        WITH edge.node AS this2, edge.relationship AS this1
-                        RETURN collect({ node: { content: this2.content, __resolveType: \\"Post\\" } }) AS var4
-                    }
-                    RETURN { edges: var4 } AS var5
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              CALL (this0) {
+                MATCH (this0)-[this1:HAS_POST]->(this2:Post)
+                WHERE ($isAuthenticated = true AND EXISTS {
+                  MATCH (this2)<-[:HAS_POST]-(this3:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
+                })
+                WITH collect({node: this2, relationship: this1}) AS edges
+                CALL (edges) {
+                  UNWIND edges AS edge
+                  WITH edge.node AS this2, edge.relationship AS this1
+                  RETURN collect({node: {content: this2.content, __resolveType: 'Post'}}) AS var4
                 }
-                RETURN collect({ node: { id: this0.id, postsConnection: var5, __resolveType: \\"User\\" } }) AS var6
+                RETURN {edges: var4} AS var5
+              }
+              RETURN collect({node: {id: this0.id, postsConnection: var5, __resolveType: 'User'}}) AS var6
             }
-            RETURN { edges: var6 } AS this"
+            RETURN {edges: var6} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -317,27 +317,27 @@ describe("Connection auth filter", () => {
             "CYPHER 5
             MATCH (this0:User)
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub))
-            WITH collect({ node: this0 }) AS edges
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                CALL (this0) {
-                    MATCH (this0)-[this1:HAS_POST]->(this2:Post)
-                    WHERE (this2.id = $param2 AND ($isAuthenticated = true AND EXISTS {
-                        MATCH (this2)<-[:HAS_POST]-(this3:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
-                    }))
-                    WITH collect({ node: this2, relationship: this1 }) AS edges
-                    CALL (edges) {
-                        UNWIND edges AS edge
-                        WITH edge.node AS this2, edge.relationship AS this1
-                        RETURN collect({ node: { content: this2.content, __resolveType: \\"Post\\" } }) AS var4
-                    }
-                    RETURN { edges: var4 } AS var5
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              CALL (this0) {
+                MATCH (this0)-[this1:HAS_POST]->(this2:Post)
+                WHERE (this2.id = $param2 AND ($isAuthenticated = true AND EXISTS {
+                  MATCH (this2)<-[:HAS_POST]-(this3:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
+                }))
+                WITH collect({node: this2, relationship: this1}) AS edges
+                CALL (edges) {
+                  UNWIND edges AS edge
+                  WITH edge.node AS this2, edge.relationship AS this1
+                  RETURN collect({node: {content: this2.content, __resolveType: 'Post'}}) AS var4
                 }
-                RETURN collect({ node: { id: this0.id, postsConnection: var5, __resolveType: \\"User\\" } }) AS var6
+                RETURN {edges: var4} AS var5
+              }
+              RETURN collect({node: {id: this0.id, postsConnection: var5, __resolveType: 'User'}}) AS var6
             }
-            RETURN { edges: var6 } AS this"
+            RETURN {edges: var6} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -379,24 +379,24 @@ describe("Connection auth filter", () => {
             "CYPHER 5
             MATCH (this0:User)
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub))
-            WITH collect({ node: this0 }) AS edges
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                CALL (this0) {
-                    MATCH (this0)-[this1:HAS_POST]->(this2:Post)
-                    WITH DISTINCT this2
-                    WITH *
-                    WHERE (this2.content = $param2 AND ($isAuthenticated = true AND EXISTS {
-                        MATCH (this2)<-[:HAS_POST]-(this3:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
-                    }))
-                    WITH this2 { .content } AS this2
-                    RETURN collect(this2) AS var4
-                }
-                RETURN collect({ node: { id: this0.id, posts: var4, __resolveType: \\"User\\" } }) AS var5
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              CALL (this0) {
+                MATCH (this0)-[this1:HAS_POST]->(this2:Post)
+                WITH DISTINCT this2
+                WITH *
+                WHERE (this2.content = $param2 AND ($isAuthenticated = true AND EXISTS {
+                  MATCH (this2)<-[:HAS_POST]-(this3:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
+                }))
+                WITH this2 { .content } AS this2
+                RETURN collect(this2) AS var4
+              }
+              RETURN collect({node: {id: this0.id, posts: var4, __resolveType: 'User'}}) AS var5
             }
-            RETURN { edges: var5 } AS this"
+            RETURN {edges: var5} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -440,27 +440,27 @@ describe("Connection auth filter", () => {
             "CYPHER 5
             MATCH (this0:User)
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub))
-            WITH collect({ node: this0 }) AS edges
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                CALL (this0) {
-                    CALL (*) {
-                        WITH *
-                        MATCH (this0)-[this1:HAS_POST]->(this2:Post)
-                        WHERE ($isAuthenticated = true AND EXISTS {
-                            MATCH (this2)<-[:HAS_POST]-(this3:User)
-                            WHERE ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
-                        })
-                        WITH this2 { .id, __resolveType: \\"Post\\", __id: id(this2) } AS var4
-                        RETURN var4
-                    }
-                    WITH var4
-                    RETURN collect(var4) AS var4
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              CALL (this0) {
+                CALL (*) {
+                  WITH *
+                  MATCH (this0)-[this1:HAS_POST]->(this2:Post)
+                  WHERE ($isAuthenticated = true AND EXISTS {
+                    MATCH (this2)<-[:HAS_POST]-(this3:User)
+                    WHERE ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
+                  })
+                  WITH this2 { .id, __resolveType: 'Post', __id: elementId(this2) } AS var4
+                  RETURN var4
                 }
-                RETURN collect({ node: { id: this0.id, content: var4, __resolveType: \\"User\\" } }) AS var5
+                WITH var4
+                RETURN collect(var4) AS var4
+              }
+              RETURN collect({node: {id: this0.id, content: var4, __resolveType: 'User'}}) AS var5
             }
-            RETURN { edges: var5 } AS this"
+            RETURN {edges: var5} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -507,31 +507,31 @@ describe("Connection auth filter", () => {
             "CYPHER 5
             MATCH (this0:User)
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub))
-            WITH collect({ node: this0 }) AS edges
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              CALL (this0) {
                 CALL (this0) {
-                    CALL (this0) {
-                        CALL (this0) {
-                            WITH this0
-                            MATCH (this0)-[this1:HAS_POST]->(this2:Post)
-                            WHERE ($isAuthenticated = true AND EXISTS {
-                                MATCH (this2)<-[:HAS_POST]-(this3:User)
-                                WHERE ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
-                            })
-                            WITH { node: { __resolveType: \\"Post\\", __id: id(this2), id: this2.id } } AS edge
-                            RETURN edge
-                        }
-                        RETURN collect(edge) AS edges
-                    }
-                    WITH edges
-                    WITH edges, size(edges) AS totalCount
-                    RETURN { edges: edges, totalCount: totalCount } AS var4
+                  CALL (this0) {
+                    WITH this0
+                    MATCH (this0)-[this1:HAS_POST]->(this2:Post)
+                    WHERE ($isAuthenticated = true AND EXISTS {
+                      MATCH (this2)<-[:HAS_POST]-(this3:User)
+                      WHERE ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
+                    })
+                    WITH {node: {__resolveType: 'Post', __id: elementId(this2), id: this2.id}} AS edge
+                    RETURN edge
+                  }
+                  RETURN collect(edge) AS edges
                 }
-                RETURN collect({ node: { id: this0.id, contentConnection: var4, __resolveType: \\"User\\" } }) AS var5
+                WITH edges
+                WITH edges, size(edges) AS totalCount
+                RETURN {edges: edges, totalCount: totalCount} AS var4
+              }
+              RETURN collect({node: {id: this0.id, contentConnection: var4, __resolveType: 'User'}}) AS var5
             }
-            RETURN { edges: var5 } AS this"
+            RETURN {edges: var5} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -578,31 +578,31 @@ describe("Connection auth filter", () => {
             "CYPHER 5
             MATCH (this0:User)
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub))
-            WITH collect({ node: this0 }) AS edges
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              CALL (this0) {
                 CALL (this0) {
-                    CALL (this0) {
-                        CALL (this0) {
-                            WITH this0
-                            MATCH (this0)-[this1:HAS_POST]->(this2:Post)
-                            WHERE (this2.id = $param2 AND ($isAuthenticated = true AND EXISTS {
-                                MATCH (this2)<-[:HAS_POST]-(this3:User)
-                                WHERE ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
-                            }))
-                            WITH { node: { __resolveType: \\"Post\\", __id: id(this2), id: this2.id } } AS edge
-                            RETURN edge
-                        }
-                        RETURN collect(edge) AS edges
-                    }
-                    WITH edges
-                    WITH edges, size(edges) AS totalCount
-                    RETURN { edges: edges, totalCount: totalCount } AS var4
+                  CALL (this0) {
+                    WITH this0
+                    MATCH (this0)-[this1:HAS_POST]->(this2:Post)
+                    WHERE (this2.id = $param2 AND ($isAuthenticated = true AND EXISTS {
+                      MATCH (this2)<-[:HAS_POST]-(this3:User)
+                      WHERE ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
+                    }))
+                    WITH {node: {__resolveType: 'Post', __id: elementId(this2), id: this2.id}} AS edge
+                    RETURN edge
+                  }
+                  RETURN collect(edge) AS edges
                 }
-                RETURN collect({ node: { id: this0.id, contentConnection: var4, __resolveType: \\"User\\" } }) AS var5
+                WITH edges
+                WITH edges, size(edges) AS totalCount
+                RETURN {edges: edges, totalCount: totalCount} AS var4
+              }
+              RETURN collect({node: {id: this0.id, contentConnection: var4, __resolveType: 'User'}}) AS var5
             }
-            RETURN { edges: var5 } AS this"
+            RETURN {edges: var5} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/directives/authorization/arguments/where/interface-relationships/implementation-where.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/where/interface-relationships/implementation-where.test.ts
@@ -113,8 +113,8 @@ describe("Cypher Auth Where", () => {
             MATCH (this:Post)
             WITH *
             WHERE ($isAuthenticated = true AND EXISTS {
-                MATCH (this)<-[:HAS_CONTENT]-(this0:User)
-                WHERE ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)
+              MATCH (this)<-[:HAS_CONTENT]-(this0:User)
+              WHERE ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)
             })
             RETURN this { .id } AS this"
         `);
@@ -149,8 +149,8 @@ describe("Cypher Auth Where", () => {
             MATCH (this:Post)
             WITH *
             WHERE (this.content = $param0 AND ($isAuthenticated = true AND EXISTS {
-                MATCH (this)<-[:HAS_CONTENT]-(this0:User)
-                WHERE ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)
+              MATCH (this)<-[:HAS_CONTENT]-(this0:User)
+              WHERE ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)
             }))
             RETURN this { .id } AS this"
         `);
@@ -192,23 +192,23 @@ describe("Cypher Auth Where", () => {
             WITH *
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             CALL (this) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this)-[this0:HAS_CONTENT]->(this1:Comment)
-                    WITH this1 { __resolveType: \\"Comment\\", __id: id(this1) } AS var2
-                    RETURN var2
-                    UNION
-                    WITH *
-                    MATCH (this)-[this3:HAS_CONTENT]->(this4:Post)
-                    WHERE ($isAuthenticated = true AND EXISTS {
-                        MATCH (this4)<-[:HAS_CONTENT]-(this5:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this5.id = $jwt.sub)
-                    })
-                    WITH this4 { .id, __resolveType: \\"Post\\", __id: id(this4) } AS var2
-                    RETURN var2
-                }
-                WITH var2
-                RETURN collect(var2) AS var2
+              CALL (*) {
+                WITH *
+                MATCH (this)-[this0:HAS_CONTENT]->(this1:Comment)
+                WITH this1 { __resolveType: 'Comment', __id: elementId(this1) } AS var2
+                RETURN var2
+                UNION
+                WITH *
+                MATCH (this)-[this3:HAS_CONTENT]->(this4:Post)
+                WHERE ($isAuthenticated = true AND EXISTS {
+                  MATCH (this4)<-[:HAS_CONTENT]-(this5:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this5.id = $jwt.sub)
+                })
+                WITH this4 { .id, __resolveType: 'Post', __id: elementId(this4) } AS var2
+                RETURN var2
+              }
+              WITH var2
+              RETURN collect(var2) AS var2
             }
             RETURN this { .id, content: var2 } AS this"
         `);
@@ -253,27 +253,27 @@ describe("Cypher Auth Where", () => {
             WITH *
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             CALL (this) {
+              CALL (this) {
                 CALL (this) {
-                    CALL (this) {
-                        WITH this
-                        MATCH (this)-[this0:HAS_CONTENT]->(this1:Comment)
-                        WITH { node: { __resolveType: \\"Comment\\", __id: id(this1) } } AS edge
-                        RETURN edge
-                        UNION
-                        WITH this
-                        MATCH (this)-[this2:HAS_CONTENT]->(this3:Post)
-                        WHERE ($isAuthenticated = true AND EXISTS {
-                            MATCH (this3)<-[:HAS_CONTENT]-(this4:User)
-                            WHERE ($jwt.sub IS NOT NULL AND this4.id = $jwt.sub)
-                        })
-                        WITH { node: { __resolveType: \\"Post\\", __id: id(this3), id: this3.id } } AS edge
-                        RETURN edge
-                    }
-                    RETURN collect(edge) AS edges
+                  WITH this
+                  MATCH (this)-[this0:HAS_CONTENT]->(this1:Comment)
+                  WITH {node: {__resolveType: 'Comment', __id: elementId(this1)}} AS edge
+                  RETURN edge
+                  UNION
+                  WITH this
+                  MATCH (this)-[this2:HAS_CONTENT]->(this3:Post)
+                  WHERE ($isAuthenticated = true AND EXISTS {
+                    MATCH (this3)<-[:HAS_CONTENT]-(this4:User)
+                    WHERE ($jwt.sub IS NOT NULL AND this4.id = $jwt.sub)
+                  })
+                  WITH {node: {__resolveType: 'Post', __id: elementId(this3), id: this3.id}} AS edge
+                  RETURN edge
                 }
-                WITH edges
-                WITH edges, size(edges) AS totalCount
-                RETURN { edges: edges, totalCount: totalCount } AS var5
+                RETURN collect(edge) AS edges
+              }
+              WITH edges
+              WITH edges, size(edges) AS totalCount
+              RETURN {edges: edges, totalCount: totalCount} AS var5
             }
             RETURN this { .id, contentConnection: var5 } AS this"
         `);
@@ -318,28 +318,28 @@ describe("Cypher Auth Where", () => {
             WITH *
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             CALL (this) {
+              CALL (this) {
                 CALL (this) {
-                    CALL (this) {
-                        WITH this
-                        MATCH (this)-[this0:HAS_CONTENT]->(this1:Comment)
-                        WHERE this1.id = $param2
-                        WITH { node: { __resolveType: \\"Comment\\", __id: id(this1) } } AS edge
-                        RETURN edge
-                        UNION
-                        WITH this
-                        MATCH (this)-[this2:HAS_CONTENT]->(this3:Post)
-                        WHERE (this3.id = $param3 AND ($isAuthenticated = true AND EXISTS {
-                            MATCH (this3)<-[:HAS_CONTENT]-(this4:User)
-                            WHERE ($jwt.sub IS NOT NULL AND this4.id = $jwt.sub)
-                        }))
-                        WITH { node: { __resolveType: \\"Post\\", __id: id(this3), id: this3.id } } AS edge
-                        RETURN edge
-                    }
-                    RETURN collect(edge) AS edges
+                  WITH this
+                  MATCH (this)-[this0:HAS_CONTENT]->(this1:Comment)
+                  WHERE this1.id = $param2
+                  WITH {node: {__resolveType: 'Comment', __id: elementId(this1)}} AS edge
+                  RETURN edge
+                  UNION
+                  WITH this
+                  MATCH (this)-[this2:HAS_CONTENT]->(this3:Post)
+                  WHERE (this3.id = $param3 AND ($isAuthenticated = true AND EXISTS {
+                    MATCH (this3)<-[:HAS_CONTENT]-(this4:User)
+                    WHERE ($jwt.sub IS NOT NULL AND this4.id = $jwt.sub)
+                  }))
+                  WITH {node: {__resolveType: 'Post', __id: elementId(this3), id: this3.id}} AS edge
+                  RETURN edge
                 }
-                WITH edges
-                WITH edges, size(edges) AS totalCount
-                RETURN { edges: edges, totalCount: totalCount } AS var5
+                RETURN collect(edge) AS edges
+              }
+              WITH edges
+              WITH edges, size(edges) AS totalCount
+              RETURN {edges: edges, totalCount: totalCount} AS var5
             }
             RETURN this { .id, contentConnection: var5 } AS this"
         `);
@@ -378,16 +378,15 @@ describe("Cypher Auth Where", () => {
             MATCH (this:Post)
             WITH *
             WHERE ($isAuthenticated = true AND EXISTS {
-                MATCH (this)<-[:HAS_CONTENT]-(this0:User)
-                WHERE ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)
+              MATCH (this)<-[:HAS_CONTENT]-(this0:User)
+              WHERE ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)
             })
-            SET
-                this.content = $param2
+            SET this.content = $param2
             WITH this
             WITH *
             WHERE ($isAuthenticated = true AND EXISTS {
-                MATCH (this)<-[:HAS_CONTENT]-(this1:User)
-                WHERE ($jwt.sub IS NOT NULL AND this1.id = $jwt.sub)
+              MATCH (this)<-[:HAS_CONTENT]-(this1:User)
+              WHERE ($jwt.sub IS NOT NULL AND this1.id = $jwt.sub)
             })
             RETURN this { .id } AS this"
         `);
@@ -425,16 +424,15 @@ describe("Cypher Auth Where", () => {
             MATCH (this:Post)
             WITH *
             WHERE (this.content = $param0 AND ($isAuthenticated = true AND EXISTS {
-                MATCH (this)<-[:HAS_CONTENT]-(this0:User)
-                WHERE ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)
+              MATCH (this)<-[:HAS_CONTENT]-(this0:User)
+              WHERE ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)
             }))
-            SET
-                this.content = $param3
+            SET this.content = $param3
             WITH this
             WITH *
             WHERE ($isAuthenticated = true AND EXISTS {
-                MATCH (this)<-[:HAS_CONTENT]-(this1:User)
-                WHERE ($jwt.sub IS NOT NULL AND this1.id = $jwt.sub)
+              MATCH (this)<-[:HAS_CONTENT]-(this1:User)
+              WHERE ($jwt.sub IS NOT NULL AND this1.id = $jwt.sub)
             })
             RETURN this { .id } AS this"
         `);
@@ -474,21 +472,19 @@ describe("Cypher Auth Where", () => {
             WITH *
             WITH *
             CALL (*) {
-                MATCH (this)-[this0:HAS_CONTENT]->(this1:Comment)
-                WITH *
-                SET
-                    this1.id = $param0
+              MATCH (this)-[this0:HAS_CONTENT]->(this1:Comment)
+              WITH *
+              SET this1.id = $param0
             }
             WITH *
             CALL (*) {
-                MATCH (this)-[this2:HAS_CONTENT]->(this3:Post)
-                WITH *
-                WHERE ($isAuthenticated = true AND EXISTS {
-                    MATCH (this3)<-[:HAS_CONTENT]-(this4:User)
-                    WHERE ($jwt.sub IS NOT NULL AND this4.id = $jwt.sub)
-                })
-                SET
-                    this3.id = $param3
+              MATCH (this)-[this2:HAS_CONTENT]->(this3:Post)
+              WITH *
+              WHERE ($isAuthenticated = true AND EXISTS {
+                MATCH (this3)<-[:HAS_CONTENT]-(this4:User)
+                WHERE ($jwt.sub IS NOT NULL AND this4.id = $jwt.sub)
+              })
+              SET this3.id = $param3
             }
             WITH this
             WITH *
@@ -527,8 +523,8 @@ describe("Cypher Auth Where", () => {
             "CYPHER 5
             MATCH (this:Post)
             WHERE ($isAuthenticated = true AND EXISTS {
-                MATCH (this)<-[:HAS_CONTENT]-(this0:User)
-                WHERE ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)
+              MATCH (this)<-[:HAS_CONTENT]-(this0:User)
+              WHERE ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)
             })
             DETACH DELETE this"
         `);
@@ -562,8 +558,8 @@ describe("Cypher Auth Where", () => {
             "CYPHER 5
             MATCH (this:Post)
             WHERE (this.content = $param0 AND ($isAuthenticated = true AND EXISTS {
-                MATCH (this)<-[:HAS_CONTENT]-(this0:User)
-                WHERE ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)
+              MATCH (this)<-[:HAS_CONTENT]-(this0:User)
+              WHERE ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)
             }))
             DETACH DELETE this"
         `);
@@ -600,24 +596,24 @@ describe("Cypher Auth Where", () => {
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             WITH *
             CALL (*) {
-                OPTIONAL MATCH (this)-[this0:HAS_CONTENT]->(this1:Comment)
-                WITH this0, collect(DISTINCT this1) AS var2
-                CALL (var2) {
-                    UNWIND var2 AS var3
-                    DETACH DELETE var3
-                }
+              OPTIONAL MATCH (this)-[this0:HAS_CONTENT]->(this1:Comment)
+              WITH this0, collect(DISTINCT this1) AS var2
+              CALL (var2) {
+                UNWIND var2 AS var3
+                DETACH DELETE var3
+              }
             }
             CALL (*) {
-                OPTIONAL MATCH (this)-[this4:HAS_CONTENT]->(this5:Post)
-                WHERE ($isAuthenticated = true AND EXISTS {
-                    MATCH (this5)<-[:HAS_CONTENT]-(this6:User)
-                    WHERE ($jwt.sub IS NOT NULL AND this6.id = $jwt.sub)
-                })
-                WITH this4, collect(DISTINCT this5) AS var7
-                CALL (var7) {
-                    UNWIND var7 AS var8
-                    DETACH DELETE var8
-                }
+              OPTIONAL MATCH (this)-[this4:HAS_CONTENT]->(this5:Post)
+              WHERE ($isAuthenticated = true AND EXISTS {
+                MATCH (this5)<-[:HAS_CONTENT]-(this6:User)
+                WHERE ($jwt.sub IS NOT NULL AND this6.id = $jwt.sub)
+              })
+              WITH this4, collect(DISTINCT this5) AS var7
+              CALL (var7) {
+                UNWIND var7 AS var8
+                DETACH DELETE var8
+              }
             }
             WITH *
             DETACH DELETE this"
@@ -657,30 +653,30 @@ describe("Cypher Auth Where", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                CREATE (this0:User)
-                SET
-                    this0.id = $param0,
-                    this0.name = $param1,
-                    this0.password = $param2
-                WITH *
-                CALL (this0) {
-                    MATCH (this1:Comment)
-                    CREATE (this0)-[this2:HAS_CONTENT]->(this1)
-                }
-                WITH *
-                CALL (this0) {
-                    MATCH (this3:Post)
-                    WHERE ($isAuthenticated = true AND EXISTS {
-                        MATCH (this3)<-[:HAS_CONTENT]-(this4:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this4.id = $jwt.sub)
-                    })
-                    CREATE (this0)-[this5:HAS_CONTENT]->(this3)
-                }
-                RETURN this0 AS this
+              CREATE (this0:User)
+              SET
+                this0.id = $param0,
+                this0.name = $param1,
+                this0.password = $param2
+              WITH *
+              CALL (this0) {
+                MATCH (this1:Comment)
+                CREATE (this0)-[this2:HAS_CONTENT]->(this1)
+              }
+              WITH *
+              CALL (this0) {
+                MATCH (this3:Post)
+                WHERE ($isAuthenticated = true AND EXISTS {
+                  MATCH (this3)<-[:HAS_CONTENT]-(this4:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this4.id = $jwt.sub)
+                })
+                CREATE (this0)-[this5:HAS_CONTENT]->(this3)
+              }
+              RETURN this0 AS this
             }
             WITH this
             CALL (this) {
-                RETURN this { .id } AS var6
+              RETURN this { .id } AS var6
             }
             RETURN collect(var6) AS data"
         `);
@@ -727,31 +723,31 @@ describe("Cypher Auth Where", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                CREATE (this0:User)
-                SET
-                    this0.id = $param0,
-                    this0.name = $param1,
-                    this0.password = $param2
-                WITH *
-                CALL (this0) {
-                    MATCH (this1:Comment)
-                    WHERE this1.id = $param3
-                    CREATE (this0)-[this2:HAS_CONTENT]->(this1)
-                }
-                WITH *
-                CALL (this0) {
-                    MATCH (this3:Post)
-                    WHERE (($isAuthenticated = true AND EXISTS {
-                        MATCH (this3)<-[:HAS_CONTENT]-(this4:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this4.id = $jwt.sub)
-                    }) AND this3.id = $param6)
-                    CREATE (this0)-[this5:HAS_CONTENT]->(this3)
-                }
-                RETURN this0 AS this
+              CREATE (this0:User)
+              SET
+                this0.id = $param0,
+                this0.name = $param1,
+                this0.password = $param2
+              WITH *
+              CALL (this0) {
+                MATCH (this1:Comment)
+                WHERE this1.id = $param3
+                CREATE (this0)-[this2:HAS_CONTENT]->(this1)
+              }
+              WITH *
+              CALL (this0) {
+                MATCH (this3:Post)
+                WHERE (($isAuthenticated = true AND EXISTS {
+                  MATCH (this3)<-[:HAS_CONTENT]-(this4:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this4.id = $jwt.sub)
+                }) AND this3.id = $param6)
+                CREATE (this0)-[this5:HAS_CONTENT]->(this3)
+              }
+              RETURN this0 AS this
             }
             WITH this
             CALL (this) {
-                RETURN this { .id } AS var6
+              RETURN this { .id } AS var6
             }
             RETURN collect(var6) AS data"
         `);
@@ -794,18 +790,18 @@ describe("Cypher Auth Where", () => {
             WITH *
             WITH *
             CALL (*) {
-                CALL (this) {
-                    MATCH (this0:Comment)
-                    CREATE (this)-[this1:HAS_CONTENT]->(this0)
-                }
-                CALL (this) {
-                    MATCH (this2:Post)
-                    WHERE ($isAuthenticated = true AND EXISTS {
-                        MATCH (this2)<-[:HAS_CONTENT]-(this3:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
-                    })
-                    CREATE (this)-[this4:HAS_CONTENT]->(this2)
-                }
+              CALL (this) {
+                MATCH (this0:Comment)
+                CREATE (this)-[this1:HAS_CONTENT]->(this0)
+              }
+              CALL (this) {
+                MATCH (this2:Post)
+                WHERE ($isAuthenticated = true AND EXISTS {
+                  MATCH (this2)<-[:HAS_CONTENT]-(this3:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
+                })
+                CREATE (this)-[this4:HAS_CONTENT]->(this2)
+              }
             }
             WITH this
             WITH *
@@ -846,19 +842,19 @@ describe("Cypher Auth Where", () => {
             WITH *
             WITH *
             CALL (*) {
-                CALL (this) {
-                    MATCH (this0:Comment)
-                    WHERE this0.id = $param0
-                    CREATE (this)-[this1:HAS_CONTENT]->(this0)
-                }
-                CALL (this) {
-                    MATCH (this2:Post)
-                    WHERE (($isAuthenticated = true AND EXISTS {
-                        MATCH (this2)<-[:HAS_CONTENT]-(this3:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
-                    }) AND this2.id = $param3)
-                    CREATE (this)-[this4:HAS_CONTENT]->(this2)
-                }
+              CALL (this) {
+                MATCH (this0:Comment)
+                WHERE this0.id = $param0
+                CREATE (this)-[this1:HAS_CONTENT]->(this0)
+              }
+              CALL (this) {
+                MATCH (this2:Post)
+                WHERE (($isAuthenticated = true AND EXISTS {
+                  MATCH (this2)<-[:HAS_CONTENT]-(this3:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
+                }) AND this2.id = $param3)
+                CREATE (this)-[this4:HAS_CONTENT]->(this2)
+              }
             }
             WITH this
             WITH *
@@ -901,20 +897,20 @@ describe("Cypher Auth Where", () => {
             WITH *
             WITH *
             CALL (*) {
-                CALL (this) {
-                    OPTIONAL MATCH (this)-[this0:HAS_CONTENT]->(this1:Comment)
-                    WITH *
-                    DELETE this0
-                }
-                CALL (this) {
-                    OPTIONAL MATCH (this)-[this2:HAS_CONTENT]->(this3:Post)
-                    WHERE ($isAuthenticated = true AND EXISTS {
-                        MATCH (this3)<-[:HAS_CONTENT]-(this4:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this4.id = $jwt.sub)
-                    })
-                    WITH *
-                    DELETE this2
-                }
+              CALL (this) {
+                OPTIONAL MATCH (this)-[this0:HAS_CONTENT]->(this1:Comment)
+                WITH *
+                DELETE this0
+              }
+              CALL (this) {
+                OPTIONAL MATCH (this)-[this2:HAS_CONTENT]->(this3:Post)
+                WHERE ($isAuthenticated = true AND EXISTS {
+                  MATCH (this3)<-[:HAS_CONTENT]-(this4:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this4.id = $jwt.sub)
+                })
+                WITH *
+                DELETE this2
+              }
             }
             WITH this
             WITH *
@@ -955,21 +951,21 @@ describe("Cypher Auth Where", () => {
             WITH *
             WITH *
             CALL (*) {
-                CALL (this) {
-                    OPTIONAL MATCH (this)-[this0:HAS_CONTENT]->(this1:Comment)
-                    WHERE this1.id = $param0
-                    WITH *
-                    DELETE this0
-                }
-                CALL (this) {
-                    OPTIONAL MATCH (this)-[this2:HAS_CONTENT]->(this3:Post)
-                    WHERE (($isAuthenticated = true AND EXISTS {
-                        MATCH (this3)<-[:HAS_CONTENT]-(this4:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this4.id = $jwt.sub)
-                    }) AND this3.id = $param3)
-                    WITH *
-                    DELETE this2
-                }
+              CALL (this) {
+                OPTIONAL MATCH (this)-[this0:HAS_CONTENT]->(this1:Comment)
+                WHERE this1.id = $param0
+                WITH *
+                DELETE this0
+              }
+              CALL (this) {
+                OPTIONAL MATCH (this)-[this2:HAS_CONTENT]->(this3:Post)
+                WHERE (($isAuthenticated = true AND EXISTS {
+                  MATCH (this3)<-[:HAS_CONTENT]-(this4:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this4.id = $jwt.sub)
+                }) AND this3.id = $param3)
+                WITH *
+                DELETE this2
+              }
             }
             WITH this
             WITH *

--- a/packages/graphql/tests/tck/directives/authorization/arguments/where/where.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/where/where.test.ts
@@ -170,15 +170,15 @@ describe("Cypher Auth Where", () => {
             WITH *
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             CALL (this) {
-                MATCH (this)-[this0:HAS_POST]->(this1:Post)
-                WITH DISTINCT this1
-                WITH *
-                WHERE ($isAuthenticated = true AND EXISTS {
-                    MATCH (this1)<-[:HAS_POST]-(this2:User)
-                    WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
-                })
-                WITH this1 { .content } AS this1
-                RETURN collect(this1) AS var3
+              MATCH (this)-[this0:HAS_POST]->(this1:Post)
+              WITH DISTINCT this1
+              WITH *
+              WHERE ($isAuthenticated = true AND EXISTS {
+                MATCH (this1)<-[:HAS_POST]-(this2:User)
+                WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
+              })
+              WITH this1 { .content } AS this1
+              RETURN collect(this1) AS var3
             }
             RETURN this { .id, posts: var3 } AS this"
         `);
@@ -223,18 +223,18 @@ describe("Cypher Auth Where", () => {
             WITH *
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             CALL (this) {
-                MATCH (this)-[this0:HAS_POST]->(this1:Post)
-                WHERE ($isAuthenticated = true AND EXISTS {
-                    MATCH (this1)<-[:HAS_POST]-(this2:User)
-                    WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
-                })
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ node: { content: this1.content, __resolveType: \\"Post\\" } }) AS var3
-                }
-                RETURN { edges: var3 } AS var4
+              MATCH (this)-[this0:HAS_POST]->(this1:Post)
+              WHERE ($isAuthenticated = true AND EXISTS {
+                MATCH (this1)<-[:HAS_POST]-(this2:User)
+                WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
+              })
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({node: {content: this1.content, __resolveType: 'Post'}}) AS var3
+              }
+              RETURN {edges: var3} AS var4
             }
             RETURN this { .id, postsConnection: var4 } AS this"
         `);
@@ -279,18 +279,18 @@ describe("Cypher Auth Where", () => {
             WITH *
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             CALL (this) {
-                MATCH (this)-[this0:HAS_POST]->(this1:Post)
-                WHERE (this1.id = $param2 AND ($isAuthenticated = true AND EXISTS {
-                    MATCH (this1)<-[:HAS_POST]-(this2:User)
-                    WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
-                }))
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ node: { content: this1.content, __resolveType: \\"Post\\" } }) AS var3
-                }
-                RETURN { edges: var3 } AS var4
+              MATCH (this)-[this0:HAS_POST]->(this1:Post)
+              WHERE (this1.id = $param2 AND ($isAuthenticated = true AND EXISTS {
+                MATCH (this1)<-[:HAS_POST]-(this2:User)
+                WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
+              }))
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({node: {content: this1.content, __resolveType: 'Post'}}) AS var3
+              }
+              RETURN {edges: var3} AS var4
             }
             RETURN this { .id, postsConnection: var4 } AS this"
         `);
@@ -332,15 +332,15 @@ describe("Cypher Auth Where", () => {
             WITH *
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             CALL (this) {
-                MATCH (this)-[this0:HAS_POST]->(this1:Post)
-                WITH DISTINCT this1
-                WITH *
-                WHERE (this1.content = $param2 AND ($isAuthenticated = true AND EXISTS {
-                    MATCH (this1)<-[:HAS_POST]-(this2:User)
-                    WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
-                }))
-                WITH this1 { .content } AS this1
-                RETURN collect(this1) AS var3
+              MATCH (this)-[this0:HAS_POST]->(this1:Post)
+              WITH DISTINCT this1
+              WITH *
+              WHERE (this1.content = $param2 AND ($isAuthenticated = true AND EXISTS {
+                MATCH (this1)<-[:HAS_POST]-(this2:User)
+                WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
+              }))
+              WITH this1 { .content } AS this1
+              RETURN collect(this1) AS var3
             }
             RETURN this { .id, posts: var3 } AS this"
         `);
@@ -384,18 +384,18 @@ describe("Cypher Auth Where", () => {
             WITH *
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             CALL (this) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this)-[this0:HAS_POST]->(this1:Post)
-                    WHERE ($isAuthenticated = true AND EXISTS {
-                        MATCH (this1)<-[:HAS_POST]-(this2:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
-                    })
-                    WITH this1 { .id, __resolveType: \\"Post\\", __id: id(this1) } AS var3
-                    RETURN var3
-                }
-                WITH var3
-                RETURN collect(var3) AS var3
+              CALL (*) {
+                WITH *
+                MATCH (this)-[this0:HAS_POST]->(this1:Post)
+                WHERE ($isAuthenticated = true AND EXISTS {
+                  MATCH (this1)<-[:HAS_POST]-(this2:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
+                })
+                WITH this1 { .id, __resolveType: 'Post', __id: elementId(this1) } AS var3
+                RETURN var3
+              }
+              WITH var3
+              RETURN collect(var3) AS var3
             }
             RETURN this { .id, content: var3 } AS this"
         `);
@@ -442,22 +442,22 @@ describe("Cypher Auth Where", () => {
             WITH *
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             CALL (this) {
+              CALL (this) {
                 CALL (this) {
-                    CALL (this) {
-                        WITH this
-                        MATCH (this)-[this0:HAS_POST]->(this1:Post)
-                        WHERE ($isAuthenticated = true AND EXISTS {
-                            MATCH (this1)<-[:HAS_POST]-(this2:User)
-                            WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
-                        })
-                        WITH { node: { __resolveType: \\"Post\\", __id: id(this1), id: this1.id } } AS edge
-                        RETURN edge
-                    }
-                    RETURN collect(edge) AS edges
+                  WITH this
+                  MATCH (this)-[this0:HAS_POST]->(this1:Post)
+                  WHERE ($isAuthenticated = true AND EXISTS {
+                    MATCH (this1)<-[:HAS_POST]-(this2:User)
+                    WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
+                  })
+                  WITH {node: {__resolveType: 'Post', __id: elementId(this1), id: this1.id}} AS edge
+                  RETURN edge
                 }
-                WITH edges
-                WITH edges, size(edges) AS totalCount
-                RETURN { edges: edges, totalCount: totalCount } AS var3
+                RETURN collect(edge) AS edges
+              }
+              WITH edges
+              WITH edges, size(edges) AS totalCount
+              RETURN {edges: edges, totalCount: totalCount} AS var3
             }
             RETURN this { .id, contentConnection: var3 } AS this"
         `);
@@ -504,22 +504,22 @@ describe("Cypher Auth Where", () => {
             WITH *
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             CALL (this) {
+              CALL (this) {
                 CALL (this) {
-                    CALL (this) {
-                        WITH this
-                        MATCH (this)-[this0:HAS_POST]->(this1:Post)
-                        WHERE (this1.id = $param2 AND ($isAuthenticated = true AND EXISTS {
-                            MATCH (this1)<-[:HAS_POST]-(this2:User)
-                            WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
-                        }))
-                        WITH { node: { __resolveType: \\"Post\\", __id: id(this1), id: this1.id } } AS edge
-                        RETURN edge
-                    }
-                    RETURN collect(edge) AS edges
+                  WITH this
+                  MATCH (this)-[this0:HAS_POST]->(this1:Post)
+                  WHERE (this1.id = $param2 AND ($isAuthenticated = true AND EXISTS {
+                    MATCH (this1)<-[:HAS_POST]-(this2:User)
+                    WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
+                  }))
+                  WITH {node: {__resolveType: 'Post', __id: elementId(this1), id: this1.id}} AS edge
+                  RETURN edge
                 }
-                WITH edges
-                WITH edges, size(edges) AS totalCount
-                RETURN { edges: edges, totalCount: totalCount } AS var3
+                RETURN collect(edge) AS edges
+              }
+              WITH edges
+              WITH edges, size(edges) AS totalCount
+              RETURN {edges: edges, totalCount: totalCount} AS var3
             }
             RETURN this { .id, contentConnection: var3 } AS this"
         `);
@@ -559,8 +559,7 @@ describe("Cypher Auth Where", () => {
             MATCH (this:User)
             WITH *
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
-            SET
-                this.name = $param2
+            SET this.name = $param2
             WITH this
             WITH *
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
@@ -602,8 +601,7 @@ describe("Cypher Auth Where", () => {
             MATCH (this:User)
             WITH *
             WHERE (this.name = $param0 AND ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)))
-            SET
-                this.name = $param3
+            SET this.name = $param3
             WITH this
             WITH *
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
@@ -650,28 +648,27 @@ describe("Cypher Auth Where", () => {
             WITH *
             WITH *
             CALL (*) {
-                MATCH (this)-[this0:HAS_POST]->(this1:Post)
-                WITH *
-                WHERE ($isAuthenticated = true AND EXISTS {
-                    MATCH (this1)<-[:HAS_POST]-(this2:User)
-                    WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
-                })
-                SET
-                    this1.id = $param2
+              MATCH (this)-[this0:HAS_POST]->(this1:Post)
+              WITH *
+              WHERE ($isAuthenticated = true AND EXISTS {
+                MATCH (this1)<-[:HAS_POST]-(this2:User)
+                WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
+              })
+              SET this1.id = $param2
             }
             WITH this
             WITH *
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             CALL (this) {
-                MATCH (this)-[this3:HAS_POST]->(this4:Post)
-                WITH DISTINCT this4
-                WITH *
-                WHERE ($isAuthenticated = true AND EXISTS {
-                    MATCH (this4)<-[:HAS_POST]-(this5:User)
-                    WHERE ($jwt.sub IS NOT NULL AND this5.id = $jwt.sub)
-                })
-                WITH this4 { .id } AS this4
-                RETURN collect(this4) AS var6
+              MATCH (this)-[this3:HAS_POST]->(this4:Post)
+              WITH DISTINCT this4
+              WITH *
+              WHERE ($isAuthenticated = true AND EXISTS {
+                MATCH (this4)<-[:HAS_POST]-(this5:User)
+                WHERE ($jwt.sub IS NOT NULL AND this5.id = $jwt.sub)
+              })
+              WITH this4 { .id } AS this4
+              RETURN collect(this4) AS var6
             }
             RETURN this { .id, posts: var6 } AS this"
         `);
@@ -779,16 +776,16 @@ describe("Cypher Auth Where", () => {
             WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             WITH *
             CALL (*) {
-                OPTIONAL MATCH (this)-[this0:HAS_POST]->(this1:Post)
-                WHERE ($isAuthenticated = true AND EXISTS {
-                    MATCH (this1)<-[:HAS_POST]-(this2:User)
-                    WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
-                })
-                WITH this0, collect(DISTINCT this1) AS var3
-                CALL (var3) {
-                    UNWIND var3 AS var4
-                    DETACH DELETE var4
-                }
+              OPTIONAL MATCH (this)-[this0:HAS_POST]->(this1:Post)
+              WHERE ($isAuthenticated = true AND EXISTS {
+                MATCH (this1)<-[:HAS_POST]-(this2:User)
+                WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
+              })
+              WITH this0, collect(DISTINCT this1) AS var3
+              CALL (var3) {
+                UNWIND var3 AS var4
+                DETACH DELETE var4
+              }
             }
             WITH *
             DETACH DELETE this"
@@ -830,25 +827,25 @@ describe("Cypher Auth Where", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                CREATE (this0:User)
-                SET
-                    this0.id = $param0,
-                    this0.name = $param1,
-                    this0.password = $param2
-                WITH *
-                CALL (this0) {
-                    MATCH (this1:Post)
-                    WHERE ($isAuthenticated = true AND EXISTS {
-                        MATCH (this1)<-[:HAS_POST]-(this2:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
-                    })
-                    CREATE (this0)-[this3:HAS_POST]->(this1)
-                }
-                RETURN this0 AS this
+              CREATE (this0:User)
+              SET
+                this0.id = $param0,
+                this0.name = $param1,
+                this0.password = $param2
+              WITH *
+              CALL (this0) {
+                MATCH (this1:Post)
+                WHERE ($isAuthenticated = true AND EXISTS {
+                  MATCH (this1)<-[:HAS_POST]-(this2:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
+                })
+                CREATE (this0)-[this3:HAS_POST]->(this1)
+              }
+              RETURN this0 AS this
             }
             WITH this
             CALL (this) {
-                RETURN this { .id } AS var4
+              RETURN this { .id } AS var4
             }
             RETURN collect(var4) AS data"
         `);
@@ -897,25 +894,25 @@ describe("Cypher Auth Where", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                CREATE (this0:User)
-                SET
-                    this0.id = $param0,
-                    this0.name = $param1,
-                    this0.password = $param2
-                WITH *
-                CALL (this0) {
-                    MATCH (this1:Post)
-                    WHERE (($isAuthenticated = true AND EXISTS {
-                        MATCH (this1)<-[:HAS_POST]-(this2:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
-                    }) AND this1.id = $param5)
-                    CREATE (this0)-[this3:HAS_POST]->(this1)
-                }
-                RETURN this0 AS this
+              CREATE (this0:User)
+              SET
+                this0.id = $param0,
+                this0.name = $param1,
+                this0.password = $param2
+              WITH *
+              CALL (this0) {
+                MATCH (this1:Post)
+                WHERE (($isAuthenticated = true AND EXISTS {
+                  MATCH (this1)<-[:HAS_POST]-(this2:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
+                }) AND this1.id = $param5)
+                CREATE (this0)-[this3:HAS_POST]->(this1)
+              }
+              RETURN this0 AS this
             }
             WITH this
             CALL (this) {
-                RETURN this { .id } AS var4
+              RETURN this { .id } AS var4
             }
             RETURN collect(var4) AS data"
         `);
@@ -959,14 +956,14 @@ describe("Cypher Auth Where", () => {
             WITH *
             WITH *
             CALL (*) {
-                CALL (this) {
-                    MATCH (this0:Post)
-                    WHERE ($isAuthenticated = true AND EXISTS {
-                        MATCH (this0)<-[:HAS_POST]-(this1:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this1.id = $jwt.sub)
-                    })
-                    CREATE (this)-[this2:HAS_POST]->(this0)
-                }
+              CALL (this) {
+                MATCH (this0:Post)
+                WHERE ($isAuthenticated = true AND EXISTS {
+                  MATCH (this0)<-[:HAS_POST]-(this1:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this1.id = $jwt.sub)
+                })
+                CREATE (this)-[this2:HAS_POST]->(this0)
+              }
             }
             WITH this
             WITH *
@@ -1009,14 +1006,14 @@ describe("Cypher Auth Where", () => {
             WITH *
             WITH *
             CALL (*) {
-                CALL (this) {
-                    MATCH (this0:Post)
-                    WHERE (($isAuthenticated = true AND EXISTS {
-                        MATCH (this0)<-[:HAS_POST]-(this1:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this1.id = $jwt.sub)
-                    }) AND this0.id = $param2)
-                    CREATE (this)-[this2:HAS_POST]->(this0)
-                }
+              CALL (this) {
+                MATCH (this0:Post)
+                WHERE (($isAuthenticated = true AND EXISTS {
+                  MATCH (this0)<-[:HAS_POST]-(this1:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this1.id = $jwt.sub)
+                }) AND this0.id = $param2)
+                CREATE (this)-[this2:HAS_POST]->(this0)
+              }
             }
             WITH this
             WITH *
@@ -1060,15 +1057,15 @@ describe("Cypher Auth Where", () => {
             WITH *
             WITH *
             CALL (*) {
-                CALL (this) {
-                    OPTIONAL MATCH (this)-[this0:HAS_POST]->(this1:Post)
-                    WHERE ($isAuthenticated = true AND EXISTS {
-                        MATCH (this1)<-[:HAS_POST]-(this2:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
-                    })
-                    WITH *
-                    DELETE this0
-                }
+              CALL (this) {
+                OPTIONAL MATCH (this)-[this0:HAS_POST]->(this1:Post)
+                WHERE ($isAuthenticated = true AND EXISTS {
+                  MATCH (this1)<-[:HAS_POST]-(this2:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
+                })
+                WITH *
+                DELETE this0
+              }
             }
             WITH this
             WITH *
@@ -1111,15 +1108,15 @@ describe("Cypher Auth Where", () => {
             WITH *
             WITH *
             CALL (*) {
-                CALL (this) {
-                    OPTIONAL MATCH (this)-[this0:HAS_POST]->(this1:Post)
-                    WHERE (($isAuthenticated = true AND EXISTS {
-                        MATCH (this1)<-[:HAS_POST]-(this2:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
-                    }) AND this1.id = $param2)
-                    WITH *
-                    DELETE this0
-                }
+              CALL (this) {
+                OPTIONAL MATCH (this)-[this0:HAS_POST]->(this1:Post)
+                WHERE (($isAuthenticated = true AND EXISTS {
+                  MATCH (this1)<-[:HAS_POST]-(this2:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
+                }) AND this1.id = $param2)
+                WITH *
+                DELETE this0
+              }
             }
             WITH this
             WITH *

--- a/packages/graphql/tests/tck/directives/authorization/projection-connection-union.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/projection-connection-union.test.ts
@@ -91,35 +91,35 @@ describe("Cypher Auth Projection On Connections On Unions", () => {
             "CYPHER 5
             MATCH (this:User)
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
             CALL (this) {
+              CALL (this) {
                 CALL (this) {
-                    CALL (this) {
-                        WITH this
-                        MATCH (this)-[this0:PUBLISHED]->(this1:Post)
-                        CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                            MATCH (this1)<-[:HAS_POST]-(this2:User)
-                            WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
-                        }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                        CALL (this1) {
-                            MATCH (this1)<-[this3:HAS_POST]-(this4:User)
-                            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this4.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                            WITH collect({ node: this4, relationship: this3 }) AS edges
-                            CALL (edges) {
-                                UNWIND edges AS edge
-                                WITH edge.node AS this4, edge.relationship AS this3
-                                RETURN collect({ node: { name: this4.name, __resolveType: \\"User\\" } }) AS var5
-                            }
-                            RETURN { edges: var5 } AS var6
-                        }
-                        WITH { node: { __resolveType: \\"Post\\", __id: id(this1), content: this1.content, creatorConnection: var6 } } AS edge
-                        RETURN edge
+                  WITH this
+                  MATCH (this)-[this0:PUBLISHED]->(this1:Post)
+                  CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
+                    MATCH (this1)<-[:HAS_POST]-(this2:User)
+                    WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
+                  }), '@neo4j/graphql/FORBIDDEN', [])
+                  CALL (this1) {
+                    MATCH (this1)<-[this3:HAS_POST]-(this4:User)
+                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this4.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
+                    WITH collect({node: this4, relationship: this3}) AS edges
+                    CALL (edges) {
+                      UNWIND edges AS edge
+                      WITH edge.node AS this4, edge.relationship AS this3
+                      RETURN collect({node: {name: this4.name, __resolveType: 'User'}}) AS var5
                     }
-                    RETURN collect(edge) AS edges
+                    RETURN {edges: var5} AS var6
+                  }
+                  WITH {node: {__resolveType: 'Post', __id: elementId(this1), content: this1.content, creatorConnection: var6}} AS edge
+                  RETURN edge
                 }
-                WITH edges
-                WITH edges, size(edges) AS totalCount
-                RETURN { edges: edges, totalCount: totalCount } AS var7
+                RETURN collect(edge) AS edges
+              }
+              WITH edges
+              WITH edges, size(edges) AS totalCount
+              RETURN {edges: edges, totalCount: totalCount} AS var7
             }
             RETURN this { contentConnection: var7 } AS this"
         `);

--- a/packages/graphql/tests/tck/directives/authorization/projection-connection.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/projection-connection.test.ts
@@ -81,20 +81,20 @@ describe("Cypher Auth Projection On Connections", () => {
             "CYPHER 5
             MATCH (this:User)
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
             CALL (this) {
-                MATCH (this)-[this0:HAS_POST]->(this1:Post)
-                CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                    MATCH (this1)<-[:HAS_POST]-(this2:User)
-                    WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
-                }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ node: { content: this1.content, __resolveType: \\"Post\\" } }) AS var3
-                }
-                RETURN { edges: var3 } AS var4
+              MATCH (this)-[this0:HAS_POST]->(this1:Post)
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
+                MATCH (this1)<-[:HAS_POST]-(this2:User)
+                WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
+              }), '@neo4j/graphql/FORBIDDEN', [])
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({node: {content: this1.content, __resolveType: 'Post'}}) AS var3
+              }
+              RETURN {edges: var3} AS var4
             }
             RETURN this { .name, postsConnection: var4 } AS this"
         `);
@@ -142,31 +142,31 @@ describe("Cypher Auth Projection On Connections", () => {
             "CYPHER 5
             MATCH (this:User)
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
             CALL (this) {
-                MATCH (this)-[this0:HAS_POST]->(this1:Post)
-                CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                    MATCH (this1)<-[:HAS_POST]-(this2:User)
-                    WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
-                }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
+              MATCH (this)-[this0:HAS_POST]->(this1:Post)
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
+                MATCH (this1)<-[:HAS_POST]-(this2:User)
+                WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
+              }), '@neo4j/graphql/FORBIDDEN', [])
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                CALL (this1) {
+                  MATCH (this1)<-[this3:HAS_POST]-(this4:User)
+                  CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this4.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
+                  WITH collect({node: this4, relationship: this3}) AS edges
+                  CALL (edges) {
                     UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    CALL (this1) {
-                        MATCH (this1)<-[this3:HAS_POST]-(this4:User)
-                        CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this4.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                        WITH collect({ node: this4, relationship: this3 }) AS edges
-                        CALL (edges) {
-                            UNWIND edges AS edge
-                            WITH edge.node AS this4, edge.relationship AS this3
-                            RETURN collect({ node: { name: this4.name, __resolveType: \\"User\\" } }) AS var5
-                        }
-                        RETURN { edges: var5 } AS var6
-                    }
-                    RETURN collect({ node: { content: this1.content, creatorConnection: var6, __resolveType: \\"Post\\" } }) AS var7
+                    WITH edge.node AS this4, edge.relationship AS this3
+                    RETURN collect({node: {name: this4.name, __resolveType: 'User'}}) AS var5
+                  }
+                  RETURN {edges: var5} AS var6
                 }
-                RETURN { edges: var7 } AS var8
+                RETURN collect({node: {content: this1.content, creatorConnection: var6, __resolveType: 'Post'}}) AS var7
+              }
+              RETURN {edges: var7} AS var8
             }
             RETURN this { .name, postsConnection: var8 } AS this"
         `);
@@ -246,28 +246,28 @@ describe("Cypher Auth Projection On top-level connections", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             MATCH (this0:User)
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            WITH collect({ node: this0 }) AS edges
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                CALL (this0) {
-                    MATCH (this0)-[this1:HAS_POST]->(this2:Post)
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                        MATCH (this2)<-[:HAS_POST]-(this3:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
-                    }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    WITH collect({ node: this2, relationship: this1 }) AS edges
-                    CALL (edges) {
-                        UNWIND edges AS edge
-                        WITH edge.node AS this2, edge.relationship AS this1
-                        RETURN collect({ node: { content: this2.content, __resolveType: \\"Post\\" } }) AS var4
-                    }
-                    RETURN { edges: var4 } AS var5
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              CALL (this0) {
+                MATCH (this0)-[this1:HAS_POST]->(this2:Post)
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
+                  MATCH (this2)<-[:HAS_POST]-(this3:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
+                }), '@neo4j/graphql/FORBIDDEN', [])
+                WITH collect({node: this2, relationship: this1}) AS edges
+                CALL (edges) {
+                  UNWIND edges AS edge
+                  WITH edge.node AS this2, edge.relationship AS this1
+                  RETURN collect({node: {content: this2.content, __resolveType: 'Post'}}) AS var4
                 }
-                RETURN collect({ node: { name: this0.name, postsConnection: var5, __resolveType: \\"User\\" } }) AS var6
+                RETURN {edges: var4} AS var5
+              }
+              RETURN collect({node: {name: this0.name, postsConnection: var5, __resolveType: 'User'}}) AS var6
             }
-            RETURN { edges: var6 } AS this"
+            RETURN {edges: var6} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -316,39 +316,39 @@ describe("Cypher Auth Projection On top-level connections", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             MATCH (this0:User)
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            WITH collect({ node: this0 }) AS edges
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                CALL (this0) {
-                    MATCH (this0)-[this1:HAS_POST]->(this2:Post)
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                        MATCH (this2)<-[:HAS_POST]-(this3:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
-                    }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    WITH collect({ node: this2, relationship: this1 }) AS edges
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              CALL (this0) {
+                MATCH (this0)-[this1:HAS_POST]->(this2:Post)
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
+                  MATCH (this2)<-[:HAS_POST]-(this3:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
+                }), '@neo4j/graphql/FORBIDDEN', [])
+                WITH collect({node: this2, relationship: this1}) AS edges
+                CALL (edges) {
+                  UNWIND edges AS edge
+                  WITH edge.node AS this2, edge.relationship AS this1
+                  CALL (this2) {
+                    MATCH (this2)<-[this4:HAS_POST]-(this5:User)
+                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this5.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
+                    WITH collect({node: this5, relationship: this4}) AS edges
                     CALL (edges) {
-                        UNWIND edges AS edge
-                        WITH edge.node AS this2, edge.relationship AS this1
-                        CALL (this2) {
-                            MATCH (this2)<-[this4:HAS_POST]-(this5:User)
-                            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this5.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                            WITH collect({ node: this5, relationship: this4 }) AS edges
-                            CALL (edges) {
-                                UNWIND edges AS edge
-                                WITH edge.node AS this5, edge.relationship AS this4
-                                RETURN collect({ node: { name: this5.name, __resolveType: \\"User\\" } }) AS var6
-                            }
-                            RETURN { edges: var6 } AS var7
-                        }
-                        RETURN collect({ node: { content: this2.content, creatorConnection: var7, __resolveType: \\"Post\\" } }) AS var8
+                      UNWIND edges AS edge
+                      WITH edge.node AS this5, edge.relationship AS this4
+                      RETURN collect({node: {name: this5.name, __resolveType: 'User'}}) AS var6
                     }
-                    RETURN { edges: var8 } AS var9
+                    RETURN {edges: var6} AS var7
+                  }
+                  RETURN collect({node: {content: this2.content, creatorConnection: var7, __resolveType: 'Post'}}) AS var8
                 }
-                RETURN collect({ node: { name: this0.name, postsConnection: var9, __resolveType: \\"User\\" } }) AS var10
+                RETURN {edges: var8} AS var9
+              }
+              RETURN collect({node: {name: this0.name, postsConnection: var9, __resolveType: 'User'}}) AS var10
             }
-            RETURN { edges: var10 } AS this"
+            RETURN {edges: var10} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/directives/authorization/projection-interface-relationships.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/projection-interface-relationships.test.ts
@@ -91,20 +91,20 @@ describe("Auth projections for interface relationship fields", () => {
             "CYPHER 5
             MATCH (this:Actor)
             CALL (this) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                    WITH this1 { .title, .runtime, __resolveType: \\"Movie\\", __id: id(this1) } AS var2
-                    RETURN var2
-                    UNION
-                    WITH *
-                    MATCH (this)-[this3:ACTED_IN]->(this4:Series)
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this4.episodes = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    WITH this4 { .title, .episodes, __resolveType: \\"Series\\", __id: id(this4) } AS var2
-                    RETURN var2
-                }
-                WITH var2
-                RETURN collect(var2) AS var2
+              CALL (*) {
+                WITH *
+                MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+                WITH this1 { .title, .runtime, __resolveType: 'Movie', __id: elementId(this1) } AS var2
+                RETURN var2
+                UNION
+                WITH *
+                MATCH (this)-[this3:ACTED_IN]->(this4:Series)
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this4.episodes = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
+                WITH this4 { .title, .episodes, __resolveType: 'Series', __id: elementId(this4) } AS var2
+                RETURN var2
+              }
+              WITH var2
+              RETURN collect(var2) AS var2
             }
             RETURN this { actedIn: var2 } AS this"
         `);

--- a/packages/graphql/tests/tck/directives/authorization/projection.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/projection.test.ts
@@ -69,13 +69,12 @@ describe("Cypher Auth Projection", () => {
             MATCH (this:User)
             WITH *
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
             WITH *
-            SET
-                this.id = $param2
+            SET this.id = $param2
             WITH this
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
             RETURN this { .id } AS this"
         `);
 
@@ -113,10 +112,9 @@ describe("Cypher Auth Projection", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:User)
-                SET
-                    create_this1.id = create_var0.id
-                RETURN create_this1
+              CREATE (create_this1:User)
+              SET create_this1.id = create_var0.id
+              RETURN create_this1
             }
             RETURN collect(create_this1 { .id }) AS data"
         `);

--- a/packages/graphql/tests/tck/directives/autogenerate.test.ts
+++ b/packages/graphql/tests/tck/directives/autogenerate.test.ts
@@ -55,11 +55,11 @@ describe("Cypher autogenerate directive", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Movie)
-                SET
-                    create_this1.id = randomUUID(),
-                    create_this1.name = create_var0.name
-                RETURN create_this1
+              CREATE (create_this1:Movie)
+              SET
+                create_this1.id = randomUUID(),
+                create_this1.name = create_var0.name
+              RETURN create_this1
             }
             RETURN collect(create_this1 { .id, .name }) AS data"
         `);
@@ -93,8 +93,7 @@ describe("Cypher autogenerate directive", () => {
             "CYPHER 5
             MATCH (this:Movie)
             WITH *
-            SET
-                this.name = $param0
+            SET this.name = $param0
             WITH this
             RETURN this { .id, .name } AS this"
         `);

--- a/packages/graphql/tests/tck/directives/coalesce.test.ts
+++ b/packages/graphql/tests/tck/directives/coalesce.test.ts
@@ -91,8 +91,8 @@ describe("Cypher coalesce()", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             MATCH (this:User)
-            WHERE (coalesce(this.id, \\"00000000-00000000-00000000-00000000\\") = $param0 AND coalesce(this.name, \\"Jane Smith\\") =~ $param1 AND coalesce(this.numberOfFriends, 0) > $param2 AND coalesce(this.rating, 2.5) < $param3 AND this.fromInterface = $param4 AND coalesce(this.toBeOverridden, \\"Overridden\\") = $param5 AND NOT (coalesce(this.verified, false) = $param6))
-            RETURN this { name: coalesce(this.name, \\"Jane Smith\\") } AS this"
+            WHERE (coalesce(this.id, '00000000-00000000-00000000-00000000') = $param0 AND coalesce(this.name, 'Jane Smith') =~ $param1 AND coalesce(this.numberOfFriends, 0) > $param2 AND coalesce(this.rating, 2.5) < $param3 AND this.fromInterface = $param4 AND coalesce(this.toBeOverridden, 'Overridden') = $param5 AND NOT (coalesce(this.verified, false) = $param6))
+            RETURN this { name: coalesce(this.name, 'Jane Smith') } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -148,8 +148,8 @@ describe("Cypher coalesce()", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             MATCH (this:Movie)
-            WHERE coalesce(this.status, \\"ACTIVE\\") = $param0
-            RETURN this { .id, status: coalesce(this.status, \\"ACTIVE\\") } AS this"
+            WHERE coalesce(this.status, 'ACTIVE') = $param0
+            RETURN this { .id, status: coalesce(this.status, 'ACTIVE') } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -207,15 +207,15 @@ describe("Cypher coalesce()", () => {
             "CYPHER 5
             MATCH (this:Actor)
             CALL (this) {
-                MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                WHERE coalesce(this1.status, \\"ACTIVE\\") = $param0
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ node: { id: this1.id, status: coalesce(this1.status, \\"ACTIVE\\"), __resolveType: \\"Movie\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+              WHERE coalesce(this1.status, 'ACTIVE') = $param0
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({node: {id: this1.id, status: coalesce(this1.status, 'ACTIVE'), __resolveType: 'Movie'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { moviesConnection: var3 } AS this"
         `);
@@ -268,15 +268,15 @@ describe("Cypher coalesce()", () => {
             "CYPHER 5
             MATCH (this:Actor)
             CALL (this) {
-                MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                WHERE coalesce(this1.statuses, [\\"ACTIVE\\", \\"INACTIVE\\"]) = $param0
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ node: { id: this1.id, statuses: coalesce(this1.statuses, [\\"ACTIVE\\", \\"INACTIVE\\"]), __resolveType: \\"Movie\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+              WHERE coalesce(this1.statuses, ['ACTIVE', 'INACTIVE']) = $param0
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({node: {id: this1.id, statuses: coalesce(this1.statuses, ['ACTIVE', 'INACTIVE']), __resolveType: 'Movie'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { moviesConnection: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/directives/customResolver.test.ts
+++ b/packages/graphql/tests/tck/directives/customResolver.test.ts
@@ -255,19 +255,19 @@ describe("@customResolver directive", () => {
                 "CYPHER 5
                 MATCH (this:Author)
                 CALL (this) {
-                    CALL (*) {
-                        WITH *
-                        MATCH (this)-[this0:WROTE]->(this1:Book)
-                        WITH this1 { .title, __resolveType: \\"Book\\", __id: id(this1) } AS var2
-                        RETURN var2
-                        UNION
-                        WITH *
-                        MATCH (this)-[this3:WROTE]->(this4:Journal)
-                        WITH this4 { .subject, __resolveType: \\"Journal\\", __id: id(this4) } AS var2
-                        RETURN var2
-                    }
-                    WITH var2
-                    RETURN collect(var2) AS var2
+                  CALL (*) {
+                    WITH *
+                    MATCH (this)-[this0:WROTE]->(this1:Book)
+                    WITH this1 { .title, __resolveType: 'Book', __id: elementId(this1) } AS var2
+                    RETURN var2
+                    UNION
+                    WITH *
+                    MATCH (this)-[this3:WROTE]->(this4:Journal)
+                    WITH this4 { .subject, __resolveType: 'Journal', __id: elementId(this4) } AS var2
+                    RETURN var2
+                  }
+                  WITH var2
+                  RETURN collect(var2) AS var2
                 }
                 RETURN this { .name, publications: var2 } AS this"
             `);
@@ -315,19 +315,19 @@ describe("@customResolver directive", () => {
                 "CYPHER 5
                 MATCH (this:Author)
                 CALL (this) {
-                    CALL (*) {
-                        WITH *
-                        MATCH (this)-[this0:WROTE]->(this1:Book)
-                        WITH this1 { .title, __resolveType: \\"Book\\", __id: id(this1) } AS var2
-                        RETURN var2
-                        UNION
-                        WITH *
-                        MATCH (this)-[this3:WROTE]->(this4:Journal)
-                        WITH this4 { .subject, __resolveType: \\"Journal\\", __id: id(this4) } AS var2
-                        RETURN var2
-                    }
-                    WITH var2
-                    RETURN collect(var2) AS var2
+                  CALL (*) {
+                    WITH *
+                    MATCH (this)-[this0:WROTE]->(this1:Book)
+                    WITH this1 { .title, __resolveType: 'Book', __id: elementId(this1) } AS var2
+                    RETURN var2
+                    UNION
+                    WITH *
+                    MATCH (this)-[this3:WROTE]->(this4:Journal)
+                    WITH this4 { .subject, __resolveType: 'Journal', __id: elementId(this4) } AS var2
+                    RETURN var2
+                  }
+                  WITH var2
+                  RETURN collect(var2) AS var2
                 }
                 RETURN this { .name, publications: var2 } AS this"
             `);
@@ -350,19 +350,19 @@ describe("@customResolver directive", () => {
                 "CYPHER 5
                 MATCH (this:Author)
                 CALL (this) {
-                    CALL (*) {
-                        WITH *
-                        MATCH (this)-[this0:WROTE]->(this1:Book)
-                        WITH this1 { .title, __resolveType: \\"Book\\", __id: id(this1) } AS var2
-                        RETURN var2
-                        UNION
-                        WITH *
-                        MATCH (this)-[this3:WROTE]->(this4:Journal)
-                        WITH this4 { .subject, __resolveType: \\"Journal\\", __id: id(this4) } AS var2
-                        RETURN var2
-                    }
-                    WITH var2
-                    RETURN collect(var2) AS var2
+                  CALL (*) {
+                    WITH *
+                    MATCH (this)-[this0:WROTE]->(this1:Book)
+                    WITH this1 { .title, __resolveType: 'Book', __id: elementId(this1) } AS var2
+                    RETURN var2
+                    UNION
+                    WITH *
+                    MATCH (this)-[this3:WROTE]->(this4:Journal)
+                    WITH this4 { .subject, __resolveType: 'Journal', __id: elementId(this4) } AS var2
+                    RETURN var2
+                  }
+                  WITH var2
+                  RETURN collect(var2) AS var2
                 }
                 RETURN this { .name, publications: var2 } AS this"
             `);
@@ -437,19 +437,19 @@ describe("@customResolver directive", () => {
                 "CYPHER 5
                 MATCH (this:Author)
                 CALL (this) {
-                    CALL (*) {
-                        WITH *
-                        MATCH (this)-[this0:WROTE]->(this1:Book)
-                        WITH this1 { .publicationYear, .title, __resolveType: \\"Book\\", __id: id(this1) } AS var2
-                        RETURN var2
-                        UNION
-                        WITH *
-                        MATCH (this)-[this3:WROTE]->(this4:Journal)
-                        WITH this4 { .publicationYear, .subject, __resolveType: \\"Journal\\", __id: id(this4) } AS var2
-                        RETURN var2
-                    }
-                    WITH var2
-                    RETURN collect(var2) AS var2
+                  CALL (*) {
+                    WITH *
+                    MATCH (this)-[this0:WROTE]->(this1:Book)
+                    WITH this1 { .publicationYear, .title, __resolveType: 'Book', __id: elementId(this1) } AS var2
+                    RETURN var2
+                    UNION
+                    WITH *
+                    MATCH (this)-[this3:WROTE]->(this4:Journal)
+                    WITH this4 { .publicationYear, .subject, __resolveType: 'Journal', __id: elementId(this4) } AS var2
+                    RETURN var2
+                  }
+                  WITH var2
+                  RETURN collect(var2) AS var2
                 }
                 RETURN this { .name, publications: var2 } AS this"
             `);
@@ -497,19 +497,19 @@ describe("@customResolver directive", () => {
                 "CYPHER 5
                 MATCH (this:Author)
                 CALL (this) {
-                    CALL (*) {
-                        WITH *
-                        MATCH (this)-[this0:WROTE]->(this1:Book)
-                        WITH this1 { .publicationYear, .title, __resolveType: \\"Book\\", __id: id(this1) } AS var2
-                        RETURN var2
-                        UNION
-                        WITH *
-                        MATCH (this)-[this3:WROTE]->(this4:Journal)
-                        WITH this4 { .publicationYear, .subject, __resolveType: \\"Journal\\", __id: id(this4) } AS var2
-                        RETURN var2
-                    }
-                    WITH var2
-                    RETURN collect(var2) AS var2
+                  CALL (*) {
+                    WITH *
+                    MATCH (this)-[this0:WROTE]->(this1:Book)
+                    WITH this1 { .publicationYear, .title, __resolveType: 'Book', __id: elementId(this1) } AS var2
+                    RETURN var2
+                    UNION
+                    WITH *
+                    MATCH (this)-[this3:WROTE]->(this4:Journal)
+                    WITH this4 { .publicationYear, .subject, __resolveType: 'Journal', __id: elementId(this4) } AS var2
+                    RETURN var2
+                  }
+                  WITH var2
+                  RETURN collect(var2) AS var2
                 }
                 RETURN this { .name, publications: var2 } AS this"
             `);
@@ -532,19 +532,19 @@ describe("@customResolver directive", () => {
                 "CYPHER 5
                 MATCH (this:Author)
                 CALL (this) {
-                    CALL (*) {
-                        WITH *
-                        MATCH (this)-[this0:WROTE]->(this1:Book)
-                        WITH this1 { .publicationYear, .title, __resolveType: \\"Book\\", __id: id(this1) } AS var2
-                        RETURN var2
-                        UNION
-                        WITH *
-                        MATCH (this)-[this3:WROTE]->(this4:Journal)
-                        WITH this4 { .publicationYear, .subject, __resolveType: \\"Journal\\", __id: id(this4) } AS var2
-                        RETURN var2
-                    }
-                    WITH var2
-                    RETURN collect(var2) AS var2
+                  CALL (*) {
+                    WITH *
+                    MATCH (this)-[this0:WROTE]->(this1:Book)
+                    WITH this1 { .publicationYear, .title, __resolveType: 'Book', __id: elementId(this1) } AS var2
+                    RETURN var2
+                    UNION
+                    WITH *
+                    MATCH (this)-[this3:WROTE]->(this4:Journal)
+                    WITH this4 { .publicationYear, .subject, __resolveType: 'Journal', __id: elementId(this4) } AS var2
+                    RETURN var2
+                  }
+                  WITH var2
+                  RETURN collect(var2) AS var2
                 }
                 RETURN this { .name, publications: var2 } AS this"
             `);

--- a/packages/graphql/tests/tck/directives/cypher/cypher-interface.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher/cypher-interface.test.ts
@@ -141,26 +141,26 @@ describe("Cypher directive on interface", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (n)
-                WHERE (n:TVShow OR n:Movie) AND ($param0 IS NULL OR n.title = $param0)
-                RETURN n
+              MATCH (n)
+              WHERE (n:TVShow OR n:Movie) AND ($param0 IS NULL OR n.title = $param0)
+              RETURN n
             }
             WITH n AS this0
             CALL (this0) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this0)
-                    WHERE this0:TVShow
-                    WITH this0 { .title, __resolveType: \\"TVShow\\", __id: id(this0) } AS var1
-                    RETURN var1
-                    UNION
-                    WITH *
-                    MATCH (this0)
-                    WHERE this0:Movie
-                    WITH this0 { .title, __resolveType: \\"Movie\\", __id: id(this0) } AS var1
-                    RETURN var1
-                }
+              CALL (*) {
+                WITH *
+                MATCH (this0)
+                WHERE this0:TVShow
+                WITH this0 { .title, __resolveType: 'TVShow', __id: elementId(this0) } AS var1
                 RETURN var1
+                UNION
+                WITH *
+                MATCH (this0)
+                WHERE this0:Movie
+                WITH this0 { .title, __resolveType: 'Movie', __id: elementId(this0) } AS var1
+                RETURN var1
+              }
+              RETURN var1
             }
             RETURN var1 AS this0"
         `);
@@ -186,26 +186,26 @@ describe("Cypher directive on interface", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (n)
-                WHERE (n:TVShow OR n:Movie) AND ($param0 IS NULL OR n.title = $param0)
-                RETURN n
+              MATCH (n)
+              WHERE (n:TVShow OR n:Movie) AND ($param0 IS NULL OR n.title = $param0)
+              RETURN n
             }
             WITH n AS this0
             CALL (this0) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this0)
-                    WHERE this0:TVShow
-                    WITH this0 { __resolveType: \\"TVShow\\", __id: id(this0) } AS var1
-                    RETURN var1
-                    UNION
-                    WITH *
-                    MATCH (this0)
-                    WHERE this0:Movie
-                    WITH this0 { __resolveType: \\"Movie\\", __id: id(this0) } AS var1
-                    RETURN var1
-                }
+              CALL (*) {
+                WITH *
+                MATCH (this0)
+                WHERE this0:TVShow
+                WITH this0 { __resolveType: 'TVShow', __id: elementId(this0) } AS var1
                 RETURN var1
+                UNION
+                WITH *
+                MATCH (this0)
+                WHERE this0:Movie
+                WITH this0 { __resolveType: 'Movie', __id: elementId(this0) } AS var1
+                RETURN var1
+              }
+              RETURN var1
             }
             RETURN var1 AS this0"
         `);
@@ -244,53 +244,53 @@ describe("Cypher directive on interface", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (n)
-                WHERE (n:TVShow OR n:Movie) AND ($param0 IS NULL OR n.title = $param0)
-                RETURN n
+              MATCH (n)
+              WHERE (n:TVShow OR n:Movie) AND ($param0 IS NULL OR n.title = $param0)
+              RETURN n
             }
             WITH n AS this0
             CALL (this0) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this0)
-                    WHERE this0:TVShow
-                    CALL (this0) {
-                        CALL (this0) {
-                            WITH this0 AS this
-                            MATCH (a:Actor)
-                            RETURN a
-                        }
-                        WITH a AS this1
-                        CALL (this1) {
-                            CALL (this1) {
-                                WITH this1 AS this
-                                MATCH (m:Movie {title: $param1})
-                                RETURN m
-                            }
-                            WITH m AS this2
-                            WITH this2 { .title } AS this2
-                            RETURN collect(this2) AS var3
-                        }
-                        WITH this1 { .name, movies: var3 } AS this1
-                        RETURN collect(this1) AS var4
+              CALL (*) {
+                WITH *
+                MATCH (this0)
+                WHERE this0:TVShow
+                CALL (this0) {
+                  CALL (this0) {
+                    WITH this0 AS this
+                    MATCH (a:Actor)
+                    RETURN a
+                  }
+                  WITH a AS this1
+                  CALL (this1) {
+                    CALL (this1) {
+                      WITH this1 AS this
+                      MATCH (m:Movie {title: $param1})
+                      RETURN m
                     }
-                    WITH this0 { .title, actors: var4, __resolveType: \\"TVShow\\", __id: id(this0) } AS var5
-                    RETURN var5
-                    UNION
-                    WITH *
-                    MATCH (this0)
-                    WHERE this0:Movie
-                    CALL (this0) {
-                        MATCH (this0)<-[this6:ACTED_IN]-(this7:Actor)
-                        WHERE this7.name = $param2
-                        WITH DISTINCT this7
-                        WITH this7 { .name } AS this7
-                        RETURN collect(this7) AS var8
-                    }
-                    WITH this0 { .title, actors: var8, __resolveType: \\"Movie\\", __id: id(this0) } AS var5
-                    RETURN var5
+                    WITH m AS this2
+                    WITH this2 { .title } AS this2
+                    RETURN collect(this2) AS var3
+                  }
+                  WITH this1 { .name, movies: var3 } AS this1
+                  RETURN collect(this1) AS var4
                 }
+                WITH this0 { .title, actors: var4, __resolveType: 'TVShow', __id: elementId(this0) } AS var5
                 RETURN var5
+                UNION
+                WITH *
+                MATCH (this0)
+                WHERE this0:Movie
+                CALL (this0) {
+                  MATCH (this0)<-[this6:ACTED_IN]-(this7:Actor)
+                  WHERE this7.name = $param2
+                  WITH DISTINCT this7
+                  WITH this7 { .name } AS this7
+                  RETURN collect(this7) AS var8
+                }
+                WITH this0 { .title, actors: var8, __resolveType: 'Movie', __id: elementId(this0) } AS var5
+                RETURN var5
+              }
+              RETURN var5
             }
             RETURN var5 AS this0"
         `);
@@ -318,27 +318,27 @@ describe("Cypher directive on interface", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (n)
-                WHERE (n:TVShow OR n:Movie) AND ($param0 IS NULL OR n.title = $param0)
-                RETURN n
-                LIMIT 1
+              MATCH (n)
+              WHERE (n:TVShow OR n:Movie) AND ($param0 IS NULL OR n.title = $param0)
+              RETURN n
+              LIMIT 1
             }
             WITH n AS this0
             CALL (this0) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this0)
-                    WHERE this0:TVShow
-                    WITH this0 { .title, __resolveType: \\"TVShow\\", __id: id(this0) } AS var1
-                    RETURN var1
-                    UNION
-                    WITH *
-                    MATCH (this0)
-                    WHERE this0:Movie
-                    WITH this0 { .title, __resolveType: \\"Movie\\", __id: id(this0) } AS var1
-                    RETURN var1
-                }
+              CALL (*) {
+                WITH *
+                MATCH (this0)
+                WHERE this0:TVShow
+                WITH this0 { .title, __resolveType: 'TVShow', __id: elementId(this0) } AS var1
                 RETURN var1
+                UNION
+                WITH *
+                MATCH (this0)
+                WHERE this0:Movie
+                WITH this0 { .title, __resolveType: 'Movie', __id: elementId(this0) } AS var1
+                RETURN var1
+              }
+              RETURN var1
             }
             RETURN var1 AS this0"
         `);
@@ -364,27 +364,27 @@ describe("Cypher directive on interface", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (n)
-                WHERE (n:TVShow OR n:Movie) AND ($param0 IS NULL OR n.title = $param0)
-                RETURN n
-                LIMIT 1
+              MATCH (n)
+              WHERE (n:TVShow OR n:Movie) AND ($param0 IS NULL OR n.title = $param0)
+              RETURN n
+              LIMIT 1
             }
             WITH n AS this0
             CALL (this0) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this0)
-                    WHERE this0:TVShow
-                    WITH this0 { __resolveType: \\"TVShow\\", __id: id(this0) } AS var1
-                    RETURN var1
-                    UNION
-                    WITH *
-                    MATCH (this0)
-                    WHERE this0:Movie
-                    WITH this0 { __resolveType: \\"Movie\\", __id: id(this0) } AS var1
-                    RETURN var1
-                }
+              CALL (*) {
+                WITH *
+                MATCH (this0)
+                WHERE this0:TVShow
+                WITH this0 { __resolveType: 'TVShow', __id: elementId(this0) } AS var1
                 RETURN var1
+                UNION
+                WITH *
+                MATCH (this0)
+                WHERE this0:Movie
+                WITH this0 { __resolveType: 'Movie', __id: elementId(this0) } AS var1
+                RETURN var1
+              }
+              RETURN var1
             }
             RETURN var1 AS this0"
         `);
@@ -423,53 +423,53 @@ describe("Cypher directive on interface", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (n)
-                WHERE (n:TVShow OR n:Movie) AND ($param0 IS NULL OR n.title = $param0)
-                RETURN n
+              MATCH (n)
+              WHERE (n:TVShow OR n:Movie) AND ($param0 IS NULL OR n.title = $param0)
+              RETURN n
             }
             WITH n AS this0
             CALL (this0) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this0)
-                    WHERE this0:TVShow
-                    CALL (this0) {
-                        CALL (this0) {
-                            WITH this0 AS this
-                            MATCH (a:Actor)
-                            RETURN a
-                        }
-                        WITH a AS this1
-                        CALL (this1) {
-                            CALL (this1) {
-                                WITH this1 AS this
-                                MATCH (m:Movie {title: $param1})
-                                RETURN m
-                            }
-                            WITH m AS this2
-                            WITH this2 { .title } AS this2
-                            RETURN collect(this2) AS var3
-                        }
-                        WITH this1 { .name, movies: var3 } AS this1
-                        RETURN collect(this1) AS var4
+              CALL (*) {
+                WITH *
+                MATCH (this0)
+                WHERE this0:TVShow
+                CALL (this0) {
+                  CALL (this0) {
+                    WITH this0 AS this
+                    MATCH (a:Actor)
+                    RETURN a
+                  }
+                  WITH a AS this1
+                  CALL (this1) {
+                    CALL (this1) {
+                      WITH this1 AS this
+                      MATCH (m:Movie {title: $param1})
+                      RETURN m
                     }
-                    WITH this0 { .title, actors: var4, __resolveType: \\"TVShow\\", __id: id(this0) } AS var5
-                    RETURN var5
-                    UNION
-                    WITH *
-                    MATCH (this0)
-                    WHERE this0:Movie
-                    CALL (this0) {
-                        MATCH (this0)<-[this6:ACTED_IN]-(this7:Actor)
-                        WHERE this7.name = $param2
-                        WITH DISTINCT this7
-                        WITH this7 { .name } AS this7
-                        RETURN collect(this7) AS var8
-                    }
-                    WITH this0 { .title, actors: var8, __resolveType: \\"Movie\\", __id: id(this0) } AS var5
-                    RETURN var5
+                    WITH m AS this2
+                    WITH this2 { .title } AS this2
+                    RETURN collect(this2) AS var3
+                  }
+                  WITH this1 { .name, movies: var3 } AS this1
+                  RETURN collect(this1) AS var4
                 }
+                WITH this0 { .title, actors: var4, __resolveType: 'TVShow', __id: elementId(this0) } AS var5
                 RETURN var5
+                UNION
+                WITH *
+                MATCH (this0)
+                WHERE this0:Movie
+                CALL (this0) {
+                  MATCH (this0)<-[this6:ACTED_IN]-(this7:Actor)
+                  WHERE this7.name = $param2
+                  WITH DISTINCT this7
+                  WITH this7 { .name } AS this7
+                  RETURN collect(this7) AS var8
+                }
+                WITH this0 { .title, actors: var8, __resolveType: 'Movie', __id: elementId(this0) } AS var5
+                RETURN var5
+              }
+              RETURN var5
             }
             RETURN var5 AS this0"
         `);
@@ -513,57 +513,57 @@ describe("Cypher directive on interface", () => {
             "CYPHER 5
             MATCH (this:Actor)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (n)
-                    WHERE (n:TVShow OR n:Movie) AND ($param0 IS NULL OR n.title = $param0)
-                    RETURN n
-                }
-                WITH n AS this0
-                CALL (this0) {
-                    CALL (*) {
-                        WITH *
-                        MATCH (this0)
-                        WHERE this0:TVShow
-                        CALL (this0) {
-                            CALL (this0) {
-                                WITH this0 AS this
-                                MATCH (a:Actor)
-                                RETURN a
-                            }
-                            WITH a AS this1
-                            CALL (this1) {
-                                CALL (this1) {
-                                    WITH this1 AS this
-                                    MATCH (m:Movie {title: $param1})
-                                    RETURN m
-                                }
-                                WITH m AS this2
-                                WITH this2 { .title } AS this2
-                                RETURN collect(this2) AS var3
-                            }
-                            WITH this1 { .name, movies: var3 } AS this1
-                            RETURN collect(this1) AS var4
-                        }
-                        WITH this0 { .title, actors: var4, __resolveType: \\"TVShow\\", __id: id(this0) } AS var5
-                        RETURN var5
-                        UNION
-                        WITH *
-                        MATCH (this0)
-                        WHERE this0:Movie
-                        CALL (this0) {
-                            MATCH (this0)<-[this6:ACTED_IN]-(this7:Actor)
-                            WHERE this7.name = $param2
-                            WITH DISTINCT this7
-                            WITH this7 { .name } AS this7
-                            RETURN collect(this7) AS var8
-                        }
-                        WITH this0 { .title, actors: var8, __resolveType: \\"Movie\\", __id: id(this0) } AS var5
-                        RETURN var5
+              CALL (this) {
+                WITH this AS this
+                MATCH (n)
+                WHERE (n:TVShow OR n:Movie) AND ($param0 IS NULL OR n.title = $param0)
+                RETURN n
+              }
+              WITH n AS this0
+              CALL (this0) {
+                CALL (*) {
+                  WITH *
+                  MATCH (this0)
+                  WHERE this0:TVShow
+                  CALL (this0) {
+                    CALL (this0) {
+                      WITH this0 AS this
+                      MATCH (a:Actor)
+                      RETURN a
                     }
-                    RETURN var5
+                    WITH a AS this1
+                    CALL (this1) {
+                      CALL (this1) {
+                        WITH this1 AS this
+                        MATCH (m:Movie {title: $param1})
+                        RETURN m
+                      }
+                      WITH m AS this2
+                      WITH this2 { .title } AS this2
+                      RETURN collect(this2) AS var3
+                    }
+                    WITH this1 { .name, movies: var3 } AS this1
+                    RETURN collect(this1) AS var4
+                  }
+                  WITH this0 { .title, actors: var4, __resolveType: 'TVShow', __id: elementId(this0) } AS var5
+                  RETURN var5
+                  UNION
+                  WITH *
+                  MATCH (this0)
+                  WHERE this0:Movie
+                  CALL (this0) {
+                    MATCH (this0)<-[this6:ACTED_IN]-(this7:Actor)
+                    WHERE this7.name = $param2
+                    WITH DISTINCT this7
+                    WITH this7 { .name } AS this7
+                    RETURN collect(this7) AS var8
+                  }
+                  WITH this0 { .title, actors: var8, __resolveType: 'Movie', __id: elementId(this0) } AS var5
+                  RETURN var5
                 }
-                RETURN collect(var5) AS this0
+                RETURN var5
+              }
+              RETURN collect(var5) AS this0
             }
             RETURN this { moviesOrTVShows: this0 } AS this"
         `);

--- a/packages/graphql/tests/tck/directives/cypher/cypher-union.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher/cypher-union.test.ts
@@ -144,26 +144,26 @@ describe("Cypher directive on union", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (n)
-                WHERE (n:TVShow OR n:Movie) AND ($param0 IS NULL OR n.title = $param0)
-                RETURN n
+              MATCH (n)
+              WHERE (n:TVShow OR n:Movie) AND ($param0 IS NULL OR n.title = $param0)
+              RETURN n
             }
             WITH n AS this0
             CALL (this0) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this0)
-                    WHERE this0:Movie
-                    WITH this0 { .title, __resolveType: \\"Movie\\", __id: id(this0) } AS var1
-                    RETURN var1
-                    UNION
-                    WITH *
-                    MATCH (this0)
-                    WHERE this0:TVShow
-                    WITH this0 { .title, __resolveType: \\"TVShow\\", __id: id(this0) } AS var1
-                    RETURN var1
-                }
+              CALL (*) {
+                WITH *
+                MATCH (this0)
+                WHERE this0:Movie
+                WITH this0 { .title, __resolveType: 'Movie', __id: elementId(this0) } AS var1
                 RETURN var1
+                UNION
+                WITH *
+                MATCH (this0)
+                WHERE this0:TVShow
+                WITH this0 { .title, __resolveType: 'TVShow', __id: elementId(this0) } AS var1
+                RETURN var1
+              }
+              RETURN var1
             }
             RETURN var1 AS this0"
         `);
@@ -189,26 +189,26 @@ describe("Cypher directive on union", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (n)
-                WHERE (n:TVShow OR n:Movie) AND ($param0 IS NULL OR n.title = $param0)
-                RETURN n
+              MATCH (n)
+              WHERE (n:TVShow OR n:Movie) AND ($param0 IS NULL OR n.title = $param0)
+              RETURN n
             }
             WITH n AS this0
             CALL (this0) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this0)
-                    WHERE this0:Movie
-                    WITH this0 { __resolveType: \\"Movie\\", __id: id(this0) } AS var1
-                    RETURN var1
-                    UNION
-                    WITH *
-                    MATCH (this0)
-                    WHERE this0:TVShow
-                    WITH this0 { __resolveType: \\"TVShow\\", __id: id(this0) } AS var1
-                    RETURN var1
-                }
+              CALL (*) {
+                WITH *
+                MATCH (this0)
+                WHERE this0:Movie
+                WITH this0 { __resolveType: 'Movie', __id: elementId(this0) } AS var1
                 RETURN var1
+                UNION
+                WITH *
+                MATCH (this0)
+                WHERE this0:TVShow
+                WITH this0 { __resolveType: 'TVShow', __id: elementId(this0) } AS var1
+                RETURN var1
+              }
+              RETURN var1
             }
             RETURN var1 AS this0"
         `);
@@ -248,53 +248,53 @@ describe("Cypher directive on union", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (n)
-                WHERE (n:TVShow OR n:Movie) AND ($param0 IS NULL OR n.title = $param0)
-                RETURN n
+              MATCH (n)
+              WHERE (n:TVShow OR n:Movie) AND ($param0 IS NULL OR n.title = $param0)
+              RETURN n
             }
             WITH n AS this0
             CALL (this0) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this0)
-                    WHERE this0:Movie
-                    CALL (this0) {
-                        MATCH (this0)<-[this1:ACTED_IN]-(this2:Actor)
-                        WHERE this2.name = $param1
-                        WITH DISTINCT this2
-                        WITH this2 { .name } AS this2
-                        RETURN collect(this2) AS var3
-                    }
-                    WITH this0 { .title, actors: var3, __resolveType: \\"Movie\\", __id: id(this0) } AS var4
-                    RETURN var4
-                    UNION
-                    WITH *
-                    MATCH (this0)
-                    WHERE this0:TVShow
-                    CALL (this0) {
-                        CALL (this0) {
-                            WITH this0 AS this
-                            MATCH (a:Actor)
-                            RETURN a
-                        }
-                        WITH a AS this5
-                        CALL (this5) {
-                            CALL (this5) {
-                                WITH this5 AS this
-                                MATCH (m:Movie {title: $param2})
-                                RETURN m
-                            }
-                            WITH m AS this6
-                            WITH this6 { .title } AS this6
-                            RETURN collect(this6) AS var7
-                        }
-                        WITH this5 { .name, movies: var7 } AS this5
-                        RETURN collect(this5) AS var8
-                    }
-                    WITH this0 { .title, actors: var8, __resolveType: \\"TVShow\\", __id: id(this0) } AS var4
-                    RETURN var4
+              CALL (*) {
+                WITH *
+                MATCH (this0)
+                WHERE this0:Movie
+                CALL (this0) {
+                  MATCH (this0)<-[this1:ACTED_IN]-(this2:Actor)
+                  WHERE this2.name = $param1
+                  WITH DISTINCT this2
+                  WITH this2 { .name } AS this2
+                  RETURN collect(this2) AS var3
                 }
+                WITH this0 { .title, actors: var3, __resolveType: 'Movie', __id: elementId(this0) } AS var4
                 RETURN var4
+                UNION
+                WITH *
+                MATCH (this0)
+                WHERE this0:TVShow
+                CALL (this0) {
+                  CALL (this0) {
+                    WITH this0 AS this
+                    MATCH (a:Actor)
+                    RETURN a
+                  }
+                  WITH a AS this5
+                  CALL (this5) {
+                    CALL (this5) {
+                      WITH this5 AS this
+                      MATCH (m:Movie {title: $param2})
+                      RETURN m
+                    }
+                    WITH m AS this6
+                    WITH this6 { .title } AS this6
+                    RETURN collect(this6) AS var7
+                  }
+                  WITH this5 { .name, movies: var7 } AS this5
+                  RETURN collect(this5) AS var8
+                }
+                WITH this0 { .title, actors: var8, __resolveType: 'TVShow', __id: elementId(this0) } AS var4
+                RETURN var4
+              }
+              RETURN var4
             }
             RETURN var4 AS this0"
         `);
@@ -327,27 +327,27 @@ describe("Cypher directive on union", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (n)
-                WHERE (n:TVShow OR n:Movie) AND ($param0 IS NULL OR n.title = $param0)
-                RETURN n
-                LIMIT 1
+              MATCH (n)
+              WHERE (n:TVShow OR n:Movie) AND ($param0 IS NULL OR n.title = $param0)
+              RETURN n
+              LIMIT 1
             }
             WITH n AS this0
             CALL (this0) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this0)
-                    WHERE this0:Movie
-                    WITH this0 { .title, __resolveType: \\"Movie\\", __id: id(this0) } AS var1
-                    RETURN var1
-                    UNION
-                    WITH *
-                    MATCH (this0)
-                    WHERE this0:TVShow
-                    WITH this0 { .title, __resolveType: \\"TVShow\\", __id: id(this0) } AS var1
-                    RETURN var1
-                }
+              CALL (*) {
+                WITH *
+                MATCH (this0)
+                WHERE this0:Movie
+                WITH this0 { .title, __resolveType: 'Movie', __id: elementId(this0) } AS var1
                 RETURN var1
+                UNION
+                WITH *
+                MATCH (this0)
+                WHERE this0:TVShow
+                WITH this0 { .title, __resolveType: 'TVShow', __id: elementId(this0) } AS var1
+                RETURN var1
+              }
+              RETURN var1
             }
             RETURN var1 AS this0"
         `);
@@ -373,27 +373,27 @@ describe("Cypher directive on union", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (n)
-                WHERE (n:TVShow OR n:Movie) AND ($param0 IS NULL OR n.title = $param0)
-                RETURN n
-                LIMIT 1
+              MATCH (n)
+              WHERE (n:TVShow OR n:Movie) AND ($param0 IS NULL OR n.title = $param0)
+              RETURN n
+              LIMIT 1
             }
             WITH n AS this0
             CALL (this0) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this0)
-                    WHERE this0:Movie
-                    WITH this0 { __resolveType: \\"Movie\\", __id: id(this0) } AS var1
-                    RETURN var1
-                    UNION
-                    WITH *
-                    MATCH (this0)
-                    WHERE this0:TVShow
-                    WITH this0 { __resolveType: \\"TVShow\\", __id: id(this0) } AS var1
-                    RETURN var1
-                }
+              CALL (*) {
+                WITH *
+                MATCH (this0)
+                WHERE this0:Movie
+                WITH this0 { __resolveType: 'Movie', __id: elementId(this0) } AS var1
                 RETURN var1
+                UNION
+                WITH *
+                MATCH (this0)
+                WHERE this0:TVShow
+                WITH this0 { __resolveType: 'TVShow', __id: elementId(this0) } AS var1
+                RETURN var1
+              }
+              RETURN var1
             }
             RETURN var1 AS this0"
         `);
@@ -433,53 +433,53 @@ describe("Cypher directive on union", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (n)
-                WHERE (n:TVShow OR n:Movie) AND ($param0 IS NULL OR n.title = $param0)
-                RETURN n
+              MATCH (n)
+              WHERE (n:TVShow OR n:Movie) AND ($param0 IS NULL OR n.title = $param0)
+              RETURN n
             }
             WITH n AS this0
             CALL (this0) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this0)
-                    WHERE this0:Movie
-                    CALL (this0) {
-                        MATCH (this0)<-[this1:ACTED_IN]-(this2:Actor)
-                        WHERE this2.name = $param1
-                        WITH DISTINCT this2
-                        WITH this2 { .name } AS this2
-                        RETURN collect(this2) AS var3
-                    }
-                    WITH this0 { .title, actors: var3, __resolveType: \\"Movie\\", __id: id(this0) } AS var4
-                    RETURN var4
-                    UNION
-                    WITH *
-                    MATCH (this0)
-                    WHERE this0:TVShow
-                    CALL (this0) {
-                        CALL (this0) {
-                            WITH this0 AS this
-                            MATCH (a:Actor)
-                            RETURN a
-                        }
-                        WITH a AS this5
-                        CALL (this5) {
-                            CALL (this5) {
-                                WITH this5 AS this
-                                MATCH (m:Movie {title: $param2})
-                                RETURN m
-                            }
-                            WITH m AS this6
-                            WITH this6 { .title } AS this6
-                            RETURN collect(this6) AS var7
-                        }
-                        WITH this5 { .name, movies: var7 } AS this5
-                        RETURN collect(this5) AS var8
-                    }
-                    WITH this0 { .title, actors: var8, __resolveType: \\"TVShow\\", __id: id(this0) } AS var4
-                    RETURN var4
+              CALL (*) {
+                WITH *
+                MATCH (this0)
+                WHERE this0:Movie
+                CALL (this0) {
+                  MATCH (this0)<-[this1:ACTED_IN]-(this2:Actor)
+                  WHERE this2.name = $param1
+                  WITH DISTINCT this2
+                  WITH this2 { .name } AS this2
+                  RETURN collect(this2) AS var3
                 }
+                WITH this0 { .title, actors: var3, __resolveType: 'Movie', __id: elementId(this0) } AS var4
                 RETURN var4
+                UNION
+                WITH *
+                MATCH (this0)
+                WHERE this0:TVShow
+                CALL (this0) {
+                  CALL (this0) {
+                    WITH this0 AS this
+                    MATCH (a:Actor)
+                    RETURN a
+                  }
+                  WITH a AS this5
+                  CALL (this5) {
+                    CALL (this5) {
+                      WITH this5 AS this
+                      MATCH (m:Movie {title: $param2})
+                      RETURN m
+                    }
+                    WITH m AS this6
+                    WITH this6 { .title } AS this6
+                    RETURN collect(this6) AS var7
+                  }
+                  WITH this5 { .name, movies: var7 } AS this5
+                  RETURN collect(this5) AS var8
+                }
+                WITH this0 { .title, actors: var8, __resolveType: 'TVShow', __id: elementId(this0) } AS var4
+                RETURN var4
+              }
+              RETURN var4
             }
             RETURN var4 AS this0"
         `);
@@ -524,57 +524,57 @@ describe("Cypher directive on union", () => {
             "CYPHER 5
             MATCH (this:Actor)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (n)
-                    WHERE (n:TVShow OR n:Movie) AND ($param0 IS NULL OR n.title = $param0)
-                    RETURN n
-                }
-                WITH n AS this0
-                CALL (this0) {
-                    CALL (*) {
-                        WITH *
-                        MATCH (this0)
-                        WHERE this0:Movie
-                        CALL (this0) {
-                            MATCH (this0)<-[this1:ACTED_IN]-(this2:Actor)
-                            WHERE this2.name = $param1
-                            WITH DISTINCT this2
-                            WITH this2 { .name } AS this2
-                            RETURN collect(this2) AS var3
-                        }
-                        WITH this0 { .title, actors: var3, __resolveType: \\"Movie\\", __id: id(this0) } AS var4
-                        RETURN var4
-                        UNION
-                        WITH *
-                        MATCH (this0)
-                        WHERE this0:TVShow
-                        CALL (this0) {
-                            CALL (this0) {
-                                WITH this0 AS this
-                                MATCH (a:Actor)
-                                RETURN a
-                            }
-                            WITH a AS this5
-                            CALL (this5) {
-                                CALL (this5) {
-                                    WITH this5 AS this
-                                    MATCH (m:Movie {title: $param2})
-                                    RETURN m
-                                }
-                                WITH m AS this6
-                                WITH this6 { .title } AS this6
-                                RETURN collect(this6) AS var7
-                            }
-                            WITH this5 { .name, movies: var7 } AS this5
-                            RETURN collect(this5) AS var8
-                        }
-                        WITH this0 { .title, actors: var8, __resolveType: \\"TVShow\\", __id: id(this0) } AS var4
-                        RETURN var4
+              CALL (this) {
+                WITH this AS this
+                MATCH (n)
+                WHERE (n:TVShow OR n:Movie) AND ($param0 IS NULL OR n.title = $param0)
+                RETURN n
+              }
+              WITH n AS this0
+              CALL (this0) {
+                CALL (*) {
+                  WITH *
+                  MATCH (this0)
+                  WHERE this0:Movie
+                  CALL (this0) {
+                    MATCH (this0)<-[this1:ACTED_IN]-(this2:Actor)
+                    WHERE this2.name = $param1
+                    WITH DISTINCT this2
+                    WITH this2 { .name } AS this2
+                    RETURN collect(this2) AS var3
+                  }
+                  WITH this0 { .title, actors: var3, __resolveType: 'Movie', __id: elementId(this0) } AS var4
+                  RETURN var4
+                  UNION
+                  WITH *
+                  MATCH (this0)
+                  WHERE this0:TVShow
+                  CALL (this0) {
+                    CALL (this0) {
+                      WITH this0 AS this
+                      MATCH (a:Actor)
+                      RETURN a
                     }
-                    RETURN var4
+                    WITH a AS this5
+                    CALL (this5) {
+                      CALL (this5) {
+                        WITH this5 AS this
+                        MATCH (m:Movie {title: $param2})
+                        RETURN m
+                      }
+                      WITH m AS this6
+                      WITH this6 { .title } AS this6
+                      RETURN collect(this6) AS var7
+                    }
+                    WITH this5 { .name, movies: var7 } AS this5
+                    RETURN collect(this5) AS var8
+                  }
+                  WITH this0 { .title, actors: var8, __resolveType: 'TVShow', __id: elementId(this0) } AS var4
+                  RETURN var4
                 }
-                RETURN collect(var4) AS this0
+                RETURN var4
+              }
+              RETURN collect(var4) AS this0
             }
             RETURN this { moviesOrTVShows: this0 } AS this"
         `);

--- a/packages/graphql/tests/tck/directives/cypher/cypher.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher/cypher.test.ts
@@ -116,14 +116,14 @@ describe("Cypher directive", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (a:Actor)
-                    RETURN a
-                }
-                WITH a AS this0
-                WITH this0 { .name } AS this0
-                RETURN head(collect(this0)) AS var1
+              CALL (this) {
+                WITH this AS this
+                MATCH (a:Actor)
+                RETURN a
+              }
+              WITH a AS this0
+              WITH this0 { .name } AS this0
+              RETURN head(collect(this0)) AS var1
             }
             RETURN this { .title, topActor: var1 } AS this"
         `);
@@ -146,12 +146,12 @@ describe("Cypher directive", () => {
             "CYPHER 5
             MATCH (this:Actor)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    RETURN rand() as res
-                }
-                WITH res AS this0
-                RETURN this0 AS var1
+              CALL (this) {
+                WITH this AS this
+                RETURN rand() as res
+              }
+              WITH res AS this0
+              RETURN this0 AS var1
             }
             RETURN this { randomNumber: var1 } AS this"
         `);
@@ -176,12 +176,12 @@ describe("Cypher directive", () => {
             WITH *
             LIMIT $param0
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    RETURN rand() as res
-                }
-                WITH res AS this0
-                RETURN this0 AS var1
+              CALL (this) {
+                WITH this AS this
+                RETURN rand() as res
+              }
+              WITH res AS this0
+              RETURN this0 AS var1
             }
             RETURN this { randomNumber: var1 } AS this"
         `);
@@ -211,12 +211,12 @@ describe("Cypher directive", () => {
             "CYPHER 5
             MATCH (this:Actor)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    RETURN rand() as res
-                }
-                WITH res AS this0
-                RETURN this0 AS var1
+              CALL (this) {
+                WITH this AS this
+                RETURN rand() as res
+              }
+              WITH res AS this0
+              RETURN this0 AS var1
             }
             WITH *
             ORDER BY var1 ASC
@@ -255,24 +255,24 @@ describe("Cypher directive", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (a:Actor)
-                    RETURN a
-                }
-                WITH a AS this0
+              CALL (this) {
+                WITH this AS this
+                MATCH (a:Actor)
+                RETURN a
+              }
+              WITH a AS this0
+              CALL (this0) {
                 CALL (this0) {
-                    CALL (this0) {
-                        WITH this0 AS this
-                        MATCH (m:Movie {title: $param0})
-                        RETURN m
-                    }
-                    WITH m AS this1
-                    WITH this1 { .title } AS this1
-                    RETURN collect(this1) AS var2
+                  WITH this0 AS this
+                  MATCH (m:Movie {title: $param0})
+                  RETURN m
                 }
-                WITH this0 { .name, movies: var2 } AS this0
-                RETURN head(collect(this0)) AS var3
+                WITH m AS this1
+                WITH this1 { .title } AS this1
+                RETURN collect(this1) AS var2
+              }
+              WITH this0 { .name, movies: var2 } AS this0
+              RETURN head(collect(this0)) AS var3
             }
             RETURN this { .title, topActor: var3 } AS this"
         `);
@@ -311,44 +311,44 @@ describe("Cypher directive", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
+              CALL (this) {
+                WITH this AS this
+                MATCH (a:Actor)
+                RETURN a
+              }
+              WITH a AS this0
+              CALL (this0) {
+                CALL (this0) {
+                  WITH this0 AS this
+                  MATCH (m:Movie {title: $param0})
+                  RETURN m
+                }
+                WITH m AS this1
+                CALL (this1) {
+                  CALL (this1) {
+                    WITH this1 AS this
                     MATCH (a:Actor)
                     RETURN a
-                }
-                WITH a AS this0
-                CALL (this0) {
-                    CALL (this0) {
-                        WITH this0 AS this
-                        MATCH (m:Movie {title: $param0})
-                        RETURN m
+                  }
+                  WITH a AS this2
+                  CALL (this2) {
+                    CALL (this2) {
+                      WITH this2 AS this
+                      MATCH (m:Movie {title: $param1})
+                      RETURN m
                     }
-                    WITH m AS this1
-                    CALL (this1) {
-                        CALL (this1) {
-                            WITH this1 AS this
-                            MATCH (a:Actor)
-                            RETURN a
-                        }
-                        WITH a AS this2
-                        CALL (this2) {
-                            CALL (this2) {
-                                WITH this2 AS this
-                                MATCH (m:Movie {title: $param1})
-                                RETURN m
-                            }
-                            WITH m AS this3
-                            WITH this3 { .title } AS this3
-                            RETURN collect(this3) AS var4
-                        }
-                        WITH this2 { .name, movies: var4 } AS this2
-                        RETURN head(collect(this2)) AS var5
-                    }
-                    WITH this1 { .title, topActor: var5 } AS this1
-                    RETURN collect(this1) AS var6
+                    WITH m AS this3
+                    WITH this3 { .title } AS this3
+                    RETURN collect(this3) AS var4
+                  }
+                  WITH this2 { .name, movies: var4 } AS this2
+                  RETURN head(collect(this2)) AS var5
                 }
-                WITH this0 { .name, movies: var6 } AS this0
-                RETURN head(collect(this0)) AS var7
+                WITH this1 { .title, topActor: var5 } AS this1
+                RETURN collect(this1) AS var6
+              }
+              WITH this0 { .name, movies: var6 } AS this0
+              RETURN head(collect(this0)) AS var7
             }
             RETURN this { .title, topActor: var7 } AS this"
         `);
@@ -382,24 +382,24 @@ describe("Cypher directive", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (a:Actor)
-                    RETURN a
-                }
-                WITH a AS this0
+              CALL (this) {
+                WITH this AS this
+                MATCH (a:Actor)
+                RETURN a
+              }
+              WITH a AS this0
+              CALL (this0) {
                 CALL (this0) {
-                    CALL (this0) {
-                        WITH this0 AS this
-                        MATCH (m:Movie {title: $param0})
-                        RETURN m
-                    }
-                    WITH m AS this1
-                    WITH this1 { .title } AS this1
-                    RETURN collect(this1) AS var2
+                  WITH this0 AS this
+                  MATCH (m:Movie {title: $param0})
+                  RETURN m
                 }
-                WITH this0 { .name, movies: var2 } AS this0
-                RETURN head(collect(this0)) AS var3
+                WITH m AS this1
+                WITH this1 { .title } AS this1
+                RETURN collect(this1) AS var2
+              }
+              WITH this0 { .name, movies: var2 } AS this0
+              RETURN head(collect(this0)) AS var3
             }
             RETURN this { .title, topActor: var3 } AS this"
         `);
@@ -454,15 +454,15 @@ describe("Cypher directive", () => {
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
                 "CYPHER 5
                 CALL {
-                    MATCH (m:Movie {title: $param0})
-                    RETURN m
+                  MATCH (m:Movie {title: $param0})
+                  RETURN m
                 }
                 WITH m AS this0
                 CALL (this0) {
-                    MATCH (this0)<-[this1:ACTED_IN]-(this2:Actor)
-                    WITH DISTINCT this2
-                    WITH this2 { .name } AS this2
-                    RETURN collect(this2) AS var3
+                  MATCH (this0)<-[this1:ACTED_IN]-(this2:Actor)
+                  WITH DISTINCT this2
+                  WITH this2 { .name } AS this2
+                  RETURN collect(this2) AS var3
                 }
                 WITH this0 { .title, actors: var3 } AS this0
                 RETURN this0 AS this"
@@ -517,15 +517,15 @@ describe("Cypher directive", () => {
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
                 "CYPHER 5
                 CALL {
-                    MATCH (m:Movie {title: $param0})
-                    RETURN m
+                  MATCH (m:Movie {title: $param0})
+                  RETURN m
                 }
                 WITH m AS this0
                 CALL (this0) {
-                    MATCH (this0)<-[this1:ACTED_IN]-(this2:Actor)
-                    WITH DISTINCT this2
-                    WITH this2 { .name } AS this2
-                    RETURN collect(this2) AS var3
+                  MATCH (this0)<-[this1:ACTED_IN]-(this2:Actor)
+                  WITH DISTINCT this2
+                  WITH this2 { .name } AS this2
+                  RETURN collect(this2) AS var3
                 }
                 WITH this0 { .title, actors: var3 } AS this0
                 RETURN this0 AS this"
@@ -580,20 +580,20 @@ describe("Cypher directive", () => {
                 "CYPHER 5
                 MATCH (this:Movie)
                 CALL (this) {
-                    CALL (this) {
-                        WITH this AS this
-                        MATCH (m:Movie {title: $param0})
-                        RETURN m
-                    }
-                    WITH m AS this0
-                    CALL (this0) {
-                        MATCH (this0)<-[this1:ACTED_IN]-(this2:Actor)
-                        WITH DISTINCT this2
-                        WITH this2 { .name } AS this2
-                        RETURN collect(this2) AS var3
-                    }
-                    WITH this0 { .title, actors: var3 } AS this0
-                    RETURN collect(this0) AS var4
+                  CALL (this) {
+                    WITH this AS this
+                    MATCH (m:Movie {title: $param0})
+                    RETURN m
+                  }
+                  WITH m AS this0
+                  CALL (this0) {
+                    MATCH (this0)<-[this1:ACTED_IN]-(this2:Actor)
+                    WITH DISTINCT this2
+                    WITH this2 { .name } AS this2
+                    RETURN collect(this2) AS var3
+                  }
+                  WITH this0 { .title, actors: var3 } AS this0
+                  RETURN collect(this0) AS var4
                 }
                 RETURN this { custom: var4 } AS this"
             `);

--- a/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-aggregation.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-aggregation.test.ts
@@ -60,24 +60,24 @@ describe("cypher directive filtering - Aggregation", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:Movie)
+              MATCH (this:Movie)
+              CALL (this) {
                 CALL (this) {
-                    CALL (this) {
-                        WITH this AS this
-                        MATCH (this)
-                        RETURN this.custom_field as s
-                    }
-                    WITH s AS this0
-                    RETURN this0 AS var1
+                  WITH this AS this
+                  MATCH (this)
+                  RETURN this.custom_field as s
                 }
-                WITH *
-                WHERE var1 STARTS WITH $param0
-                WITH DISTINCT this
-                ORDER BY size(this.title) DESC
-                WITH collect(this.title) AS list
-                RETURN { shortest: last(list) } AS var2
+                WITH s AS this0
+                RETURN this0 AS var1
+              }
+              WITH *
+              WHERE var1 STARTS WITH $param0
+              WITH DISTINCT this
+              ORDER BY size(this.title) DESC
+              WITH collect(this.title) AS list
+              RETURN {shortest: last(list)} AS var2
             }
-            RETURN { aggregate: { node: { title: var2 } } } AS this"
+            RETURN {aggregate: {node: {title: var2}}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -126,22 +126,22 @@ describe("cypher directive filtering - Aggregation", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:Movie)
+              MATCH (this:Movie)
+              CALL (this) {
                 CALL (this) {
-                    CALL (this) {
-                        WITH this AS this
-                        MATCH (this)
-                        RETURN this.custom_field as s
-                    }
-                    WITH s AS this0
-                    RETURN this0 AS var1
+                  WITH this AS this
+                  MATCH (this)
+                  RETURN this.custom_field as s
                 }
-                WITH *
-                WHERE var1 > $param0
-                WITH DISTINCT this
-                RETURN { min: min(this.released) } AS var2
+                WITH s AS this0
+                RETURN this0 AS var1
+              }
+              WITH *
+              WHERE var1 > $param0
+              WITH DISTINCT this
+              RETURN {min: min(this.released)} AS var2
             }
-            RETURN { aggregate: { node: { released: var2 } } } AS this"
+            RETURN {aggregate: {node: {released: var2}}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -193,25 +193,25 @@ describe("cypher directive filtering - Aggregation", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:Movie)
+              MATCH (this:Movie)
+              CALL (this) {
                 CALL (this) {
-                    CALL (this) {
-                        WITH this AS this
-                        MATCH (this)
-                        RETURN this.custom_field as s
-                    }
-                    UNWIND s AS var0
-                    WITH var0 AS this1
-                    RETURN collect(this1) AS var2
+                  WITH this AS this
+                  MATCH (this)
+                  RETURN this.custom_field as s
                 }
-                WITH *
-                WHERE $param0 IN var2
-                WITH DISTINCT this
-                ORDER BY size(this.title) DESC
-                WITH collect(this.title) AS list
-                RETURN { longest: head(list) } AS var3
+                UNWIND s AS var0
+                WITH var0 AS this1
+                RETURN collect(this1) AS var2
+              }
+              WITH *
+              WHERE $param0 IN var2
+              WITH DISTINCT this
+              ORDER BY size(this.title) DESC
+              WITH collect(this.title) AS list
+              RETURN {longest: head(list)} AS var3
             }
-            RETURN { aggregate: { node: { title: var3 } } } AS this"
+            RETURN {aggregate: {node: {title: var3}}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -260,25 +260,25 @@ describe("cypher directive filtering - Aggregation", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:Movie)
+              MATCH (this:Movie)
+              CALL (this) {
                 CALL (this) {
-                    CALL (this) {
-                        WITH this AS this
-                        MATCH (this)
-                        RETURN this.custom_field as s
-                    }
-                    UNWIND s AS var0
-                    WITH var0 AS this1
-                    RETURN collect(this1) AS var2
+                  WITH this AS this
+                  MATCH (this)
+                  RETURN this.custom_field as s
                 }
-                WITH *
-                WHERE $param0 IN var2
-                WITH DISTINCT this
-                ORDER BY size(this.title) DESC
-                WITH collect(this.title) AS list
-                RETURN { longest: head(list) } AS var3
+                UNWIND s AS var0
+                WITH var0 AS this1
+                RETURN collect(this1) AS var2
+              }
+              WITH *
+              WHERE $param0 IN var2
+              WITH DISTINCT this
+              ORDER BY size(this.title) DESC
+              WITH collect(this.title) AS list
+              RETURN {longest: head(list)} AS var3
             }
-            RETURN { aggregate: { node: { title: var3 } } } AS this"
+            RETURN {aggregate: {node: {title: var3}}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-auth-top-level.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-auth-top-level.test.ts
@@ -72,16 +72,16 @@ describe("cypher directive filtering top level - Auth", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (m:Movie) RETURN m
+              MATCH (m:Movie) RETURN m
             }
             WITH m AS this0
             CALL (this0) {
-                CALL (this0) {
-                    WITH this0 AS this
-                    RETURN \\"hello\\" AS s
-                }
-                WITH s AS this1
-                RETURN this1 AS var2
+              CALL (this0) {
+                WITH this0 AS this
+                RETURN \\"hello\\" AS s
+              }
+              WITH s AS this1
+              RETURN this1 AS var2
             }
             WITH *
             WHERE ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND var2 IS NOT NULL AND var2 = $jwt.custom_value))
@@ -149,24 +149,24 @@ describe("cypher directive filtering top level - Auth", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (m:Movie) RETURN m
+              MATCH (m:Movie) RETURN m
             }
             WITH m AS this0
             CALL (this0) {
-                CALL (this0) {
-                    WITH this0 AS this
-                    RETURN \\"hello\\" AS s
-                }
-                WITH s AS this1
-                RETURN this1 AS var2
+              CALL (this0) {
+                WITH this0 AS this
+                RETURN \\"hello\\" AS s
+              }
+              WITH s AS this1
+              RETURN this1 AS var2
             }
             CALL (this0) {
-                CALL (this0) {
-                    WITH this0 AS this
-                    RETURN \\"hello\\" AS s
-                }
-                WITH s AS this3
-                RETURN this3 AS var4
+              CALL (this0) {
+                WITH this0 AS this
+                RETURN \\"hello\\" AS s
+              }
+              WITH s AS this3
+              RETURN this3 AS var4
             }
             WITH *
             WHERE ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND var4 IS NOT NULL AND var4 = $jwt.custom_value))
@@ -234,7 +234,7 @@ describe("cypher directive filtering top level - Auth", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (m:Movie) RETURN m
+              MATCH (m:Movie) RETURN m
             }
             WITH m AS this0
             WITH this0 { .title } AS this0
@@ -297,18 +297,18 @@ describe("cypher directive filtering top level - Auth", () => {
             "CYPHER 5
             MATCH (this:Actor)
             CALL (this) {
-                MATCH (this)-[:ACTED_IN]->(this0:Movie)
+              MATCH (this)-[:ACTED_IN]->(this0:Movie)
+              CALL (this0) {
                 CALL (this0) {
-                    CALL (this0) {
-                        WITH this0 AS this
-                        RETURN \\"hello\\" AS s
-                    }
-                    WITH s AS this1
-                    RETURN this1 AS var2
+                  WITH this0 AS this
+                  RETURN \\"hello\\" AS s
                 }
-                WITH *
-                WHERE ($jwt.custom_value IS NOT NULL AND var2 IS NOT NULL AND var2 = $jwt.custom_value)
-                RETURN count(this0) > 0 AS var3
+                WITH s AS this1
+                RETURN this1 AS var2
+              }
+              WITH *
+              WHERE ($jwt.custom_value IS NOT NULL AND var2 IS NOT NULL AND var2 = $jwt.custom_value)
+              RETURN count(this0) > 0 AS var3
             }
             WITH *
             WHERE ($isAuthenticated = true AND var3 = true)
@@ -375,16 +375,16 @@ describe("cypher directive filtering top level - Auth", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (m:Movie) RETURN m
+              MATCH (m:Movie) RETURN m
             }
             WITH m AS this0
             CALL (this0) {
-                CALL (this0) {
-                    WITH this0 AS this
-                    RETURN \\"hello\\" AS s
-                }
-                WITH s AS this1
-                RETURN this1 AS var2
+              CALL (this0) {
+                WITH this0 AS this
+                RETURN \\"hello\\" AS s
+              }
+              WITH s AS this1
+              RETURN this1 AS var2
             }
             WITH *
             WHERE ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND var2 IS NOT NULL AND var2 = $jwt.custom_value))
@@ -454,20 +454,20 @@ describe("cypher directive filtering top level - Auth", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (m:Movie) RETURN m
+              MATCH (m:Movie) RETURN m
             }
             WITH m AS this0
             CALL (this0) {
-                CALL (this0) {
-                    WITH this0 AS this
-                    MATCH (this)
-                    RETURN this.custom_field AS s
-                }
-                WITH s AS this1
-                RETURN this1 AS var2
+              CALL (this0) {
+                WITH this0 AS this
+                MATCH (this)
+                RETURN this.custom_field AS s
+              }
+              WITH s AS this1
+              RETURN this1 AS var2
             }
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND var2 IS NOT NULL AND var2 = $jwt.custom_value)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND var2 IS NOT NULL AND var2 = $jwt.custom_value)), '@neo4j/graphql/FORBIDDEN', [])
             WITH this0 { .title } AS this0
             RETURN this0 AS this"
         `);

--- a/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-auth.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-auth.test.ts
@@ -69,12 +69,12 @@ describe("cypher directive filtering - Auth", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    RETURN \\"hello\\" AS s
-                }
-                WITH s AS this0
-                RETURN this0 AS var1
+              CALL (this) {
+                WITH this AS this
+                RETURN \\"hello\\" AS s
+              }
+              WITH s AS this0
+              RETURN this0 AS var1
             }
             WITH *
             WHERE ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND var1 IS NOT NULL AND var1 = $jwt.custom_value))
@@ -138,22 +138,22 @@ describe("cypher directive filtering - Auth", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    RETURN \\"hello\\" AS s
-                }
-                WITH s AS this0
-                RETURN this0 AS var1
+              CALL (this) {
+                WITH this AS this
+                RETURN \\"hello\\" AS s
+              }
+              WITH s AS this0
+              RETURN this0 AS var1
             }
             WITH *
             WHERE ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND var1 IS NOT NULL AND var1 = $jwt.custom_value))
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    RETURN \\"hello\\" AS s
-                }
-                WITH s AS this2
-                RETURN this2 AS var3
+              CALL (this) {
+                WITH this AS this
+                RETURN \\"hello\\" AS s
+              }
+              WITH s AS this2
+              RETURN this2 AS var3
             }
             RETURN this { custom_field: var3 } AS this"
         `);
@@ -269,18 +269,18 @@ describe("cypher directive filtering - Auth", () => {
             "CYPHER 5
             MATCH (this:Actor)
             CALL (this) {
-                MATCH (this)-[:ACTED_IN]->(this0:Movie)
+              MATCH (this)-[:ACTED_IN]->(this0:Movie)
+              CALL (this0) {
                 CALL (this0) {
-                    CALL (this0) {
-                        WITH this0 AS this
-                        RETURN \\"hello\\" AS s
-                    }
-                    WITH s AS this1
-                    RETURN this1 AS var2
+                  WITH this0 AS this
+                  RETURN \\"hello\\" AS s
                 }
-                WITH *
-                WHERE ($jwt.custom_value IS NOT NULL AND var2 IS NOT NULL AND var2 = $jwt.custom_value)
-                RETURN count(this0) > 0 AS var3
+                WITH s AS this1
+                RETURN this1 AS var2
+              }
+              WITH *
+              WHERE ($jwt.custom_value IS NOT NULL AND var2 IS NOT NULL AND var2 = $jwt.custom_value)
+              RETURN count(this0) > 0 AS var3
             }
             WITH *
             WHERE ($isAuthenticated = true AND var3 = true)
@@ -344,12 +344,12 @@ describe("cypher directive filtering - Auth", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    RETURN \\"hello\\" AS s
-                }
-                WITH s AS this0
-                RETURN this0 AS var1
+              CALL (this) {
+                WITH this AS this
+                RETURN \\"hello\\" AS s
+              }
+              WITH s AS this0
+              RETURN this0 AS var1
             }
             WITH *
             WHERE ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND var1 IS NOT NULL AND var1 = $jwt.custom_value))
@@ -415,16 +415,16 @@ describe("cypher directive filtering - Auth", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)
-                    RETURN this.custom_field AS s
-                }
-                WITH s AS this0
-                RETURN this0 AS var1
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)
+                RETURN this.custom_field AS s
+              }
+              WITH s AS this0
+              RETURN this0 AS var1
             }
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND var1 IS NOT NULL AND var1 = $jwt.custom_value)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND var1 IS NOT NULL AND var1 = $jwt.custom_value)), '@neo4j/graphql/FORBIDDEN', [])
             RETURN this { .title } AS this"
         `);
 

--- a/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-connect.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-connect.test.ts
@@ -79,40 +79,38 @@ describe("cypher directive filtering", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                CREATE (this0:Movie)
-                SET
-                    this0.title = $param0
-                WITH *
-                CREATE (this1:Actor)
-                MERGE (this0)<-[this2:ACTED_IN]-(this1)
-                SET
-                    this1.name = $param1
-                WITH *
-                CALL (this0) {
-                    MATCH (this3:Actor)
-                    CALL (this3) {
-                        CALL (this3) {
-                            WITH this3 AS this
-                            RETURN \\"hello world!\\" AS s
-                        }
-                        WITH s AS this4
-                        RETURN this4 AS var5
-                    }
-                    WITH *
-                    WHERE (this3.name = $param2 AND var5 = $param3)
-                    CREATE (this0)<-[this6:ACTED_IN]-(this3)
+              CREATE (this0:Movie)
+              SET this0.title = $param0
+              WITH *
+              CREATE (this1:Actor)
+              MERGE (this0)<-[this2:ACTED_IN]-(this1)
+              SET this1.name = $param1
+              WITH *
+              CALL (this0) {
+                MATCH (this3:Actor)
+                CALL (this3) {
+                  CALL (this3) {
+                    WITH this3 AS this
+                    RETURN \\"hello world!\\" AS s
+                  }
+                  WITH s AS this4
+                  RETURN this4 AS var5
                 }
-                RETURN this0 AS this
+                WITH *
+                WHERE (this3.name = $param2 AND var5 = $param3)
+                CREATE (this0)<-[this6:ACTED_IN]-(this3)
+              }
+              RETURN this0 AS this
             }
             WITH this
             CALL (this) {
-                CALL (this) {
-                    MATCH (this)<-[this7:ACTED_IN]-(this8:Actor)
-                    WITH DISTINCT this8
-                    WITH this8 { .name } AS this8
-                    RETURN collect(this8) AS var9
-                }
-                RETURN this { .title, actors: var9 } AS var10
+              CALL (this) {
+                MATCH (this)<-[this7:ACTED_IN]-(this8:Actor)
+                WITH DISTINCT this8
+                WITH this8 { .name } AS this8
+                RETURN collect(this8) AS var9
+              }
+              RETURN this { .title, actors: var9 } AS var10
             }
             RETURN collect(var10) AS data"
         `);

--- a/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-list-auth.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-list-auth.test.ts
@@ -70,26 +70,26 @@ describe("cypher directive filtering - List Auth", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)
-                    RETURN this.custom_field as list
-                }
-                UNWIND list AS var0
-                WITH var0 AS this1
-                RETURN collect(this1) AS var2
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)
+                RETURN this.custom_field as list
+              }
+              UNWIND list AS var0
+              WITH var0 AS this1
+              RETURN collect(this1) AS var2
             }
             WITH *
             WHERE ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND var2 IS NOT NULL AND $jwt.custom_value IN var2))
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)
-                    RETURN this.custom_field as list
-                }
-                UNWIND list AS var3
-                WITH var3 AS this4
-                RETURN collect(this4) AS var5
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)
+                RETURN this.custom_field as list
+              }
+              UNWIND list AS var3
+              WITH var3 AS this4
+              RETURN collect(this4) AS var5
             }
             RETURN this { custom_list: var5 } AS this"
         `);
@@ -153,14 +153,14 @@ describe("cypher directive filtering - List Auth", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)
-                    RETURN this.custom_field as list
-                }
-                UNWIND list AS var0
-                WITH var0 AS this1
-                RETURN collect(this1) AS var2
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)
+                RETURN this.custom_field as list
+              }
+              UNWIND list AS var0
+              WITH var0 AS this1
+              RETURN collect(this1) AS var2
             }
             WITH *
             WHERE ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND var2 IS NOT NULL AND $jwt.custom_value IN var2))
@@ -225,26 +225,26 @@ describe("cypher directive filtering - List Auth", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)
-                    RETURN this.custom_field as list
-                }
-                UNWIND list AS var0
-                WITH var0 AS this1
-                RETURN collect(this1) AS var2
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)
+                RETURN this.custom_field as list
+              }
+              UNWIND list AS var0
+              WITH var0 AS this1
+              RETURN collect(this1) AS var2
             }
             WITH *
             WHERE ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND var2 IS NOT NULL AND $jwt.custom_value IN var2))
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)
-                    RETURN this.custom_field as list
-                }
-                UNWIND list AS var3
-                WITH var3 AS this4
-                RETURN collect(this4) AS var5
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)
+                RETURN this.custom_field as list
+              }
+              UNWIND list AS var3
+              WITH var3 AS this4
+              RETURN collect(this4) AS var5
             }
             RETURN this { custom_list: var5 } AS this"
         `);
@@ -362,20 +362,20 @@ describe("cypher directive filtering - List Auth", () => {
             "CYPHER 5
             MATCH (this:Actor)
             CALL (this) {
-                MATCH (this)-[:ACTED_IN]->(this0:Movie)
+              MATCH (this)-[:ACTED_IN]->(this0:Movie)
+              CALL (this0) {
                 CALL (this0) {
-                    CALL (this0) {
-                        WITH this0 AS this
-                        MATCH (this)
-                        RETURN this.custom_field as list
-                    }
-                    UNWIND list AS var1
-                    WITH var1 AS this2
-                    RETURN collect(this2) AS var3
+                  WITH this0 AS this
+                  MATCH (this)
+                  RETURN this.custom_field as list
                 }
-                WITH *
-                WHERE ($jwt.custom_value IS NOT NULL AND var3 IS NOT NULL AND var3 = $jwt.custom_value)
-                RETURN count(this0) > 0 AS var4
+                UNWIND list AS var1
+                WITH var1 AS this2
+                RETURN collect(this2) AS var3
+              }
+              WITH *
+              WHERE ($jwt.custom_value IS NOT NULL AND var3 IS NOT NULL AND var3 = $jwt.custom_value)
+              RETURN count(this0) > 0 AS var4
             }
             WITH *
             WHERE ($isAuthenticated = true AND var4 = true)
@@ -440,14 +440,14 @@ describe("cypher directive filtering - List Auth", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)
-                    RETURN this.custom_field as list
-                }
-                UNWIND list AS var0
-                WITH var0 AS this1
-                RETURN collect(this1) AS var2
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)
+                RETURN this.custom_field as list
+              }
+              UNWIND list AS var0
+              WITH var0 AS this1
+              RETURN collect(this1) AS var2
             }
             WITH *
             WHERE ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND var2 IS NOT NULL AND $jwt.custom_value IN var2))
@@ -513,17 +513,17 @@ describe("cypher directive filtering - List Auth", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)
-                    RETURN ['a', 'b', 'c'] as list
-                }
-                UNWIND list AS var0
-                WITH var0 AS this1
-                RETURN collect(this1) AS var2
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)
+                RETURN ['a', 'b', 'c'] as list
+              }
+              UNWIND list AS var0
+              WITH var0 AS this1
+              RETURN collect(this1) AS var2
             }
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND var2 IS NOT NULL AND $jwt.custom_value IN var2)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND var2 IS NOT NULL AND $jwt.custom_value IN var2)), '@neo4j/graphql/FORBIDDEN', [])
             RETURN this { .title } AS this"
         `);
 

--- a/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-list.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-list.test.ts
@@ -53,13 +53,13 @@ describe("cypher directive filtering - Lists", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    RETURN ['a', 'b', 'c'] as list
-                }
-                UNWIND list AS var0
-                WITH var0 AS this1
-                RETURN collect(this1) AS var2
+              CALL (this) {
+                WITH this AS this
+                RETURN ['a', 'b', 'c'] as list
+              }
+              UNWIND list AS var0
+              WITH var0 AS this1
+              RETURN collect(this1) AS var2
             }
             WITH *
             WHERE $param0 IN var2

--- a/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-misc.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-misc.test.ts
@@ -65,31 +65,31 @@ describe("cypher directive filtering - Auth", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    RETURN \\"hello world!\\" AS s
-                }
-                WITH s AS this0
-                RETURN this0 AS var1
+              CALL (this) {
+                WITH this AS this
+                RETURN \\"hello world!\\" AS s
+              }
+              WITH s AS this0
+              RETURN this0 AS var1
             }
             WITH *
             WHERE (var1 = $param0 AND EXISTS {
-                MATCH (this)<-[:ACTED_IN]-(this2:Actor)
-                WHERE this2.name = $param1
+              MATCH (this)<-[:ACTED_IN]-(this2:Actor)
+              WHERE this2.name = $param1
             })
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    RETURN \\"hello world!\\" AS s
-                }
-                WITH s AS this3
-                RETURN this3 AS var4
+              CALL (this) {
+                WITH this AS this
+                RETURN \\"hello world!\\" AS s
+              }
+              WITH s AS this3
+              RETURN this3 AS var4
             }
             CALL (this) {
-                MATCH (this)<-[this5:ACTED_IN]-(this6:Actor)
-                WITH DISTINCT this6
-                WITH this6 { .name } AS this6
-                RETURN collect(this6) AS var7
+              MATCH (this)<-[this5:ACTED_IN]-(this6:Actor)
+              WITH DISTINCT this6
+              WITH this6 { .name } AS this6
+              RETURN collect(this6) AS var7
             }
             RETURN this { .title, custom_field: var4, actors: var7 } AS this"
         `);
@@ -143,20 +143,20 @@ describe("cypher directive filtering - Auth", () => {
             "CYPHER 5
             MATCH (this:Actor)
             CALL (this) {
-                MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                WITH DISTINCT this1
+              MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+              WITH DISTINCT this1
+              CALL (this1) {
                 CALL (this1) {
-                    CALL (this1) {
-                        WITH this1 AS this
-                        RETURN \\"hello world!\\" AS s
-                    }
-                    WITH s AS this2
-                    RETURN this2 AS var3
+                  WITH this1 AS this
+                  RETURN \\"hello world!\\" AS s
                 }
-                WITH *
-                WHERE var3 = $param0
-                WITH this1 { .title } AS this1
-                RETURN collect(this1) AS var4
+                WITH s AS this2
+                RETURN this2 AS var3
+              }
+              WITH *
+              WHERE var3 = $param0
+              WITH this1 { .title } AS this1
+              RETURN collect(this1) AS var4
             }
             RETURN this { .name, movies: var4 } AS this"
         `);
@@ -209,21 +209,21 @@ describe("cypher directive filtering - Auth", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    RETURN \\"hello world!\\" AS s
-                }
-                WITH s AS this0
-                RETURN this0 AS var1
+              CALL (this) {
+                WITH this AS this
+                RETURN \\"hello world!\\" AS s
+              }
+              WITH s AS this0
+              RETURN this0 AS var1
             }
             WITH *
             WHERE var1 = $param0
             CALL (this) {
-                MATCH (this)<-[this2:ACTED_IN]-(this3:Actor)
-                WHERE this3.name = $param1
-                WITH DISTINCT this3
-                WITH this3 { .name } AS this3
-                RETURN collect(this3) AS var4
+              MATCH (this)<-[this2:ACTED_IN]-(this3:Actor)
+              WHERE this3.name = $param1
+              WITH DISTINCT this3
+              WITH this3 { .name } AS this3
+              RETURN collect(this3) AS var4
             }
             RETURN this { .title, actors: var4 } AS this"
         `);
@@ -291,28 +291,28 @@ describe("cypher directive filtering - Auth", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    RETURN \\"hello world!\\" AS s
-                }
-                WITH s AS this0
-                RETURN this0 AS var1
+              CALL (this) {
+                WITH this AS this
+                RETURN \\"hello world!\\" AS s
+              }
+              WITH s AS this0
+              RETURN this0 AS var1
             }
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    RETURN 100 AS i
-                }
-                WITH i AS this2
-                RETURN this2 AS var3
+              CALL (this) {
+                WITH this AS this
+                RETURN 100 AS i
+              }
+              WITH i AS this2
+              RETURN this2 AS var3
             }
             WITH *
             WHERE (var1 = $param0 AND var3 > $param1)
             CALL (this) {
-                MATCH (this)<-[this4:ACTED_IN]-(this5:Actor)
-                WITH DISTINCT this5
-                WITH this5 { .name } AS this5
-                RETURN collect(this5) AS var6
+              MATCH (this)<-[this4:ACTED_IN]-(this5:Actor)
+              WITH DISTINCT this5
+              WITH this5 { .name } AS this5
+              RETURN collect(this5) AS var6
             }
             RETURN this { .title, actors: var6 } AS this"
         `);
@@ -376,30 +376,30 @@ describe("cypher directive filtering - Auth", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    RETURN \\"hello world!\\" AS s
-                }
-                WITH s AS this0
-                RETURN this0 AS var1
+              CALL (this) {
+                WITH this AS this
+                RETURN \\"hello world!\\" AS s
+              }
+              WITH s AS this0
+              RETURN this0 AS var1
             }
             WITH *
             WHERE var1 = $param0
             CALL (this) {
-                MATCH (this)<-[this2:ACTED_IN]-(this3:Actor)
-                WITH DISTINCT this3
+              MATCH (this)<-[this2:ACTED_IN]-(this3:Actor)
+              WITH DISTINCT this3
+              CALL (this3) {
                 CALL (this3) {
-                    CALL (this3) {
-                        WITH this3 AS this
-                        RETURN \\"goodbye!\\" AS s
-                    }
-                    WITH s AS this4
-                    RETURN this4 AS var5
+                  WITH this3 AS this
+                  RETURN \\"goodbye!\\" AS s
                 }
-                WITH *
-                WHERE (this3.name = $param1 AND var5 = $param2)
-                WITH this3 { .name } AS this3
-                RETURN collect(this3) AS var6
+                WITH s AS this4
+                RETURN this4 AS var5
+              }
+              WITH *
+              WHERE (this3.name = $param1 AND var5 = $param2)
+              WITH this3 { .name } AS this3
+              RETURN collect(this3) AS var6
             }
             RETURN this { .title, actors: var6 } AS this"
         `);

--- a/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-one-to-one-relationship.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-one-to-one-relationship.test.ts
@@ -68,13 +68,13 @@ describe("cypher directive filtering - One To One Relationship", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:ACTED_IN]->(actor:Actor)
-                    RETURN actor
-                }
-                WITH actor AS this0
-                RETURN head(collect(this0)) AS this1
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:ACTED_IN]->(actor:Actor)
+                RETURN actor
+              }
+              WITH actor AS this0
+              RETURN head(collect(this0)) AS this1
             }
             WITH *
             WHERE this1.name = $param0
@@ -135,13 +135,13 @@ describe("cypher directive filtering - One To One Relationship", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:ACTED_IN]->(actor:Actor)
-                    RETURN actor
-                }
-                WITH actor AS this0
-                RETURN head(collect(this0)) AS this1
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:ACTED_IN]->(actor:Actor)
+                RETURN actor
+              }
+              WITH actor AS this0
+              RETURN head(collect(this0)) AS this1
             }
             WITH *
             WHERE (this.released = $param0 AND (this1.name = $param1 AND this1.age > $param2))
@@ -211,25 +211,25 @@ describe("cypher directive filtering - One To One Relationship", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)<-[:ACTED_IN]-(actor:Actor)
-                    RETURN actor
-                }
-                WITH actor AS this0
-                RETURN head(collect(this0)) AS this1
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                RETURN actor
+              }
+              WITH actor AS this0
+              RETURN head(collect(this0)) AS this1
             }
             WITH *
             WHERE this1.name = $param0
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)<-[:ACTED_IN]-(actor:Actor)
-                    RETURN actor
-                }
-                WITH actor AS this2
-                WITH this2 { .name } AS this2
-                RETURN head(collect(this2)) AS var3
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                RETURN actor
+              }
+              WITH actor AS this2
+              WITH this2 { .name } AS this2
+              RETURN head(collect(this2)) AS var3
             }
             RETURN this { .title, actor: var3 } AS this"
         `);
@@ -287,13 +287,13 @@ describe("cypher directive filtering - One To One Relationship", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)<-[:ACTED_IN]-(actor:Actor)
-                    RETURN actor
-                }
-                WITH actor AS this0
-                RETURN head(collect(this0)) AS this1
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                RETURN actor
+              }
+              WITH actor AS this0
+              RETURN head(collect(this0)) AS this1
             }
             WITH *
             WHERE (this.released = $param0 AND this1 IS NULL)
@@ -356,13 +356,13 @@ describe("cypher directive filtering - One To One Relationship", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)<-[:ACTED_IN]-(actor:Actor)
-                    RETURN actor
-                }
-                WITH actor AS this0
-                RETURN head(collect(this0)) AS this1
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                RETURN actor
+              }
+              WITH actor AS this0
+              RETURN head(collect(this0)) AS this1
             }
             WITH *
             WHERE (this.released IN $param0 AND NOT (this1 IS NULL))
@@ -441,46 +441,46 @@ describe("cypher directive filtering - One To One Relationship", () => {
             "CYPHER 5
             MATCH (this:Person)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:DIRECTED]->(movie:Movie)
-                    RETURN movie
-                }
-                WITH movie AS this0
-                RETURN head(collect(this0)) AS this1
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:DIRECTED]->(movie:Movie)
+                RETURN movie
+              }
+              WITH movie AS this0
+              RETURN head(collect(this0)) AS this1
             }
             WITH *
             WHERE this1.title = $param0
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:DIRECTED]->(movie:Movie)
-                    RETURN movie
-                }
-                WITH movie AS this2
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:DIRECTED]->(movie:Movie)
+                RETURN movie
+              }
+              WITH movie AS this2
+              CALL (this2) {
                 CALL (this2) {
-                    CALL (this2) {
-                        WITH this2 AS this
-                        MATCH (this)<-[:DIRECTED]-(director:Person)
-                        RETURN director
-                    }
-                    WITH director AS this3
-                    WITH this3 { .name } AS this3
-                    RETURN head(collect(this3)) AS var4
+                  WITH this2 AS this
+                  MATCH (this)<-[:DIRECTED]-(director:Person)
+                  RETURN director
                 }
+                WITH director AS this3
+                WITH this3 { .name } AS this3
+                RETURN head(collect(this3)) AS var4
+              }
+              CALL (this2) {
                 CALL (this2) {
-                    CALL (this2) {
-                        WITH this2 AS this
-                        MATCH (this)<-[:DIRECTED]-(director:Person)
-                        RETURN director
-                    }
-                    WITH director AS this5
-                    RETURN head(collect(this5)) AS this6
+                  WITH this2 AS this
+                  MATCH (this)<-[:DIRECTED]-(director:Person)
+                  RETURN director
                 }
-                WITH *
-                WHERE ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND this6.name = $jwt.custom_value))
-                WITH this2 { .title, directed_by: var4 } AS this2
-                RETURN head(collect(this2)) AS var7
+                WITH director AS this5
+                RETURN head(collect(this5)) AS this6
+              }
+              WITH *
+              WHERE ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND this6.name = $jwt.custom_value))
+              WITH this2 { .title, directed_by: var4 } AS this2
+              RETURN head(collect(this2)) AS var7
             }
             RETURN this { directed: var7 } AS this"
         `);
@@ -557,46 +557,46 @@ describe("cypher directive filtering - One To One Relationship", () => {
             "CYPHER 5
             MATCH (this:Person)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:DIRECTED]->(movie:Movie)
-                    RETURN movie
-                }
-                WITH movie AS this0
-                RETURN head(collect(this0)) AS this1
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:DIRECTED]->(movie:Movie)
+                RETURN movie
+              }
+              WITH movie AS this0
+              RETURN head(collect(this0)) AS this1
             }
             WITH *
             WHERE this1.title = $param0
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:DIRECTED]->(movie:Movie)
-                    RETURN movie
-                }
-                WITH movie AS this2
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:DIRECTED]->(movie:Movie)
+                RETURN movie
+              }
+              WITH movie AS this2
+              CALL (this2) {
                 CALL (this2) {
-                    CALL (this2) {
-                        WITH this2 AS this
-                        MATCH (this)<-[:DIRECTED]-(director:Person)
-                        RETURN director
-                    }
-                    WITH director AS this3
-                    WITH this3 { .name } AS this3
-                    RETURN head(collect(this3)) AS var4
+                  WITH this2 AS this
+                  MATCH (this)<-[:DIRECTED]-(director:Person)
+                  RETURN director
                 }
+                WITH director AS this3
+                WITH this3 { .name } AS this3
+                RETURN head(collect(this3)) AS var4
+              }
+              CALL (this2) {
                 CALL (this2) {
-                    CALL (this2) {
-                        WITH this2 AS this
-                        MATCH (this)<-[:DIRECTED]-(director:Person)
-                        RETURN director
-                    }
-                    WITH director AS this5
-                    RETURN head(collect(this5)) AS this6
+                  WITH this2 AS this
+                  MATCH (this)<-[:DIRECTED]-(director:Person)
+                  RETURN director
                 }
-                WITH *
-                WHERE ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND this6.name = $jwt.custom_value))
-                WITH this2 { .title, directed_by: var4 } AS this2
-                RETURN head(collect(this2)) AS var7
+                WITH director AS this5
+                RETURN head(collect(this5)) AS this6
+              }
+              WITH *
+              WHERE ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND this6.name = $jwt.custom_value))
+              WITH this2 { .title, directed_by: var4 } AS this2
+              RETURN head(collect(this2)) AS var7
             }
             RETURN this { directed: var7 } AS this"
         `);
@@ -674,46 +674,46 @@ describe("cypher directive filtering - One To One Relationship", () => {
             "CYPHER 5
             MATCH (this:Person)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:DIRECTED]->(movie:Movie)
-                    RETURN movie
-                }
-                WITH movie AS this0
-                RETURN head(collect(this0)) AS this1
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:DIRECTED]->(movie:Movie)
+                RETURN movie
+              }
+              WITH movie AS this0
+              RETURN head(collect(this0)) AS this1
             }
             WITH *
             WHERE this1.title = $param0
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:DIRECTED]->(movie:Movie)
-                    RETURN movie
-                }
-                WITH movie AS this2
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:DIRECTED]->(movie:Movie)
+                RETURN movie
+              }
+              WITH movie AS this2
+              CALL (this2) {
                 CALL (this2) {
-                    CALL (this2) {
-                        WITH this2 AS this
-                        MATCH (this)<-[:DIRECTED]-(director:Person)
-                        RETURN director
-                    }
-                    WITH director AS this3
-                    WITH this3 { .name } AS this3
-                    RETURN head(collect(this3)) AS var4
+                  WITH this2 AS this
+                  MATCH (this)<-[:DIRECTED]-(director:Person)
+                  RETURN director
                 }
+                WITH director AS this3
+                WITH this3 { .name } AS this3
+                RETURN head(collect(this3)) AS var4
+              }
+              CALL (this2) {
                 CALL (this2) {
-                    CALL (this2) {
-                        WITH this2 AS this
-                        MATCH (this)<-[:DIRECTED]-(director:Person)
-                        RETURN director
-                    }
-                    WITH director AS this5
-                    RETURN head(collect(this5)) AS this6
+                  WITH this2 AS this
+                  MATCH (this)<-[:DIRECTED]-(director:Person)
+                  RETURN director
                 }
-                WITH *
-                WHERE ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND this6.name = $jwt.custom_value))
-                WITH this2 { .title, directed_by: var4 } AS this2
-                RETURN head(collect(this2)) AS var7
+                WITH director AS this5
+                RETURN head(collect(this5)) AS this6
+              }
+              WITH *
+              WHERE ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND this6.name = $jwt.custom_value))
+              WITH this2 { .title, directed_by: var4 } AS this2
+              RETURN head(collect(this2)) AS var7
             }
             RETURN this { directed: var7 } AS this"
         `);
@@ -791,46 +791,46 @@ describe("cypher directive filtering - One To One Relationship", () => {
             "CYPHER 5
             MATCH (this:Person)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:DIRECTED]->(movie:Movie)
-                    RETURN movie
-                }
-                WITH movie AS this0
-                RETURN head(collect(this0)) AS this1
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:DIRECTED]->(movie:Movie)
+                RETURN movie
+              }
+              WITH movie AS this0
+              RETURN head(collect(this0)) AS this1
             }
             WITH *
             WHERE this1.title = $param0
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:DIRECTED]->(movie:Movie)
-                    RETURN movie
-                }
-                WITH movie AS this2
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:DIRECTED]->(movie:Movie)
+                RETURN movie
+              }
+              WITH movie AS this2
+              CALL (this2) {
                 CALL (this2) {
-                    CALL (this2) {
-                        WITH this2 AS this
-                        MATCH (this)<-[:DIRECTED]-(director:Person)
-                        RETURN director
-                    }
-                    WITH director AS this3
-                    WITH this3 { .name } AS this3
-                    RETURN head(collect(this3)) AS var4
+                  WITH this2 AS this
+                  MATCH (this)<-[:DIRECTED]-(director:Person)
+                  RETURN director
                 }
+                WITH director AS this3
+                WITH this3 { .name } AS this3
+                RETURN head(collect(this3)) AS var4
+              }
+              CALL (this2) {
                 CALL (this2) {
-                    CALL (this2) {
-                        WITH this2 AS this
-                        MATCH (this)<-[:DIRECTED]-(director:Person)
-                        RETURN director
-                    }
-                    WITH director AS this5
-                    RETURN head(collect(this5)) AS this6
+                  WITH this2 AS this
+                  MATCH (this)<-[:DIRECTED]-(director:Person)
+                  RETURN director
                 }
-                WITH *
-                WHERE ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND this6.name = $jwt.custom_value))
-                WITH this2 { .title, directed_by: var4 } AS this2
-                RETURN head(collect(this2)) AS var7
+                WITH director AS this5
+                RETURN head(collect(this5)) AS this6
+              }
+              WITH *
+              WHERE ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND this6.name = $jwt.custom_value))
+              WITH this2 { .title, directed_by: var4 } AS this2
+              RETURN head(collect(this2)) AS var7
             }
             RETURN this { directed: var7 } AS this"
         `);
@@ -909,46 +909,46 @@ describe("cypher directive filtering - One To One Relationship", () => {
             "CYPHER 5
             MATCH (this:Person)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:DIRECTED]->(movie:Movie)
-                    RETURN movie
-                }
-                WITH movie AS this0
-                RETURN head(collect(this0)) AS this1
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:DIRECTED]->(movie:Movie)
+                RETURN movie
+              }
+              WITH movie AS this0
+              RETURN head(collect(this0)) AS this1
             }
             WITH *
             WHERE this1.title = $param0
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:DIRECTED]->(movie:Movie)
-                    RETURN movie
-                }
-                WITH movie AS this2
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:DIRECTED]->(movie:Movie)
+                RETURN movie
+              }
+              WITH movie AS this2
+              CALL (this2) {
                 CALL (this2) {
-                    CALL (this2) {
-                        WITH this2 AS this
-                        MATCH (this)<-[:DIRECTED]-(director:Person)
-                        RETURN director
-                    }
-                    WITH director AS this3
-                    WITH this3 { .name } AS this3
-                    RETURN head(collect(this3)) AS var4
+                  WITH this2 AS this
+                  MATCH (this)<-[:DIRECTED]-(director:Person)
+                  RETURN director
                 }
+                WITH director AS this3
+                WITH this3 { .name } AS this3
+                RETURN head(collect(this3)) AS var4
+              }
+              CALL (this2) {
                 CALL (this2) {
-                    CALL (this2) {
-                        WITH this2 AS this
-                        MATCH (this)<-[:DIRECTED]-(director:Person)
-                        RETURN director
-                    }
-                    WITH director AS this5
-                    RETURN head(collect(this5)) AS this6
+                  WITH this2 AS this
+                  MATCH (this)<-[:DIRECTED]-(director:Person)
+                  RETURN director
                 }
-                WITH *
-                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND this6.name = $jwt.custom_value)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                WITH this2 { .title, directed_by: var4 } AS this2
-                RETURN head(collect(this2)) AS var7
+                WITH director AS this5
+                RETURN head(collect(this5)) AS this6
+              }
+              WITH *
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND this6.name = $jwt.custom_value)), '@neo4j/graphql/FORBIDDEN', [])
+              WITH this2 { .title, directed_by: var4 } AS this2
+              RETURN head(collect(this2)) AS var7
             }
             RETURN this { directed: var7 } AS this"
         `);
@@ -1027,46 +1027,46 @@ describe("cypher directive filtering - One To One Relationship", () => {
             "CYPHER 5
             MATCH (this:Person)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:DIRECTED]->(movie:Movie)
-                    RETURN movie
-                }
-                WITH movie AS this0
-                RETURN head(collect(this0)) AS this1
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:DIRECTED]->(movie:Movie)
+                RETURN movie
+              }
+              WITH movie AS this0
+              RETURN head(collect(this0)) AS this1
             }
             WITH *
             WHERE this1.title = $param0
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:DIRECTED]->(movie:Movie)
-                    RETURN movie
-                }
-                WITH movie AS this2
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:DIRECTED]->(movie:Movie)
+                RETURN movie
+              }
+              WITH movie AS this2
+              CALL (this2) {
                 CALL (this2) {
-                    CALL (this2) {
-                        WITH this2 AS this
-                        MATCH (this)<-[:DIRECTED]-(director:Person)
-                        RETURN director
-                    }
-                    WITH director AS this3
-                    WITH this3 { .name } AS this3
-                    RETURN head(collect(this3)) AS var4
+                  WITH this2 AS this
+                  MATCH (this)<-[:DIRECTED]-(director:Person)
+                  RETURN director
                 }
+                WITH director AS this3
+                WITH this3 { .name } AS this3
+                RETURN head(collect(this3)) AS var4
+              }
+              CALL (this2) {
                 CALL (this2) {
-                    CALL (this2) {
-                        WITH this2 AS this
-                        MATCH (this)<-[:DIRECTED]-(director:Person)
-                        RETURN director
-                    }
-                    WITH director AS this5
-                    RETURN head(collect(this5)) AS this6
+                  WITH this2 AS this
+                  MATCH (this)<-[:DIRECTED]-(director:Person)
+                  RETURN director
                 }
-                WITH *
-                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND this6.name = $jwt.custom_value)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                WITH this2 { .title, directed_by: var4 } AS this2
-                RETURN head(collect(this2)) AS var7
+                WITH director AS this5
+                RETURN head(collect(this5)) AS this6
+              }
+              WITH *
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND this6.name = $jwt.custom_value)), '@neo4j/graphql/FORBIDDEN', [])
+              WITH this2 { .title, directed_by: var4 } AS this2
+              RETURN head(collect(this2)) AS var7
             }
             RETURN this { directed: var7 } AS this"
         `);
@@ -1144,46 +1144,46 @@ describe("cypher directive filtering - One To One Relationship", () => {
             "CYPHER 5
             MATCH (this:Person)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:DIRECTED]->(movie:Movie)
-                    RETURN movie
-                }
-                WITH movie AS this0
-                RETURN head(collect(this0)) AS this1
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:DIRECTED]->(movie:Movie)
+                RETURN movie
+              }
+              WITH movie AS this0
+              RETURN head(collect(this0)) AS this1
             }
             WITH *
             WHERE this1.title = $param0
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:DIRECTED]->(movie:Movie)
-                    RETURN movie
-                }
-                WITH movie AS this2
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:DIRECTED]->(movie:Movie)
+                RETURN movie
+              }
+              WITH movie AS this2
+              CALL (this2) {
                 CALL (this2) {
-                    CALL (this2) {
-                        WITH this2 AS this
-                        MATCH (this)<-[:DIRECTED]-(director:Person)
-                        RETURN director
-                    }
-                    WITH director AS this3
-                    WITH this3 { .name } AS this3
-                    RETURN head(collect(this3)) AS var4
+                  WITH this2 AS this
+                  MATCH (this)<-[:DIRECTED]-(director:Person)
+                  RETURN director
                 }
+                WITH director AS this3
+                WITH this3 { .name } AS this3
+                RETURN head(collect(this3)) AS var4
+              }
+              CALL (this2) {
                 CALL (this2) {
-                    CALL (this2) {
-                        WITH this2 AS this
-                        MATCH (this)<-[:DIRECTED]-(director:Person)
-                        RETURN director
-                    }
-                    WITH director AS this5
-                    RETURN head(collect(this5)) AS this6
+                  WITH this2 AS this
+                  MATCH (this)<-[:DIRECTED]-(director:Person)
+                  RETURN director
                 }
-                WITH *
-                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND this6.name = $jwt.custom_value)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                WITH this2 { .title, directed_by: var4 } AS this2
-                RETURN head(collect(this2)) AS var7
+                WITH director AS this5
+                RETURN head(collect(this5)) AS this6
+              }
+              WITH *
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND this6.name = $jwt.custom_value)), '@neo4j/graphql/FORBIDDEN', [])
+              WITH this2 { .title, directed_by: var4 } AS this2
+              RETURN head(collect(this2)) AS var7
             }
             RETURN this { directed: var7 } AS this"
         `);
@@ -1261,46 +1261,46 @@ describe("cypher directive filtering - One To One Relationship", () => {
             "CYPHER 5
             MATCH (this:Person)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:DIRECTED]->(movie:Movie)
-                    RETURN movie
-                }
-                WITH movie AS this0
-                RETURN head(collect(this0)) AS this1
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:DIRECTED]->(movie:Movie)
+                RETURN movie
+              }
+              WITH movie AS this0
+              RETURN head(collect(this0)) AS this1
             }
             WITH *
             WHERE this1.title = $param0
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:DIRECTED]->(movie:Movie)
-                    RETURN movie
-                }
-                WITH movie AS this2
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:DIRECTED]->(movie:Movie)
+                RETURN movie
+              }
+              WITH movie AS this2
+              CALL (this2) {
                 CALL (this2) {
-                    CALL (this2) {
-                        WITH this2 AS this
-                        MATCH (this)<-[:DIRECTED]-(director:Person)
-                        RETURN director
-                    }
-                    WITH director AS this3
-                    WITH this3 { .name } AS this3
-                    RETURN head(collect(this3)) AS var4
+                  WITH this2 AS this
+                  MATCH (this)<-[:DIRECTED]-(director:Person)
+                  RETURN director
                 }
+                WITH director AS this3
+                WITH this3 { .name } AS this3
+                RETURN head(collect(this3)) AS var4
+              }
+              CALL (this2) {
                 CALL (this2) {
-                    CALL (this2) {
-                        WITH this2 AS this
-                        MATCH (this)<-[:DIRECTED]-(director:Person)
-                        RETURN director
-                    }
-                    WITH director AS this5
-                    RETURN head(collect(this5)) AS this6
+                  WITH this2 AS this
+                  MATCH (this)<-[:DIRECTED]-(director:Person)
+                  RETURN director
                 }
-                WITH *
-                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND this6.name = $jwt.custom_value)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                WITH this2 { .title, directed_by: var4 } AS this2
-                RETURN head(collect(this2)) AS var7
+                WITH director AS this5
+                RETURN head(collect(this5)) AS this6
+              }
+              WITH *
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.custom_value IS NOT NULL AND this6.name = $jwt.custom_value)), '@neo4j/graphql/FORBIDDEN', [])
+              WITH this2 { .title, directed_by: var4 } AS this2
+              RETURN head(collect(this2)) AS var7
             }
             RETURN this { directed: var7 } AS this"
         `);
@@ -1379,57 +1379,57 @@ describe("cypher directive filtering - One To One Relationship", () => {
             "CYPHER 5
             MATCH (this:Person)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:DIRECTED]->(movie:Movie)
-                    RETURN movie
-                }
-                WITH movie AS this0
-                RETURN head(collect(this0)) AS this1
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:DIRECTED]->(movie:Movie)
+                RETURN movie
+              }
+              WITH movie AS this0
+              RETURN head(collect(this0)) AS this1
             }
             WITH *
             WHERE this1.title = $param0
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:DIRECTED]->(movie:Movie)
-                    RETURN movie
-                }
-                WITH movie AS this2
-                CALL (this2) {
-                    MATCH (this2)<-[this3:ACTED_IN]-(this4:Person)
-                    WITH DISTINCT this4
-                    CALL (this4) {
-                        MATCH (this4)-[this5:ACTED_IN]->(this6:Movie)
-                        WITH DISTINCT this6
-                        CALL (this6) {
-                            CALL (this6) {
-                                WITH this6 AS this
-                                MATCH (this)<-[:DIRECTED]-(director:Person)
-                                RETURN director
-                            }
-                            WITH director AS this7
-                            WITH this7 { .name } AS this7
-                            RETURN head(collect(this7)) AS var8
-                        }
-                        WITH this6 { .title, directed_by: var8 } AS this6
-                        RETURN collect(this6) AS var9
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:DIRECTED]->(movie:Movie)
+                RETURN movie
+              }
+              WITH movie AS this2
+              CALL (this2) {
+                MATCH (this2)<-[this3:ACTED_IN]-(this4:Person)
+                WITH DISTINCT this4
+                CALL (this4) {
+                  MATCH (this4)-[this5:ACTED_IN]->(this6:Movie)
+                  WITH DISTINCT this6
+                  CALL (this6) {
+                    CALL (this6) {
+                      WITH this6 AS this
+                      MATCH (this)<-[:DIRECTED]-(director:Person)
+                      RETURN director
                     }
-                    WITH this4 { .name, movies: var9 } AS this4
-                    RETURN collect(this4) AS var10
+                    WITH director AS this7
+                    WITH this7 { .name } AS this7
+                    RETURN head(collect(this7)) AS var8
+                  }
+                  WITH this6 { .title, directed_by: var8 } AS this6
+                  RETURN collect(this6) AS var9
                 }
+                WITH this4 { .name, movies: var9 } AS this4
+                RETURN collect(this4) AS var10
+              }
+              CALL (this2) {
                 CALL (this2) {
-                    CALL (this2) {
-                        WITH this2 AS this
-                        MATCH (this)<-[:DIRECTED]-(director:Person)
-                        RETURN director
-                    }
-                    WITH director AS this11
-                    WITH this11 { .name } AS this11
-                    RETURN head(collect(this11)) AS var12
+                  WITH this2 AS this
+                  MATCH (this)<-[:DIRECTED]-(director:Person)
+                  RETURN director
                 }
-                WITH this2 { .title, directed_by: var12, actors: var10 } AS this2
-                RETURN head(collect(this2)) AS var13
+                WITH director AS this11
+                WITH this11 { .name } AS this11
+                RETURN head(collect(this11)) AS var12
+              }
+              WITH this2 { .title, directed_by: var12, actors: var10 } AS this2
+              RETURN head(collect(this2)) AS var13
             }
             RETURN this { directed: var13 } AS this"
         `);
@@ -1496,25 +1496,25 @@ describe("cypher directive filtering - One To One Relationship", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)<-[:DIRECTED]-(director:Person)
-                    RETURN director
-                }
-                WITH director AS this0
-                RETURN head(collect(this0)) AS this1
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)<-[:DIRECTED]-(director:Person)
+                RETURN director
+              }
+              WITH director AS this0
+              RETURN head(collect(this0)) AS this1
             }
             WITH *
             WHERE (this.title ENDS WITH $param0 AND this1.name = $param1)
             CALL (this) {
-                MATCH (this)<-[this2:ACTED_IN]-(this3:Person)
-                WITH collect({ node: this3, relationship: this2 }) AS edges, count(this3) AS totalCount
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this3, edge.relationship AS this2
-                    RETURN collect({ node: { name: this3.name, __resolveType: \\"Person\\" } }) AS var4
-                }
-                RETURN { edges: var4, totalCount: totalCount } AS var5
+              MATCH (this)<-[this2:ACTED_IN]-(this3:Person)
+              WITH collect({node: this3, relationship: this2}) AS edges, count(this3) AS totalCount
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this3, edge.relationship AS this2
+                RETURN collect({node: {name: this3.name, __resolveType: 'Person'}}) AS var4
+              }
+              RETURN {edges: var4, totalCount: totalCount} AS var5
             }
             RETURN this { actorsConnection: var5 } AS this"
         `);

--- a/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-scalar.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-scalar.test.ts
@@ -54,24 +54,24 @@ describe("cypher directive filtering", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (m:Movie)
-                    RETURN count(m) as c
-                }
-                WITH c AS this0
-                RETURN this0 AS var1
+              CALL (this) {
+                WITH this AS this
+                MATCH (m:Movie)
+                RETURN count(m) as c
+              }
+              WITH c AS this0
+              RETURN this0 AS var1
             }
             WITH *
             WHERE (this.title = $param0 AND var1 >= $param1)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (m:Movie)
-                    RETURN count(m) as c
-                }
-                WITH c AS this2
-                RETURN this2 AS var3
+              CALL (this) {
+                WITH this AS this
+                MATCH (m:Movie)
+                RETURN count(m) as c
+              }
+              WITH c AS this2
+              RETURN this2 AS var3
             }
             RETURN this { special_count: var3 } AS this"
         `);
@@ -120,24 +120,24 @@ describe("cypher directive filtering", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (m:Movie)
-                    RETURN count(m) as c
-                }
-                WITH c AS this0
-                RETURN this0 AS var1
+              CALL (this) {
+                WITH this AS this
+                MATCH (m:Movie)
+                RETURN count(m) as c
+              }
+              WITH c AS this0
+              RETURN this0 AS var1
             }
             WITH *
             WHERE (this.title = $param0 AND var1 >= $param1)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (m:Movie)
-                    RETURN count(m) as c
-                }
-                WITH c AS this2
-                RETURN this2 AS var3
+              CALL (this) {
+                WITH this AS this
+                MATCH (m:Movie)
+                RETURN count(m) as c
+              }
+              WITH c AS this2
+              RETURN this2 AS var3
             }
             RETURN this { special_count: var3 } AS this"
         `);
@@ -186,13 +186,13 @@ describe("cypher directive filtering", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (m:Movie)
-                    RETURN count(m) as c
-                }
-                WITH c AS this0
-                RETURN this0 AS var1
+              CALL (this) {
+                WITH this AS this
+                MATCH (m:Movie)
+                RETURN count(m) as c
+              }
+              WITH c AS this0
+              RETURN this0 AS var1
             }
             WITH *
             WHERE var1 >= $param0
@@ -248,12 +248,12 @@ describe("cypher directive filtering", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    RETURN \\"Toyota\\" as s
-                }
-                WITH s AS this0
-                RETURN this0 AS var1
+              CALL (this) {
+                WITH this AS this
+                RETURN \\"Toyota\\" as s
+              }
+              WITH s AS this0
+              RETURN this0 AS var1
             }
             WITH *
             WHERE toLower(var1) = toLower($param0)
@@ -306,12 +306,12 @@ describe("cypher directive filtering", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    RETURN \\"Toyota\\" as s
-                }
-                WITH s AS this0
-                RETURN this0 AS var1
+              CALL (this) {
+                WITH this AS this
+                RETURN \\"Toyota\\" as s
+              }
+              WITH s AS this0
+              RETURN this0 AS var1
             }
             WITH *
             WHERE toLower(var1) CONTAINS toLower($param0)
@@ -364,12 +364,12 @@ describe("cypher directive filtering", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    RETURN \\"Toyota\\" as s
-                }
-                WITH s AS this0
-                RETURN this0 AS var1
+              CALL (this) {
+                WITH this AS this
+                RETURN \\"Toyota\\" as s
+              }
+              WITH s AS this0
+              RETURN this0 AS var1
             }
             WITH *
             WHERE toLower(var1) STARTS WITH toLower($param0)
@@ -422,12 +422,12 @@ describe("cypher directive filtering", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    RETURN \\"Toyota\\" as s
-                }
-                WITH s AS this0
-                RETURN this0 AS var1
+              CALL (this) {
+                WITH this AS this
+                RETURN \\"Toyota\\" as s
+              }
+              WITH s AS this0
+              RETURN this0 AS var1
             }
             WITH *
             WHERE toLower(var1) ENDS WITH toLower($param0)
@@ -480,12 +480,12 @@ describe("cypher directive filtering", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    RETURN \\"Toyota\\" as s
-                }
-                WITH s AS this0
-                RETURN this0 AS var1
+              CALL (this) {
+                WITH this AS this
+                RETURN \\"Toyota\\" as s
+              }
+              WITH s AS this0
+              RETURN this0 AS var1
             }
             WITH *
             WHERE toLower(var1) IN [var2 IN $param0 | toLower(var2)]

--- a/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-sorting.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-sorting.test.ts
@@ -63,32 +63,32 @@ describe("cypher directive filtering", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    WITH this
-                    RETURN this.title AS s
-                }
-                WITH s AS this0
-                RETURN this0 AS var1
+              CALL (this) {
+                WITH this AS this
+                WITH this
+                RETURN this.title AS s
+              }
+              WITH s AS this0
+              RETURN this0 AS var1
             }
             WITH *
             WHERE var1 STARTS WITH $param0
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    WITH this
-                    RETURN this.title AS s
-                }
-                WITH s AS this2
-                RETURN this2 AS var3
+              CALL (this) {
+                WITH this AS this
+                WITH this
+                RETURN this.title AS s
+              }
+              WITH s AS this2
+              RETURN this2 AS var3
             }
             WITH *
             ORDER BY var3 DESC
             CALL (this) {
-                MATCH (this)<-[this4:ACTED_IN]-(this5:Actor)
-                WITH DISTINCT this5
-                WITH this5 { .name } AS this5
-                RETURN collect(this5) AS var6
+              MATCH (this)<-[this4:ACTED_IN]-(this5:Actor)
+              WITH DISTINCT this5
+              WITH this5 { .name } AS this5
+              RETURN collect(this5) AS var6
             }
             RETURN this { .title, actors: var6, custom_field: var3 } AS this"
         `);
@@ -141,22 +141,22 @@ describe("cypher directive filtering", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    RETURN \\"hello world!\\" AS s
-                }
-                WITH s AS this0
-                RETURN this0 AS var1
+              CALL (this) {
+                WITH this AS this
+                RETURN \\"hello world!\\" AS s
+              }
+              WITH s AS this0
+              RETURN this0 AS var1
             }
             WITH *
             WHERE var1 = $param0
             WITH *
             ORDER BY this.title DESC
             CALL (this) {
-                MATCH (this)<-[this2:ACTED_IN]-(this3:Actor)
-                WITH DISTINCT this3
-                WITH this3 { .name } AS this3
-                RETURN collect(this3) AS var4
+              MATCH (this)<-[this2:ACTED_IN]-(this3:Actor)
+              WITH DISTINCT this3
+              WITH this3 { .name } AS this3
+              RETURN collect(this3) AS var4
             }
             RETURN this { .title, actors: var4 } AS this"
         `);

--- a/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-spatial.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-spatial.test.ts
@@ -57,22 +57,22 @@ describe("cypher directive filtering - Auth", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    RETURN point({ longitude: 1.0, latitude: 1.0 }) AS l
-                }
-                WITH l AS this0
-                RETURN this0 AS var1
+              CALL (this) {
+                WITH this AS this
+                RETURN point({ longitude: 1.0, latitude: 1.0 }) AS l
+              }
+              WITH l AS this0
+              RETURN this0 AS var1
             }
             WITH *
             WHERE point.distance(var1, point($param0.point)) = $param0.distance
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    RETURN point({ longitude: 1.0, latitude: 1.0 }) AS l
-                }
-                WITH l AS this2
-                RETURN this2 AS var3
+              CALL (this) {
+                WITH this AS this
+                RETURN point({ longitude: 1.0, latitude: 1.0 }) AS l
+              }
+              WITH l AS this2
+              RETURN this2 AS var3
             }
             RETURN this { .title, special_location: var3 } AS this"
         `);
@@ -127,22 +127,22 @@ describe("cypher directive filtering - Auth", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    RETURN point({ x: 1.0, y: 1.0, z: 1.0 }) AS l
-                }
-                WITH l AS this0
-                RETURN this0 AS var1
+              CALL (this) {
+                WITH this AS this
+                RETURN point({ x: 1.0, y: 1.0, z: 1.0 }) AS l
+              }
+              WITH l AS this0
+              RETURN this0 AS var1
             }
             WITH *
             WHERE point.distance(var1, point($param0.point)) = $param0.distance
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    RETURN point({ x: 1.0, y: 1.0, z: 1.0 }) AS l
-                }
-                WITH l AS this2
-                RETURN this2 AS var3
+              CALL (this) {
+                WITH this AS this
+                RETURN point({ x: 1.0, y: 1.0, z: 1.0 }) AS l
+              }
+              WITH l AS this2
+              RETURN this2 AS var3
             }
             RETURN this { .title, special_location: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-temporal.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher/filtering/cypher-filtering-temporal.test.ts
@@ -54,22 +54,22 @@ describe("cypher directive filtering - Auth", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    RETURN datetime(\\"2024-09-03T15:30:00Z\\") AS t
-                }
-                WITH t AS this0
-                RETURN this0 AS var1
+              CALL (this) {
+                WITH this AS this
+                RETURN datetime(\\"2024-09-03T15:30:00Z\\") AS t
+              }
+              WITH t AS this0
+              RETURN this0 AS var1
             }
             WITH *
             WHERE var1 > datetime($param0)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    RETURN datetime(\\"2024-09-03T15:30:00Z\\") AS t
-                }
-                WITH t AS this2
-                RETURN this2 AS var3
+              CALL (this) {
+                WITH this AS this
+                RETURN datetime(\\"2024-09-03T15:30:00Z\\") AS t
+              }
+              WITH t AS this2
+              RETURN this2 AS var3
             }
             RETURN this { .title, special_time: var3 } AS this"
         `);
@@ -112,12 +112,12 @@ describe("cypher directive filtering - Auth", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    RETURN duration('P14DT16H12M') AS d
-                }
-                WITH d AS this0
-                RETURN this0 AS var1
+              CALL (this) {
+                WITH this AS this
+                RETURN duration('P14DT16H12M') AS d
+              }
+              WITH d AS this0
+              RETURN this0 AS var1
             }
             WITH *
             WHERE var1 = $param0

--- a/packages/graphql/tests/tck/directives/cypher/filtering/relationships/cypher-filtering-relationship-auth.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher/filtering/relationships/cypher-filtering-relationship-auth.test.ts
@@ -83,23 +83,23 @@ describe("cypher directive filtering - relationship auth filter", () => {
             "CYPHER 5
             MATCH (this0:Movie)
             CALL (this0) {
-                CALL (this0) {
-                    WITH this0 AS this
-                    MATCH (this)<-[:ACTED_IN]-(actor:Actor)
-                    RETURN actor
-                }
-                WITH actor AS this1
-                RETURN collect(this1) AS this2
+              CALL (this0) {
+                WITH this0 AS this
+                MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                RETURN actor
+              }
+              WITH actor AS this1
+              RETURN collect(this1) AS this2
             }
             WITH *
             WHERE (this0.rating < $param0 AND ($isAuthenticated = true AND any(this3 IN this2 WHERE ($jwt.custom_value IS NOT NULL AND this3.name = $jwt.custom_value))))
-            WITH collect({ node: this0 }) AS edges
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var4
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              RETURN collect({node: {title: this0.title, __resolveType: 'Movie'}}) AS var4
             }
-            RETURN { edges: var4 } AS this"
+            RETURN {edges: var4} AS this"
         `);
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -174,23 +174,23 @@ describe("cypher directive filtering - relationship auth filter", () => {
             "CYPHER 5
             MATCH (this0:Movie)
             CALL (this0) {
-                CALL (this0) {
-                    WITH this0 AS this
-                    MATCH (this)<-[:ACTED_IN]-(actor:Actor)
-                    RETURN actor
-                }
-                WITH actor AS this1
-                RETURN collect(this1) AS this2
+              CALL (this0) {
+                WITH this0 AS this
+                MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                RETURN actor
+              }
+              WITH actor AS this1
+              RETURN collect(this1) AS this2
             }
             WITH *
             WHERE (this0.rating < $param0 AND ($isAuthenticated = true AND any(this3 IN this2 WHERE ($jwt.custom_value IS NOT NULL AND this3.name = $jwt.custom_value))))
-            WITH collect({ node: this0 }) AS edges
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var4
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              RETURN collect({node: {title: this0.title, __resolveType: 'Movie'}}) AS var4
             }
-            RETURN { edges: var4 } AS this"
+            RETURN {edges: var4} AS this"
         `);
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -265,24 +265,24 @@ describe("cypher directive filtering - relationship auth filter", () => {
             "CYPHER 5
             MATCH (this0:Movie)
             CALL (this0) {
-                CALL (this0) {
-                    WITH this0 AS this
-                    MATCH (this)<-[:ACTED_IN]-(actor:Actor)
-                    RETURN actor
-                }
-                WITH actor AS this1
-                RETURN collect(this1) AS this2
+              CALL (this0) {
+                WITH this0 AS this
+                MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                RETURN actor
+              }
+              WITH actor AS this1
+              RETURN collect(this1) AS this2
             }
             WITH *
             WHERE this0.rating < $param0
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND any(this3 IN this2 WHERE ($jwt.custom_value IS NOT NULL AND this3.name = $jwt.custom_value))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            WITH collect({ node: this0 }) AS edges
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND any(this3 IN this2 WHERE ($jwt.custom_value IS NOT NULL AND this3.name = $jwt.custom_value))), '@neo4j/graphql/FORBIDDEN', [])
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var4
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              RETURN collect({node: {title: this0.title, __resolveType: 'Movie'}}) AS var4
             }
-            RETURN { edges: var4 } AS this"
+            RETURN {edges: var4} AS this"
         `);
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -357,24 +357,24 @@ describe("cypher directive filtering - relationship auth filter", () => {
             "CYPHER 5
             MATCH (this0:Movie)
             CALL (this0) {
-                CALL (this0) {
-                    WITH this0 AS this
-                    MATCH (this)<-[:ACTED_IN]-(actor:Actor)
-                    RETURN actor
-                }
-                WITH actor AS this1
-                RETURN collect(this1) AS this2
+              CALL (this0) {
+                WITH this0 AS this
+                MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                RETURN actor
+              }
+              WITH actor AS this1
+              RETURN collect(this1) AS this2
             }
             WITH *
             WHERE this0.rating > $param0
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND any(this3 IN this2 WHERE ($jwt.custom_value IS NOT NULL AND this3.name = $jwt.custom_value))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            WITH collect({ node: this0 }) AS edges
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND any(this3 IN this2 WHERE ($jwt.custom_value IS NOT NULL AND this3.name = $jwt.custom_value))), '@neo4j/graphql/FORBIDDEN', [])
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var4
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              RETURN collect({node: {title: this0.title, __resolveType: 'Movie'}}) AS var4
             }
-            RETURN { edges: var4 } AS this"
+            RETURN {edges: var4} AS this"
         `);
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/directives/cypher/filtering/relationships/cypher-filtering-relationship-connection.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher/filtering/relationships/cypher-filtering-relationship-connection.test.ts
@@ -70,23 +70,23 @@ describe("Connection API - cypher directive filtering - Relationship", () => {
             "CYPHER 5
             MATCH (this0:Movie)
             CALL (this0) {
-                CALL (this0) {
-                    WITH this0 AS this
-                    MATCH (this)<-[:ACTED_IN]-(actor:Actor)
-                    RETURN actor
-                }
-                WITH actor AS this1
-                RETURN collect(this1) AS this2
+              CALL (this0) {
+                WITH this0 AS this
+                MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                RETURN actor
+              }
+              WITH actor AS this1
+              RETURN collect(this1) AS this2
             }
             WITH *
             WHERE NOT (any(this3 IN this2 WHERE this3.name = $param0))
-            WITH collect({ node: this0 }) AS edges
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var4
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              RETURN collect({node: {title: this0.title, __resolveType: 'Movie'}}) AS var4
             }
-            RETURN { edges: var4 } AS this"
+            RETURN {edges: var4} AS this"
         `);
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -144,23 +144,23 @@ describe("Connection API - cypher directive filtering - Relationship", () => {
             "CYPHER 5
             MATCH (this0:Movie)
             CALL (this0) {
-                CALL (this0) {
-                    WITH this0 AS this
-                    MATCH (this)<-[:ACTED_IN]-(actor:Actor)
-                    RETURN actor
-                }
-                WITH actor AS this1
-                RETURN collect(this1) AS this2
+              CALL (this0) {
+                WITH this0 AS this
+                MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                RETURN actor
+              }
+              WITH actor AS this1
+              RETURN collect(this1) AS this2
             }
             WITH *
             WHERE all(this3 IN this2 WHERE this3.name = $param0)
-            WITH collect({ node: this0 }) AS edges
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var4
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              RETURN collect({node: {title: this0.title, __resolveType: 'Movie'}}) AS var4
             }
-            RETURN { edges: var4 } AS this"
+            RETURN {edges: var4} AS this"
         `);
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -218,23 +218,23 @@ describe("Connection API - cypher directive filtering - Relationship", () => {
             "CYPHER 5
             MATCH (this0:Movie)
             CALL (this0) {
-                CALL (this0) {
-                    WITH this0 AS this
-                    MATCH (this)<-[:ACTED_IN]-(actor:Actor)
-                    RETURN actor
-                }
-                WITH actor AS this1
-                RETURN collect(this1) AS this2
+              CALL (this0) {
+                WITH this0 AS this
+                MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                RETURN actor
+              }
+              WITH actor AS this1
+              RETURN collect(this1) AS this2
             }
             WITH *
             WHERE single(this3 IN this2 WHERE this3.name = $param0)
-            WITH collect({ node: this0 }) AS edges
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var4
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              RETURN collect({node: {title: this0.title, __resolveType: 'Movie'}}) AS var4
             }
-            RETURN { edges: var4 } AS this"
+            RETURN {edges: var4} AS this"
         `);
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -292,23 +292,23 @@ describe("Connection API - cypher directive filtering - Relationship", () => {
             "CYPHER 5
             MATCH (this0:Movie)
             CALL (this0) {
-                CALL (this0) {
-                    WITH this0 AS this
-                    MATCH (this)<-[:ACTED_IN]-(actor:Actor)
-                    RETURN actor
-                }
-                WITH actor AS this1
-                RETURN collect(this1) AS this2
+              CALL (this0) {
+                WITH this0 AS this
+                MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                RETURN actor
+              }
+              WITH actor AS this1
+              RETURN collect(this1) AS this2
             }
             WITH *
             WHERE any(this3 IN this2 WHERE this3.name = $param0)
-            WITH collect({ node: this0 }) AS edges
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var4
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              RETURN collect({node: {title: this0.title, __resolveType: 'Movie'}}) AS var4
             }
-            RETURN { edges: var4 } AS this"
+            RETURN {edges: var4} AS this"
         `);
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -366,25 +366,25 @@ describe("Connection API - cypher directive filtering - Relationship", () => {
             "CYPHER 5
             MATCH (this0:Movie)
             CALL (this0) {
-                CALL (this0) {
-                    WITH this0 AS this
-                    MATCH (this)<-[:ACTED_IN]-(actor:Actor)
-                    RETURN actor
-                }
-                WITH actor AS this1
-                RETURN collect(this1) AS this2
+              CALL (this0) {
+                WITH this0 AS this
+                MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                RETURN actor
+              }
+              WITH actor AS this1
+              RETURN collect(this1) AS this2
             }
             WITH *
             WHERE any(this3 IN this2 WHERE this3.name = $param0)
-            WITH collect({ node: this0 }) AS edges
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                WITH *
-                ORDER BY this0.title DESC
-                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var4
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              WITH *
+              ORDER BY this0.title DESC
+              RETURN collect({node: {title: this0.title, __resolveType: 'Movie'}}) AS var4
             }
-            RETURN { edges: var4 } AS this"
+            RETURN {edges: var4} AS this"
         `);
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -442,23 +442,23 @@ describe("Connection API - cypher directive filtering - Relationship", () => {
             "CYPHER 5
             MATCH (this0:Movie)
             CALL (this0) {
-                CALL (this0) {
-                    WITH this0 AS this
-                    MATCH (this)<-[:ACTED_IN]-(actor:Actor)
-                    RETURN actor
-                }
-                WITH actor AS this1
-                RETURN collect(this1) AS this2
+              CALL (this0) {
+                WITH this0 AS this
+                MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                RETURN actor
+              }
+              WITH actor AS this1
+              RETURN collect(this1) AS this2
             }
             WITH *
             WHERE none(this3 IN this2 WHERE this3.name = $param0)
-            WITH collect({ node: this0 }) AS edges
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var4
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              RETURN collect({node: {title: this0.title, __resolveType: 'Movie'}}) AS var4
             }
-            RETURN { edges: var4 } AS this"
+            RETURN {edges: var4} AS this"
         `);
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -543,32 +543,32 @@ describe("Connection API - cypher directive filtering - Relationship", () => {
             "CYPHER 5
             MATCH (this0:Movie)
             CALL (this0) {
-                CALL (this0) {
-                    WITH this0 AS this
-                    MATCH (this)<-[:ACTED_IN]-(actor:Actor)
-                    RETURN actor
-                }
-                WITH actor AS this1
-                RETURN collect(this1) AS this2
+              CALL (this0) {
+                WITH this0 AS this
+                MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                RETURN actor
+              }
+              WITH actor AS this1
+              RETURN collect(this1) AS this2
             }
             CALL (this0) {
-                CALL (this0) {
-                    WITH this0 AS this
-                    MATCH (this)-[:IN_GENRE]->(g:Genre)
-                    RETURN g
-                }
-                WITH g AS this3
-                RETURN collect(this3) AS this4
+              CALL (this0) {
+                WITH this0 AS this
+                MATCH (this)-[:IN_GENRE]->(g:Genre)
+                RETURN g
+              }
+              WITH g AS this3
+              RETURN collect(this3) AS this4
             }
             WITH *
             WHERE (any(this5 IN this2 WHERE this5.name = $param0) OR any(this6 IN this4 WHERE this6.name = $param1))
-            WITH collect({ node: this0 }) AS edges
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var7
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              RETURN collect({node: {title: this0.title, __resolveType: 'Movie'}}) AS var7
             }
-            RETURN { edges: var7 } AS this"
+            RETURN {edges: var7} AS this"
         `);
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/directives/cypher/filtering/relationships/cypher-filtering-relationship.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher/filtering/relationships/cypher-filtering-relationship.test.ts
@@ -66,13 +66,13 @@ describe("cypher directive filtering - Relationship", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)<-[:ACTED_IN]-(actor:Actor)
-                    RETURN actor
-                }
-                WITH actor AS this0
-                RETURN collect(this0) AS this1
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                RETURN actor
+              }
+              WITH actor AS this0
+              RETURN collect(this0) AS this1
             }
             WITH *
             WHERE NOT (any(this2 IN this1 WHERE this2.name = $param0))
@@ -130,13 +130,13 @@ describe("cypher directive filtering - Relationship", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)<-[:ACTED_IN]-(actor:Actor)
-                    RETURN actor
-                }
-                WITH actor AS this0
-                RETURN collect(this0) AS this1
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                RETURN actor
+              }
+              WITH actor AS this0
+              RETURN collect(this0) AS this1
             }
             WITH *
             WHERE all(this2 IN this1 WHERE this2.name = $param0)
@@ -194,13 +194,13 @@ describe("cypher directive filtering - Relationship", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)<-[:ACTED_IN]-(actor:Actor)
-                    RETURN actor
-                }
-                WITH actor AS this0
-                RETURN collect(this0) AS this1
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                RETURN actor
+              }
+              WITH actor AS this0
+              RETURN collect(this0) AS this1
             }
             WITH *
             WHERE single(this2 IN this1 WHERE this2.name = $param0)
@@ -258,13 +258,13 @@ describe("cypher directive filtering - Relationship", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)<-[:ACTED_IN]-(actor:Actor)
-                    RETURN actor
-                }
-                WITH actor AS this0
-                RETURN collect(this0) AS this1
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                RETURN actor
+              }
+              WITH actor AS this0
+              RETURN collect(this0) AS this1
             }
             WITH *
             WHERE any(this2 IN this1 WHERE this2.name = $param0)
@@ -321,13 +321,13 @@ describe("cypher directive filtering - Relationship", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)<-[:ACTED_IN]-(actor:Actor)
-                    RETURN actor
-                }
-                WITH actor AS this0
-                RETURN collect(this0) AS this1
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                RETURN actor
+              }
+              WITH actor AS this0
+              RETURN collect(this0) AS this1
             }
             WITH *
             WHERE none(this2 IN this1 WHERE this2.name = $param0)
@@ -412,22 +412,22 @@ describe("cypher directive filtering - Relationship", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)<-[:ACTED_IN]-(actor:Actor)
-                    RETURN actor
-                }
-                WITH actor AS this0
-                RETURN collect(this0) AS this1
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                RETURN actor
+              }
+              WITH actor AS this0
+              RETURN collect(this0) AS this1
             }
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:IN_GENRE]->(g:Genre)
-                    RETURN g
-                }
-                WITH g AS this2
-                RETURN collect(this2) AS this3
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:IN_GENRE]->(g:Genre)
+                RETURN g
+              }
+              WITH g AS this2
+              RETURN collect(this2) AS this3
             }
             WITH *
             WHERE (any(this4 IN this1 WHERE this4.name = $param0) OR any(this5 IN this3 WHERE this5.name = $param1))

--- a/packages/graphql/tests/tck/directives/cypher/relationship-properties/cypher-in-relationship-prop.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher/relationship-properties/cypher-in-relationship-prop.test.ts
@@ -78,22 +78,22 @@ describe("cypher directive in relationship properties", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    CALL (this0) {
-                        CALL (this0) {
-                            WITH this0 AS this
-                            RETURN this.screenTimeMinutes / 60 AS c
-                        }
-                        WITH c AS this2
-                        RETURN this2 AS var3
-                    }
-                    RETURN collect({ properties: { screenTimeHours: var3, __resolveType: \\"ActedIn\\" }, node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var4
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                CALL (this0) {
+                  CALL (this0) {
+                    WITH this0 AS this
+                    RETURN this.screenTimeMinutes / 60 AS c
+                  }
+                  WITH c AS this2
+                  RETURN this2 AS var3
                 }
-                RETURN { edges: var4 } AS var5
+                RETURN collect({properties: {screenTimeHours: var3, __resolveType: 'ActedIn'}, node: {name: this1.name, __resolveType: 'Actor'}}) AS var4
+              }
+              RETURN {edges: var4} AS var5
             }
             RETURN this { .title, actorsConnection: var5 } AS this"
         `);

--- a/packages/graphql/tests/tck/directives/interface-relationships/create/connect.test.ts
+++ b/packages/graphql/tests/tck/directives/interface-relationships/create/connect.test.ts
@@ -92,45 +92,42 @@ describe("Interface Relationships - Create connect", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                CREATE (this0:Actor)
-                SET
-                    this0.name = $param0
-                WITH *
-                CALL (this0) {
-                    MATCH (this1:Movie)
-                    WHERE this1.title STARTS WITH $param1
-                    CREATE (this0)-[this2:ACTED_IN]->(this1)
-                    SET
-                        this2.screenTime = $param2
-                }
-                WITH *
-                CALL (this0) {
-                    MATCH (this3:Series)
-                    WHERE this3.title STARTS WITH $param3
-                    CREATE (this0)-[this4:ACTED_IN]->(this3)
-                    SET
-                        this4.screenTime = $param4
-                }
-                RETURN this0 AS this
+              CREATE (this0:Actor)
+              SET this0.name = $param0
+              WITH *
+              CALL (this0) {
+                MATCH (this1:Movie)
+                WHERE this1.title STARTS WITH $param1
+                CREATE (this0)-[this2:ACTED_IN]->(this1)
+                SET this2.screenTime = $param2
+              }
+              WITH *
+              CALL (this0) {
+                MATCH (this3:Series)
+                WHERE this3.title STARTS WITH $param3
+                CREATE (this0)-[this4:ACTED_IN]->(this3)
+                SET this4.screenTime = $param4
+              }
+              RETURN this0 AS this
             }
             WITH this
             CALL (this) {
-                CALL (this) {
-                    CALL (*) {
-                        WITH *
-                        MATCH (this)-[this5:ACTED_IN]->(this6:Movie)
-                        WITH this6 { .title, .runtime, __resolveType: \\"Movie\\", __id: id(this6) } AS var7
-                        RETURN var7
-                        UNION
-                        WITH *
-                        MATCH (this)-[this8:ACTED_IN]->(this9:Series)
-                        WITH this9 { .title, .episodes, __resolveType: \\"Series\\", __id: id(this9) } AS var7
-                        RETURN var7
-                    }
-                    WITH var7
-                    RETURN collect(var7) AS var7
+              CALL (this) {
+                CALL (*) {
+                  WITH *
+                  MATCH (this)-[this5:ACTED_IN]->(this6:Movie)
+                  WITH this6 { .title, .runtime, __resolveType: 'Movie', __id: elementId(this6) } AS var7
+                  RETURN var7
+                  UNION
+                  WITH *
+                  MATCH (this)-[this8:ACTED_IN]->(this9:Series)
+                  WITH this9 { .title, .episodes, __resolveType: 'Series', __id: elementId(this9) } AS var7
+                  RETURN var7
                 }
-                RETURN this { .name, actedIn: var7 } AS var10
+                WITH var7
+                RETURN collect(var7) AS var7
+              }
+              RETURN this { .name, actedIn: var7 } AS var10
             }
             RETURN collect(var10) AS data"
         `);

--- a/packages/graphql/tests/tck/directives/interface-relationships/create/create.test.ts
+++ b/packages/graphql/tests/tck/directives/interface-relationships/create/create.test.ts
@@ -92,36 +92,35 @@ describe("Interface Relationships - Create create", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                CREATE (this0:Actor)
-                SET
-                    this0.name = $param0
-                WITH *
-                CREATE (this1:Movie)
-                MERGE (this0)-[this2:ACTED_IN]->(this1)
-                SET
-                    this1.title = $param1,
-                    this1.runtime = $param2,
-                    this2.screenTime = $param3
-                RETURN this0 AS this
+              CREATE (this0:Actor)
+              SET this0.name = $param0
+              WITH *
+              CREATE (this1:Movie)
+              MERGE (this0)-[this2:ACTED_IN]->(this1)
+              SET
+                this1.title = $param1,
+                this1.runtime = $param2,
+                this2.screenTime = $param3
+              RETURN this0 AS this
             }
             WITH this
             CALL (this) {
-                CALL (this) {
-                    CALL (*) {
-                        WITH *
-                        MATCH (this)-[this3:ACTED_IN]->(this4:Movie)
-                        WITH this4 { .title, .runtime, __resolveType: \\"Movie\\", __id: id(this4) } AS var5
-                        RETURN var5
-                        UNION
-                        WITH *
-                        MATCH (this)-[this6:ACTED_IN]->(this7:Series)
-                        WITH this7 { .title, .episodes, __resolveType: \\"Series\\", __id: id(this7) } AS var5
-                        RETURN var5
-                    }
-                    WITH var5
-                    RETURN collect(var5) AS var5
+              CALL (this) {
+                CALL (*) {
+                  WITH *
+                  MATCH (this)-[this3:ACTED_IN]->(this4:Movie)
+                  WITH this4 { .title, .runtime, __resolveType: 'Movie', __id: elementId(this4) } AS var5
+                  RETURN var5
+                  UNION
+                  WITH *
+                  MATCH (this)-[this6:ACTED_IN]->(this7:Series)
+                  WITH this7 { .title, .episodes, __resolveType: 'Series', __id: elementId(this7) } AS var5
+                  RETURN var5
                 }
-                RETURN this { .name, actedIn: var5 } AS var8
+                WITH var5
+                RETURN collect(var5) AS var5
+              }
+              RETURN this { .name, actedIn: var5 } AS var8
             }
             RETURN collect(var8) AS data"
         `);

--- a/packages/graphql/tests/tck/directives/interface-relationships/delete/delete.test.ts
+++ b/packages/graphql/tests/tck/directives/interface-relationships/delete/delete.test.ts
@@ -75,22 +75,22 @@ describe("Interface Relationships - Delete delete", () => {
             MATCH (this:Actor)
             WITH *
             CALL (*) {
-                OPTIONAL MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                WHERE this1.title STARTS WITH $param0
-                WITH this0, collect(DISTINCT this1) AS var2
-                CALL (var2) {
-                    UNWIND var2 AS var3
-                    DETACH DELETE var3
-                }
+              OPTIONAL MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+              WHERE this1.title STARTS WITH $param0
+              WITH this0, collect(DISTINCT this1) AS var2
+              CALL (var2) {
+                UNWIND var2 AS var3
+                DETACH DELETE var3
+              }
             }
             CALL (*) {
-                OPTIONAL MATCH (this)-[this4:ACTED_IN]->(this5:Series)
-                WHERE this5.title STARTS WITH $param1
-                WITH this4, collect(DISTINCT this5) AS var6
-                CALL (var6) {
-                    UNWIND var6 AS var7
-                    DETACH DELETE var7
-                }
+              OPTIONAL MATCH (this)-[this4:ACTED_IN]->(this5:Series)
+              WHERE this5.title STARTS WITH $param1
+              WITH this4, collect(DISTINCT this5) AS var6
+              CALL (var6) {
+                UNWIND var6 AS var7
+                DETACH DELETE var7
+              }
             }
             WITH *
             DETACH DELETE this"
@@ -128,42 +128,42 @@ describe("Interface Relationships - Delete delete", () => {
             MATCH (this:Actor)
             WITH *
             CALL (*) {
-                OPTIONAL MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                WHERE this1.title STARTS WITH $param0
-                WITH *
-                CALL (*) {
-                    OPTIONAL MATCH (this1)<-[this2:ACTED_IN]-(this3:Actor)
-                    WHERE this3.name = $param1
-                    WITH this2, collect(DISTINCT this3) AS var4
-                    CALL (var4) {
-                        UNWIND var4 AS var5
-                        DETACH DELETE var5
-                    }
+              OPTIONAL MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+              WHERE this1.title STARTS WITH $param0
+              WITH *
+              CALL (*) {
+                OPTIONAL MATCH (this1)<-[this2:ACTED_IN]-(this3:Actor)
+                WHERE this3.name = $param1
+                WITH this2, collect(DISTINCT this3) AS var4
+                CALL (var4) {
+                  UNWIND var4 AS var5
+                  DETACH DELETE var5
                 }
-                WITH this0, collect(DISTINCT this1) AS var6
-                CALL (var6) {
-                    UNWIND var6 AS var7
-                    DETACH DELETE var7
-                }
+              }
+              WITH this0, collect(DISTINCT this1) AS var6
+              CALL (var6) {
+                UNWIND var6 AS var7
+                DETACH DELETE var7
+              }
             }
             CALL (*) {
-                OPTIONAL MATCH (this)-[this8:ACTED_IN]->(this9:Series)
-                WHERE this9.title STARTS WITH $param2
-                WITH *
-                CALL (*) {
-                    OPTIONAL MATCH (this9)<-[this10:ACTED_IN]-(this11:Actor)
-                    WHERE this11.name = $param3
-                    WITH this10, collect(DISTINCT this11) AS var12
-                    CALL (var12) {
-                        UNWIND var12 AS var13
-                        DETACH DELETE var13
-                    }
+              OPTIONAL MATCH (this)-[this8:ACTED_IN]->(this9:Series)
+              WHERE this9.title STARTS WITH $param2
+              WITH *
+              CALL (*) {
+                OPTIONAL MATCH (this9)<-[this10:ACTED_IN]-(this11:Actor)
+                WHERE this11.name = $param3
+                WITH this10, collect(DISTINCT this11) AS var12
+                CALL (var12) {
+                  UNWIND var12 AS var13
+                  DETACH DELETE var13
                 }
-                WITH this8, collect(DISTINCT this9) AS var14
-                CALL (var14) {
-                    UNWIND var14 AS var15
-                    DETACH DELETE var15
-                }
+              }
+              WITH this8, collect(DISTINCT this9) AS var14
+              CALL (var14) {
+                UNWIND var14 AS var15
+                DETACH DELETE var15
+              }
             }
             WITH *
             DETACH DELETE this"

--- a/packages/graphql/tests/tck/directives/interface-relationships/read.test.ts
+++ b/packages/graphql/tests/tck/directives/interface-relationships/read.test.ts
@@ -78,19 +78,19 @@ describe("Interface Relationships", () => {
             "CYPHER 5
             MATCH (this:Actor)
             CALL (this) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                    WITH this1 { .title, .runtime, __resolveType: \\"Movie\\", __id: id(this1) } AS var2
-                    RETURN var2
-                    UNION
-                    WITH *
-                    MATCH (this)-[this3:ACTED_IN]->(this4:Series)
-                    WITH this4 { .title, .episodes, __resolveType: \\"Series\\", __id: id(this4) } AS var2
-                    RETURN var2
-                }
-                WITH var2
-                RETURN collect(var2) AS var2
+              CALL (*) {
+                WITH *
+                MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+                WITH this1 { .title, .runtime, __resolveType: 'Movie', __id: elementId(this1) } AS var2
+                RETURN var2
+                UNION
+                WITH *
+                MATCH (this)-[this3:ACTED_IN]->(this4:Series)
+                WITH this4 { .title, .episodes, __resolveType: 'Series', __id: elementId(this4) } AS var2
+                RETURN var2
+              }
+              WITH var2
+              RETURN collect(var2) AS var2
             }
             RETURN this { actedIn: var2 } AS this"
         `);
@@ -121,22 +121,22 @@ describe("Interface Relationships", () => {
             "CYPHER 5
             MATCH (this:Actor)
             CALL (this) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                    WITH this1 { .title, .runtime, __resolveType: \\"Movie\\", __id: id(this1) } AS var2
-                    RETURN var2
-                    UNION
-                    WITH *
-                    MATCH (this)-[this3:ACTED_IN]->(this4:Series)
-                    WITH this4 { .title, .episodes, __resolveType: \\"Series\\", __id: id(this4) } AS var2
-                    RETURN var2
-                }
-                WITH var2
-                ORDER BY var2.title DESC
-                SKIP $param0
-                LIMIT $param1
-                RETURN collect(var2) AS var2
+              CALL (*) {
+                WITH *
+                MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+                WITH this1 { .title, .runtime, __resolveType: 'Movie', __id: elementId(this1) } AS var2
+                RETURN var2
+                UNION
+                WITH *
+                MATCH (this)-[this3:ACTED_IN]->(this4:Series)
+                WITH this4 { .title, .episodes, __resolveType: 'Series', __id: elementId(this4) } AS var2
+                RETURN var2
+              }
+              WITH var2
+              ORDER BY var2.title DESC
+              SKIP $param0
+              LIMIT $param1
+              RETURN collect(var2) AS var2
             }
             RETURN this { actedIn: var2 } AS this"
         `);
@@ -185,23 +185,23 @@ describe("Interface Relationships", () => {
             "CYPHER 5
             MATCH (this:Actor)
             CALL (this) {
+              CALL (this) {
                 CALL (this) {
-                    CALL (this) {
-                        WITH this
-                        MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                        WITH { properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { __resolveType: \\"Movie\\", __id: id(this1), runtime: this1.runtime, title: this1.title } } AS edge
-                        RETURN edge
-                        UNION
-                        WITH this
-                        MATCH (this)-[this2:ACTED_IN]->(this3:Series)
-                        WITH { properties: { screenTime: this2.screenTime, __resolveType: \\"ActedIn\\" }, node: { __resolveType: \\"Series\\", __id: id(this3), episodes: this3.episodes, title: this3.title } } AS edge
-                        RETURN edge
-                    }
-                    RETURN collect(edge) AS edges
+                  WITH this
+                  MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+                  WITH {properties: {screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {__resolveType: 'Movie', __id: elementId(this1), runtime: this1.runtime, title: this1.title}} AS edge
+                  RETURN edge
+                  UNION
+                  WITH this
+                  MATCH (this)-[this2:ACTED_IN]->(this3:Series)
+                  WITH {properties: {screenTime: this2.screenTime, __resolveType: 'ActedIn'}, node: {__resolveType: 'Series', __id: elementId(this3), episodes: this3.episodes, title: this3.title}} AS edge
+                  RETURN edge
                 }
-                WITH edges
-                WITH edges, size(edges) AS totalCount
-                RETURN { edges: edges, totalCount: totalCount } AS var4
+                RETURN collect(edge) AS edges
+              }
+              WITH edges
+              WITH edges, size(edges) AS totalCount
+              RETURN {edges: edges, totalCount: totalCount} AS var4
             }
             RETURN this { actedInConnection: var4 } AS this"
         `);
@@ -241,25 +241,25 @@ describe("Interface Relationships", () => {
             "CYPHER 5
             MATCH (this:Actor)
             CALL (this) {
+              CALL (this) {
                 CALL (this) {
-                    CALL (this) {
-                        WITH this
-                        MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                        WHERE (this1.title STARTS WITH $param0 AND this0.screenTime > $param1)
-                        WITH { properties: { screenTime: this0.screenTime, __resolveType: \\"ActedIn\\" }, node: { __resolveType: \\"Movie\\", __id: id(this1), runtime: this1.runtime, title: this1.title } } AS edge
-                        RETURN edge
-                        UNION
-                        WITH this
-                        MATCH (this)-[this2:ACTED_IN]->(this3:Series)
-                        WHERE (this3.title STARTS WITH $param2 AND this2.screenTime > $param3)
-                        WITH { properties: { screenTime: this2.screenTime, __resolveType: \\"ActedIn\\" }, node: { __resolveType: \\"Series\\", __id: id(this3), episodes: this3.episodes, title: this3.title } } AS edge
-                        RETURN edge
-                    }
-                    RETURN collect(edge) AS edges
+                  WITH this
+                  MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+                  WHERE (this1.title STARTS WITH $param0 AND this0.screenTime > $param1)
+                  WITH {properties: {screenTime: this0.screenTime, __resolveType: 'ActedIn'}, node: {__resolveType: 'Movie', __id: elementId(this1), runtime: this1.runtime, title: this1.title}} AS edge
+                  RETURN edge
+                  UNION
+                  WITH this
+                  MATCH (this)-[this2:ACTED_IN]->(this3:Series)
+                  WHERE (this3.title STARTS WITH $param2 AND this2.screenTime > $param3)
+                  WITH {properties: {screenTime: this2.screenTime, __resolveType: 'ActedIn'}, node: {__resolveType: 'Series', __id: elementId(this3), episodes: this3.episodes, title: this3.title}} AS edge
+                  RETURN edge
                 }
-                WITH edges
-                WITH edges, size(edges) AS totalCount
-                RETURN { edges: edges, totalCount: totalCount } AS var4
+                RETURN collect(edge) AS edges
+              }
+              WITH edges
+              WITH edges, size(edges) AS totalCount
+              RETURN {edges: edges, totalCount: totalCount} AS var4
             }
             RETURN this { actedInConnection: var4 } AS this"
         `);

--- a/packages/graphql/tests/tck/directives/interface-relationships/update/connect.test.ts
+++ b/packages/graphql/tests/tck/directives/interface-relationships/update/connect.test.ts
@@ -83,20 +83,18 @@ describe("Interface Relationships - Update connect", () => {
             WITH *
             WITH *
             CALL (*) {
-                CALL (this) {
-                    MATCH (this0:Movie)
-                    WHERE this0.title STARTS WITH $param0
-                    CREATE (this)-[this1:ACTED_IN]->(this0)
-                    SET
-                        this1.screenTime = $param1
-                }
-                CALL (this) {
-                    MATCH (this2:Series)
-                    WHERE this2.title STARTS WITH $param2
-                    CREATE (this)-[this3:ACTED_IN]->(this2)
-                    SET
-                        this3.screenTime = $param3
-                }
+              CALL (this) {
+                MATCH (this0:Movie)
+                WHERE this0.title STARTS WITH $param0
+                CREATE (this)-[this1:ACTED_IN]->(this0)
+                SET this1.screenTime = $param1
+              }
+              CALL (this) {
+                MATCH (this2:Series)
+                WHERE this2.title STARTS WITH $param2
+                CREATE (this)-[this3:ACTED_IN]->(this2)
+                SET this3.screenTime = $param3
+              }
             }
             WITH this
             RETURN this { .name } AS this"
@@ -152,34 +150,30 @@ describe("Interface Relationships - Update connect", () => {
             WITH *
             WITH *
             CALL (*) {
-                CALL (this) {
-                    MATCH (this0:Movie)
-                    WHERE this0.title STARTS WITH $param0
-                    CALL (this0) {
-                        MATCH (this1:Actor)
-                        WHERE this1.name = $param1
-                        CREATE (this0)<-[this2:ACTED_IN]-(this1)
-                        SET
-                            this2.screenTime = $param2
-                    }
-                    CREATE (this)-[this3:ACTED_IN]->(this0)
-                    SET
-                        this3.screenTime = $param3
+              CALL (this) {
+                MATCH (this0:Movie)
+                WHERE this0.title STARTS WITH $param0
+                CALL (this0) {
+                  MATCH (this1:Actor)
+                  WHERE this1.name = $param1
+                  CREATE (this0)<-[this2:ACTED_IN]-(this1)
+                  SET this2.screenTime = $param2
                 }
-                CALL (this) {
-                    MATCH (this4:Series)
-                    WHERE this4.title STARTS WITH $param4
-                    CALL (this4) {
-                        MATCH (this5:Actor)
-                        WHERE this5.name = $param5
-                        CREATE (this4)<-[this6:ACTED_IN]-(this5)
-                        SET
-                            this6.screenTime = $param6
-                    }
-                    CREATE (this)-[this7:ACTED_IN]->(this4)
-                    SET
-                        this7.screenTime = $param7
+                CREATE (this)-[this3:ACTED_IN]->(this0)
+                SET this3.screenTime = $param3
+              }
+              CALL (this) {
+                MATCH (this4:Series)
+                WHERE this4.title STARTS WITH $param4
+                CALL (this4) {
+                  MATCH (this5:Actor)
+                  WHERE this5.name = $param5
+                  CREATE (this4)<-[this6:ACTED_IN]-(this5)
+                  SET this6.screenTime = $param6
                 }
+                CREATE (this)-[this7:ACTED_IN]->(this4)
+                SET this7.screenTime = $param7
+              }
             }
             WITH this
             RETURN this { .name } AS this"

--- a/packages/graphql/tests/tck/directives/interface-relationships/update/create.test.ts
+++ b/packages/graphql/tests/tck/directives/interface-relationships/update/create.test.ts
@@ -92,28 +92,28 @@ describe("Interface Relationships - Update create", () => {
             WITH *
             WITH *
             CALL (*) {
-                CREATE (this0:Movie)
-                MERGE (this)-[this1:ACTED_IN]->(this0)
-                SET
-                    this0.title = $param0,
-                    this0.runtime = $param1,
-                    this1.screenTime = $param2
+              CREATE (this0:Movie)
+              MERGE (this)-[this1:ACTED_IN]->(this0)
+              SET
+                this0.title = $param0,
+                this0.runtime = $param1,
+                this1.screenTime = $param2
             }
             WITH this
             CALL (this) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this)-[this2:ACTED_IN]->(this3:Movie)
-                    WITH this3 { .title, .runtime, __resolveType: \\"Movie\\", __id: id(this3) } AS var4
-                    RETURN var4
-                    UNION
-                    WITH *
-                    MATCH (this)-[this5:ACTED_IN]->(this6:Series)
-                    WITH this6 { .title, .episodes, __resolveType: \\"Series\\", __id: id(this6) } AS var4
-                    RETURN var4
-                }
-                WITH var4
-                RETURN collect(var4) AS var4
+              CALL (*) {
+                WITH *
+                MATCH (this)-[this2:ACTED_IN]->(this3:Movie)
+                WITH this3 { .title, .runtime, __resolveType: 'Movie', __id: elementId(this3) } AS var4
+                RETURN var4
+                UNION
+                WITH *
+                MATCH (this)-[this5:ACTED_IN]->(this6:Series)
+                WITH this6 { .title, .episodes, __resolveType: 'Series', __id: elementId(this6) } AS var4
+                RETURN var4
+              }
+              WITH var4
+              RETURN collect(var4) AS var4
             }
             RETURN this { .name, actedIn: var4 } AS this"
         `);

--- a/packages/graphql/tests/tck/directives/interface-relationships/update/delete.test.ts
+++ b/packages/graphql/tests/tck/directives/interface-relationships/update/delete.test.ts
@@ -77,23 +77,23 @@ describe("Interface Relationships - Update delete", () => {
             WITH *
             WITH *
             CALL (*) {
-                OPTIONAL MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                WHERE this1.title STARTS WITH $param0
-                WITH this0, collect(DISTINCT this1) AS var2
-                CALL (var2) {
-                    UNWIND var2 AS var3
-                    DETACH DELETE var3
-                }
+              OPTIONAL MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+              WHERE this1.title STARTS WITH $param0
+              WITH this0, collect(DISTINCT this1) AS var2
+              CALL (var2) {
+                UNWIND var2 AS var3
+                DETACH DELETE var3
+              }
             }
             WITH *
             CALL (*) {
-                OPTIONAL MATCH (this)-[this4:ACTED_IN]->(this5:Series)
-                WHERE this5.title STARTS WITH $param1
-                WITH this4, collect(DISTINCT this5) AS var6
-                CALL (var6) {
-                    UNWIND var6 AS var7
-                    DETACH DELETE var7
-                }
+              OPTIONAL MATCH (this)-[this4:ACTED_IN]->(this5:Series)
+              WHERE this5.title STARTS WITH $param1
+              WITH this4, collect(DISTINCT this5) AS var6
+              CALL (var6) {
+                UNWIND var6 AS var7
+                DETACH DELETE var7
+              }
             }
             WITH this
             RETURN this { .name } AS this"
@@ -135,43 +135,43 @@ describe("Interface Relationships - Update delete", () => {
             WITH *
             WITH *
             CALL (*) {
-                OPTIONAL MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                WHERE this1.title STARTS WITH $param0
-                WITH *
-                CALL (*) {
-                    OPTIONAL MATCH (this1)<-[this2:ACTED_IN]-(this3:Actor)
-                    WHERE this3.name = $param1
-                    WITH this2, collect(DISTINCT this3) AS var4
-                    CALL (var4) {
-                        UNWIND var4 AS var5
-                        DETACH DELETE var5
-                    }
+              OPTIONAL MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+              WHERE this1.title STARTS WITH $param0
+              WITH *
+              CALL (*) {
+                OPTIONAL MATCH (this1)<-[this2:ACTED_IN]-(this3:Actor)
+                WHERE this3.name = $param1
+                WITH this2, collect(DISTINCT this3) AS var4
+                CALL (var4) {
+                  UNWIND var4 AS var5
+                  DETACH DELETE var5
                 }
-                WITH this0, collect(DISTINCT this1) AS var6
-                CALL (var6) {
-                    UNWIND var6 AS var7
-                    DETACH DELETE var7
-                }
+              }
+              WITH this0, collect(DISTINCT this1) AS var6
+              CALL (var6) {
+                UNWIND var6 AS var7
+                DETACH DELETE var7
+              }
             }
             WITH *
             CALL (*) {
-                OPTIONAL MATCH (this)-[this8:ACTED_IN]->(this9:Series)
-                WHERE this9.title STARTS WITH $param2
-                WITH *
-                CALL (*) {
-                    OPTIONAL MATCH (this9)<-[this10:ACTED_IN]-(this11:Actor)
-                    WHERE this11.name = $param3
-                    WITH this10, collect(DISTINCT this11) AS var12
-                    CALL (var12) {
-                        UNWIND var12 AS var13
-                        DETACH DELETE var13
-                    }
+              OPTIONAL MATCH (this)-[this8:ACTED_IN]->(this9:Series)
+              WHERE this9.title STARTS WITH $param2
+              WITH *
+              CALL (*) {
+                OPTIONAL MATCH (this9)<-[this10:ACTED_IN]-(this11:Actor)
+                WHERE this11.name = $param3
+                WITH this10, collect(DISTINCT this11) AS var12
+                CALL (var12) {
+                  UNWIND var12 AS var13
+                  DETACH DELETE var13
                 }
-                WITH this8, collect(DISTINCT this9) AS var14
-                CALL (var14) {
-                    UNWIND var14 AS var15
-                    DETACH DELETE var15
-                }
+              }
+              WITH this8, collect(DISTINCT this9) AS var14
+              CALL (var14) {
+                UNWIND var14 AS var15
+                DETACH DELETE var15
+              }
             }
             WITH this
             RETURN this { .name } AS this"

--- a/packages/graphql/tests/tck/directives/interface-relationships/update/disconnect.test.ts
+++ b/packages/graphql/tests/tck/directives/interface-relationships/update/disconnect.test.ts
@@ -79,18 +79,18 @@ describe("Interface Relationships - Update disconnect", () => {
             WITH *
             WITH *
             CALL (*) {
-                CALL (this) {
-                    OPTIONAL MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                    WHERE this1.title STARTS WITH $param0
-                    WITH *
-                    DELETE this0
-                }
-                CALL (this) {
-                    OPTIONAL MATCH (this)-[this2:ACTED_IN]->(this3:Series)
-                    WHERE this3.title STARTS WITH $param1
-                    WITH *
-                    DELETE this2
-                }
+              CALL (this) {
+                OPTIONAL MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+                WHERE this1.title STARTS WITH $param0
+                WITH *
+                DELETE this0
+              }
+              CALL (this) {
+                OPTIONAL MATCH (this)-[this2:ACTED_IN]->(this3:Series)
+                WHERE this3.title STARTS WITH $param1
+                WITH *
+                DELETE this2
+              }
             }
             WITH this
             RETURN this { .name } AS this"
@@ -132,34 +132,34 @@ describe("Interface Relationships - Update disconnect", () => {
             WITH *
             WITH *
             CALL (*) {
-                CALL (this) {
-                    OPTIONAL MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                    WHERE this1.title STARTS WITH $param0
-                    CALL (this1) {
-                        CALL (this1) {
-                            OPTIONAL MATCH (this1)<-[this2:ACTED_IN]-(this3:Actor)
-                            WHERE this3.name = $param1
-                            WITH *
-                            DELETE this2
-                        }
-                    }
+              CALL (this) {
+                OPTIONAL MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+                WHERE this1.title STARTS WITH $param0
+                CALL (this1) {
+                  CALL (this1) {
+                    OPTIONAL MATCH (this1)<-[this2:ACTED_IN]-(this3:Actor)
+                    WHERE this3.name = $param1
                     WITH *
-                    DELETE this0
+                    DELETE this2
+                  }
                 }
-                CALL (this) {
-                    OPTIONAL MATCH (this)-[this4:ACTED_IN]->(this5:Series)
-                    WHERE this5.title STARTS WITH $param2
-                    CALL (this5) {
-                        CALL (this5) {
-                            OPTIONAL MATCH (this5)<-[this6:ACTED_IN]-(this7:Actor)
-                            WHERE this7.name = $param3
-                            WITH *
-                            DELETE this6
-                        }
-                    }
+                WITH *
+                DELETE this0
+              }
+              CALL (this) {
+                OPTIONAL MATCH (this)-[this4:ACTED_IN]->(this5:Series)
+                WHERE this5.title STARTS WITH $param2
+                CALL (this5) {
+                  CALL (this5) {
+                    OPTIONAL MATCH (this5)<-[this6:ACTED_IN]-(this7:Actor)
+                    WHERE this7.name = $param3
                     WITH *
-                    DELETE this4
+                    DELETE this6
+                  }
                 }
+                WITH *
+                DELETE this4
+              }
             }
             WITH this
             RETURN this { .name } AS this"

--- a/packages/graphql/tests/tck/directives/interface-relationships/update/update.test.ts
+++ b/packages/graphql/tests/tck/directives/interface-relationships/update/update.test.ts
@@ -86,19 +86,17 @@ describe("Interface Relationships - Update update", () => {
             WITH *
             WITH *
             CALL (*) {
-                MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                WITH *
-                WHERE this1.title = $param0
-                SET
-                    this1.title = $param1
+              MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+              WITH *
+              WHERE this1.title = $param0
+              SET this1.title = $param1
             }
             WITH *
             CALL (*) {
-                MATCH (this)-[this2:ACTED_IN]->(this3:Series)
-                WITH *
-                WHERE this3.title = $param2
-                SET
-                    this3.title = $param3
+              MATCH (this)-[this2:ACTED_IN]->(this3:Series)
+              WITH *
+              WHERE this3.title = $param2
+              SET this3.title = $param3
             }
             WITH this
             RETURN this { .name } AS this"
@@ -142,29 +140,27 @@ describe("Interface Relationships - Update update", () => {
             WITH *
             WITH *
             CALL (*) {
-                MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+              MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+              WITH *
+              WHERE this1.title = $param0
+              WITH *
+              CALL (*) {
+                MATCH (this1)<-[this2:ACTED_IN]-(this3:Actor)
                 WITH *
-                WHERE this1.title = $param0
-                WITH *
-                CALL (*) {
-                    MATCH (this1)<-[this2:ACTED_IN]-(this3:Actor)
-                    WITH *
-                    SET
-                        this3.name = $param1
-                }
+                SET this3.name = $param1
+              }
             }
             WITH *
             CALL (*) {
-                MATCH (this)-[this4:ACTED_IN]->(this5:Series)
+              MATCH (this)-[this4:ACTED_IN]->(this5:Series)
+              WITH *
+              WHERE this5.title = $param2
+              WITH *
+              CALL (*) {
+                MATCH (this5)<-[this6:ACTED_IN]-(this7:Actor)
                 WITH *
-                WHERE this5.title = $param2
-                WITH *
-                CALL (*) {
-                    MATCH (this5)<-[this6:ACTED_IN]-(this7:Actor)
-                    WITH *
-                    SET
-                        this7.name = $param3
-                }
+                SET this7.name = $param3
+              }
             }
             WITH this
             RETURN this { .name } AS this"

--- a/packages/graphql/tests/tck/directives/node/node-additional-labels.test.ts
+++ b/packages/graphql/tests/tck/directives/node/node-additional-labels.test.ts
@@ -56,7 +56,7 @@ describe("Node directive with additionalLabels", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
-            MATCH (this:Film:Multimedia)
+            MATCH (this:Film&Multimedia)
             RETURN this { .title } AS this"
         `);
 
@@ -79,12 +79,12 @@ describe("Node directive with additionalLabels", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
-            MATCH (this:Film:Multimedia)
+            MATCH (this:Film&Multimedia)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor:Person)
-                WITH DISTINCT this1
-                WITH this1 { .name } AS this1
-                RETURN collect(this1) AS var2
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor&Person)
+              WITH DISTINCT this1
+              WITH this1 { .name } AS this1
+              RETURN collect(this1) AS var2
             }
             RETURN this { .title, actors: var2 } AS this"
         `);
@@ -114,19 +114,17 @@ describe("Node directive with additionalLabels", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Film:Multimedia)
-                SET
-                    create_this1.id = create_var0.id
-                WITH create_this1, create_var0
-                CALL (create_this1, create_var0) {
-                    UNWIND create_var0.actors.create AS create_var2
-                    CREATE (create_this3:Actor:Person)
-                    SET
-                        create_this3.name = create_var2.node.name
-                    MERGE (create_this1)<-[create_this4:ACTED_IN]-(create_this3)
-                    RETURN collect(NULL) AS create_var5
-                }
-                RETURN create_this1
+              CREATE (create_this1:Film&Multimedia)
+              SET create_this1.id = create_var0.id
+              WITH create_this1, create_var0
+              CALL (create_this1, create_var0) {
+                UNWIND create_var0.actors.create AS create_var2
+                CREATE (create_this3:Actor&Person)
+                SET create_this3.name = create_var2.node.name
+                MERGE (create_this1)<-[create_this4:ACTED_IN]-(create_this3)
+                RETURN collect(NULL) AS create_var5
+              }
+              RETURN create_this1
             }
             RETURN collect(create_this1 { .id }) AS data"
         `);
@@ -176,7 +174,7 @@ describe("Node directive with additionalLabels", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
-            MATCH (this:Film:Multimedia)
+            MATCH (this:Film&Multimedia)
             WHERE this.id = $param0
             DETACH DELETE this"
         `);
@@ -203,11 +201,10 @@ describe("Node directive with additionalLabels", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
-            MATCH (this:Film:Multimedia)
+            MATCH (this:Film&Multimedia)
             WITH *
             WHERE this.id = $param0
-            SET
-                this.id = $param1
+            SET this.id = $param1
             WITH this
             RETURN this { .id } AS this"
         `);

--- a/packages/graphql/tests/tck/directives/node/node-label-interface.test.ts
+++ b/packages/graphql/tests/tck/directives/node/node-label-interface.test.ts
@@ -69,23 +69,23 @@ describe("Node directive with interface", () => {
             MATCH (this:Film)
             WHERE this.title = $param0
             CALL (this) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this)-[this0:SEARCH]->(this1:Category:ExtraLabel1:ExtraLabel2)
-                    WHERE this1.name = $param1
-                    WITH this1 { .name, __resolveType: \\"Genre\\", __id: id(this1) } AS var2
-                    RETURN var2
-                    UNION
-                    WITH *
-                    MATCH (this)-[this3:SEARCH]->(this4:Film)
-                    WHERE this4.name = $param2
-                    WITH this4 { .title, __resolveType: \\"Movie\\", __id: id(this4) } AS var2
-                    RETURN var2
-                }
-                WITH var2
-                SKIP $param3
-                LIMIT $param4
-                RETURN collect(var2) AS var2
+              CALL (*) {
+                WITH *
+                MATCH (this)-[this0:SEARCH]->(this1:Category&ExtraLabel1&ExtraLabel2)
+                WHERE this1.name = $param1
+                WITH this1 { .name, __resolveType: 'Genre', __id: elementId(this1) } AS var2
+                RETURN var2
+                UNION
+                WITH *
+                MATCH (this)-[this3:SEARCH]->(this4:Film)
+                WHERE this4.name = $param2
+                WITH this4 { .title, __resolveType: 'Movie', __id: elementId(this4) } AS var2
+                RETURN var2
+              }
+              WITH var2
+              SKIP $param3
+              LIMIT $param4
+              RETURN collect(var2) AS var2
             }
             RETURN this { search: var2 } AS this"
         `);

--- a/packages/graphql/tests/tck/directives/node/node-label-jwt.test.ts
+++ b/packages/graphql/tests/tck/directives/node/node-label-jwt.test.ts
@@ -85,14 +85,14 @@ describe("Label in Node directive", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
-            MATCH (this:Actor:Person)
+            MATCH (this:Actor&Person)
             WHERE this.age > $param0
             CALL (this) {
-                MATCH (this)-[this0:ACTED_IN]->(this1:Film)
-                WHERE this1.title = $param1
-                WITH DISTINCT this1
-                WITH this1 { .title } AS this1
-                RETURN collect(this1) AS var2
+              MATCH (this)-[this0:ACTED_IN]->(this1:Film)
+              WHERE this1.title = $param1
+              WITH DISTINCT this1
+              WITH this1 { .title } AS this1
+              RETURN collect(this1) AS var2
             }
             RETURN this { .name, movies: var2 } AS this"
         `);
@@ -126,10 +126,9 @@ describe("Label in Node directive", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Film)
-                SET
-                    create_this1.title = create_var0.title
-                RETURN create_this1
+              CREATE (create_this1:Film)
+              SET create_this1.title = create_var0.title
+              RETURN create_this1
             }
             RETURN collect(create_this1 { .title }) AS data"
         `);

--- a/packages/graphql/tests/tck/directives/node/node-label-union.test.ts
+++ b/packages/graphql/tests/tck/directives/node/node-label-union.test.ts
@@ -70,23 +70,23 @@ describe("Node directive with unions", () => {
             MATCH (this:Film)
             WHERE this.title = $param0
             CALL (this) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this)-[this0:SEARCH]->(this1:Category:ExtraLabel1:ExtraLabel2)
-                    WHERE this1.name = $param1
-                    WITH this1 { .name, __resolveType: \\"Genre\\", __id: id(this1) } AS var2
-                    RETURN var2
-                    UNION
-                    WITH *
-                    MATCH (this)-[this3:SEARCH]->(this4:Film)
-                    WHERE this4.title = $param2
-                    WITH this4 { .title, __resolveType: \\"Movie\\", __id: id(this4) } AS var2
-                    RETURN var2
-                }
-                WITH var2
-                SKIP $param3
-                LIMIT $param4
-                RETURN collect(var2) AS var2
+              CALL (*) {
+                WITH *
+                MATCH (this)-[this0:SEARCH]->(this1:Category&ExtraLabel1&ExtraLabel2)
+                WHERE this1.name = $param1
+                WITH this1 { .name, __resolveType: 'Genre', __id: elementId(this1) } AS var2
+                RETURN var2
+                UNION
+                WITH *
+                MATCH (this)-[this3:SEARCH]->(this4:Film)
+                WHERE this4.title = $param2
+                WITH this4 { .title, __resolveType: 'Movie', __id: elementId(this4) } AS var2
+                RETURN var2
+              }
+              WITH var2
+              SKIP $param3
+              LIMIT $param4
+              RETURN collect(var2) AS var2
             }
             RETURN this { search: var2 } AS this"
         `);

--- a/packages/graphql/tests/tck/directives/node/node-label.test.ts
+++ b/packages/graphql/tests/tck/directives/node/node-label.test.ts
@@ -81,10 +81,10 @@ describe("Label in Node directive", () => {
             "CYPHER 5
             MATCH (this:Film)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Person)
-                WITH DISTINCT this1
-                WITH this1 { .name } AS this1
-                RETURN collect(this1) AS var2
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Person)
+              WITH DISTINCT this1
+              WITH this1 { .name } AS this1
+              RETURN collect(this1) AS var2
             }
             RETURN this { .title, actors: var2 } AS this"
         `);
@@ -114,14 +114,14 @@ describe("Label in Node directive", () => {
             "CYPHER 5
             MATCH (this:Film)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Person)
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ node: { name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Person)
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({node: {name: this1.name, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);
@@ -146,10 +146,9 @@ describe("Label in Node directive", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Film)
-                SET
-                    create_this1.id = create_var0.id
-                RETURN create_this1
+              CREATE (create_this1:Film)
+              SET create_this1.id = create_var0.id
+              RETURN create_this1
             }
             RETURN collect(create_this1 { .id }) AS data"
         `);
@@ -187,19 +186,17 @@ describe("Label in Node directive", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Film)
-                SET
-                    create_this1.id = create_var0.id
-                WITH create_this1, create_var0
-                CALL (create_this1, create_var0) {
-                    UNWIND create_var0.actors.create AS create_var2
-                    CREATE (create_this3:Person)
-                    SET
-                        create_this3.name = create_var2.node.name
-                    MERGE (create_this1)<-[create_this4:ACTED_IN]-(create_this3)
-                    RETURN collect(NULL) AS create_var5
-                }
-                RETURN create_this1
+              CREATE (create_this1:Film)
+              SET create_this1.id = create_var0.id
+              WITH create_this1, create_var0
+              CALL (create_this1, create_var0) {
+                UNWIND create_var0.actors.create AS create_var2
+                CREATE (create_this3:Person)
+                SET create_this3.name = create_var2.node.name
+                MERGE (create_this1)<-[create_this4:ACTED_IN]-(create_this3)
+                RETURN collect(NULL) AS create_var5
+              }
+              RETURN create_this1
             }
             RETURN collect(create_this1 { .id }) AS data"
         `);
@@ -254,8 +251,7 @@ describe("Label in Node directive", () => {
             MATCH (this:Film)
             WITH *
             WHERE this.id = $param0
-            SET
-                this.id = $param1
+            SET this.id = $param1
             WITH this
             RETURN this { .id } AS this"
         `);
@@ -300,11 +296,10 @@ describe("Label in Node directive", () => {
             WHERE this.id = $param0
             WITH *
             CALL (*) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Person)
-                WITH *
-                WHERE this1.name = $param1
-                SET
-                    this1.name = $param2
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Person)
+              WITH *
+              WHERE this1.name = $param1
+              SET this1.name = $param2
             }
             WITH this
             RETURN this { .id } AS this"
@@ -342,11 +337,11 @@ describe("Label in Node directive", () => {
             WHERE this.id = $param0
             WITH *
             CALL (*) {
-                CALL (this) {
-                    MATCH (this0:Person)
-                    WHERE this0.name = $param1
-                    CREATE (this)<-[this1:ACTED_IN]-(this0)
-                }
+              CALL (this) {
+                MATCH (this0:Person)
+                WHERE this0.name = $param1
+                CREATE (this)<-[this1:ACTED_IN]-(this0)
+              }
             }
             WITH this
             RETURN this { .id } AS this"
@@ -383,12 +378,12 @@ describe("Label in Node directive", () => {
             WHERE this.id = $param0
             WITH *
             CALL (*) {
-                CALL (this) {
-                    OPTIONAL MATCH (this)<-[this0:ACTED_IN]-(this1:Person)
-                    WHERE this1.name = $param1
-                    WITH *
-                    DELETE this0
-                }
+              CALL (this) {
+                OPTIONAL MATCH (this)<-[this0:ACTED_IN]-(this1:Person)
+                WHERE this1.name = $param1
+                WITH *
+                DELETE this0
+              }
             }
             WITH this
             RETURN this { .id } AS this"
@@ -447,13 +442,13 @@ describe("Label in Node directive", () => {
             WHERE this.id = $param0
             WITH *
             CALL (*) {
-                OPTIONAL MATCH (this)<-[this0:ACTED_IN]-(this1:Person)
-                WHERE this1.name = $param1
-                WITH this0, collect(DISTINCT this1) AS var2
-                CALL (var2) {
-                    UNWIND var2 AS var3
-                    DETACH DELETE var3
-                }
+              OPTIONAL MATCH (this)<-[this0:ACTED_IN]-(this1:Person)
+              WHERE this1.name = $param1
+              WITH this0, collect(DISTINCT this1) AS var2
+              CALL (var2) {
+                UNWIND var2 AS var3
+                DETACH DELETE var3
+              }
             }
             WITH *
             DETACH DELETE this"
@@ -482,8 +477,8 @@ describe("Label in Node directive", () => {
             "CYPHER 5
             MATCH (this:Film)
             WHERE EXISTS {
-                MATCH (this)<-[:ACTED_IN]-(this0:Person)
-                WHERE this0.name = $param0
+              MATCH (this)<-[:ACTED_IN]-(this0:Person)
+              WHERE this0.name = $param0
             }
             DETACH DELETE this"
         `);

--- a/packages/graphql/tests/tck/directives/node/node-with-auth-projection.test.ts
+++ b/packages/graphql/tests/tck/directives/node/node-with-auth-projection.test.ts
@@ -77,20 +77,20 @@ describe("Cypher Auth Projection On Connections", () => {
             "CYPHER 5
             MATCH (this:Person)
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
             CALL (this) {
-                MATCH (this)-[this0:HAS_POST]->(this1:Comment)
-                CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                    MATCH (this1)<-[:HAS_POST]-(this2:Person)
-                    WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
-                }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ node: { content: this1.content, __resolveType: \\"Post\\" } }) AS var3
-                }
-                RETURN { edges: var3 } AS var4
+              MATCH (this)-[this0:HAS_POST]->(this1:Comment)
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
+                MATCH (this1)<-[:HAS_POST]-(this2:Person)
+                WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
+              }), '@neo4j/graphql/FORBIDDEN', [])
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({node: {content: this1.content, __resolveType: 'Post'}}) AS var3
+              }
+              RETURN {edges: var3} AS var4
             }
             RETURN this { .name, postsConnection: var4 } AS this"
         `);

--- a/packages/graphql/tests/tck/directives/node/node-with-auth.test.ts
+++ b/packages/graphql/tests/tck/directives/node/node-with-auth.test.ts
@@ -83,7 +83,7 @@ describe("Node Directive", () => {
             "CYPHER 5
             MATCH (this:Person)
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
             RETURN this { .id } AS this"
         `);
 
@@ -116,10 +116,10 @@ describe("Node Directive", () => {
             "CYPHER 5
             MATCH (this:Comment)
             WHERE EXISTS {
-                MATCH (this)<-[:HAS_POST]-(this0:Person)
-                WHERE this0.id = $param0
+              MATCH (this)<-[:HAS_POST]-(this0:Person)
+              WHERE this0.id = $param0
             }
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
             WITH *
             DETACH DELETE this"
         `);

--- a/packages/graphql/tests/tck/directives/plural.test.ts
+++ b/packages/graphql/tests/tck/directives/plural.test.ts
@@ -74,10 +74,10 @@ describe("Plural directive", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (this:Tech)
-                RETURN { nodes: count(DISTINCT this) } AS var0
+              MATCH (this:Tech)
+              RETURN {nodes: count(DISTINCT this)} AS var0
             }
-            RETURN { aggregate: { count: var0 } } AS this"
+            RETURN {aggregate: {count: var0}} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -100,10 +100,9 @@ describe("Plural directive", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Tech)
-                SET
-                    create_this1.name = create_var0.name
-                RETURN create_this1
+              CREATE (create_this1:Tech)
+              SET create_this1.name = create_var0.name
+              RETURN create_this1
             }
             RETURN collect(create_this1 { .name }) AS data"
         `);
@@ -136,8 +135,7 @@ describe("Plural directive", () => {
             "CYPHER 5
             MATCH (this:Tech)
             WITH *
-            SET
-                this.name = $param0
+            SET this.name = $param0
             WITH this
             RETURN this { .name } AS this"
         `);

--- a/packages/graphql/tests/tck/directives/relationship.test.ts
+++ b/packages/graphql/tests/tck/directives/relationship.test.ts
@@ -67,10 +67,10 @@ describe("Cypher relationship", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WITH DISTINCT this1
-                WITH this1 { .name } AS this1
-                RETURN collect(this1) AS var2
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WITH DISTINCT this1
+              WITH this1 { .name } AS this1
+              RETURN collect(this1) AS var2
             }
             RETURN this { .title, actors: var2 } AS this"
         `);

--- a/packages/graphql/tests/tck/directives/vector/auth.test.ts
+++ b/packages/graphql/tests/tck/directives/vector/auth.test.ts
@@ -86,18 +86,18 @@ describe("Cypher -> vector -> Auth", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
-            CALL db.index.vector.queryNodes(\\"movie_index\\", 4, $param0) YIELD node AS this0, score AS var1
+            CALL db.index.vector.queryNodes('movie_index', 4, $param0) YIELD node AS this0, score AS var1
             WHERE ($param1 IN labels(this0) AND ($isAuthenticated = true AND EXISTS {
-                MATCH (this0)<-[:DIRECTED]-(this2:Person)
-                WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
+              MATCH (this0)<-[:DIRECTED]-(this2:Person)
+              WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
             }))
-            WITH collect({ node: this0 }) AS edges
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var3
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              RETURN collect({node: {title: this0.title, __resolveType: 'Movie'}}) AS var3
             }
-            RETURN { edges: var3 } AS this"
+            RETURN {edges: var3} AS this"
         `);
 
         expect(result.params).toMatchInlineSnapshot(`
@@ -284,19 +284,19 @@ describe("Cypher -> vector -> Auth", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
-            CALL db.index.vector.queryNodes(\\"movie_index\\", 4, $param0) YIELD node AS this0, score AS var1
+            CALL db.index.vector.queryNodes('movie_index', 4, $param0) YIELD node AS this0, score AS var1
             WHERE $param1 IN labels(this0)
             CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                MATCH (this0)<-[:DIRECTED]-(this2:Person)
-                WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
-            }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            WITH collect({ node: this0 }) AS edges
+              MATCH (this0)<-[:DIRECTED]-(this2:Person)
+              WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
+            }), '@neo4j/graphql/FORBIDDEN', [])
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var3
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              RETURN collect({node: {title: this0.title, __resolveType: 'Movie'}}) AS var3
             }
-            RETURN { edges: var3 } AS this"
+            RETURN {edges: var3} AS this"
         `);
 
         expect(result.params).toMatchInlineSnapshot(`
@@ -485,22 +485,22 @@ describe("Cypher -> vector -> Auth", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
-            CALL db.index.vector.queryNodes(\\"movie_index\\", 4, $param0) YIELD node AS this0, score AS var1
+            CALL db.index.vector.queryNodes('movie_index', 4, $param0) YIELD node AS this0, score AS var1
             WHERE $param1 IN labels(this0)
             CALL apoc.util.validate(NOT ($isAuthenticated = true AND (EXISTS {
-                MATCH (this0)<-[:DIRECTED]-(this2:Person)
-                WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
+              MATCH (this0)<-[:DIRECTED]-(this2:Person)
+              WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
             } AND NOT (EXISTS {
-                MATCH (this0)<-[:DIRECTED]-(this2:Person)
-                WHERE NOT ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
-            }))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            WITH collect({ node: this0 }) AS edges
+              MATCH (this0)<-[:DIRECTED]-(this2:Person)
+              WHERE NOT ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
+            }))), '@neo4j/graphql/FORBIDDEN', [])
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var3
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              RETURN collect({node: {title: this0.title, __resolveType: 'Movie'}}) AS var3
             }
-            RETURN { edges: var3 } AS this"
+            RETURN {edges: var3} AS this"
         `);
 
         expect(result.params).toMatchInlineSnapshot(`
@@ -691,19 +691,19 @@ describe("Cypher -> vector -> Auth", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
-            CALL db.index.vector.queryNodes(\\"movie_index\\", 4, $param0) YIELD node AS this0, score AS var1
+            CALL db.index.vector.queryNodes('movie_index', 4, $param0) YIELD node AS this0, score AS var1
             WHERE $param1 IN labels(this0)
             CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                MATCH (this0)<-[this2:DIRECTED]-(this3:Person)
-                WHERE ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
-            }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            WITH collect({ node: this0 }) AS edges
+              MATCH (this0)<-[this2:DIRECTED]-(this3:Person)
+              WHERE ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
+            }), '@neo4j/graphql/FORBIDDEN', [])
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var4
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              RETURN collect({node: {title: this0.title, __resolveType: 'Movie'}}) AS var4
             }
-            RETURN { edges: var4 } AS this"
+            RETURN {edges: var4} AS this"
         `);
 
         expect(result.params).toMatchInlineSnapshot(`
@@ -897,22 +897,22 @@ describe("Cypher -> vector -> Auth", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
-            CALL db.index.vector.queryNodes(\\"movie_index\\", 4, $param0) YIELD node AS this0, score AS var1
+            CALL db.index.vector.queryNodes('movie_index', 4, $param0) YIELD node AS this0, score AS var1
             WHERE $param1 IN labels(this0)
             CALL apoc.util.validate(NOT ($isAuthenticated = true AND (EXISTS {
-                MATCH (this0)<-[this2:DIRECTED]-(this3:Person)
-                WHERE ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
+              MATCH (this0)<-[this2:DIRECTED]-(this3:Person)
+              WHERE ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
             } AND NOT (EXISTS {
-                MATCH (this0)<-[this2:DIRECTED]-(this3:Person)
-                WHERE NOT ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
-            }))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            WITH collect({ node: this0 }) AS edges
+              MATCH (this0)<-[this2:DIRECTED]-(this3:Person)
+              WHERE NOT ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
+            }))), '@neo4j/graphql/FORBIDDEN', [])
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var4
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              RETURN collect({node: {title: this0.title, __resolveType: 'Movie'}}) AS var4
             }
-            RETURN { edges: var4 } AS this"
+            RETURN {edges: var4} AS this"
         `);
 
         expect(result.params).toMatchInlineSnapshot(`
@@ -1107,19 +1107,19 @@ describe("Cypher -> vector -> Auth", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
-            CALL db.index.vector.queryNodes(\\"movie_index\\", 4, $param0) YIELD node AS this0, score AS var1
+            CALL db.index.vector.queryNodes('movie_index', 4, $param0) YIELD node AS this0, score AS var1
             WHERE $param1 IN labels(this0)
             CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                MATCH (this0)<-[this2:DIRECTED]-(this3:Person)
-                WHERE ($param3 IS NOT NULL AND this2.year = $param3)
-            }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            WITH collect({ node: this0 }) AS edges
+              MATCH (this0)<-[this2:DIRECTED]-(this3:Person)
+              WHERE ($param3 IS NOT NULL AND this2.year = $param3)
+            }), '@neo4j/graphql/FORBIDDEN', [])
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var4
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              RETURN collect({node: {title: this0.title, __resolveType: 'Movie'}}) AS var4
             }
-            RETURN { edges: var4 } AS this"
+            RETURN {edges: var4} AS this"
         `);
 
         expect(result.params).toMatchInlineSnapshot(`
@@ -1311,22 +1311,22 @@ describe("Cypher -> vector -> Auth", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
-            CALL db.index.vector.queryNodes(\\"movie_index\\", 4, $param0) YIELD node AS this0, score AS var1
+            CALL db.index.vector.queryNodes('movie_index', 4, $param0) YIELD node AS this0, score AS var1
             WHERE $param1 IN labels(this0)
             CALL apoc.util.validate(NOT ($isAuthenticated = true AND (EXISTS {
-                MATCH (this0)<-[this2:DIRECTED]-(this3:Person)
-                WHERE ($param3 IS NOT NULL AND this2.year = $param3)
+              MATCH (this0)<-[this2:DIRECTED]-(this3:Person)
+              WHERE ($param3 IS NOT NULL AND this2.year = $param3)
             } AND NOT (EXISTS {
-                MATCH (this0)<-[this2:DIRECTED]-(this3:Person)
-                WHERE NOT ($param3 IS NOT NULL AND this2.year = $param3)
-            }))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            WITH collect({ node: this0 }) AS edges
+              MATCH (this0)<-[this2:DIRECTED]-(this3:Person)
+              WHERE NOT ($param3 IS NOT NULL AND this2.year = $param3)
+            }))), '@neo4j/graphql/FORBIDDEN', [])
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var4
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              RETURN collect({node: {title: this0.title, __resolveType: 'Movie'}}) AS var4
             }
-            RETURN { edges: var4 } AS this"
+            RETURN {edges: var4} AS this"
         `);
 
         expect(result.params).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/directives/vector/match.test.ts
+++ b/packages/graphql/tests/tck/directives/vector/match.test.ts
@@ -76,16 +76,16 @@ describe("Vector index match", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
-            CALL db.index.vector.queryNodes(\\"movie_index\\", 4, $param0) YIELD node AS this0, score AS var1
+            CALL db.index.vector.queryNodes('movie_index', 4, $param0) YIELD node AS this0, score AS var1
             WHERE $param1 IN labels(this0)
-            WITH collect({ node: this0, score: var1 }) AS edges
+            WITH collect({node: this0, score: var1}) AS edges
             WITH edges, size(edges) AS totalCount
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0, edge.score AS var1
-                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" }, score: var1 }) AS var2
+              UNWIND edges AS edge
+              WITH edge.node AS this0, edge.score AS var1
+              RETURN collect({node: {title: this0.title, __resolveType: 'Movie'}, score: var1}) AS var2
             }
-            RETURN { edges: var2 } AS this"
+            RETURN {edges: var2} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -249,16 +249,16 @@ describe("Vector index match", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
-            CALL db.index.vector.queryNodes(\\"movie_index\\", 4, $param0) YIELD node AS this0, score AS var1
+            CALL db.index.vector.queryNodes('movie_index', 4, $param0) YIELD node AS this0, score AS var1
             WHERE ($param1 IN labels(this0) AND this0.released > $param2)
-            WITH collect({ node: this0, score: var1 }) AS edges
+            WITH collect({node: this0, score: var1}) AS edges
             WITH edges, size(edges) AS totalCount
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0, edge.score AS var1
-                RETURN collect({ node: { title: this0.title, released: this0.released, __resolveType: \\"Movie\\" }, score: var1 }) AS var2
+              UNWIND edges AS edge
+              WITH edge.node AS this0, edge.score AS var1
+              RETURN collect({node: {title: this0.title, released: this0.released, __resolveType: 'Movie'}, score: var1}) AS var2
             }
-            RETURN { edges: var2 } AS this"
+            RETURN {edges: var2} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -424,18 +424,18 @@ describe("Vector index match", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
-            CALL db.index.vector.queryNodes(\\"movie_index\\", 4, $param0) YIELD node AS this0, score AS var1
+            CALL db.index.vector.queryNodes('movie_index', 4, $param0) YIELD node AS this0, score AS var1
             WHERE $param1 IN labels(this0)
-            WITH collect({ node: this0, score: var1 }) AS edges
+            WITH collect({node: this0, score: var1}) AS edges
             WITH edges, size(edges) AS totalCount
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0, edge.score AS var1
-                WITH *
-                ORDER BY this0.title DESC
-                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" }, score: var1 }) AS var2
+              UNWIND edges AS edge
+              WITH edge.node AS this0, edge.score AS var1
+              WITH *
+              ORDER BY this0.title DESC
+              RETURN collect({node: {title: this0.title, __resolveType: 'Movie'}, score: var1}) AS var2
             }
-            RETURN { edges: var2 } AS this"
+            RETURN {edges: var2} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/directives/vector/phrase.test.ts
+++ b/packages/graphql/tests/tck/directives/vector/phrase.test.ts
@@ -86,17 +86,17 @@ describe("phrase input - genAI plugin", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
-            WITH genai.vector.encode($param0, \\"OpenAI\\", { token: \\"my-token\\", model: \\"my-model\\", dimensions: 256 }) AS var0
-            CALL db.index.vector.queryNodes(\\"movie_index\\", 4, var0) YIELD node AS this1, score AS var2
+            WITH genai.vector.encode($param0, 'OpenAI', {token: 'my-token', model: 'my-model', dimensions: 256}) AS var0
+            CALL db.index.vector.queryNodes('movie_index', 4, var0) YIELD node AS this1, score AS var2
             WHERE $param1 IN labels(this1)
-            WITH collect({ node: this1, score: var2 }) AS edges
+            WITH collect({node: this1, score: var2}) AS edges
             WITH edges, size(edges) AS totalCount
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this1, edge.score AS var2
-                RETURN collect({ node: { title: this1.title, __resolveType: \\"Movie\\" }, score: var2 }) AS var3
+              UNWIND edges AS edge
+              WITH edge.node AS this1, edge.score AS var2
+              RETURN collect({node: {title: this1.title, __resolveType: 'Movie'}, score: var2}) AS var3
             }
-            RETURN { edges: var3 } AS this"
+            RETURN {edges: var3} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/directives/vector/score.test.ts
+++ b/packages/graphql/tests/tck/directives/vector/score.test.ts
@@ -74,16 +74,16 @@ describe("Cypher -> vector -> Score", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
-            CALL db.index.vector.queryNodes(\\"movie_index\\", 4, $param0) YIELD node AS this0, score AS var1
+            CALL db.index.vector.queryNodes('movie_index', 4, $param0) YIELD node AS this0, score AS var1
             WHERE ($param1 IN labels(this0) AND var1 >= $param2)
-            WITH collect({ node: this0, score: var1 }) AS edges
+            WITH collect({node: this0, score: var1}) AS edges
             WITH edges, size(edges) AS totalCount
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0, edge.score AS var1
-                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" }, score: var1 }) AS var2
+              UNWIND edges AS edge
+              WITH edge.node AS this0, edge.score AS var1
+              RETURN collect({node: {title: this0.title, __resolveType: 'Movie'}, score: var1}) AS var2
             }
-            RETURN { edges: var2 } AS this"
+            RETURN {edges: var2} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -246,18 +246,18 @@ describe("Cypher -> vector -> Score", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
-            CALL db.index.vector.queryNodes(\\"movie_index\\", 4, $param0) YIELD node AS this0, score AS var1
+            CALL db.index.vector.queryNodes('movie_index', 4, $param0) YIELD node AS this0, score AS var1
             WHERE $param1 IN labels(this0)
-            WITH collect({ node: this0, score: var1 }) AS edges
+            WITH collect({node: this0, score: var1}) AS edges
             WITH edges, size(edges) AS totalCount
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0, edge.score AS var1
-                WITH *
-                ORDER BY var1 ASC
-                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" }, score: var1 }) AS var2
+              UNWIND edges AS edge
+              WITH edge.node AS this0, edge.score AS var1
+              WITH *
+              ORDER BY var1 ASC
+              RETURN collect({node: {title: this0.title, __resolveType: 'Movie'}, score: var1}) AS var2
             }
-            RETURN { edges: var2 } AS this"
+            RETURN {edges: var2} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -419,18 +419,18 @@ describe("Cypher -> vector -> Score", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
-            CALL db.index.vector.queryNodes(\\"movie_index\\", 4, $param0) YIELD node AS this0, score AS var1
+            CALL db.index.vector.queryNodes('movie_index', 4, $param0) YIELD node AS this0, score AS var1
             WHERE $param1 IN labels(this0)
-            WITH collect({ node: this0, score: var1 }) AS edges
+            WITH collect({node: this0, score: var1}) AS edges
             WITH edges, size(edges) AS totalCount
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0, edge.score AS var1
-                WITH *
-                ORDER BY var1 ASC, this0.title DESC
-                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" }, score: var1 }) AS var2
+              UNWIND edges AS edge
+              WITH edge.node AS this0, edge.score AS var1
+              WITH *
+              ORDER BY var1 ASC, this0.title DESC
+              RETURN collect({node: {title: this0.title, __resolveType: 'Movie'}, score: var1}) AS var2
             }
-            RETURN { edges: var2 } AS this"
+            RETURN {edges: var2} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/disable-escaping.test.ts
+++ b/packages/graphql/tests/tck/disable-escaping.test.ts
@@ -62,10 +62,10 @@ describe("Disable escaping", () => {
             "CYPHER 5
             MATCH (this:\`Movie:Film\`)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN|PATICIPATED]-(this1:Actor)
-                WITH DISTINCT this1
-                WITH this1 { .name } AS this1
-                RETURN collect(this1) AS var2
+              MATCH (this)<-[this0:ACTED_IN|PATICIPATED]-(this1:Actor)
+              WITH DISTINCT this1
+              WITH this1 { .name } AS this1
+              RETURN collect(this1) AS var2
             }
             RETURN this { actors: var2 } AS this"
         `);
@@ -98,10 +98,10 @@ describe("Disable escaping", () => {
             "CYPHER 5
             MATCH (this:Movie:Film)
             CALL (this) {
-                MATCH (this)<-[this0:\`ACTED_IN|PATICIPATED\`]-(this1:Actor)
-                WITH DISTINCT this1
-                WITH this1 { .name } AS this1
-                RETURN collect(this1) AS var2
+              MATCH (this)<-[this0:\`ACTED_IN|PATICIPATED\`]-(this1:Actor)
+              WITH DISTINCT this1
+              WITH this1 { .name } AS this1
+              RETURN collect(this1) AS var2
             }
             RETURN this { actors: var2 } AS this"
         `);

--- a/packages/graphql/tests/tck/federation/authorization.test.ts
+++ b/packages/graphql/tests/tck/federation/authorization.test.ts
@@ -204,8 +204,8 @@ describe("Federation and authorization", () => {
             "CYPHER 5
             MATCH (this:Post)
             CALL (this) {
-                MATCH (this)<-[this0:AUTHORED]-(this1:User)
-                RETURN count(this1) > $param0 AS var2
+              MATCH (this)<-[this0:AUTHORED]-(this1:User)
+              RETURN count(this1) > $param0 AS var2
             }
             WITH *
             WHERE (this.id = $param1 AND ($isAuthenticated = true AND var2 = true))

--- a/packages/graphql/tests/tck/fragments.test.ts
+++ b/packages/graphql/tests/tck/fragments.test.ts
@@ -105,19 +105,19 @@ describe("Cypher Fragment", () => {
             "CYPHER 5
             MATCH (this:User)
             CALL (this) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this)-[this0:OWNS]->(this1:Tile)
-                    WITH this1 { .id, __resolveType: \\"Tile\\", __id: id(this1) } AS var2
-                    RETURN var2
-                    UNION
-                    WITH *
-                    MATCH (this)-[this3:OWNS]->(this4:Character)
-                    WITH this4 { .id, __resolveType: \\"Character\\", __id: id(this4) } AS var2
-                    RETURN var2
-                }
-                WITH var2
-                RETURN collect(var2) AS var2
+              CALL (*) {
+                WITH *
+                MATCH (this)-[this0:OWNS]->(this1:Tile)
+                WITH this1 { .id, __resolveType: 'Tile', __id: elementId(this1) } AS var2
+                RETURN var2
+                UNION
+                WITH *
+                MATCH (this)-[this3:OWNS]->(this4:Character)
+                WITH this4 { .id, __resolveType: 'Character', __id: elementId(this4) } AS var2
+                RETURN var2
+              }
+              WITH var2
+              RETURN collect(var2) AS var2
             }
             RETURN this { .id, owns: var2 } AS this"
         `);
@@ -215,19 +215,19 @@ describe("Cypher Fragment", () => {
             MATCH (this:Actor)
             WHERE this.name = $param0
             CALL (this) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                    WITH this1 { .runtime, .title, __resolveType: \\"Movie\\", __id: id(this1) } AS var2
-                    RETURN var2
-                    UNION
-                    WITH *
-                    MATCH (this)-[this3:ACTED_IN]->(this4:Series)
-                    WITH this4 { .runtime, .title, __resolveType: \\"Series\\", __id: id(this4) } AS var2
-                    RETURN var2
-                }
-                WITH var2
-                RETURN collect(var2) AS var2
+              CALL (*) {
+                WITH *
+                MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+                WITH this1 { .runtime, .title, __resolveType: 'Movie', __id: elementId(this1) } AS var2
+                RETURN var2
+                UNION
+                WITH *
+                MATCH (this)-[this3:ACTED_IN]->(this4:Series)
+                WITH this4 { .runtime, .title, __resolveType: 'Series', __id: elementId(this4) } AS var2
+                RETURN var2
+              }
+              WITH var2
+              RETURN collect(var2) AS var2
             }
             RETURN this { .name, actedIn: var2 } AS this"
         `);

--- a/packages/graphql/tests/tck/fulltext/auth.test.ts
+++ b/packages/graphql/tests/tck/fulltext/auth.test.ts
@@ -79,18 +79,18 @@ describe("Cypher -> fulltext -> Auth", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
-            CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
+            CALL db.index.fulltext.queryNodes('MovieTitle', $param0) YIELD node AS this0, score AS var1
             WHERE ($param1 IN labels(this0) AND ($isAuthenticated = true AND EXISTS {
-                MATCH (this0)<-[:DIRECTED]-(this2:Person)
-                WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
+              MATCH (this0)<-[:DIRECTED]-(this2:Person)
+              WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
             }))
-            WITH collect({ node: this0 }) AS edges
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var3
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              RETURN collect({node: {title: this0.title, __resolveType: 'Movie'}}) AS var3
             }
-            RETURN { edges: var3 } AS this"
+            RETURN {edges: var3} AS this"
         `);
 
         expect(result.params).toMatchInlineSnapshot(`
@@ -150,19 +150,19 @@ describe("Cypher -> fulltext -> Auth", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
-            CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
+            CALL db.index.fulltext.queryNodes('MovieTitle', $param0) YIELD node AS this0, score AS var1
             WHERE $param1 IN labels(this0)
             CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                MATCH (this0)<-[:DIRECTED]-(this2:Person)
-                WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
-            }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            WITH collect({ node: this0 }) AS edges
+              MATCH (this0)<-[:DIRECTED]-(this2:Person)
+              WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
+            }), '@neo4j/graphql/FORBIDDEN', [])
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var3
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              RETURN collect({node: {title: this0.title, __resolveType: 'Movie'}}) AS var3
             }
-            RETURN { edges: var3 } AS this"
+            RETURN {edges: var3} AS this"
         `);
 
         expect(result.params).toMatchInlineSnapshot(`
@@ -222,22 +222,22 @@ describe("Cypher -> fulltext -> Auth", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
-            CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
+            CALL db.index.fulltext.queryNodes('MovieTitle', $param0) YIELD node AS this0, score AS var1
             WHERE $param1 IN labels(this0)
             CALL apoc.util.validate(NOT ($isAuthenticated = true AND (EXISTS {
-                MATCH (this0)<-[:DIRECTED]-(this2:Person)
-                WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
+              MATCH (this0)<-[:DIRECTED]-(this2:Person)
+              WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
             } AND NOT (EXISTS {
-                MATCH (this0)<-[:DIRECTED]-(this2:Person)
-                WHERE NOT ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
-            }))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            WITH collect({ node: this0 }) AS edges
+              MATCH (this0)<-[:DIRECTED]-(this2:Person)
+              WHERE NOT ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
+            }))), '@neo4j/graphql/FORBIDDEN', [])
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var3
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              RETURN collect({node: {title: this0.title, __resolveType: 'Movie'}}) AS var3
             }
-            RETURN { edges: var3 } AS this"
+            RETURN {edges: var3} AS this"
         `);
 
         expect(result.params).toMatchInlineSnapshot(`
@@ -302,19 +302,19 @@ describe("Cypher -> fulltext -> Auth", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
-            CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
+            CALL db.index.fulltext.queryNodes('MovieTitle', $param0) YIELD node AS this0, score AS var1
             WHERE $param1 IN labels(this0)
             CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                MATCH (this0)<-[this2:DIRECTED]-(this3:Person)
-                WHERE ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
-            }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            WITH collect({ node: this0 }) AS edges
+              MATCH (this0)<-[this2:DIRECTED]-(this3:Person)
+              WHERE ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
+            }), '@neo4j/graphql/FORBIDDEN', [])
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var4
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              RETURN collect({node: {title: this0.title, __resolveType: 'Movie'}}) AS var4
             }
-            RETURN { edges: var4 } AS this"
+            RETURN {edges: var4} AS this"
         `);
 
         expect(result.params).toMatchInlineSnapshot(`
@@ -379,22 +379,22 @@ describe("Cypher -> fulltext -> Auth", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
-            CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
+            CALL db.index.fulltext.queryNodes('MovieTitle', $param0) YIELD node AS this0, score AS var1
             WHERE $param1 IN labels(this0)
             CALL apoc.util.validate(NOT ($isAuthenticated = true AND (EXISTS {
-                MATCH (this0)<-[this2:DIRECTED]-(this3:Person)
-                WHERE ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
+              MATCH (this0)<-[this2:DIRECTED]-(this3:Person)
+              WHERE ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
             } AND NOT (EXISTS {
-                MATCH (this0)<-[this2:DIRECTED]-(this3:Person)
-                WHERE NOT ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
-            }))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            WITH collect({ node: this0 }) AS edges
+              MATCH (this0)<-[this2:DIRECTED]-(this3:Person)
+              WHERE NOT ($jwt.sub IS NOT NULL AND this3.id = $jwt.sub)
+            }))), '@neo4j/graphql/FORBIDDEN', [])
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var4
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              RETURN collect({node: {title: this0.title, __resolveType: 'Movie'}}) AS var4
             }
-            RETURN { edges: var4 } AS this"
+            RETURN {edges: var4} AS this"
         `);
 
         expect(result.params).toMatchInlineSnapshot(`
@@ -463,19 +463,19 @@ describe("Cypher -> fulltext -> Auth", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
-            CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
+            CALL db.index.fulltext.queryNodes('MovieTitle', $param0) YIELD node AS this0, score AS var1
             WHERE $param1 IN labels(this0)
             CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                MATCH (this0)<-[this2:DIRECTED]-(this3:Person)
-                WHERE ($param3 IS NOT NULL AND this2.year = $param3)
-            }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            WITH collect({ node: this0 }) AS edges
+              MATCH (this0)<-[this2:DIRECTED]-(this3:Person)
+              WHERE ($param3 IS NOT NULL AND this2.year = $param3)
+            }), '@neo4j/graphql/FORBIDDEN', [])
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var4
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              RETURN collect({node: {title: this0.title, __resolveType: 'Movie'}}) AS var4
             }
-            RETURN { edges: var4 } AS this"
+            RETURN {edges: var4} AS this"
         `);
 
         expect(result.params).toMatchInlineSnapshot(`
@@ -541,22 +541,22 @@ describe("Cypher -> fulltext -> Auth", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
-            CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
+            CALL db.index.fulltext.queryNodes('MovieTitle', $param0) YIELD node AS this0, score AS var1
             WHERE $param1 IN labels(this0)
             CALL apoc.util.validate(NOT ($isAuthenticated = true AND (EXISTS {
-                MATCH (this0)<-[this2:DIRECTED]-(this3:Person)
-                WHERE ($param3 IS NOT NULL AND this2.year = $param3)
+              MATCH (this0)<-[this2:DIRECTED]-(this3:Person)
+              WHERE ($param3 IS NOT NULL AND this2.year = $param3)
             } AND NOT (EXISTS {
-                MATCH (this0)<-[this2:DIRECTED]-(this3:Person)
-                WHERE NOT ($param3 IS NOT NULL AND this2.year = $param3)
-            }))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            WITH collect({ node: this0 }) AS edges
+              MATCH (this0)<-[this2:DIRECTED]-(this3:Person)
+              WHERE NOT ($param3 IS NOT NULL AND this2.year = $param3)
+            }))), '@neo4j/graphql/FORBIDDEN', [])
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var4
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              RETURN collect({node: {title: this0.title, __resolveType: 'Movie'}}) AS var4
             }
-            RETURN { edges: var4 } AS this"
+            RETURN {edges: var4} AS this"
         `);
 
         expect(result.params).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/fulltext/match.test.ts
+++ b/packages/graphql/tests/tck/fulltext/match.test.ts
@@ -55,15 +55,15 @@ describe("Cypher -> fulltext -> Match", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
-            CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
+            CALL db.index.fulltext.queryNodes('MovieTitle', $param0) YIELD node AS this0, score AS var1
             WHERE $param1 IN labels(this0)
-            WITH collect({ node: this0 }) AS edges
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var2
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              RETURN collect({node: {title: this0.title, __resolveType: 'Movie'}}) AS var2
             }
-            RETURN { edges: var2 } AS this"
+            RETURN {edges: var2} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -91,15 +91,15 @@ describe("Cypher -> fulltext -> Match", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
-            CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
+            CALL db.index.fulltext.queryNodes('MovieTitle', $param0) YIELD node AS this0, score AS var1
             WHERE ($param1 IN labels(this0) AND this0.title = $param2)
-            WITH collect({ node: this0 }) AS edges
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var2
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              RETURN collect({node: {title: this0.title, __resolveType: 'Movie'}}) AS var2
             }
-            RETURN { edges: var2 } AS this"
+            RETURN {edges: var2} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/fulltext/node-labels.test.ts
+++ b/packages/graphql/tests/tck/fulltext/node-labels.test.ts
@@ -51,15 +51,15 @@ describe("Cypher -> fulltext -> Additional Labels", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
-            CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
+            CALL db.index.fulltext.queryNodes('MovieTitle', $param0) YIELD node AS this0, score AS var1
             WHERE ($param1 IN labels(this0) AND $param2 IN labels(this0))
-            WITH collect({ node: this0 }) AS edges
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var2
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              RETURN collect({node: {title: this0.title, __resolveType: 'Movie'}}) AS var2
             }
-            RETURN { edges: var2 } AS this"
+            RETURN {edges: var2} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -108,15 +108,15 @@ describe("Cypher -> fulltext -> Additional Labels", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
-            CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
+            CALL db.index.fulltext.queryNodes('MovieTitle', $param0) YIELD node AS this0, score AS var1
             WHERE ($param1 IN labels(this0) AND $param2 IN labels(this0))
-            WITH collect({ node: this0 }) AS edges
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var2
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              RETURN collect({node: {title: this0.title, __resolveType: 'Movie'}}) AS var2
             }
-            RETURN { edges: var2 } AS this"
+            RETURN {edges: var2} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/fulltext/score.test.ts
+++ b/packages/graphql/tests/tck/fulltext/score.test.ts
@@ -58,16 +58,16 @@ describe("Cypher -> fulltext -> Score", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
-            CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
+            CALL db.index.fulltext.queryNodes('MovieTitle', $param0) YIELD node AS this0, score AS var1
             WHERE $param1 IN labels(this0)
-            WITH collect({ node: this0, score: var1 }) AS edges
+            WITH collect({node: this0, score: var1}) AS edges
             WITH edges, size(edges) AS totalCount
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0, edge.score AS var1
-                RETURN collect({ node: { title: this0.title, released: this0.released, __resolveType: \\"Movie\\" }, score: var1 }) AS var2
+              UNWIND edges AS edge
+              WITH edge.node AS this0, edge.score AS var1
+              RETURN collect({node: {title: this0.title, released: this0.released, __resolveType: 'Movie'}, score: var1}) AS var2
             }
-            RETURN { edges: var2 } AS this"
+            RETURN {edges: var2} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -97,16 +97,16 @@ describe("Cypher -> fulltext -> Score", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
-            CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
+            CALL db.index.fulltext.queryNodes('MovieTitle', $param0) YIELD node AS this0, score AS var1
             WHERE ($param1 IN labels(this0) AND this0.released > $param2)
-            WITH collect({ node: this0, score: var1 }) AS edges
+            WITH collect({node: this0, score: var1}) AS edges
             WITH edges, size(edges) AS totalCount
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0, edge.score AS var1
-                RETURN collect({ node: { title: this0.title, released: this0.released, __resolveType: \\"Movie\\" }, score: var1 }) AS var2
+              UNWIND edges AS edge
+              WITH edge.node AS this0, edge.score AS var1
+              RETURN collect({node: {title: this0.title, released: this0.released, __resolveType: 'Movie'}, score: var1}) AS var2
             }
-            RETURN { edges: var2 } AS this"
+            RETURN {edges: var2} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -139,16 +139,16 @@ describe("Cypher -> fulltext -> Score", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
-            CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
+            CALL db.index.fulltext.queryNodes('MovieTitle', $param0) YIELD node AS this0, score AS var1
             WHERE ($param1 IN labels(this0) AND var1 >= $param2)
-            WITH collect({ node: this0, score: var1 }) AS edges
+            WITH collect({node: this0, score: var1}) AS edges
             WITH edges, size(edges) AS totalCount
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0, edge.score AS var1
-                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" }, score: var1 }) AS var2
+              UNWIND edges AS edge
+              WITH edge.node AS this0, edge.score AS var1
+              RETURN collect({node: {title: this0.title, __resolveType: 'Movie'}, score: var1}) AS var2
             }
-            RETURN { edges: var2 } AS this"
+            RETURN {edges: var2} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -178,18 +178,18 @@ describe("Cypher -> fulltext -> Score", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
-            CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
+            CALL db.index.fulltext.queryNodes('MovieTitle', $param0) YIELD node AS this0, score AS var1
             WHERE $param1 IN labels(this0)
-            WITH collect({ node: this0, score: var1 }) AS edges
+            WITH collect({node: this0, score: var1}) AS edges
             WITH edges, size(edges) AS totalCount
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0, edge.score AS var1
-                WITH *
-                ORDER BY this0.title DESC
-                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" }, score: var1 }) AS var2
+              UNWIND edges AS edge
+              WITH edge.node AS this0, edge.score AS var1
+              WITH *
+              ORDER BY this0.title DESC
+              RETURN collect({node: {title: this0.title, __resolveType: 'Movie'}, score: var1}) AS var2
             }
-            RETURN { edges: var2 } AS this"
+            RETURN {edges: var2} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -218,18 +218,18 @@ describe("Cypher -> fulltext -> Score", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
-            CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
+            CALL db.index.fulltext.queryNodes('MovieTitle', $param0) YIELD node AS this0, score AS var1
             WHERE $param1 IN labels(this0)
-            WITH collect({ node: this0, score: var1 }) AS edges
+            WITH collect({node: this0, score: var1}) AS edges
             WITH edges, size(edges) AS totalCount
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0, edge.score AS var1
-                WITH *
-                ORDER BY var1 ASC
-                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" }, score: var1 }) AS var2
+              UNWIND edges AS edge
+              WITH edge.node AS this0, edge.score AS var1
+              WITH *
+              ORDER BY var1 ASC
+              RETURN collect({node: {title: this0.title, __resolveType: 'Movie'}, score: var1}) AS var2
             }
-            RETURN { edges: var2 } AS this"
+            RETURN {edges: var2} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -258,18 +258,18 @@ describe("Cypher -> fulltext -> Score", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
-            CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this0, score AS var1
+            CALL db.index.fulltext.queryNodes('MovieTitle', $param0) YIELD node AS this0, score AS var1
             WHERE $param1 IN labels(this0)
-            WITH collect({ node: this0, score: var1 }) AS edges
+            WITH collect({node: this0, score: var1}) AS edges
             WITH edges, size(edges) AS totalCount
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0, edge.score AS var1
-                WITH *
-                ORDER BY var1 ASC, this0.title DESC
-                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" }, score: var1 }) AS var2
+              UNWIND edges AS edge
+              WITH edge.node AS this0, edge.score AS var1
+              WITH *
+              ORDER BY var1 ASC, this0.title DESC
+              RETURN collect({node: {title: this0.title, __resolveType: 'Movie'}, score: var1}) AS var2
             }
-            RETURN { edges: var2 } AS this"
+            RETURN {edges: var2} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/info.test.ts
+++ b/packages/graphql/tests/tck/info.test.ts
@@ -60,21 +60,19 @@ describe("info", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Movie)
-                SET
-                    create_this1.title = create_var0.title
-                WITH create_this1, create_var0
-                CALL (create_this1, create_var0) {
-                    UNWIND create_var0.actors.create AS create_var2
-                    CREATE (create_this3:Actor)
-                    SET
-                        create_this3.name = create_var2.node.name
-                    MERGE (create_this1)<-[create_this4:ACTED_IN]-(create_this3)
-                    RETURN collect(NULL) AS create_var5
-                }
-                RETURN create_this1
+              CREATE (create_this1:Movie)
+              SET create_this1.title = create_var0.title
+              WITH create_this1, create_var0
+              CALL (create_this1, create_var0) {
+                UNWIND create_var0.actors.create AS create_var2
+                CREATE (create_this3:Actor)
+                SET create_this3.name = create_var2.node.name
+                MERGE (create_this1)<-[create_this4:ACTED_IN]-(create_this3)
+                RETURN collect(NULL) AS create_var5
+              }
+              RETURN create_this1
             }
-            RETURN \\"Query cannot conclude with CALL\\""
+            RETURN 'Query cannot conclude with CALL'"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/issues/1132.test.ts
+++ b/packages/graphql/tests/tck/issues/1132.test.ts
@@ -70,11 +70,11 @@ describe("https://github.com/neo4j/graphql/issues/1132", () => {
             WITH *
             WITH *
             CALL (*) {
-                CALL (this) {
-                    MATCH (this0:Target)
-                    WHERE this0.id = $param0
-                    CREATE (this)-[this1:HAS_TARGET]->(this0)
-                }
+              CALL (this) {
+                MATCH (this0:Target)
+                WHERE this0.id = $param0
+                CREATE (this)-[this1:HAS_TARGET]->(this0)
+              }
             }
             WITH this
             RETURN this { .id } AS this"
@@ -135,14 +135,14 @@ describe("https://github.com/neo4j/graphql/issues/1132", () => {
             WITH *
             WITH *
             CALL (*) {
-                CALL (this) {
-                    OPTIONAL MATCH (this)-[this0:HAS_TARGET]->(this1:Target)
-                    WHERE this1.id = $param0
-                    WITH *
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    WITH *
-                    DELETE this0
-                }
+              CALL (this) {
+                OPTIONAL MATCH (this)-[this0:HAS_TARGET]->(this1:Target)
+                WHERE this1.id = $param0
+                WITH *
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
+                WITH *
+                DELETE this0
+              }
             }
             WITH this
             RETURN this { .id } AS this"

--- a/packages/graphql/tests/tck/issues/1150.test.ts
+++ b/packages/graphql/tests/tck/issues/1150.test.ts
@@ -112,37 +112,37 @@ describe("https://github.com/neo4j/graphql/issues/1150", () => {
             MATCH (this:Drive)
             WHERE this.current = $param0
             CALL (this) {
-                MATCH (this)-[this0:CONSISTS_OF]->(this1:DriveComposition)
-                WHERE this0.current = $param1
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
+              MATCH (this)-[this0:CONSISTS_OF]->(this1:DriveComposition)
+              WHERE this0.current = $param1
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                CALL (this1) {
+                  CALL (this1) {
                     CALL (this1) {
-                        CALL (this1) {
-                            CALL (this1) {
-                                WITH this1
-                                MATCH (this1)-[this2:HAS]->(this3:Battery)
-                                WHERE this2.current = $param2
-                                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                                WITH { properties: { current: this2.current, __resolveType: \\"RelationProps\\" }, node: { __resolveType: \\"Battery\\", __id: id(this3), id: this3.id } } AS edge
-                                RETURN edge
-                                UNION
-                                WITH this1
-                                MATCH (this1)-[this4:HAS]->(this5:CombustionEngine)
-                                WHERE this4.current = $param6
-                                WITH { properties: { current: this4.current, __resolveType: \\"RelationProps\\" }, node: { __resolveType: \\"CombustionEngine\\", __id: id(this5), id: this5.id } } AS edge
-                                RETURN edge
-                            }
-                            RETURN collect(edge) AS edges
-                        }
-                        WITH edges
-                        WITH edges, size(edges) AS totalCount
-                        RETURN { edges: edges, totalCount: totalCount } AS var6
+                      WITH this1
+                      MATCH (this1)-[this2:HAS]->(this3:Battery)
+                      WHERE this2.current = $param2
+                      CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
+                      WITH {properties: {current: this2.current, __resolveType: 'RelationProps'}, node: {__resolveType: 'Battery', __id: elementId(this3), id: this3.id}} AS edge
+                      RETURN edge
+                      UNION
+                      WITH this1
+                      MATCH (this1)-[this4:HAS]->(this5:CombustionEngine)
+                      WHERE this4.current = $param6
+                      WITH {properties: {current: this4.current, __resolveType: 'RelationProps'}, node: {__resolveType: 'CombustionEngine', __id: elementId(this5), id: this5.id}} AS edge
+                      RETURN edge
                     }
-                    RETURN collect({ node: { driveComponentConnection: var6, __resolveType: \\"DriveComposition\\" } }) AS var7
+                    RETURN collect(edge) AS edges
+                  }
+                  WITH edges
+                  WITH edges, size(edges) AS totalCount
+                  RETURN {edges: edges, totalCount: totalCount} AS var6
                 }
-                RETURN { edges: var7 } AS var8
+                RETURN collect({node: {driveComponentConnection: var6, __resolveType: 'DriveComposition'}}) AS var7
+              }
+              RETURN {edges: var7} AS var8
             }
             RETURN this { .current, driveCompositionsConnection: var8 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/1249.test.ts
+++ b/packages/graphql/tests/tck/issues/1249.test.ts
@@ -82,22 +82,22 @@ describe("https://github.com/neo4j/graphql/issues/1249", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
-            MATCH (this:Bulk:BULK)
+            MATCH (this:Bulk&BULK)
             CALL (this) {
-                MATCH (this)-[this0:MATERIAL_BULK]->(this1:Material)
-                WITH DISTINCT this1
-                CALL (this1) {
-                    MATCH (this1)-[this2:MATERIAL_SUPPLIER]->(this3:Supplier)
-                    WITH collect({ node: this3, relationship: this2 }) AS edges
-                    CALL (edges) {
-                        UNWIND edges AS edge
-                        WITH edge.node AS this3, edge.relationship AS this2
-                        RETURN collect({ properties: { supplierMaterialNumber: this2.supplierMaterialNumber, __resolveType: \\"RelationMaterialSupplier\\" }, node: { supplierId: this3.supplierId, __resolveType: \\"Supplier\\" } }) AS var4
-                    }
-                    RETURN { edges: var4 } AS var5
+              MATCH (this)-[this0:MATERIAL_BULK]->(this1:Material)
+              WITH DISTINCT this1
+              CALL (this1) {
+                MATCH (this1)-[this2:MATERIAL_SUPPLIER]->(this3:Supplier)
+                WITH collect({node: this3, relationship: this2}) AS edges
+                CALL (edges) {
+                  UNWIND edges AS edge
+                  WITH edge.node AS this3, edge.relationship AS this2
+                  RETURN collect({properties: {supplierMaterialNumber: this2.supplierMaterialNumber, __resolveType: 'RelationMaterialSupplier'}, node: {supplierId: this3.supplierId, __resolveType: 'Supplier'}}) AS var4
                 }
-                WITH this1 { .id, suppliersConnection: var5 } AS this1
-                RETURN collect(this1) AS var6
+                RETURN {edges: var4} AS var5
+              }
+              WITH this1 { .id, suppliersConnection: var5 } AS this1
+              RETURN collect(this1) AS var6
             }
             RETURN this { .supplierMaterialNumber, material: var6 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/1320.test.ts
+++ b/packages/graphql/tests/tck/issues/1320.test.ts
@@ -77,20 +77,20 @@ describe("https://github.com/neo4j/graphql/issues/1320", () => {
             "CYPHER 5
             MATCH (this:Team)
             CALL (this) {
-                CALL (this) {
-                    MATCH (this)-[this0:OWNS_RISK]->(this1:Risk)
-                    WHERE $param0 IN this1.mitigationState
-                    RETURN { nodes: count(DISTINCT this1) } AS var2
-                }
-                RETURN { aggregate: { count: var2 } } AS var3
+              CALL (this) {
+                MATCH (this)-[this0:OWNS_RISK]->(this1:Risk)
+                WHERE $param0 IN this1.mitigationState
+                RETURN {nodes: count(DISTINCT this1)} AS var2
+              }
+              RETURN {aggregate: {count: var2}} AS var3
             }
             CALL (this) {
-                CALL (this) {
-                    MATCH (this)-[this4:OWNS_RISK]->(this5:Risk)
-                    WHERE $param1 IN this5.mitigationState
-                    RETURN { nodes: count(DISTINCT this5) } AS var6
-                }
-                RETURN { aggregate: { count: var6 } } AS var7
+              CALL (this) {
+                MATCH (this)-[this4:OWNS_RISK]->(this5:Risk)
+                WHERE $param1 IN this5.mitigationState
+                RETURN {nodes: count(DISTINCT this5)} AS var6
+              }
+              RETURN {aggregate: {count: var6}} AS var7
             }
             RETURN this { accepted: var3, identified: var7 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/1348.test.ts
+++ b/packages/graphql/tests/tck/issues/1348.test.ts
@@ -79,24 +79,24 @@ describe("https://github.com/neo4j/graphql/issues/1348", () => {
             "CYPHER 5
             MATCH (this:ProgrammeItem)
             CALL (this) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this)-[this0:RELATES_TO]-(this1:Series)
-                    WITH this1 { .productTitle, __resolveType: \\"Series\\", __id: id(this1) } AS var2
-                    RETURN var2
-                    UNION
-                    WITH *
-                    MATCH (this)-[this3:RELATES_TO]-(this4:Season)
-                    WITH this4 { .productTitle, __resolveType: \\"Season\\", __id: id(this4) } AS var2
-                    RETURN var2
-                    UNION
-                    WITH *
-                    MATCH (this)-[this5:RELATES_TO]-(this6:ProgrammeItem)
-                    WITH this6 { .productTitle, __resolveType: \\"ProgrammeItem\\", __id: id(this6) } AS var2
-                    RETURN var2
-                }
-                WITH var2
-                RETURN collect(var2) AS var2
+              CALL (*) {
+                WITH *
+                MATCH (this)-[this0:RELATES_TO]-(this1:Series)
+                WITH this1 { .productTitle, __resolveType: 'Series', __id: elementId(this1) } AS var2
+                RETURN var2
+                UNION
+                WITH *
+                MATCH (this)-[this3:RELATES_TO]-(this4:Season)
+                WITH this4 { .productTitle, __resolveType: 'Season', __id: elementId(this4) } AS var2
+                RETURN var2
+                UNION
+                WITH *
+                MATCH (this)-[this5:RELATES_TO]-(this6:ProgrammeItem)
+                WITH this6 { .productTitle, __resolveType: 'ProgrammeItem', __id: elementId(this6) } AS var2
+                RETURN var2
+              }
+              WITH var2
+              RETURN collect(var2) AS var2
             }
             RETURN this { .productTitle, .episodeNumber, releatsTo: var2 } AS this"
         `);
@@ -135,28 +135,28 @@ describe("https://github.com/neo4j/graphql/issues/1348", () => {
             "CYPHER 5
             MATCH (this:ProgrammeItem)
             CALL (this) {
+              CALL (this) {
                 CALL (this) {
-                    CALL (this) {
-                        WITH this
-                        MATCH (this)-[this0:RELATES_TO]-(this1:Series)
-                        WITH { node: { __resolveType: \\"Series\\", __id: id(this1), productTitle: this1.productTitle } } AS edge
-                        RETURN edge
-                        UNION
-                        WITH this
-                        MATCH (this)-[this2:RELATES_TO]-(this3:Season)
-                        WITH { node: { __resolveType: \\"Season\\", __id: id(this3), productTitle: this3.productTitle } } AS edge
-                        RETURN edge
-                        UNION
-                        WITH this
-                        MATCH (this)-[this4:RELATES_TO]-(this5:ProgrammeItem)
-                        WITH { node: { __resolveType: \\"ProgrammeItem\\", __id: id(this5), productTitle: this5.productTitle } } AS edge
-                        RETURN edge
-                    }
-                    RETURN collect(edge) AS edges
+                  WITH this
+                  MATCH (this)-[this0:RELATES_TO]-(this1:Series)
+                  WITH {node: {__resolveType: 'Series', __id: elementId(this1), productTitle: this1.productTitle}} AS edge
+                  RETURN edge
+                  UNION
+                  WITH this
+                  MATCH (this)-[this2:RELATES_TO]-(this3:Season)
+                  WITH {node: {__resolveType: 'Season', __id: elementId(this3), productTitle: this3.productTitle}} AS edge
+                  RETURN edge
+                  UNION
+                  WITH this
+                  MATCH (this)-[this4:RELATES_TO]-(this5:ProgrammeItem)
+                  WITH {node: {__resolveType: 'ProgrammeItem', __id: elementId(this5), productTitle: this5.productTitle}} AS edge
+                  RETURN edge
                 }
-                WITH edges
-                WITH edges, size(edges) AS totalCount
-                RETURN { edges: edges, totalCount: totalCount } AS var6
+                RETURN collect(edge) AS edges
+              }
+              WITH edges
+              WITH edges, size(edges) AS totalCount
+              RETURN {edges: edges, totalCount: totalCount} AS var6
             }
             RETURN this { .productTitle, .episodeNumber, releatsToConnection: var6 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/1364.test.ts
+++ b/packages/graphql/tests/tck/issues/1364.test.ts
@@ -93,24 +93,24 @@ describe("https://github.com/neo4j/graphql/issues/1364", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             MATCH (this0:Movie)
-            WITH collect({ node: this0 }) AS edges
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              CALL (this0) {
                 CALL (this0) {
-                    CALL (this0) {
-                        WITH this0 AS this
-                        MATCH (this)-[:HAS_GENRE]->(genre:Genre)
-                        RETURN count(DISTINCT genre) as result
-                    }
-                    WITH result AS this1
-                    RETURN this1 AS var2
+                  WITH this0 AS this
+                  MATCH (this)-[:HAS_GENRE]->(genre:Genre)
+                  RETURN count(DISTINCT genre) as result
                 }
-                WITH *
-                ORDER BY this0.title ASC
-                RETURN collect({ node: { title: this0.title, totalGenres: var2, __resolveType: \\"Movie\\" } }) AS var3
+                WITH result AS this1
+                RETURN this1 AS var2
+              }
+              WITH *
+              ORDER BY this0.title ASC
+              RETURN collect({node: {title: this0.title, totalGenres: var2, __resolveType: 'Movie'}}) AS var3
             }
-            RETURN { edges: var3 } AS this"
+            RETURN {edges: var3} AS this"
         `);
     });
 
@@ -133,24 +133,24 @@ describe("https://github.com/neo4j/graphql/issues/1364", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             MATCH (this0:Movie)
-            WITH collect({ node: this0 }) AS edges
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              CALL (this0) {
                 CALL (this0) {
-                    CALL (this0) {
-                        WITH this0 AS this
-                        MATCH (this)-[:HAS_GENRE]->(genre:Genre)
-                        RETURN count(DISTINCT genre) as result
-                    }
-                    WITH result AS this1
-                    RETURN this1 AS var2
+                  WITH this0 AS this
+                  MATCH (this)-[:HAS_GENRE]->(genre:Genre)
+                  RETURN count(DISTINCT genre) as result
                 }
-                WITH *
-                ORDER BY var2 ASC
-                RETURN collect({ node: { title: this0.title, totalGenres: var2, __resolveType: \\"Movie\\" } }) AS var3
+                WITH result AS this1
+                RETURN this1 AS var2
+              }
+              WITH *
+              ORDER BY var2 ASC
+              RETURN collect({node: {title: this0.title, totalGenres: var2, __resolveType: 'Movie'}}) AS var3
             }
-            RETURN { edges: var3 } AS this"
+            RETURN {edges: var3} AS this"
         `);
     });
 
@@ -174,33 +174,33 @@ describe("https://github.com/neo4j/graphql/issues/1364", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             MATCH (this0:Movie)
-            WITH collect({ node: this0 }) AS edges
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              CALL (this0) {
                 CALL (this0) {
-                    CALL (this0) {
-                        WITH this0 AS this
-                        MATCH (this)-[:HAS_GENRE]->(genre:Genre)
-                        RETURN count(DISTINCT genre) as result
-                    }
-                    WITH result AS this1
-                    RETURN this1 AS var2
+                  WITH this0 AS this
+                  MATCH (this)-[:HAS_GENRE]->(genre:Genre)
+                  RETURN count(DISTINCT genre) as result
                 }
+                WITH result AS this1
+                RETURN this1 AS var2
+              }
+              CALL (this0) {
                 CALL (this0) {
-                    CALL (this0) {
-                        WITH this0 AS this
-                        MATCH (this)<-[:ACTED_IN]-(actor:Actor)
-                        RETURN count(DISTINCT actor) as result
-                    }
-                    WITH result AS this3
-                    RETURN this3 AS var4
+                  WITH this0 AS this
+                  MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+                  RETURN count(DISTINCT actor) as result
                 }
-                WITH *
-                ORDER BY var2 ASC
-                RETURN collect({ node: { title: this0.title, totalGenres: var2, totalActors: var4, __resolveType: \\"Movie\\" } }) AS var5
+                WITH result AS this3
+                RETURN this3 AS var4
+              }
+              WITH *
+              ORDER BY var2 ASC
+              RETURN collect({node: {title: this0.title, totalGenres: var2, totalActors: var4, __resolveType: 'Movie'}}) AS var5
             }
-            RETURN { edges: var5 } AS this"
+            RETURN {edges: var5} AS this"
         `);
     });
 });

--- a/packages/graphql/tests/tck/issues/1528.test.ts
+++ b/packages/graphql/tests/tck/issues/1528.test.ts
@@ -72,25 +72,25 @@ describe("https://github.com/neo4j/graphql/issues/1528", () => {
             "CYPHER 5
             MATCH (this:Genre)
             CALL (this) {
-                MATCH (this)<-[this0:IS_GENRE]-(this1:Movie)
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    CALL (this1) {
-                        CALL (this1) {
-                            WITH this1 AS this
-                            MATCH (this)<-[:ACTED_IN]-(ac:Person)
-                            RETURN count(ac) as res
-                        }
-                        WITH res AS this2
-                        RETURN this2 AS var3
-                    }
-                    WITH *
-                    ORDER BY var3 DESC
-                    RETURN collect({ node: { title: this1.title, actorsCount: var3, __resolveType: \\"Movie\\" } }) AS var4
+              MATCH (this)<-[this0:IS_GENRE]-(this1:Movie)
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                CALL (this1) {
+                  CALL (this1) {
+                    WITH this1 AS this
+                    MATCH (this)<-[:ACTED_IN]-(ac:Person)
+                    RETURN count(ac) as res
+                  }
+                  WITH res AS this2
+                  RETURN this2 AS var3
                 }
-                RETURN { edges: var4 } AS var5
+                WITH *
+                ORDER BY var3 DESC
+                RETURN collect({node: {title: this1.title, actorsCount: var3, __resolveType: 'Movie'}}) AS var4
+              }
+              RETURN {edges: var4} AS var5
             }
             RETURN this { moviesConnection: var5 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/1535.test.ts
+++ b/packages/graphql/tests/tck/issues/1535.test.ts
@@ -81,19 +81,19 @@ describe("https://github.com/neo4j/graphql/issues/1535", () => {
             "CYPHER 5
             MATCH (this:Tenant)
             CALL (this) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this)<-[this0:HOSTED_BY]-(this1:Screening)
-                    WITH this1 { .id, __resolveType: \\"Screening\\", __id: id(this1) } AS var2
-                    RETURN var2
-                    UNION
-                    WITH *
-                    MATCH (this)<-[this3:HOSTED_BY]-(this4:Booking)
-                    WITH this4 { .id, __resolveType: \\"Booking\\", __id: id(this4) } AS var2
-                    RETURN var2
-                }
-                WITH var2
-                RETURN collect(var2) AS var2
+              CALL (*) {
+                WITH *
+                MATCH (this)<-[this0:HOSTED_BY]-(this1:Screening)
+                WITH this1 { .id, __resolveType: 'Screening', __id: elementId(this1) } AS var2
+                RETURN var2
+                UNION
+                WITH *
+                MATCH (this)<-[this3:HOSTED_BY]-(this4:Booking)
+                WITH this4 { .id, __resolveType: 'Booking', __id: elementId(this4) } AS var2
+                RETURN var2
+              }
+              WITH var2
+              RETURN collect(var2) AS var2
             }
             RETURN this { .id, .name, events232: var2 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/1566.test.ts
+++ b/packages/graphql/tests/tck/issues/1566.test.ts
@@ -83,29 +83,29 @@ describe("https://github.com/neo4j/graphql/issues/1566", () => {
             MATCH (this:Community)
             WHERE this.id = $param0
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    Match(this)-[:COMMUNITY_CONTENTPIECE_HASCONTENTPIECES|:COMMUNITY_PROJECT_HASASSOCIATEDPROJECTS]-(pag)
-                       return pag SKIP ($param1 * $pageIndex) LIMIT $param1
+              CALL (this) {
+                WITH this AS this
+                Match(this)-[:COMMUNITY_CONTENTPIECE_HASCONTENTPIECES|:COMMUNITY_PROJECT_HASASSOCIATEDPROJECTS]-(pag)
+                   return pag SKIP ($param1 * $pageIndex) LIMIT $param1
+              }
+              WITH pag AS this0
+              CALL (this0) {
+                CALL (*) {
+                  WITH *
+                  MATCH (this0)
+                  WHERE this0:Content
+                  WITH this0 { .name, __resolveType: 'Content', __id: elementId(this0) } AS var1
+                  RETURN var1
+                  UNION
+                  WITH *
+                  MATCH (this0)
+                  WHERE this0:Project
+                  WITH this0 { .name, __resolveType: 'Project', __id: elementId(this0) } AS var1
+                  RETURN var1
                 }
-                WITH pag AS this0
-                CALL (this0) {
-                    CALL (*) {
-                        WITH *
-                        MATCH (this0)
-                        WHERE this0:Content
-                        WITH this0 { .name, __resolveType: \\"Content\\", __id: id(this0) } AS var1
-                        RETURN var1
-                        UNION
-                        WITH *
-                        MATCH (this0)
-                        WHERE this0:Project
-                        WITH this0 { .name, __resolveType: \\"Project\\", __id: id(this0) } AS var1
-                        RETURN var1
-                    }
-                    RETURN var1
-                }
-                RETURN collect(var1) AS this0
+                RETURN var1
+              }
+              RETURN collect(var1) AS this0
             }
             RETURN this { .id, hasFeedItems: this0 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/1628.test.ts
+++ b/packages/graphql/tests/tck/issues/1628.test.ts
@@ -60,19 +60,19 @@ describe("https://github.com/neo4j/graphql/issues/1628", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
-            MATCH (this:frbr__Work:Resource)
+            MATCH (this:frbr__Work&Resource)
             WHERE EXISTS {
-                MATCH (this)-[:dcterms__title]->(this0:dcterms_title:property)
-                WHERE this0.value CONTAINS $param0
+              MATCH (this)-[:dcterms__title]->(this0:dcterms_title&property)
+              WHERE this0.value CONTAINS $param0
             }
             WITH *
             LIMIT $param1
             CALL (this) {
-                MATCH (this)-[this1:dcterms__title]->(this2:dcterms_title:property)
-                WHERE this2.value CONTAINS $param2
-                WITH DISTINCT this2
-                WITH this2 { .value } AS this2
-                RETURN collect(this2) AS var3
+              MATCH (this)-[this1:dcterms__title]->(this2:dcterms_title&property)
+              WHERE this2.value CONTAINS $param2
+              WITH DISTINCT this2
+              WITH this2 { .value } AS this2
+              RETURN collect(this2) AS var3
             }
             RETURN this { iri: this.uri, dcterms__title: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/1687.test.ts
+++ b/packages/graphql/tests/tck/issues/1687.test.ts
@@ -64,11 +64,11 @@ describe("https://github.com/neo4j/graphql/issues/1687", () => {
             "CYPHER 5
             MATCH (this:Genre)
             WHERE (EXISTS {
-                MATCH (this)<-[this0:HAS_GENRE]-(this1)
-                WHERE (this1.title = $param0 AND this1:Movie)
+              MATCH (this)<-[this0:HAS_GENRE]-(this1)
+              WHERE (this1.title = $param0 AND this1:Movie)
             } AND NOT (EXISTS {
-                MATCH (this)<-[this0:HAS_GENRE]-(this1)
-                WHERE NOT (this1.title = $param0 AND this1:Movie)
+              MATCH (this)<-[this0:HAS_GENRE]-(this1)
+              WHERE NOT (this1.title = $param0 AND this1:Movie)
             }))
             RETURN this { .name } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/1751.test.ts
+++ b/packages/graphql/tests/tck/issues/1751.test.ts
@@ -83,18 +83,18 @@ describe("https://github.com/neo4j/graphql/issues/1751", () => {
             WHERE this.title = $param0
             WITH *
             CALL (*) {
-                OPTIONAL MATCH (this)-[this0:HAS_ADMINISTRATOR]->(this1:Admin)
-                CALL (this1) {
-                    MATCH (this1)<-[this2:HAS_ADMINISTRATOR]-(this3:Organization)
-                    RETURN count(this3) = $param1 AS var4
-                }
-                WITH *
-                WHERE var4 = true
-                WITH this0, collect(DISTINCT this1) AS var5
-                CALL (var5) {
-                    UNWIND var5 AS var6
-                    DETACH DELETE var6
-                }
+              OPTIONAL MATCH (this)-[this0:HAS_ADMINISTRATOR]->(this1:Admin)
+              CALL (this1) {
+                MATCH (this1)<-[this2:HAS_ADMINISTRATOR]-(this3:Organization)
+                RETURN count(this3) = $param1 AS var4
+              }
+              WITH *
+              WHERE var4 = true
+              WITH this0, collect(DISTINCT this1) AS var5
+              CALL (var5) {
+                UNWIND var5 AS var6
+                DETACH DELETE var6
+              }
             }
             WITH *
             DETACH DELETE this"

--- a/packages/graphql/tests/tck/issues/1779.test.ts
+++ b/packages/graphql/tests/tck/issues/1779.test.ts
@@ -61,17 +61,17 @@ describe("https://github.com/neo4j/graphql/issues/1779", () => {
             "CYPHER 5
             MATCH (this:Person)
             CALL (this) {
-                MATCH (this)-[this0:attends]->(this1:School)
-                WHERE (EXISTS {
-                    MATCH (this1)<-[:attends]-(this2:Person)
-                    WHERE this2.age > $param0
-                } AND NOT (EXISTS {
-                    MATCH (this1)<-[:attends]-(this2:Person)
-                    WHERE NOT (this2.age > $param0)
-                }))
-                WITH DISTINCT this1
-                WITH this1 { .name } AS this1
-                RETURN collect(this1) AS var3
+              MATCH (this)-[this0:attends]->(this1:School)
+              WHERE (EXISTS {
+                MATCH (this1)<-[:attends]-(this2:Person)
+                WHERE this2.age > $param0
+              } AND NOT (EXISTS {
+                MATCH (this1)<-[:attends]-(this2:Person)
+                WHERE NOT (this2.age > $param0)
+              }))
+              WITH DISTINCT this1
+              WITH this1 { .name } AS this1
+              RETURN collect(this1) AS var3
             }
             RETURN this { .name, attends: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/1783.test.ts
+++ b/packages/graphql/tests/tck/issues/1783.test.ts
@@ -129,44 +129,44 @@ describe("https://github.com/neo4j/graphql/issues/1783", () => {
             "CYPHER 5
             MATCH (this:Series)
             WHERE (this.current = $param0 AND single(this0 IN [(this)-[this3:ARCHITECTURE]->(this0:MasterData) WHERE (EXISTS {
-                MATCH (this0)-[this1:HAS_NAME]->(this2:NameDetails)
-                WHERE (this2.fullName = $param1 AND this1.current = $param2)
+              MATCH (this0)-[this1:HAS_NAME]->(this2:NameDetails)
+              WHERE (this2.fullName = $param1 AND this1.current = $param2)
             } AND this3.current = $param3) | 1] WHERE true) AND EXISTS {
-                MATCH (this)-[this4:HAS_NAME]->(this5:NameDetails)
-                WHERE (this5.fullName CONTAINS $param4 AND this4.current = $param5)
+              MATCH (this)-[this4:HAS_NAME]->(this5:NameDetails)
+              WHERE (this5.fullName CONTAINS $param4 AND this4.current = $param5)
             })
             CALL (this) {
-                MATCH (this)-[this6:HAS_NAME]->(this7:NameDetails)
-                WHERE this6.current = $param6
-                WITH collect({ node: this7, relationship: this6 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this7, edge.relationship AS this6
-                    RETURN collect({ node: { fullName: this7.fullName, __resolveType: \\"NameDetails\\" } }) AS var8
-                }
-                RETURN { edges: var8 } AS var9
+              MATCH (this)-[this6:HAS_NAME]->(this7:NameDetails)
+              WHERE this6.current = $param6
+              WITH collect({node: this7, relationship: this6}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this7, edge.relationship AS this6
+                RETURN collect({node: {fullName: this7.fullName, __resolveType: 'NameDetails'}}) AS var8
+              }
+              RETURN {edges: var8} AS var9
             }
             CALL (this) {
-                MATCH (this)-[this10:ARCHITECTURE]->(this11:MasterData)
-                WHERE this10.current = $param7
-                WITH collect({ node: this11, relationship: this10 }) AS edges
-                CALL (edges) {
+              MATCH (this)-[this10:ARCHITECTURE]->(this11:MasterData)
+              WHERE this10.current = $param7
+              WITH collect({node: this11, relationship: this10}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this11, edge.relationship AS this10
+                CALL (this11) {
+                  MATCH (this11)-[this12:HAS_NAME]->(this13:NameDetails)
+                  WHERE this12.current = $param8
+                  WITH collect({node: this13, relationship: this12}) AS edges
+                  CALL (edges) {
                     UNWIND edges AS edge
-                    WITH edge.node AS this11, edge.relationship AS this10
-                    CALL (this11) {
-                        MATCH (this11)-[this12:HAS_NAME]->(this13:NameDetails)
-                        WHERE this12.current = $param8
-                        WITH collect({ node: this13, relationship: this12 }) AS edges
-                        CALL (edges) {
-                            UNWIND edges AS edge
-                            WITH edge.node AS this13, edge.relationship AS this12
-                            RETURN collect({ node: { fullName: this13.fullName, __resolveType: \\"NameDetails\\" } }) AS var14
-                        }
-                        RETURN { edges: var14 } AS var15
-                    }
-                    RETURN collect({ node: { nameDetailsConnection: var15, __resolveType: \\"MasterData\\" } }) AS var16
+                    WITH edge.node AS this13, edge.relationship AS this12
+                    RETURN collect({node: {fullName: this13.fullName, __resolveType: 'NameDetails'}}) AS var14
+                  }
+                  RETURN {edges: var14} AS var15
                 }
-                RETURN { edges: var16 } AS var17
+                RETURN collect({node: {nameDetailsConnection: var15, __resolveType: 'MasterData'}}) AS var16
+              }
+              RETURN {edges: var16} AS var17
             }
             RETURN this { .id, nameDetailsConnection: var9, architectureConnection: var17 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/1848.test.ts
+++ b/packages/graphql/tests/tck/issues/1848.test.ts
@@ -87,30 +87,30 @@ describe("https://github.com/neo4j/graphql/issues/1848", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
-            MATCH (this:Community:UNIVERSAL)
+            MATCH (this:Community&UNIVERSAL)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    Match(this)-[:COMMUNITY_CONTENTPIECE_HASCONTENTPIECES|:COMMUNITY_PROJECT_HASASSOCIATEDPROJECTS]-(pag) return pag SKIP ($param0 * $param1) LIMIT $param0
+              CALL (this) {
+                WITH this AS this
+                Match(this)-[:COMMUNITY_CONTENTPIECE_HASCONTENTPIECES|:COMMUNITY_PROJECT_HASASSOCIATEDPROJECTS]-(pag) return pag SKIP ($param0 * $param1) LIMIT $param0
+              }
+              WITH pag AS this0
+              CALL (this0) {
+                CALL (*) {
+                  WITH *
+                  MATCH (this0)
+                  WHERE this0:ContentPiece&UNIVERSAL
+                  WITH this0 { .id, __resolveType: 'ContentPiece', __id: elementId(this0) } AS var1
+                  RETURN var1
+                  UNION
+                  WITH *
+                  MATCH (this0)
+                  WHERE this0:Project&UNIVERSAL
+                  WITH this0 { .id, __resolveType: 'Project', __id: elementId(this0) } AS var1
+                  RETURN var1
                 }
-                WITH pag AS this0
-                CALL (this0) {
-                    CALL (*) {
-                        WITH *
-                        MATCH (this0)
-                        WHERE this0:ContentPiece:UNIVERSAL
-                        WITH this0 { .id, __resolveType: \\"ContentPiece\\", __id: id(this0) } AS var1
-                        RETURN var1
-                        UNION
-                        WITH *
-                        MATCH (this0)
-                        WHERE this0:Project:UNIVERSAL
-                        WITH this0 { .id, __resolveType: \\"Project\\", __id: id(this0) } AS var1
-                        RETURN var1
-                    }
-                    RETURN var1
-                }
-                RETURN collect(var1) AS this0
+                RETURN var1
+              }
+              RETURN collect(var1) AS this0
             }
             RETURN this { .id, hasFeedItems: this0 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/190.test.ts
+++ b/packages/graphql/tests/tck/issues/190.test.ts
@@ -64,14 +64,14 @@ describe("#190", () => {
             "CYPHER 5
             MATCH (this:User)
             WHERE EXISTS {
-                MATCH (this)-[:HAS_DEMOGRAPHIC]->(this0:UserDemographics)
-                WHERE (this0.type = $param0 AND this0.value = $param1)
+              MATCH (this)-[:HAS_DEMOGRAPHIC]->(this0:UserDemographics)
+              WHERE (this0.type = $param0 AND this0.value = $param1)
             }
             CALL (this) {
-                MATCH (this)-[this1:HAS_DEMOGRAPHIC]->(this2:UserDemographics)
-                WITH DISTINCT this2
-                WITH this2 { .type, .value } AS this2
-                RETURN collect(this2) AS var3
+              MATCH (this)-[this1:HAS_DEMOGRAPHIC]->(this2:UserDemographics)
+              WITH DISTINCT this2
+              WITH this2 { .type, .value } AS this2
+              RETURN collect(this2) AS var3
             }
             RETURN this { .uid, demographics: var3 } AS this"
         `);
@@ -115,14 +115,14 @@ describe("#190", () => {
             "CYPHER 5
             MATCH (this:User)
             WHERE EXISTS {
-                MATCH (this)-[:HAS_DEMOGRAPHIC]->(this0:UserDemographics)
-                WHERE ((this0.type = $param0 AND this0.value = $param1) OR this0.type = $param2 OR this0.type = $param3)
+              MATCH (this)-[:HAS_DEMOGRAPHIC]->(this0:UserDemographics)
+              WHERE ((this0.type = $param0 AND this0.value = $param1) OR this0.type = $param2 OR this0.type = $param3)
             }
             CALL (this) {
-                MATCH (this)-[this1:HAS_DEMOGRAPHIC]->(this2:UserDemographics)
-                WITH DISTINCT this2
-                WITH this2 { .type, .value } AS this2
-                RETURN collect(this2) AS var3
+              MATCH (this)-[this1:HAS_DEMOGRAPHIC]->(this2:UserDemographics)
+              WITH DISTINCT this2
+              WITH this2 { .type, .value } AS this2
+              RETURN collect(this2) AS var3
             }
             RETURN this { .uid, demographics: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/1933.test.ts
+++ b/packages/graphql/tests/tck/issues/1933.test.ts
@@ -84,22 +84,22 @@ describe("https://github.com/neo4j/graphql/issues/1933", () => {
             "CYPHER 5
             MATCH (this:Employee)
             CALL (this) {
-                MATCH (this)-[this0:PARTICIPATES]->(this1:Project)
-                RETURN sum(this0.allocation) <= $param0 AS var2
+              MATCH (this)-[this0:PARTICIPATES]->(this1:Project)
+              RETURN sum(this0.allocation) <= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
             CALL (this) {
-                CALL (this) {
-                    MATCH (this)-[this3:PARTICIPATES]->(this4:Project)
-                    RETURN { nodes: count(DISTINCT this4) } AS var5
-                }
-                CALL (this) {
-                    MATCH (this)-[this6:PARTICIPATES]->(this7:Project)
-                    WITH DISTINCT this6
-                    RETURN { min: min(this6.allocation), max: max(this6.allocation), average: avg(this6.allocation), sum: sum(this6.allocation) } AS var8
-                }
-                RETURN { aggregate: { count: var5, edge: { allocation: var8 } } } AS var9
+              CALL (this) {
+                MATCH (this)-[this3:PARTICIPATES]->(this4:Project)
+                RETURN {nodes: count(DISTINCT this4)} AS var5
+              }
+              CALL (this) {
+                MATCH (this)-[this6:PARTICIPATES]->(this7:Project)
+                WITH DISTINCT this6
+                RETURN {min: min(this6.allocation), max: max(this6.allocation), average: avg(this6.allocation), sum: sum(this6.allocation)} AS var8
+              }
+              RETURN {aggregate: {count: var5, edge: {allocation: var8}}} AS var9
             }
             RETURN this { .employeeId, .firstName, .lastName, projectsConnection: var9 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/2022.test.ts
+++ b/packages/graphql/tests/tck/issues/2022.test.ts
@@ -90,31 +90,31 @@ describe("https://github.com/neo4j/graphql/issues/2022", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             MATCH (this0:ArtPiece)
-            WITH collect({ node: this0 }) AS edges, count(this0) AS totalCount
+            WITH collect({node: this0}) AS edges, count(this0) AS totalCount
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                CALL (this0) {
-                    MATCH (this0)-[this1:SOLD_AT_AUCTION_AS]->(this2:AuctionItem)
-                    WITH DISTINCT this2
-                    CALL (this2) {
-                        MATCH (this2)<-[this3:BOUGHT_ITEM_AT_AUCTION]-(this4:Organization)
-                        WITH DISTINCT this4
-                        WITH this4 { .name, dbId: this4.id } AS this4
-                        RETURN collect(this4) AS var5
-                    }
-                    WITH this2 { .auctionName, .lotNumber, dbId: this2.id, buyer: var5 } AS this2
-                    RETURN collect(this2) AS var6
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              CALL (this0) {
+                MATCH (this0)-[this1:SOLD_AT_AUCTION_AS]->(this2:AuctionItem)
+                WITH DISTINCT this2
+                CALL (this2) {
+                  MATCH (this2)<-[this3:BOUGHT_ITEM_AT_AUCTION]-(this4:Organization)
+                  WITH DISTINCT this4
+                  WITH this4 { .name, dbId: this4.id } AS this4
+                  RETURN collect(this4) AS var5
                 }
-                CALL (this0) {
-                    MATCH (this0)-[this7:OWNED_BY]->(this8:Organization)
-                    WITH DISTINCT this8
-                    WITH this8 { .name, dbId: this8.id } AS this8
-                    RETURN collect(this8) AS var9
-                }
-                RETURN collect({ node: { dbId: this0.id, title: this0.title, auction: var6, owner: var9, __resolveType: \\"ArtPiece\\" } }) AS var10
+                WITH this2 { .auctionName, .lotNumber, dbId: this2.id, buyer: var5 } AS this2
+                RETURN collect(this2) AS var6
+              }
+              CALL (this0) {
+                MATCH (this0)-[this7:OWNED_BY]->(this8:Organization)
+                WITH DISTINCT this8
+                WITH this8 { .name, dbId: this8.id } AS this8
+                RETURN collect(this8) AS var9
+              }
+              RETURN collect({node: {dbId: this0.id, title: this0.title, auction: var6, owner: var9, __resolveType: 'ArtPiece'}}) AS var10
             }
-            RETURN { edges: var10, totalCount: totalCount } AS this"
+            RETURN {edges: var10, totalCount: totalCount} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);

--- a/packages/graphql/tests/tck/issues/2100.test.ts
+++ b/packages/graphql/tests/tck/issues/2100.test.ts
@@ -109,30 +109,30 @@ describe("https://github.com/neo4j/graphql/issues/2100", () => {
             MATCH (this:Bacenta)
             WHERE this.id = $param0
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:HAS_HISTORY]->(:ServiceLog)-[:HAS_BUSSING]->(records:BussingRecord)-[:BUSSED_ON]->(date:TimeGraph)
-                    WITH DISTINCT records, date LIMIT $param1
-                    RETURN records ORDER BY date.date DESC
-                }
-                WITH records AS this0
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:HAS_HISTORY]->(:ServiceLog)-[:HAS_BUSSING]->(records:BussingRecord)-[:BUSSED_ON]->(date:TimeGraph)
+                WITH DISTINCT records, date LIMIT $param1
+                RETURN records ORDER BY date.date DESC
+              }
+              WITH records AS this0
+              CALL (this0) {
+                MATCH (this0)-[this1:BUSSED_ON]->(this2:TimeGraph)
+                WITH DISTINCT this2
+                WITH this2 { .date } AS this2
+                RETURN collect(this2) AS var3
+              }
+              CALL (this0) {
                 CALL (this0) {
-                    MATCH (this0)-[this1:BUSSED_ON]->(this2:TimeGraph)
-                    WITH DISTINCT this2
-                    WITH this2 { .date } AS this2
-                    RETURN collect(this2) AS var3
+                  WITH this0 AS this
+                  MATCH (this)<-[:PRESENT_AT_SERVICE|ABSENT_FROM_SERVICE]-(member:Member)
+                  RETURN COUNT(member) > 0 AS markedAttendance
                 }
-                CALL (this0) {
-                    CALL (this0) {
-                        WITH this0 AS this
-                        MATCH (this)<-[:PRESENT_AT_SERVICE|ABSENT_FROM_SERVICE]-(member:Member)
-                        RETURN COUNT(member) > 0 AS markedAttendance
-                    }
-                    WITH markedAttendance AS this4
-                    RETURN this4 AS var5
-                }
-                WITH this0 { .id, .attendance, markedAttendance: var5, serviceDate: var3 } AS this0
-                RETURN collect(this0) AS var6
+                WITH markedAttendance AS this4
+                RETURN this4 AS var5
+              }
+              WITH this0 { .id, .attendance, markedAttendance: var5, serviceDate: var3 } AS this0
+              RETURN collect(this0) AS var6
             }
             RETURN this { .id, .name, bussing: var6 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/2189.test.ts
+++ b/packages/graphql/tests/tck/issues/2189.test.ts
@@ -79,25 +79,25 @@ describe("https://github.com/neo4j/graphql/issues/2189", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Test_Item)
+              CREATE (create_this1:Test_Item)
+              SET
+                create_this1.uuid = randomUUID(),
+                create_this1.int = create_var0.int,
+                create_this1.str = create_var0.str,
+                create_this1.bool = create_var0.bool
+              WITH create_this1, create_var0
+              CALL (create_this1, create_var0) {
+                UNWIND create_var0.feedback.create AS create_var2
+                CREATE (create_this3:Test_Feedback)
                 SET
-                    create_this1.uuid = randomUUID(),
-                    create_this1.int = create_var0.int,
-                    create_this1.str = create_var0.str,
-                    create_this1.bool = create_var0.bool
-                WITH create_this1, create_var0
-                CALL (create_this1, create_var0) {
-                    UNWIND create_var0.feedback.create AS create_var2
-                    CREATE (create_this3:Test_Feedback)
-                    SET
-                        create_this3.uuid = randomUUID(),
-                        create_this3.str = create_var2.node.str
-                    MERGE (create_this1)<-[create_this4:TEST_RELATIONSHIP]-(create_this3)
-                    RETURN collect(NULL) AS create_var5
-                }
-                RETURN create_this1
+                  create_this3.uuid = randomUUID(),
+                  create_this3.str = create_var2.node.str
+                MERGE (create_this1)<-[create_this4:TEST_RELATIONSHIP]-(create_this3)
+                RETURN collect(NULL) AS create_var5
+              }
+              RETURN create_this1
             }
-            RETURN \\"Query cannot conclude with CALL\\""
+            RETURN 'Query cannot conclude with CALL'"
         `);
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -154,25 +154,25 @@ describe("https://github.com/neo4j/graphql/issues/2189", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Test_Item)
+              CREATE (create_this1:Test_Item)
+              SET
+                create_this1.uuid = randomUUID(),
+                create_this1.int = create_var0.int,
+                create_this1.str = create_var0.str,
+                create_this1.bool = create_var0.bool
+              WITH create_this1, create_var0
+              CALL (create_this1, create_var0) {
+                UNWIND create_var0.feedback.create AS create_var2
+                CREATE (create_this3:Test_Feedback)
                 SET
-                    create_this1.uuid = randomUUID(),
-                    create_this1.int = create_var0.int,
-                    create_this1.str = create_var0.str,
-                    create_this1.bool = create_var0.bool
-                WITH create_this1, create_var0
-                CALL (create_this1, create_var0) {
-                    UNWIND create_var0.feedback.create AS create_var2
-                    CREATE (create_this3:Test_Feedback)
-                    SET
-                        create_this3.uuid = randomUUID(),
-                        create_this3.str = create_var2.node.str
-                    MERGE (create_this1)<-[create_this4:TEST_RELATIONSHIP]-(create_this3)
-                    RETURN collect(NULL) AS create_var5
-                }
-                RETURN create_this1
+                  create_this3.uuid = randomUUID(),
+                  create_this3.str = create_var2.node.str
+                MERGE (create_this1)<-[create_this4:TEST_RELATIONSHIP]-(create_this3)
+                RETURN collect(NULL) AS create_var5
+              }
+              RETURN create_this1
             }
-            RETURN \\"Query cannot conclude with CALL\\""
+            RETURN 'Query cannot conclude with CALL'"
         `);
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -247,40 +247,40 @@ describe("https://github.com/neo4j/graphql/issues/2189", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Test_Item)
+              CREATE (create_this1:Test_Item)
+              SET
+                create_this1.uuid = randomUUID(),
+                create_this1.int = create_var0.int,
+                create_this1.str = create_var0.str,
+                create_this1.bool = create_var0.bool
+              WITH create_this1, create_var0
+              CALL (create_this1, create_var0) {
+                UNWIND create_var0.feedback.create AS create_var2
+                CREATE (create_this3:Test_Feedback)
                 SET
-                    create_this1.uuid = randomUUID(),
-                    create_this1.int = create_var0.int,
-                    create_this1.str = create_var0.str,
-                    create_this1.bool = create_var0.bool
-                WITH create_this1, create_var0
-                CALL (create_this1, create_var0) {
-                    UNWIND create_var0.feedback.create AS create_var2
-                    CREATE (create_this3:Test_Feedback)
-                    SET
-                        create_this3.uuid = randomUUID(),
-                        create_this3.str = create_var2.node.str
-                    MERGE (create_this1)<-[create_this4:TEST_RELATIONSHIP]-(create_this3)
-                    RETURN collect(NULL) AS create_var5
-                }
-                RETURN create_this1
+                  create_this3.uuid = randomUUID(),
+                  create_this3.str = create_var2.node.str
+                MERGE (create_this1)<-[create_this4:TEST_RELATIONSHIP]-(create_this3)
+                RETURN collect(NULL) AS create_var5
+              }
+              RETURN create_this1
             }
             CALL (create_this1) {
-                CALL (create_this1) {
-                    WITH create_this1 AS this
-                    OPTIONAL MATCH (this)<-[:TEST_RELATIONSHIP]-(t:Test_Feedback)
-                    RETURN t
-                    LIMIT 1
-                }
-                WITH t AS create_this6
-                WITH create_this6 { .bool, .str, .int, .uuid } AS create_this6
-                RETURN head(collect(create_this6)) AS create_var7
+              CALL (create_this1) {
+                WITH create_this1 AS this
+                OPTIONAL MATCH (this)<-[:TEST_RELATIONSHIP]-(t:Test_Feedback)
+                RETURN t
+                LIMIT 1
+              }
+              WITH t AS create_this6
+              WITH create_this6 { .bool, .str, .int, .uuid } AS create_this6
+              RETURN head(collect(create_this6)) AS create_var7
             }
             CALL (create_this1) {
-                MATCH (create_this1)<-[create_this8:TEST_RELATIONSHIP]-(create_this9:Test_Feedback)
-                WITH DISTINCT create_this9
-                WITH create_this9 { .uuid, .int, .str, .bool } AS create_this9
-                RETURN collect(create_this9) AS create_var10
+              MATCH (create_this1)<-[create_this8:TEST_RELATIONSHIP]-(create_this9:Test_Feedback)
+              WITH DISTINCT create_this9
+              WITH create_this9 { .uuid, .int, .str, .bool } AS create_this9
+              RETURN collect(create_this9) AS create_var10
             }
             RETURN collect(create_this1 { .bool, .int, .str, .uuid, feedbackCypher: create_var7, feedback: create_var10 }) AS data"
         `);
@@ -351,29 +351,29 @@ describe("https://github.com/neo4j/graphql/issues/2189", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Test_Item)
+              CREATE (create_this1:Test_Item)
+              SET
+                create_this1.uuid = randomUUID(),
+                create_this1.int = create_var0.int,
+                create_this1.str = create_var0.str,
+                create_this1.bool = create_var0.bool
+              WITH create_this1, create_var0
+              CALL (create_this1, create_var0) {
+                UNWIND create_var0.feedback.create AS create_var2
+                CREATE (create_this3:Test_Feedback)
                 SET
-                    create_this1.uuid = randomUUID(),
-                    create_this1.int = create_var0.int,
-                    create_this1.str = create_var0.str,
-                    create_this1.bool = create_var0.bool
-                WITH create_this1, create_var0
-                CALL (create_this1, create_var0) {
-                    UNWIND create_var0.feedback.create AS create_var2
-                    CREATE (create_this3:Test_Feedback)
-                    SET
-                        create_this3.uuid = randomUUID(),
-                        create_this3.str = create_var2.node.str
-                    MERGE (create_this1)<-[create_this4:TEST_RELATIONSHIP]-(create_this3)
-                    RETURN collect(NULL) AS create_var5
-                }
-                RETURN create_this1
+                  create_this3.uuid = randomUUID(),
+                  create_this3.str = create_var2.node.str
+                MERGE (create_this1)<-[create_this4:TEST_RELATIONSHIP]-(create_this3)
+                RETURN collect(NULL) AS create_var5
+              }
+              RETURN create_this1
             }
             CALL (create_this1) {
-                MATCH (create_this1)<-[create_this6:TEST_RELATIONSHIP]-(create_this7:Test_Feedback)
-                WITH DISTINCT create_this7
-                WITH create_this7 { .uuid, .int, .str, .bool } AS create_this7
-                RETURN collect(create_this7) AS create_var8
+              MATCH (create_this1)<-[create_this6:TEST_RELATIONSHIP]-(create_this7:Test_Feedback)
+              WITH DISTINCT create_this7
+              WITH create_this7 { .uuid, .int, .str, .bool } AS create_this7
+              RETURN collect(create_this7) AS create_var8
             }
             RETURN collect(create_this1 { .bool, .int, .str, .uuid, feedback: create_var8 }) AS data"
         `);

--- a/packages/graphql/tests/tck/issues/2249.test.ts
+++ b/packages/graphql/tests/tck/issues/2249.test.ts
@@ -91,28 +91,28 @@ describe("https://github.com/neo4j/graphql/issues/2249", () => {
             WHERE this.title = $param0
             WITH *
             CALL (*) {
-                CREATE (this0:Person)
-                MERGE (this)<-[this1:REVIEWED]-(this0)
-                SET
-                    this0.name = $param1,
-                    this0.reputation = $param2,
-                    this1.score = $param3
+              CREATE (this0:Person)
+              MERGE (this)<-[this1:REVIEWED]-(this0)
+              SET
+                this0.name = $param1,
+                this0.reputation = $param2,
+                this1.score = $param3
             }
             WITH this
             CALL (this) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this)<-[this2:REVIEWED]-(this3:Person)
-                    WITH this3 { .name, .reputation, __resolveType: \\"Person\\", __id: id(this3) } AS var4
-                    RETURN var4
-                    UNION
-                    WITH *
-                    MATCH (this)<-[this5:REVIEWED]-(this6:Influencer)
-                    WITH this6 { __resolveType: \\"Influencer\\", __id: id(this6) } AS var4
-                    RETURN var4
-                }
-                WITH var4
-                RETURN collect(var4) AS var4
+              CALL (*) {
+                WITH *
+                MATCH (this)<-[this2:REVIEWED]-(this3:Person)
+                WITH this3 { .name, .reputation, __resolveType: 'Person', __id: elementId(this3) } AS var4
+                RETURN var4
+                UNION
+                WITH *
+                MATCH (this)<-[this5:REVIEWED]-(this6:Influencer)
+                WITH this6 { __resolveType: 'Influencer', __id: elementId(this6) } AS var4
+                RETURN var4
+              }
+              WITH var4
+              RETURN collect(var4) AS var4
             }
             RETURN this { .title, reviewers: var4 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/2262.test.ts
+++ b/packages/graphql/tests/tck/issues/2262.test.ts
@@ -73,26 +73,26 @@ describe("https://github.com/neo4j/graphql/issues/2262", () => {
             MATCH (this:Component)
             WHERE this.uuid = $param0
             CALL (this) {
-                MATCH (this)<-[this0:OUTPUT]-(this1:Process)
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
+              MATCH (this)<-[this0:OUTPUT]-(this1:Process)
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                CALL (this1) {
+                  MATCH (this1)<-[this2:INPUT]-(this3:Component)
+                  WITH collect({node: this3, relationship: this2}) AS edges
+                  CALL (edges) {
                     UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    CALL (this1) {
-                        MATCH (this1)<-[this2:INPUT]-(this3:Component)
-                        WITH collect({ node: this3, relationship: this2 }) AS edges
-                        CALL (edges) {
-                            UNWIND edges AS edge
-                            WITH edge.node AS this3, edge.relationship AS this2
-                            WITH *
-                            ORDER BY this3.uuid DESC
-                            RETURN collect({ node: { uuid: this3.uuid, __resolveType: \\"Component\\" } }) AS var4
-                        }
-                        RETURN { edges: var4 } AS var5
-                    }
-                    RETURN collect({ node: { uuid: this1.uuid, componentInputsConnection: var5, __resolveType: \\"Process\\" } }) AS var6
+                    WITH edge.node AS this3, edge.relationship AS this2
+                    WITH *
+                    ORDER BY this3.uuid DESC
+                    RETURN collect({node: {uuid: this3.uuid, __resolveType: 'Component'}}) AS var4
+                  }
+                  RETURN {edges: var4} AS var5
                 }
-                RETURN { edges: var6 } AS var7
+                RETURN collect({node: {uuid: this1.uuid, componentInputsConnection: var5, __resolveType: 'Process'}}) AS var6
+              }
+              RETURN {edges: var6} AS var7
             }
             RETURN this { .uuid, upstreamProcessConnection: var7 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/2267.test.ts
+++ b/packages/graphql/tests/tck/issues/2267.test.ts
@@ -72,19 +72,19 @@ describe("https://github.com/neo4j/graphql/issues/2267", () => {
             WITH *
             ORDER BY this.displayName ASC
             CALL (this) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this)<-[this0:ACTIVITY]-(this1:Post)
-                    WITH this1 { .name, __resolveType: \\"Post\\", __id: id(this1) } AS var2
-                    RETURN var2
-                    UNION
-                    WITH *
-                    MATCH (this)<-[this3:ACTIVITY]-(this4:Story)
-                    WITH this4 { .name, __resolveType: \\"Story\\", __id: id(this4) } AS var2
-                    RETURN var2
-                }
-                WITH var2
-                RETURN collect(var2) AS var2
+              CALL (*) {
+                WITH *
+                MATCH (this)<-[this0:ACTIVITY]-(this1:Post)
+                WITH this1 { .name, __resolveType: 'Post', __id: elementId(this1) } AS var2
+                RETURN var2
+                UNION
+                WITH *
+                MATCH (this)<-[this3:ACTIVITY]-(this4:Story)
+                WITH this4 { .name, __resolveType: 'Story', __id: elementId(this4) } AS var2
+                RETURN var2
+              }
+              WITH var2
+              RETURN collect(var2) AS var2
             }
             RETURN this { .displayName, activity: var2 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/2396.test.ts
+++ b/packages/graphql/tests/tck/issues/2396.test.ts
@@ -160,27 +160,27 @@ describe("https://github.com/neo4j/graphql/issues/2396", () => {
             MATCH (this:Mandate)
             WITH *
             WHERE (EXISTS {
-                MATCH (this)-[:HAS_VALUATION]->(this0:Valuation)
-                WHERE EXISTS {
-                    MATCH (this0)-[:VALUATION_FOR]->(this1:Estate)
-                    WHERE this1.floor >= $param0
-                }
+              MATCH (this)-[:HAS_VALUATION]->(this0:Valuation)
+              WHERE EXISTS {
+                MATCH (this0)-[:VALUATION_FOR]->(this1:Estate)
+                WHERE this1.floor >= $param0
+              }
             } AND ($isAuthenticated = true AND this.archivedAt IS NULL))
             CALL (this) {
-                MATCH (this)-[this2:HAS_VALUATION]->(this3:Valuation)
-                WITH DISTINCT this3
+              MATCH (this)-[this2:HAS_VALUATION]->(this3:Valuation)
+              WITH DISTINCT this3
+              WITH *
+              WHERE ($isAuthenticated = true AND this3.archivedAt IS NULL)
+              CALL (this3) {
+                MATCH (this3)-[this4:VALUATION_FOR]->(this5:Estate)
+                WITH DISTINCT this5
                 WITH *
-                WHERE ($isAuthenticated = true AND this3.archivedAt IS NULL)
-                CALL (this3) {
-                    MATCH (this3)-[this4:VALUATION_FOR]->(this5:Estate)
-                    WITH DISTINCT this5
-                    WITH *
-                    WHERE ($isAuthenticated = true AND this5.archivedAt IS NULL)
-                    WITH this5 { .uuid } AS this5
-                    RETURN collect(this5) AS var6
-                }
-                WITH this3 { estate: var6 } AS this3
-                RETURN collect(this3) AS var7
+                WHERE ($isAuthenticated = true AND this5.archivedAt IS NULL)
+                WITH this5 { .uuid } AS this5
+                RETURN collect(this5) AS var6
+              }
+              WITH this3 { estate: var6 } AS this3
+              RETURN collect(this3) AS var7
             }
             RETURN this { valuation: var7 } AS this"
         `);
@@ -237,27 +237,27 @@ describe("https://github.com/neo4j/graphql/issues/2396", () => {
             MATCH (this:Mandate)
             WITH *
             WHERE ((this.price >= $param0 AND EXISTS {
-                MATCH (this)-[:HAS_VALUATION]->(this0:Valuation)
-                WHERE EXISTS {
-                    MATCH (this0)-[:VALUATION_FOR]->(this1:Estate)
-                    WHERE this1.floor >= $param1
-                }
+              MATCH (this)-[:HAS_VALUATION]->(this0:Valuation)
+              WHERE EXISTS {
+                MATCH (this0)-[:VALUATION_FOR]->(this1:Estate)
+                WHERE this1.floor >= $param1
+              }
             }) AND ($isAuthenticated = true AND this.archivedAt IS NULL))
             CALL (this) {
-                MATCH (this)-[this2:HAS_VALUATION]->(this3:Valuation)
-                WITH DISTINCT this3
+              MATCH (this)-[this2:HAS_VALUATION]->(this3:Valuation)
+              WITH DISTINCT this3
+              WITH *
+              WHERE ($isAuthenticated = true AND this3.archivedAt IS NULL)
+              CALL (this3) {
+                MATCH (this3)-[this4:VALUATION_FOR]->(this5:Estate)
+                WITH DISTINCT this5
                 WITH *
-                WHERE ($isAuthenticated = true AND this3.archivedAt IS NULL)
-                CALL (this3) {
-                    MATCH (this3)-[this4:VALUATION_FOR]->(this5:Estate)
-                    WITH DISTINCT this5
-                    WITH *
-                    WHERE ($isAuthenticated = true AND this5.archivedAt IS NULL)
-                    WITH this5 { .uuid } AS this5
-                    RETURN collect(this5) AS var6
-                }
-                WITH this3 { estate: var6 } AS this3
-                RETURN collect(this3) AS var7
+                WHERE ($isAuthenticated = true AND this5.archivedAt IS NULL)
+                WITH this5 { .uuid } AS this5
+                RETURN collect(this5) AS var6
+              }
+              WITH this3 { estate: var6 } AS this3
+              RETURN collect(this3) AS var7
             }
             RETURN this { valuation: var7 } AS this"
         `);
@@ -326,33 +326,33 @@ describe("https://github.com/neo4j/graphql/issues/2396", () => {
             MATCH (this:Mandate)
             WITH *
             WHERE ((this.price >= $param0 AND EXISTS {
-                MATCH (this)-[:HAS_VALUATION]->(this0:Valuation)
-                WHERE EXISTS {
-                    MATCH (this0)-[:VALUATION_FOR]->(this1:Estate)
-                    WHERE (this1.estateType IN $param1 AND this1.area >= $param2 AND this1.floor >= $param3 AND EXISTS {
-                        MATCH (this1)-[:HAS_ADDRESS]->(this2:Address)
-                        WHERE EXISTS {
-                            MATCH (this2)-[:HAS_POSTAL_CODE]->(this3:PostalCode)
-                            WHERE this3.number IN $param4
-                        }
-                    })
-                }
+              MATCH (this)-[:HAS_VALUATION]->(this0:Valuation)
+              WHERE EXISTS {
+                MATCH (this0)-[:VALUATION_FOR]->(this1:Estate)
+                WHERE (this1.estateType IN $param1 AND this1.area >= $param2 AND this1.floor >= $param3 AND EXISTS {
+                  MATCH (this1)-[:HAS_ADDRESS]->(this2:Address)
+                  WHERE EXISTS {
+                    MATCH (this2)-[:HAS_POSTAL_CODE]->(this3:PostalCode)
+                    WHERE this3.number IN $param4
+                  }
+                })
+              }
             }) AND ($isAuthenticated = true AND this.archivedAt IS NULL))
             CALL (this) {
-                MATCH (this)-[this4:HAS_VALUATION]->(this5:Valuation)
-                WITH DISTINCT this5
+              MATCH (this)-[this4:HAS_VALUATION]->(this5:Valuation)
+              WITH DISTINCT this5
+              WITH *
+              WHERE ($isAuthenticated = true AND this5.archivedAt IS NULL)
+              CALL (this5) {
+                MATCH (this5)-[this6:VALUATION_FOR]->(this7:Estate)
+                WITH DISTINCT this7
                 WITH *
-                WHERE ($isAuthenticated = true AND this5.archivedAt IS NULL)
-                CALL (this5) {
-                    MATCH (this5)-[this6:VALUATION_FOR]->(this7:Estate)
-                    WITH DISTINCT this7
-                    WITH *
-                    WHERE ($isAuthenticated = true AND this7.archivedAt IS NULL)
-                    WITH this7 { .uuid } AS this7
-                    RETURN collect(this7) AS var8
-                }
-                WITH this5 { estate: var8 } AS this5
-                RETURN collect(this5) AS var9
+                WHERE ($isAuthenticated = true AND this7.archivedAt IS NULL)
+                WITH this7 { .uuid } AS this7
+                RETURN collect(this7) AS var8
+              }
+              WITH this5 { estate: var8 } AS this5
+              RETURN collect(this5) AS var9
             }
             RETURN this { valuation: var9 } AS this"
         `);
@@ -428,36 +428,36 @@ describe("https://github.com/neo4j/graphql/issues/2396", () => {
             MATCH (this:Mandate)
             WITH *
             WHERE ((this.price >= $param0 AND EXISTS {
-                MATCH (this)-[:HAS_VALUATION]->(this0:Valuation)
-                WHERE EXISTS {
-                    MATCH (this0)-[:VALUATION_FOR]->(this1:Estate)
-                    WHERE (this1.estateType IN $param1 AND this1.area >= $param2 AND this1.floor >= $param3 AND EXISTS {
-                        MATCH (this1)-[:HAS_ADDRESS]->(this2:Address)
-                        WHERE EXISTS {
-                            MATCH (this2)-[:HAS_POSTAL_CODE]->(this3:PostalCode)
-                            WHERE this3.number IN $param4
-                        }
-                    })
-                }
+              MATCH (this)-[:HAS_VALUATION]->(this0:Valuation)
+              WHERE EXISTS {
+                MATCH (this0)-[:VALUATION_FOR]->(this1:Estate)
+                WHERE (this1.estateType IN $param1 AND this1.area >= $param2 AND this1.floor >= $param3 AND EXISTS {
+                  MATCH (this1)-[:HAS_ADDRESS]->(this2:Address)
+                  WHERE EXISTS {
+                    MATCH (this2)-[:HAS_POSTAL_CODE]->(this3:PostalCode)
+                    WHERE this3.number IN $param4
+                  }
+                })
+              }
             }) AND ($isAuthenticated = true AND this.archivedAt IS NULL))
             WITH *
             SKIP $param6
             LIMIT $param7
             CALL (this) {
-                MATCH (this)-[this4:HAS_VALUATION]->(this5:Valuation)
-                WITH DISTINCT this5
+              MATCH (this)-[this4:HAS_VALUATION]->(this5:Valuation)
+              WITH DISTINCT this5
+              WITH *
+              WHERE ($isAuthenticated = true AND this5.archivedAt IS NULL)
+              CALL (this5) {
+                MATCH (this5)-[this6:VALUATION_FOR]->(this7:Estate)
+                WITH DISTINCT this7
                 WITH *
-                WHERE ($isAuthenticated = true AND this5.archivedAt IS NULL)
-                CALL (this5) {
-                    MATCH (this5)-[this6:VALUATION_FOR]->(this7:Estate)
-                    WITH DISTINCT this7
-                    WITH *
-                    WHERE ($isAuthenticated = true AND this7.archivedAt IS NULL)
-                    WITH this7 { .uuid } AS this7
-                    RETURN collect(this7) AS var8
-                }
-                WITH this5 { estate: var8 } AS this5
-                RETURN collect(this5) AS var9
+                WHERE ($isAuthenticated = true AND this7.archivedAt IS NULL)
+                WITH this7 { .uuid } AS this7
+                RETURN collect(this7) AS var8
+              }
+              WITH this5 { estate: var8 } AS this5
+              RETURN collect(this5) AS var9
             }
             RETURN this { valuation: var9 } AS this"
         `);
@@ -541,36 +541,36 @@ describe("https://github.com/neo4j/graphql/issues/2396", () => {
             MATCH (this:Mandate)
             WITH *
             WHERE ((this.price >= $param0 AND EXISTS {
-                MATCH (this)-[:HAS_VALUATION]->(this0:Valuation)
-                WHERE EXISTS {
-                    MATCH (this0)-[:VALUATION_FOR]->(this1:Estate)
-                    WHERE (this1.estateType IN $param1 AND this1.area >= $param2 AND this1.floor >= $param3 AND EXISTS {
-                        MATCH (this1)-[:HAS_ADDRESS]->(this2:Address)
-                        WHERE EXISTS {
-                            MATCH (this2)-[:HAS_POSTAL_CODE]->(this3:PostalCode)
-                            WHERE this3.number IN $param4
-                        }
-                    })
-                }
+              MATCH (this)-[:HAS_VALUATION]->(this0:Valuation)
+              WHERE EXISTS {
+                MATCH (this0)-[:VALUATION_FOR]->(this1:Estate)
+                WHERE (this1.estateType IN $param1 AND this1.area >= $param2 AND this1.floor >= $param3 AND EXISTS {
+                  MATCH (this1)-[:HAS_ADDRESS]->(this2:Address)
+                  WHERE EXISTS {
+                    MATCH (this2)-[:HAS_POSTAL_CODE]->(this3:PostalCode)
+                    WHERE this3.number IN $param4
+                  }
+                })
+              }
             }) AND ($isAuthenticated = true AND this.archivedAt IS NULL))
             WITH *
             SKIP $param6
             LIMIT $param7
             CALL (this) {
-                MATCH (this)-[this4:HAS_VALUATION]->(this5:Valuation)
-                WITH DISTINCT this5
+              MATCH (this)-[this4:HAS_VALUATION]->(this5:Valuation)
+              WITH DISTINCT this5
+              WITH *
+              WHERE ($isAuthenticated = true AND this5.archivedAt IS NULL)
+              CALL (this5) {
+                MATCH (this5)-[this6:VALUATION_FOR]->(this7:Estate)
+                WITH DISTINCT this7
                 WITH *
-                WHERE ($isAuthenticated = true AND this5.archivedAt IS NULL)
-                CALL (this5) {
-                    MATCH (this5)-[this6:VALUATION_FOR]->(this7:Estate)
-                    WITH DISTINCT this7
-                    WITH *
-                    WHERE ($isAuthenticated = true AND this7.archivedAt IS NULL)
-                    WITH this7 { .uuid } AS this7
-                    RETURN collect(this7) AS var8
-                }
-                WITH this5 { estate: var8 } AS this5
-                RETURN collect(this5) AS var9
+                WHERE ($isAuthenticated = true AND this7.archivedAt IS NULL)
+                WITH this7 { .uuid } AS this7
+                RETURN collect(this7) AS var8
+              }
+              WITH this5 { estate: var8 } AS this5
+              RETURN collect(this5) AS var9
             }
             RETURN this { valuation: var9 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/2437.test.ts
+++ b/packages/graphql/tests/tck/issues/2437.test.ts
@@ -86,17 +86,17 @@ describe("https://github.com/neo4j/graphql/issues/2437", () => {
             WITH *
             WHERE (this.uuid = $param0 AND ($isAuthenticated = true AND this.archivedAt IS NULL))
             CALL (this) {
-                MATCH (this)-[this0:IS_VALUATION_AGENT]->(this1:Valuation)
-                WHERE ($isAuthenticated = true AND this1.archivedAt IS NULL)
-                WITH collect({ node: this1, relationship: this0 }) AS edges, count(this1) AS totalCount
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    WITH *
-                    LIMIT $param2
-                    RETURN collect({ node: { uuid: this1.uuid, __resolveType: \\"Valuation\\" } }) AS var2
-                }
-                RETURN { edges: var2, totalCount: totalCount } AS var3
+              MATCH (this)-[this0:IS_VALUATION_AGENT]->(this1:Valuation)
+              WHERE ($isAuthenticated = true AND this1.archivedAt IS NULL)
+              WITH collect({node: this1, relationship: this0}) AS edges, count(this1) AS totalCount
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                WITH *
+                LIMIT $param2
+                RETURN collect({node: {uuid: this1.uuid, __resolveType: 'Valuation'}}) AS var2
+              }
+              RETURN {edges: var2, totalCount: totalCount} AS var3
             }
             RETURN this { .uuid, valuationsConnection: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/2581.test.ts
+++ b/packages/graphql/tests/tck/issues/2581.test.ts
@@ -93,21 +93,21 @@ describe("https://github.com/neo4j/graphql/issues/2581", () => {
             "CYPHER 5
             MATCH (this:Author)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:AUTHORED_BOOK]->(b:Book) RETURN b AS result ORDER BY b.year DESC LIMIT 1
-                }
-                WITH result AS this0
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:AUTHORED_BOOK]->(b:Book) RETURN b AS result ORDER BY b.year DESC LIMIT 1
+              }
+              WITH result AS this0
+              CALL (this0) {
                 CALL (this0) {
-                    CALL (this0) {
-                        WITH this0 AS this
-                        OPTIONAL MATCH(sales:Sales) WHERE this.refID = sales.refID WITH count(sales) as result RETURN result as result
-                    }
-                    WITH result AS this1
-                    RETURN this1 AS var2
+                  WITH this0 AS this
+                  OPTIONAL MATCH(sales:Sales) WHERE this.refID = sales.refID WITH count(sales) as result RETURN result as result
                 }
-                WITH this0 { .name, .year, soldCopies: var2 } AS this0
-                RETURN head(collect(this0)) AS var3
+                WITH result AS this1
+                RETURN this1 AS var2
+              }
+              WITH this0 { .name, .year, soldCopies: var2 } AS this0
+              RETURN head(collect(this0)) AS var3
             }
             RETURN this { .name, mostRecentBook: var3 } AS this"
         `);
@@ -134,21 +134,21 @@ describe("https://github.com/neo4j/graphql/issues/2581", () => {
             "CYPHER 5
             MATCH (this:Author)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:AUTHORED_BOOK]->(b:Book) RETURN b AS result ORDER BY b.year DESC LIMIT 1
-                }
-                WITH result AS this0
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:AUTHORED_BOOK]->(b:Book) RETURN b AS result ORDER BY b.year DESC LIMIT 1
+              }
+              WITH result AS this0
+              CALL (this0) {
                 CALL (this0) {
-                    CALL (this0) {
-                        WITH this0 AS this
-                        OPTIONAL MATCH(sales:Sales) WHERE this.refID = sales.refID WITH count(sales) as result RETURN result as result
-                    }
-                    WITH result AS this1
-                    RETURN this1 AS var2
+                  WITH this0 AS this
+                  OPTIONAL MATCH(sales:Sales) WHERE this.refID = sales.refID WITH count(sales) as result RETURN result as result
                 }
-                WITH this0 { .name, .year, soldCopiesWithoutColumnName: var2 } AS this0
-                RETURN head(collect(this0)) AS var3
+                WITH result AS this1
+                RETURN this1 AS var2
+              }
+              WITH this0 { .name, .year, soldCopiesWithoutColumnName: var2 } AS this0
+              RETURN head(collect(this0)) AS var3
             }
             RETURN this { .name, mostRecentBook: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/2614.test.ts
+++ b/packages/graphql/tests/tck/issues/2614.test.ts
@@ -74,21 +74,21 @@ describe("https://github.com/neo4j/graphql/issues/2614", () => {
             "CYPHER 5
             MATCH (this:Actor)
             CALL (this) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this)-[this0:ACTED_IN]->(this1:Film)
-                    WHERE this1.title = $param0
-                    WITH this1 { .title, __resolveType: \\"Movie\\", __id: id(this1) } AS var2
-                    RETURN var2
-                    UNION
-                    WITH *
-                    MATCH (this)-[this3:ACTED_IN]->(this4:Series)
-                    WHERE this4.title = $param1
-                    WITH this4 { .title, __resolveType: \\"Series\\", __id: id(this4) } AS var2
-                    RETURN var2
-                }
-                WITH var2
-                RETURN collect(var2) AS var2
+              CALL (*) {
+                WITH *
+                MATCH (this)-[this0:ACTED_IN]->(this1:Film)
+                WHERE this1.title = $param0
+                WITH this1 { .title, __resolveType: 'Movie', __id: elementId(this1) } AS var2
+                RETURN var2
+                UNION
+                WITH *
+                MATCH (this)-[this3:ACTED_IN]->(this4:Series)
+                WHERE this4.title = $param1
+                WITH this4 { .title, __resolveType: 'Series', __id: elementId(this4) } AS var2
+                RETURN var2
+              }
+              WITH var2
+              RETURN collect(var2) AS var2
             }
             RETURN this { actedIn: var2 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/2670.test.ts
+++ b/packages/graphql/tests/tck/issues/2670.test.ts
@@ -66,14 +66,14 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
-                CALL (this1, this0) {
-                    MATCH (this1)<-[this2:IN_GENRE]-(this3:Movie)
-                    RETURN count(this3) = $param0 AS var4
-                }
-                WITH *
-                WHERE var4 = true
-                RETURN count(this1) > 0 AS var5
+              MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
+              CALL (this1, this0) {
+                MATCH (this1)<-[this2:IN_GENRE]-(this3:Movie)
+                RETURN count(this3) = $param0 AS var4
+              }
+              WITH *
+              WHERE var4 = true
+              RETURN count(this1) > 0 AS var5
             }
             WITH *
             WHERE var5 = true
@@ -105,14 +105,14 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
-                CALL (this1, this0) {
-                    MATCH (this1)<-[this2:IN_GENRE]-(this3:Movie)
-                    RETURN count(this3) < $param0 AS var4
-                }
-                WITH *
-                WHERE var4 = true
-                RETURN count(this1) > 0 AS var5
+              MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
+              CALL (this1, this0) {
+                MATCH (this1)<-[this2:IN_GENRE]-(this3:Movie)
+                RETURN count(this3) < $param0 AS var4
+              }
+              WITH *
+              WHERE var4 = true
+              RETURN count(this1) > 0 AS var5
             }
             WITH *
             WHERE var5 = true
@@ -144,14 +144,14 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
-                CALL (this1, this0) {
-                    MATCH (this1)<-[this2:IN_GENRE]-(this3:Movie)
-                    RETURN count(this3) > $param0 AS var4
-                }
-                WITH *
-                WHERE var4 = true
-                RETURN count(this1) > 0 AS var5
+              MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
+              CALL (this1, this0) {
+                MATCH (this1)<-[this2:IN_GENRE]-(this3:Movie)
+                RETURN count(this3) > $param0 AS var4
+              }
+              WITH *
+              WHERE var4 = true
+              RETURN count(this1) > 0 AS var5
             }
             WITH *
             WHERE var5 = true
@@ -189,14 +189,14 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
-                CALL (this1, this0) {
-                    MATCH (this1)<-[this2:IN_GENRE]-(this3:Movie)
-                    RETURN min(size(this3.title)) = $param0 AS var4
-                }
-                WITH *
-                WHERE var4 = true
-                RETURN count(this1) > 0 AS var5
+              MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
+              CALL (this1, this0) {
+                MATCH (this1)<-[this2:IN_GENRE]-(this3:Movie)
+                RETURN min(size(this3.title)) = $param0 AS var4
+              }
+              WITH *
+              WHERE var4 = true
+              RETURN count(this1) > 0 AS var5
             }
             WITH *
             WHERE var5 = true
@@ -234,14 +234,14 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
-                CALL (this1, this0) {
-                    MATCH (this1)<-[this2:IN_GENRE]-(this3:Movie)
-                    RETURN avg(size(this3.title)) = $param0 AS var4
-                }
-                WITH *
-                WHERE var4 = true
-                RETURN count(this1) > 0 AS var5
+              MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
+              CALL (this1, this0) {
+                MATCH (this1)<-[this2:IN_GENRE]-(this3:Movie)
+                RETURN avg(size(this3.title)) = $param0 AS var4
+              }
+              WITH *
+              WHERE var4 = true
+              RETURN count(this1) > 0 AS var5
             }
             WITH *
             WHERE var5 = true
@@ -276,14 +276,14 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
-                CALL (this1, this0) {
-                    MATCH (this1)<-[this2:IN_GENRE]-(this3:Movie)
-                    RETURN max(this2.intValue) < $param0 AS var4
-                }
-                WITH *
-                WHERE var4 = true
-                RETURN count(this1) > 0 AS var5
+              MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
+              CALL (this1, this0) {
+                MATCH (this1)<-[this2:IN_GENRE]-(this3:Movie)
+                RETURN max(this2.intValue) < $param0 AS var4
+              }
+              WITH *
+              WHERE var4 = true
+              RETURN count(this1) > 0 AS var5
             }
             WITH *
             WHERE var5 = true
@@ -321,14 +321,14 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
-                CALL (this1, this0) {
-                    MATCH (this1)<-[this2:IN_GENRE]-(this3:Movie)
-                    RETURN min(this2.intValue) = $param0 AS var4
-                }
-                WITH *
-                WHERE var4 = true
-                RETURN count(this1) > 0 AS var5
+              MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
+              CALL (this1, this0) {
+                MATCH (this1)<-[this2:IN_GENRE]-(this3:Movie)
+                RETURN min(this2.intValue) = $param0 AS var4
+              }
+              WITH *
+              WHERE var4 = true
+              RETURN count(this1) > 0 AS var5
             }
             WITH *
             WHERE var5 = true
@@ -360,14 +360,14 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
-                CALL (this1, this0) {
-                    MATCH (this1)<-[this2:IN_GENRE]-(this3:Movie)
-                    RETURN count(this3) = $param0 AS var4
-                }
-                WITH *
-                WHERE var4 = true
-                RETURN count(this1) > 0 AS var5
+              MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
+              CALL (this1, this0) {
+                MATCH (this1)<-[this2:IN_GENRE]-(this3:Movie)
+                RETURN count(this3) = $param0 AS var4
+              }
+              WITH *
+              WHERE var4 = true
+              RETURN count(this1) > 0 AS var5
             }
             WITH *
             WHERE var5 = true
@@ -399,14 +399,14 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
-                CALL (this1, this0) {
-                    MATCH (this1)<-[this2:IN_GENRE]-(this3:Movie)
-                    RETURN count(this3) = $param0 AS var4
-                }
-                WITH *
-                WHERE var4 = true
-                RETURN count(this1) > 0 AS var5
+              MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
+              CALL (this1, this0) {
+                MATCH (this1)<-[this2:IN_GENRE]-(this3:Movie)
+                RETURN count(this3) = $param0 AS var4
+              }
+              WITH *
+              WHERE var4 = true
+              RETURN count(this1) > 0 AS var5
             }
             WITH *
             WHERE var5 = false
@@ -438,24 +438,24 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
-                CALL (this1) {
-                    MATCH (this1)<-[this2:IN_GENRE]-(this3:Movie)
-                    RETURN count(this3) = $param0 AS var4
-                }
-                WITH *
-                WHERE var4 = true
-                RETURN count(this1) > 0 AS var5
+              MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
+              CALL (this1) {
+                MATCH (this1)<-[this2:IN_GENRE]-(this3:Movie)
+                RETURN count(this3) = $param0 AS var4
+              }
+              WITH *
+              WHERE var4 = true
+              RETURN count(this1) > 0 AS var5
             }
             CALL (this) {
-                MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
-                CALL (this1) {
-                    MATCH (this1)<-[this6:IN_GENRE]-(this7:Movie)
-                    RETURN count(this7) = $param1 AS var8
-                }
-                WITH *
-                WHERE NOT (var8 = true)
-                RETURN count(this1) > 0 AS var9
+              MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
+              CALL (this1) {
+                MATCH (this1)<-[this6:IN_GENRE]-(this7:Movie)
+                RETURN count(this7) = $param1 AS var8
+              }
+              WITH *
+              WHERE NOT (var8 = true)
+              RETURN count(this1) > 0 AS var9
             }
             WITH *
             WHERE (var9 = false AND var5 = true)
@@ -491,14 +491,14 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
-                CALL (this1, this0) {
-                    MATCH (this1)<-[this2:IN_GENRE]-(this3:Movie)
-                    RETURN count(this3) = $param0 AS var4
-                }
-                WITH *
-                WHERE var4 = true
-                RETURN count(this1) = 1 AS var5
+              MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
+              CALL (this1, this0) {
+                MATCH (this1)<-[this2:IN_GENRE]-(this3:Movie)
+                RETURN count(this3) = $param0 AS var4
+              }
+              WITH *
+              WHERE var4 = true
+              RETURN count(this1) = 1 AS var5
             }
             WITH *
             WHERE var5 = true
@@ -541,18 +541,18 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
-                CALL (this1, this0) {
-                    MATCH (this1)<-[this2:IN_GENRE]-(this3:Movie)
-                    RETURN count(this3) = $param0 AS var4
-                }
-                CALL (this1, this0) {
-                    MATCH (this1)<-[this5:IN_GENRE]-(this6:Series)
-                    RETURN min(size(this6.name)) = $param1 AS var7
-                }
-                WITH *
-                WHERE (var4 = true AND var7 = true)
-                RETURN count(this1) > 0 AS var8
+              MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
+              CALL (this1, this0) {
+                MATCH (this1)<-[this2:IN_GENRE]-(this3:Movie)
+                RETURN count(this3) = $param0 AS var4
+              }
+              CALL (this1, this0) {
+                MATCH (this1)<-[this5:IN_GENRE]-(this6:Series)
+                RETURN min(size(this6.name)) = $param1 AS var7
+              }
+              WITH *
+              WHERE (var4 = true AND var7 = true)
+              RETURN count(this1) > 0 AS var8
             }
             WITH *
             WHERE var8 = true
@@ -599,18 +599,18 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
-                CALL (this1, this0) {
-                    MATCH (this1)<-[this2:IN_GENRE]-(this3:Movie)
-                    RETURN count(this3) = $param0 AS var4
-                }
-                CALL (this1, this0) {
-                    MATCH (this1)<-[this5:IN_GENRE]-(this6:Series)
-                    RETURN min(size(this6.name)) = $param1 AS var7
-                }
-                WITH *
-                WHERE (var4 = true OR var7 = true)
-                RETURN count(this1) > 0 AS var8
+              MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
+              CALL (this1, this0) {
+                MATCH (this1)<-[this2:IN_GENRE]-(this3:Movie)
+                RETURN count(this3) = $param0 AS var4
+              }
+              CALL (this1, this0) {
+                MATCH (this1)<-[this5:IN_GENRE]-(this6:Series)
+                RETURN min(size(this6.name)) = $param1 AS var7
+              }
+              WITH *
+              WHERE (var4 = true OR var7 = true)
+              RETURN count(this1) > 0 AS var8
             }
             WITH *
             WHERE var8 = true
@@ -657,18 +657,18 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
-                CALL (this1, this0) {
-                    MATCH (this1)<-[this2:IN_GENRE]-(this3:Movie)
-                    RETURN count(this3) = $param0 AS var4
-                }
-                CALL (this1, this0) {
-                    MATCH (this1)<-[this5:IN_GENRE]-(this6:Series)
-                    RETURN min(size(this6.name)) = $param1 AS var7
-                }
-                WITH *
-                WHERE (var4 = true AND var7 = true)
-                RETURN count(this1) > 0 AS var8
+              MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
+              CALL (this1, this0) {
+                MATCH (this1)<-[this2:IN_GENRE]-(this3:Movie)
+                RETURN count(this3) = $param0 AS var4
+              }
+              CALL (this1, this0) {
+                MATCH (this1)<-[this5:IN_GENRE]-(this6:Series)
+                RETURN min(size(this6.name)) = $param1 AS var7
+              }
+              WITH *
+              WHERE (var4 = true AND var7 = true)
+              RETURN count(this1) > 0 AS var8
             }
             WITH *
             WHERE var8 = true
@@ -709,18 +709,18 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
-                CALL (this1, this0) {
-                    MATCH (this1)<-[this2:IN_GENRE]-(this3:Movie)
-                    RETURN count(this3) = $param0 AS var4
-                }
-                WITH *
-                WHERE var4 = true
-                RETURN count(this1) > 0 AS var5
+              MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
+              CALL (this1, this0) {
+                MATCH (this1)<-[this2:IN_GENRE]-(this3:Movie)
+                RETURN count(this3) = $param0 AS var4
+              }
+              WITH *
+              WHERE var4 = true
+              RETURN count(this1) > 0 AS var5
             }
             CALL (this) {
-                MATCH (this)-[this6:IN_GENRE]->(this7:Genre)
-                RETURN count(this7) = $param1 AS var8
+              MATCH (this)-[this6:IN_GENRE]->(this7:Genre)
+              RETURN count(this7) = $param1 AS var8
             }
             WITH *
             WHERE (var5 = true AND var8 = true)

--- a/packages/graphql/tests/tck/issues/2708.test.ts
+++ b/packages/graphql/tests/tck/issues/2708.test.ts
@@ -66,14 +66,14 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)-[:IN_GENRE]->(this0:Genre)
-                CALL (this0) {
-                    MATCH (this0)<-[this1:IN_GENRE]-(this2:Movie)
-                    RETURN count(this2) = $param0 AS var3
-                }
-                WITH *
-                WHERE var3 = true
-                RETURN count(this0) > 0 AS var4
+              MATCH (this)-[:IN_GENRE]->(this0:Genre)
+              CALL (this0) {
+                MATCH (this0)<-[this1:IN_GENRE]-(this2:Movie)
+                RETURN count(this2) = $param0 AS var3
+              }
+              WITH *
+              WHERE var3 = true
+              RETURN count(this0) > 0 AS var4
             }
             WITH *
             WHERE var4 = true
@@ -105,14 +105,14 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)-[:IN_GENRE]->(this0:Genre)
-                CALL (this0) {
-                    MATCH (this0)<-[this1:IN_GENRE]-(this2:Movie)
-                    RETURN count(this2) < $param0 AS var3
-                }
-                WITH *
-                WHERE var3 = true
-                RETURN count(this0) > 0 AS var4
+              MATCH (this)-[:IN_GENRE]->(this0:Genre)
+              CALL (this0) {
+                MATCH (this0)<-[this1:IN_GENRE]-(this2:Movie)
+                RETURN count(this2) < $param0 AS var3
+              }
+              WITH *
+              WHERE var3 = true
+              RETURN count(this0) > 0 AS var4
             }
             WITH *
             WHERE var4 = true
@@ -144,14 +144,14 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)-[:IN_GENRE]->(this0:Genre)
-                CALL (this0) {
-                    MATCH (this0)<-[this1:IN_GENRE]-(this2:Movie)
-                    RETURN count(this2) > $param0 AS var3
-                }
-                WITH *
-                WHERE var3 = true
-                RETURN count(this0) > 0 AS var4
+              MATCH (this)-[:IN_GENRE]->(this0:Genre)
+              CALL (this0) {
+                MATCH (this0)<-[this1:IN_GENRE]-(this2:Movie)
+                RETURN count(this2) > $param0 AS var3
+              }
+              WITH *
+              WHERE var3 = true
+              RETURN count(this0) > 0 AS var4
             }
             WITH *
             WHERE var4 = true
@@ -185,14 +185,14 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)-[:IN_GENRE]->(this0:Genre)
-                CALL (this0) {
-                    MATCH (this0)<-[this1:IN_GENRE]-(this2:Movie)
-                    RETURN min(size(this2.title)) = $param0 AS var3
-                }
-                WITH *
-                WHERE var3 = true
-                RETURN count(this0) > 0 AS var4
+              MATCH (this)-[:IN_GENRE]->(this0:Genre)
+              CALL (this0) {
+                MATCH (this0)<-[this1:IN_GENRE]-(this2:Movie)
+                RETURN min(size(this2.title)) = $param0 AS var3
+              }
+              WITH *
+              WHERE var3 = true
+              RETURN count(this0) > 0 AS var4
             }
             WITH *
             WHERE var4 = true
@@ -226,14 +226,14 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)-[:IN_GENRE]->(this0:Genre)
-                CALL (this0) {
-                    MATCH (this0)<-[this1:IN_GENRE]-(this2:Movie)
-                    RETURN avg(size(this2.title)) = $param0 AS var3
-                }
-                WITH *
-                WHERE var3 = true
-                RETURN count(this0) > 0 AS var4
+              MATCH (this)-[:IN_GENRE]->(this0:Genre)
+              CALL (this0) {
+                MATCH (this0)<-[this1:IN_GENRE]-(this2:Movie)
+                RETURN avg(size(this2.title)) = $param0 AS var3
+              }
+              WITH *
+              WHERE var3 = true
+              RETURN count(this0) > 0 AS var4
             }
             WITH *
             WHERE var4 = true
@@ -262,14 +262,14 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)-[:IN_GENRE]->(this0:Genre)
-                CALL (this0) {
-                    MATCH (this0)<-[this1:IN_GENRE]-(this2:Movie)
-                    RETURN max(this1.intValue) < $param0 AS var3
-                }
-                WITH *
-                WHERE var3 = true
-                RETURN count(this0) > 0 AS var4
+              MATCH (this)-[:IN_GENRE]->(this0:Genre)
+              CALL (this0) {
+                MATCH (this0)<-[this1:IN_GENRE]-(this2:Movie)
+                RETURN max(this1.intValue) < $param0 AS var3
+              }
+              WITH *
+              WHERE var3 = true
+              RETURN count(this0) > 0 AS var4
             }
             WITH *
             WHERE var4 = true
@@ -301,14 +301,14 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)-[:IN_GENRE]->(this0:Genre)
-                CALL (this0) {
-                    MATCH (this0)<-[this1:IN_GENRE]-(this2:Movie)
-                    RETURN min(this1.intValue) = $param0 AS var3
-                }
-                WITH *
-                WHERE var3 = true
-                RETURN count(this0) > 0 AS var4
+              MATCH (this)-[:IN_GENRE]->(this0:Genre)
+              CALL (this0) {
+                MATCH (this0)<-[this1:IN_GENRE]-(this2:Movie)
+                RETURN min(this1.intValue) = $param0 AS var3
+              }
+              WITH *
+              WHERE var3 = true
+              RETURN count(this0) > 0 AS var4
             }
             WITH *
             WHERE var4 = true
@@ -340,14 +340,14 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)-[:IN_GENRE]->(this0:Genre)
-                CALL (this0) {
-                    MATCH (this0)<-[this1:IN_GENRE]-(this2:Movie)
-                    RETURN count(this2) = $param0 AS var3
-                }
-                WITH *
-                WHERE var3 = true
-                RETURN count(this0) > 0 AS var4
+              MATCH (this)-[:IN_GENRE]->(this0:Genre)
+              CALL (this0) {
+                MATCH (this0)<-[this1:IN_GENRE]-(this2:Movie)
+                RETURN count(this2) = $param0 AS var3
+              }
+              WITH *
+              WHERE var3 = true
+              RETURN count(this0) > 0 AS var4
             }
             WITH *
             WHERE var4 = true
@@ -379,14 +379,14 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)-[:IN_GENRE]->(this0:Genre)
-                CALL (this0) {
-                    MATCH (this0)<-[this1:IN_GENRE]-(this2:Movie)
-                    RETURN count(this2) = $param0 AS var3
-                }
-                WITH *
-                WHERE var3 = true
-                RETURN count(this0) > 0 AS var4
+              MATCH (this)-[:IN_GENRE]->(this0:Genre)
+              CALL (this0) {
+                MATCH (this0)<-[this1:IN_GENRE]-(this2:Movie)
+                RETURN count(this2) = $param0 AS var3
+              }
+              WITH *
+              WHERE var3 = true
+              RETURN count(this0) > 0 AS var4
             }
             WITH *
             WHERE var4 = false
@@ -418,24 +418,24 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)-[:IN_GENRE]->(this0:Genre)
-                CALL (this0) {
-                    MATCH (this0)<-[this1:IN_GENRE]-(this2:Movie)
-                    RETURN count(this2) = $param0 AS var3
-                }
-                WITH *
-                WHERE var3 = true
-                RETURN count(this0) > 0 AS var4
+              MATCH (this)-[:IN_GENRE]->(this0:Genre)
+              CALL (this0) {
+                MATCH (this0)<-[this1:IN_GENRE]-(this2:Movie)
+                RETURN count(this2) = $param0 AS var3
+              }
+              WITH *
+              WHERE var3 = true
+              RETURN count(this0) > 0 AS var4
             }
             CALL (this) {
-                MATCH (this)-[:IN_GENRE]->(this0:Genre)
-                CALL (this0) {
-                    MATCH (this0)<-[this5:IN_GENRE]-(this6:Movie)
-                    RETURN count(this6) = $param1 AS var7
-                }
-                WITH *
-                WHERE NOT (var7 = true)
-                RETURN count(this0) > 0 AS var8
+              MATCH (this)-[:IN_GENRE]->(this0:Genre)
+              CALL (this0) {
+                MATCH (this0)<-[this5:IN_GENRE]-(this6:Movie)
+                RETURN count(this6) = $param1 AS var7
+              }
+              WITH *
+              WHERE NOT (var7 = true)
+              RETURN count(this0) > 0 AS var8
             }
             WITH *
             WHERE (var8 = false AND var4 = true)
@@ -471,14 +471,14 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)-[:IN_GENRE]->(this0:Genre)
-                CALL (this0) {
-                    MATCH (this0)<-[this1:IN_GENRE]-(this2:Movie)
-                    RETURN count(this2) = $param0 AS var3
-                }
-                WITH *
-                WHERE var3 = true
-                RETURN count(this0) = 1 AS var4
+              MATCH (this)-[:IN_GENRE]->(this0:Genre)
+              CALL (this0) {
+                MATCH (this0)<-[this1:IN_GENRE]-(this2:Movie)
+                RETURN count(this2) = $param0 AS var3
+              }
+              WITH *
+              WHERE var3 = true
+              RETURN count(this0) = 1 AS var4
             }
             WITH *
             WHERE var4 = true
@@ -510,24 +510,24 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)-[:IN_GENRE]->(this0:Genre)
-                CALL (this0) {
-                    MATCH (this0)<-[this1:IN_GENRE]-(this2:Movie)
-                    RETURN count(this2) = $param0 AS var3
-                }
-                WITH *
-                WHERE var3 = true
-                RETURN count(this0) > 0 AS var4
+              MATCH (this)-[:IN_GENRE]->(this0:Genre)
+              CALL (this0) {
+                MATCH (this0)<-[this1:IN_GENRE]-(this2:Movie)
+                RETURN count(this2) = $param0 AS var3
+              }
+              WITH *
+              WHERE var3 = true
+              RETURN count(this0) > 0 AS var4
             }
             CALL (this) {
-                MATCH (this)-[:IN_GENRE]->(this0:Genre)
-                CALL (this0) {
-                    MATCH (this0)<-[this5:IN_GENRE]-(this6:Movie)
-                    RETURN count(this6) = $param1 AS var7
-                }
-                WITH *
-                WHERE NOT (var7 = true)
-                RETURN count(this0) > 0 AS var8
+              MATCH (this)-[:IN_GENRE]->(this0:Genre)
+              CALL (this0) {
+                MATCH (this0)<-[this5:IN_GENRE]-(this6:Movie)
+                RETURN count(this6) = $param1 AS var7
+              }
+              WITH *
+              WHERE NOT (var7 = true)
+              RETURN count(this0) > 0 AS var8
             }
             WITH *
             WHERE (var8 = false AND var4 = true)
@@ -574,18 +574,18 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)-[:IN_GENRE]->(this0:Genre)
-                CALL (this0) {
-                    MATCH (this0)<-[this1:IN_GENRE]-(this2:Movie)
-                    RETURN count(this2) = $param0 AS var3
-                }
-                CALL (this0) {
-                    MATCH (this0)<-[this4:IN_GENRE]-(this5:Series)
-                    RETURN min(size(this5.name)) = $param1 AS var6
-                }
-                WITH *
-                WHERE (var3 = true AND var6 = true)
-                RETURN count(this0) > 0 AS var7
+              MATCH (this)-[:IN_GENRE]->(this0:Genre)
+              CALL (this0) {
+                MATCH (this0)<-[this1:IN_GENRE]-(this2:Movie)
+                RETURN count(this2) = $param0 AS var3
+              }
+              CALL (this0) {
+                MATCH (this0)<-[this4:IN_GENRE]-(this5:Series)
+                RETURN min(size(this5.name)) = $param1 AS var6
+              }
+              WITH *
+              WHERE (var3 = true AND var6 = true)
+              RETURN count(this0) > 0 AS var7
             }
             WITH *
             WHERE var7 = true
@@ -632,18 +632,18 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)-[:IN_GENRE]->(this0:Genre)
-                CALL (this0) {
-                    MATCH (this0)<-[this1:IN_GENRE]-(this2:Movie)
-                    RETURN count(this2) = $param0 AS var3
-                }
-                CALL (this0) {
-                    MATCH (this0)<-[this4:IN_GENRE]-(this5:Series)
-                    RETURN min(size(this5.name)) = $param1 AS var6
-                }
-                WITH *
-                WHERE (var3 = true OR var6 = true)
-                RETURN count(this0) > 0 AS var7
+              MATCH (this)-[:IN_GENRE]->(this0:Genre)
+              CALL (this0) {
+                MATCH (this0)<-[this1:IN_GENRE]-(this2:Movie)
+                RETURN count(this2) = $param0 AS var3
+              }
+              CALL (this0) {
+                MATCH (this0)<-[this4:IN_GENRE]-(this5:Series)
+                RETURN min(size(this5.name)) = $param1 AS var6
+              }
+              WITH *
+              WHERE (var3 = true OR var6 = true)
+              RETURN count(this0) > 0 AS var7
             }
             WITH *
             WHERE var7 = true
@@ -688,18 +688,18 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)-[:IN_GENRE]->(this0:Genre)
-                CALL (this0) {
-                    MATCH (this0)<-[this1:IN_GENRE]-(this2:Movie)
-                    RETURN count(this2) = $param0 AS var3
-                }
-                CALL (this0) {
-                    MATCH (this0)<-[this4:IN_GENRE]-(this5:Series)
-                    RETURN min(size(this5.name)) = $param1 AS var6
-                }
-                WITH *
-                WHERE (var3 = true AND var6 = true)
-                RETURN count(this0) > 0 AS var7
+              MATCH (this)-[:IN_GENRE]->(this0:Genre)
+              CALL (this0) {
+                MATCH (this0)<-[this1:IN_GENRE]-(this2:Movie)
+                RETURN count(this2) = $param0 AS var3
+              }
+              CALL (this0) {
+                MATCH (this0)<-[this4:IN_GENRE]-(this5:Series)
+                RETURN min(size(this5.name)) = $param1 AS var6
+              }
+              WITH *
+              WHERE (var3 = true AND var6 = true)
+              RETURN count(this0) > 0 AS var7
             }
             WITH *
             WHERE var7 = true
@@ -740,18 +740,18 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)-[:IN_GENRE]->(this0:Genre)
-                CALL (this0) {
-                    MATCH (this0)<-[this1:IN_GENRE]-(this2:Movie)
-                    RETURN count(this2) = $param0 AS var3
-                }
-                WITH *
-                WHERE var3 = true
-                RETURN count(this0) > 0 AS var4
+              MATCH (this)-[:IN_GENRE]->(this0:Genre)
+              CALL (this0) {
+                MATCH (this0)<-[this1:IN_GENRE]-(this2:Movie)
+                RETURN count(this2) = $param0 AS var3
+              }
+              WITH *
+              WHERE var3 = true
+              RETURN count(this0) > 0 AS var4
             }
             CALL (this) {
-                MATCH (this)-[this5:IN_GENRE]->(this6:Genre)
-                RETURN count(this6) = $param1 AS var7
+              MATCH (this)-[this5:IN_GENRE]->(this6:Genre)
+              RETURN count(this6) = $param1 AS var7
             }
             WITH *
             WHERE (var4 = true AND var7 = true)
@@ -798,32 +798,32 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)-[:IN_GENRE]->(this0:Genre)
-                CALL (this0) {
-                    MATCH (this0)<-[this1:IN_GENRE]-(this2:Movie)
-                    RETURN count(this2) = $param0 AS var3
-                }
-                CALL (this0) {
-                    MATCH (this0)<-[this4:IN_GENRE]-(this5:Series)
-                    RETURN count(this5) = $param1 AS var6
-                }
-                WITH *
-                WHERE (var3 = true OR var6 = true)
-                RETURN count(this0) > 0 AS var7
+              MATCH (this)-[:IN_GENRE]->(this0:Genre)
+              CALL (this0) {
+                MATCH (this0)<-[this1:IN_GENRE]-(this2:Movie)
+                RETURN count(this2) = $param0 AS var3
+              }
+              CALL (this0) {
+                MATCH (this0)<-[this4:IN_GENRE]-(this5:Series)
+                RETURN count(this5) = $param1 AS var6
+              }
+              WITH *
+              WHERE (var3 = true OR var6 = true)
+              RETURN count(this0) > 0 AS var7
             }
             CALL (this) {
-                MATCH (this)-[:IN_GENRE]->(this0:Genre)
-                CALL (this0) {
-                    MATCH (this0)<-[this8:IN_GENRE]-(this9:Movie)
-                    RETURN count(this9) = $param2 AS var10
-                }
-                CALL (this0) {
-                    MATCH (this0)<-[this11:IN_GENRE]-(this12:Series)
-                    RETURN count(this12) = $param3 AS var13
-                }
-                WITH *
-                WHERE NOT (var10 = true OR var13 = true)
-                RETURN count(this0) > 0 AS var14
+              MATCH (this)-[:IN_GENRE]->(this0:Genre)
+              CALL (this0) {
+                MATCH (this0)<-[this8:IN_GENRE]-(this9:Movie)
+                RETURN count(this9) = $param2 AS var10
+              }
+              CALL (this0) {
+                MATCH (this0)<-[this11:IN_GENRE]-(this12:Series)
+                RETURN count(this12) = $param3 AS var13
+              }
+              WITH *
+              WHERE NOT (var10 = true OR var13 = true)
+              RETURN count(this0) > 0 AS var14
             }
             WITH *
             WHERE (var14 = false AND var7 = true)
@@ -876,32 +876,32 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)-[:IN_GENRE]->(this0:Genre)
-                CALL (this0) {
-                    MATCH (this0)<-[this1:IN_GENRE]-(this2:Movie)
-                    RETURN count(this2) = $param0 AS var3
-                }
-                CALL (this0) {
-                    MATCH (this0)<-[this4:IN_GENRE]-(this5:Series)
-                    RETURN count(this5) = $param1 AS var6
-                }
-                WITH *
-                WHERE ((var3 = true OR this0.name = $param2) AND var6 = true)
-                RETURN count(this0) > 0 AS var7
+              MATCH (this)-[:IN_GENRE]->(this0:Genre)
+              CALL (this0) {
+                MATCH (this0)<-[this1:IN_GENRE]-(this2:Movie)
+                RETURN count(this2) = $param0 AS var3
+              }
+              CALL (this0) {
+                MATCH (this0)<-[this4:IN_GENRE]-(this5:Series)
+                RETURN count(this5) = $param1 AS var6
+              }
+              WITH *
+              WHERE ((var3 = true OR this0.name = $param2) AND var6 = true)
+              RETURN count(this0) > 0 AS var7
             }
             CALL (this) {
-                MATCH (this)-[:IN_GENRE]->(this0:Genre)
-                CALL (this0) {
-                    MATCH (this0)<-[this8:IN_GENRE]-(this9:Movie)
-                    RETURN count(this9) = $param3 AS var10
-                }
-                CALL (this0) {
-                    MATCH (this0)<-[this11:IN_GENRE]-(this12:Series)
-                    RETURN count(this12) = $param4 AS var13
-                }
-                WITH *
-                WHERE NOT ((var10 = true OR this0.name = $param5) AND var13 = true)
-                RETURN count(this0) > 0 AS var14
+              MATCH (this)-[:IN_GENRE]->(this0:Genre)
+              CALL (this0) {
+                MATCH (this0)<-[this8:IN_GENRE]-(this9:Movie)
+                RETURN count(this9) = $param3 AS var10
+              }
+              CALL (this0) {
+                MATCH (this0)<-[this11:IN_GENRE]-(this12:Series)
+                RETURN count(this12) = $param4 AS var13
+              }
+              WITH *
+              WHERE NOT ((var10 = true OR this0.name = $param5) AND var13 = true)
+              RETURN count(this0) > 0 AS var14
             }
             WITH *
             WHERE (var14 = false AND var7 = true)

--- a/packages/graphql/tests/tck/issues/2709.test.ts
+++ b/packages/graphql/tests/tck/issues/2709.test.ts
@@ -105,8 +105,8 @@ describe("https://github.com/neo4j/graphql/issues/2709", () => {
             "CYPHER 5
             MATCH (this:Film)
             WHERE EXISTS {
-                MATCH (this)<-[this0:DISTRIBUTED_BY]-(this1)
-                WHERE (this1.name = $param0 AND (this1:Dishney OR this1:Prime OR this1:Netflix))
+              MATCH (this)<-[this0:DISTRIBUTED_BY]-(this1)
+              WHERE (this1.name = $param0 AND (this1:Dishney OR this1:Prime OR this1:Netflix))
             }
             RETURN this { .title } AS this"
         `);
@@ -138,8 +138,8 @@ describe("https://github.com/neo4j/graphql/issues/2709", () => {
             "CYPHER 5
             MATCH (this:Film)
             WHERE EXISTS {
-                MATCH (this)<-[this0:DISTRIBUTED_BY]-(this1)
-                WHERE ((this1.name = $param0 OR this1.name = $param1) AND (this1:Dishney OR this1:Prime OR this1:Netflix))
+              MATCH (this)<-[this0:DISTRIBUTED_BY]-(this1)
+              WHERE ((this1.name = $param0 OR this1.name = $param1) AND (this1:Dishney OR this1:Prime OR this1:Netflix))
             }
             RETURN this { .title } AS this"
         `);
@@ -237,8 +237,8 @@ describe("https://github.com/neo4j/graphql/issues/2709 union parity", () => {
             "CYPHER 5
             MATCH (this:Film)
             WHERE EXISTS {
-                MATCH (this)<-[this0:DISTRIBUTED_BY]-(this1:Netflix)
-                WHERE this1.name = $param0
+              MATCH (this)<-[this0:DISTRIBUTED_BY]-(this1:Netflix)
+              WHERE this1.name = $param0
             }
             RETURN this { .title } AS this"
         `);
@@ -268,8 +268,8 @@ describe("https://github.com/neo4j/graphql/issues/2709 union parity", () => {
             "CYPHER 5
             MATCH (this:Film)
             WHERE EXISTS {
-                MATCH (this)<-[this0:DISTRIBUTED_BY]-(this1:Dishney)
-                WHERE this1.name = $param0
+              MATCH (this)<-[this0:DISTRIBUTED_BY]-(this1:Dishney)
+              WHERE this1.name = $param0
             }
             RETURN this { .title } AS this"
         `);
@@ -295,8 +295,8 @@ describe("https://github.com/neo4j/graphql/issues/2709 union parity", () => {
             "CYPHER 5
             MATCH (this:Film)
             WHERE EXISTS {
-                MATCH (this)<-[this0:DISTRIBUTED_BY]-(this1:Dishney)
-                WHERE this1.name = $param0
+              MATCH (this)<-[this0:DISTRIBUTED_BY]-(this1:Dishney)
+              WHERE this1.name = $param0
             }
             RETURN this { .title } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/2713.test.ts
+++ b/packages/graphql/tests/tck/issues/2713.test.ts
@@ -66,24 +66,24 @@ describe("https://github.com/neo4j/graphql/issues/2713", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
-                CALL (this1) {
-                    MATCH (this1)<-[this2:IN_GENRE]-(this3:Movie)
-                    RETURN count(this3) = $param0 AS var4
-                }
-                WITH *
-                WHERE var4 = true
-                RETURN count(this1) > 0 AS var5
+              MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
+              CALL (this1) {
+                MATCH (this1)<-[this2:IN_GENRE]-(this3:Movie)
+                RETURN count(this3) = $param0 AS var4
+              }
+              WITH *
+              WHERE var4 = true
+              RETURN count(this1) > 0 AS var5
             }
             CALL (this) {
-                MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
-                CALL (this1) {
-                    MATCH (this1)<-[this6:IN_GENRE]-(this7:Movie)
-                    RETURN count(this7) = $param1 AS var8
-                }
-                WITH *
-                WHERE NOT (var8 = true)
-                RETURN count(this1) > 0 AS var9
+              MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
+              CALL (this1) {
+                MATCH (this1)<-[this6:IN_GENRE]-(this7:Movie)
+                RETURN count(this7) = $param1 AS var8
+              }
+              WITH *
+              WHERE NOT (var8 = true)
+              RETURN count(this1) > 0 AS var9
             }
             WITH *
             WHERE (var9 = false AND var5 = true)
@@ -125,24 +125,24 @@ describe("https://github.com/neo4j/graphql/issues/2713", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
-                CALL (this1) {
-                    MATCH (this1)<-[this2:IN_GENRE]-(this3:Movie)
-                    RETURN count(this3) = $param0 AS var4
-                }
-                WITH *
-                WHERE (this1.name = $param1 AND var4 = true)
-                RETURN count(this1) > 0 AS var5
+              MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
+              CALL (this1) {
+                MATCH (this1)<-[this2:IN_GENRE]-(this3:Movie)
+                RETURN count(this3) = $param0 AS var4
+              }
+              WITH *
+              WHERE (this1.name = $param1 AND var4 = true)
+              RETURN count(this1) > 0 AS var5
             }
             CALL (this) {
-                MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
-                CALL (this1) {
-                    MATCH (this1)<-[this6:IN_GENRE]-(this7:Movie)
-                    RETURN count(this7) = $param2 AS var8
-                }
-                WITH *
-                WHERE NOT (this1.name = $param3 AND var8 = true)
-                RETURN count(this1) > 0 AS var9
+              MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
+              CALL (this1) {
+                MATCH (this1)<-[this6:IN_GENRE]-(this7:Movie)
+                RETURN count(this7) = $param2 AS var8
+              }
+              WITH *
+              WHERE NOT (this1.name = $param3 AND var8 = true)
+              RETURN count(this1) > 0 AS var9
             }
             WITH *
             WHERE (var9 = false AND var5 = true)
@@ -180,11 +180,11 @@ describe("https://github.com/neo4j/graphql/issues/2713", () => {
             "CYPHER 5
             MATCH (this:Movie)
             WHERE (EXISTS {
-                MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
-                WHERE this1.name = $param0
+              MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
+              WHERE this1.name = $param0
             } AND NOT (EXISTS {
-                MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
-                WHERE NOT (this1.name = $param0)
+              MATCH (this)-[this0:IN_GENRE]->(this1:Genre)
+              WHERE NOT (this1.name = $param0)
             }))
             RETURN this { .title } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/2766.test.ts
+++ b/packages/graphql/tests/tck/issues/2766.test.ts
@@ -72,30 +72,30 @@ describe("https://github.com/neo4j/graphql/issues/2766", () => {
             "CYPHER 5
             MATCH (this:Actor)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[]-(m:Movie {title: $param0})
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[]-(m:Movie {title: $param0})
+                RETURN m
+              }
+              WITH m AS this0
+              CALL (this0) {
+                MATCH (this0)<-[this1:ACTED_IN]-(this2:Actor)
+                WITH DISTINCT this2
+                CALL (this2) {
+                  CALL (this2) {
+                    WITH this2 AS this
+                    MATCH (this)-[]-(m:Movie {title: $param1})
                     RETURN m
+                  }
+                  WITH m AS this3
+                  WITH this3 { .title } AS this3
+                  RETURN collect(this3) AS var4
                 }
-                WITH m AS this0
-                CALL (this0) {
-                    MATCH (this0)<-[this1:ACTED_IN]-(this2:Actor)
-                    WITH DISTINCT this2
-                    CALL (this2) {
-                        CALL (this2) {
-                            WITH this2 AS this
-                            MATCH (this)-[]-(m:Movie {title: $param1})
-                            RETURN m
-                        }
-                        WITH m AS this3
-                        WITH this3 { .title } AS this3
-                        RETURN collect(this3) AS var4
-                    }
-                    WITH this2 { .name, movies: var4 } AS this2
-                    RETURN collect(this2) AS var5
-                }
-                WITH this0 { .title, actors: var5 } AS this0
-                RETURN collect(this0) AS var6
+                WITH this2 { .name, movies: var4 } AS this2
+                RETURN collect(this2) AS var5
+              }
+              WITH this0 { .title, actors: var5 } AS this0
+              RETURN collect(this0) AS var6
             }
             RETURN this { .name, movies: var6 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/2782.test.ts
+++ b/packages/graphql/tests/tck/issues/2782.test.ts
@@ -99,66 +99,66 @@ describe("https://github.com/neo4j/graphql/issues/2782", () => {
             MATCH (this:Product)
             WITH *
             SET
-                this.id = $param0,
-                this.name = $param1
+              this.id = $param0,
+              this.name = $param1
             WITH *
             CALL (*) {
-                CALL (this) {
-                    OPTIONAL MATCH (this)-[this0:HAS_COLOR]->(this1:Color)
-                    WHERE this1.name = $param2
-                    CALL (this1) {
-                        CALL (this1) {
-                            OPTIONAL MATCH (this1)<-[this2:OF_COLOR]-(this3:Photo)
-                            WHERE this3.id = $param3
-                            CALL (this3) {
-                                CALL (this3) {
-                                    OPTIONAL MATCH (this3)-[this4:OF_COLOR]->(this5:Color)
-                                    WHERE this5.id = $param4
-                                    WITH *
-                                    DELETE this4
-                                }
-                            }
-                            WITH *
-                            DELETE this2
-                        }
+              CALL (this) {
+                OPTIONAL MATCH (this)-[this0:HAS_COLOR]->(this1:Color)
+                WHERE this1.name = $param2
+                CALL (this1) {
+                  CALL (this1) {
+                    OPTIONAL MATCH (this1)<-[this2:OF_COLOR]-(this3:Photo)
+                    WHERE this3.id = $param3
+                    CALL (this3) {
+                      CALL (this3) {
+                        OPTIONAL MATCH (this3)-[this4:OF_COLOR]->(this5:Color)
+                        WHERE this5.id = $param4
+                        WITH *
+                        DELETE this4
+                      }
                     }
                     WITH *
-                    DELETE this0
+                    DELETE this2
+                  }
                 }
+                WITH *
+                DELETE this0
+              }
             }
             WITH *
             CALL (*) {
-                CALL (this) {
-                    OPTIONAL MATCH (this)-[this6:HAS_PHOTO]->(this7:Photo)
-                    WHERE this7.id = $param5
-                    CALL (this7) {
-                        CALL (this7) {
-                            OPTIONAL MATCH (this7)-[this8:OF_COLOR]->(this9:Color)
-                            WHERE this9.name = $param6
-                            WITH *
-                            DELETE this8
-                        }
-                    }
+              CALL (this) {
+                OPTIONAL MATCH (this)-[this6:HAS_PHOTO]->(this7:Photo)
+                WHERE this7.id = $param5
+                CALL (this7) {
+                  CALL (this7) {
+                    OPTIONAL MATCH (this7)-[this8:OF_COLOR]->(this9:Color)
+                    WHERE this9.name = $param6
                     WITH *
-                    DELETE this6
+                    DELETE this8
+                  }
                 }
+                WITH *
+                DELETE this6
+              }
             }
             WITH *
             CALL (*) {
-                CALL (this) {
-                    OPTIONAL MATCH (this)-[this10:HAS_PHOTO]->(this11:Photo)
-                    WHERE this11.id = $param7
-                    CALL (this11) {
-                        CALL (this11) {
-                            OPTIONAL MATCH (this11)-[this12:OF_COLOR]->(this13:Color)
-                            WHERE this13.name = $param8
-                            WITH *
-                            DELETE this12
-                        }
-                    }
+              CALL (this) {
+                OPTIONAL MATCH (this)-[this10:HAS_PHOTO]->(this11:Photo)
+                WHERE this11.id = $param7
+                CALL (this11) {
+                  CALL (this11) {
+                    OPTIONAL MATCH (this11)-[this12:OF_COLOR]->(this13:Color)
+                    WHERE this13.name = $param8
                     WITH *
-                    DELETE this10
+                    DELETE this12
+                  }
                 }
+                WITH *
+                DELETE this10
+              }
             }
             WITH this
             RETURN this { .id } AS this"

--- a/packages/graphql/tests/tck/issues/2789.test.ts
+++ b/packages/graphql/tests/tck/issues/2789.test.ts
@@ -54,18 +54,17 @@ describe("https://github.com/neo4j/graphql/issues/2789", () => {
             MATCH (this:User)
             WITH *
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($param1 IS NOT NULL AND this.id = $param1)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($param2 IS NOT NULL AND this.id = $param2)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($param1 IS NOT NULL AND this.id = $param1)), '@neo4j/graphql/FORBIDDEN', [])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($param2 IS NOT NULL AND this.id = $param2)), '@neo4j/graphql/FORBIDDEN', [])
             WITH *
-            SET
-                this.password = $param3
+            SET this.password = $param3
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($param4 IS NOT NULL AND this.id = $param4)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($param5 IS NOT NULL AND this.id = $param5)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($param4 IS NOT NULL AND this.id = $param4)), '@neo4j/graphql/FORBIDDEN', [])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($param5 IS NOT NULL AND this.id = $param5)), '@neo4j/graphql/FORBIDDEN', [])
             WITH this
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($param6 IS NOT NULL AND this.id = $param6)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($param7 IS NOT NULL AND this.id = $param7)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($param6 IS NOT NULL AND this.id = $param6)), '@neo4j/graphql/FORBIDDEN', [])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($param7 IS NOT NULL AND this.id = $param7)), '@neo4j/graphql/FORBIDDEN', [])
             RETURN this { .password } AS this"
         `);
 

--- a/packages/graphql/tests/tck/issues/2803.test.ts
+++ b/packages/graphql/tests/tck/issues/2803.test.ts
@@ -61,30 +61,30 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
             "CYPHER 5
             MATCH (this:Actor)
             CALL (this) {
-                MATCH (this)-[:ACTED_IN]->(this0:Movie)
-                CALL (this0) {
-                    MATCH (this0)<-[:ACTED_IN]-(this1:Actor)
-                    CALL (this1) {
-                        MATCH (this1)-[this2:ACTED_IN]->(this3:Movie)
-                        RETURN count(this3) > $param0 AS var4
-                    }
-                    WITH *
-                    WHERE var4 = true
-                    RETURN count(this1) > 0 AS var5
-                }
-                CALL (this0) {
-                    MATCH (this0)<-[:ACTED_IN]-(this1:Actor)
-                    CALL (this1) {
-                        MATCH (this1)-[this6:ACTED_IN]->(this7:Movie)
-                        RETURN count(this7) > $param1 AS var8
-                    }
-                    WITH *
-                    WHERE NOT (var8 = true)
-                    RETURN count(this1) > 0 AS var9
+              MATCH (this)-[:ACTED_IN]->(this0:Movie)
+              CALL (this0) {
+                MATCH (this0)<-[:ACTED_IN]-(this1:Actor)
+                CALL (this1) {
+                  MATCH (this1)-[this2:ACTED_IN]->(this3:Movie)
+                  RETURN count(this3) > $param0 AS var4
                 }
                 WITH *
-                WHERE (var9 = false AND var5 = true)
-                RETURN count(this0) > 0 AS var10
+                WHERE var4 = true
+                RETURN count(this1) > 0 AS var5
+              }
+              CALL (this0) {
+                MATCH (this0)<-[:ACTED_IN]-(this1:Actor)
+                CALL (this1) {
+                  MATCH (this1)-[this6:ACTED_IN]->(this7:Movie)
+                  RETURN count(this7) > $param1 AS var8
+                }
+                WITH *
+                WHERE NOT (var8 = true)
+                RETURN count(this1) > 0 AS var9
+              }
+              WITH *
+              WHERE (var9 = false AND var5 = true)
+              RETURN count(this0) > 0 AS var10
             }
             WITH *
             WHERE var10 = true
@@ -129,34 +129,34 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
             "CYPHER 5
             MATCH (this:Actor)
             CALL (this) {
-                MATCH (this)-[:ACTED_IN]->(this0:Movie)
-                CALL (this0) {
-                    MATCH (this0)<-[:ACTED_IN]-(this1:Actor)
-                    CALL (this1) {
-                        MATCH (this1)-[this2:ACTED_IN]->(this3:Movie)
-                        RETURN count(this3) > $param0 AS var4
-                    }
-                    WITH *
-                    WHERE var4 = true
-                    RETURN count(this1) > 0 AS var5
-                }
-                CALL (this0) {
-                    MATCH (this0)<-[:ACTED_IN]-(this1:Actor)
-                    CALL (this1) {
-                        MATCH (this1)-[this6:ACTED_IN]->(this7:Movie)
-                        RETURN count(this7) > $param1 AS var8
-                    }
-                    WITH *
-                    WHERE NOT (var8 = true)
-                    RETURN count(this1) > 0 AS var9
-                }
-                CALL (this0) {
-                    MATCH (this0)<-[this10:ACTED_IN]-(this11:Actor)
-                    RETURN count(this11) = $param2 AS var12
+              MATCH (this)-[:ACTED_IN]->(this0:Movie)
+              CALL (this0) {
+                MATCH (this0)<-[:ACTED_IN]-(this1:Actor)
+                CALL (this1) {
+                  MATCH (this1)-[this2:ACTED_IN]->(this3:Movie)
+                  RETURN count(this3) > $param0 AS var4
                 }
                 WITH *
-                WHERE ((var9 = false AND var5 = true) AND var12 = true)
-                RETURN count(this0) > 0 AS var13
+                WHERE var4 = true
+                RETURN count(this1) > 0 AS var5
+              }
+              CALL (this0) {
+                MATCH (this0)<-[:ACTED_IN]-(this1:Actor)
+                CALL (this1) {
+                  MATCH (this1)-[this6:ACTED_IN]->(this7:Movie)
+                  RETURN count(this7) > $param1 AS var8
+                }
+                WITH *
+                WHERE NOT (var8 = true)
+                RETURN count(this1) > 0 AS var9
+              }
+              CALL (this0) {
+                MATCH (this0)<-[this10:ACTED_IN]-(this11:Actor)
+                RETURN count(this11) = $param2 AS var12
+              }
+              WITH *
+              WHERE ((var9 = false AND var5 = true) AND var12 = true)
+              RETURN count(this0) > 0 AS var13
             }
             WITH *
             WHERE var13 = true
@@ -202,36 +202,36 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)<-[:ACTED_IN]-(this0:Actor)
-                CALL (this0) {
-                    MATCH (this0)-[:ACTED_IN]->(this1:Movie)
-                    CALL (this1) {
-                        MATCH (this1)<-[:ACTED_IN]-(this2:Actor)
-                        CALL (this2) {
-                            MATCH (this2)-[this3:ACTED_IN]->(this4:Movie)
-                            RETURN count(this4) > $param0 AS var5
-                        }
-                        WITH *
-                        WHERE var5 = true
-                        RETURN count(this2) > 0 AS var6
-                    }
-                    CALL (this1) {
-                        MATCH (this1)<-[:ACTED_IN]-(this2:Actor)
-                        CALL (this2) {
-                            MATCH (this2)-[this7:ACTED_IN]->(this8:Movie)
-                            RETURN count(this8) > $param1 AS var9
-                        }
-                        WITH *
-                        WHERE NOT (var9 = true)
-                        RETURN count(this2) > 0 AS var10
-                    }
-                    WITH *
-                    WHERE (var10 = false AND var6 = true)
-                    RETURN count(this1) > 0 AS var11
+              MATCH (this)<-[:ACTED_IN]-(this0:Actor)
+              CALL (this0) {
+                MATCH (this0)-[:ACTED_IN]->(this1:Movie)
+                CALL (this1) {
+                  MATCH (this1)<-[:ACTED_IN]-(this2:Actor)
+                  CALL (this2) {
+                    MATCH (this2)-[this3:ACTED_IN]->(this4:Movie)
+                    RETURN count(this4) > $param0 AS var5
+                  }
+                  WITH *
+                  WHERE var5 = true
+                  RETURN count(this2) > 0 AS var6
+                }
+                CALL (this1) {
+                  MATCH (this1)<-[:ACTED_IN]-(this2:Actor)
+                  CALL (this2) {
+                    MATCH (this2)-[this7:ACTED_IN]->(this8:Movie)
+                    RETURN count(this8) > $param1 AS var9
+                  }
+                  WITH *
+                  WHERE NOT (var9 = true)
+                  RETURN count(this2) > 0 AS var10
                 }
                 WITH *
-                WHERE var11 = true
-                RETURN count(this0) > 0 AS var12
+                WHERE (var10 = false AND var6 = true)
+                RETURN count(this1) > 0 AS var11
+              }
+              WITH *
+              WHERE var11 = true
+              RETURN count(this0) > 0 AS var12
             }
             WITH *
             WHERE var12 = true
@@ -282,48 +282,48 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)<-[:ACTED_IN]-(this0:Actor)
-                CALL (this0) {
-                    MATCH (this0)-[:ACTED_IN]->(this1:Movie)
-                    CALL (this1) {
-                        MATCH (this1)<-[:ACTED_IN]-(this2:Actor)
-                        CALL (this2) {
-                            MATCH (this2)-[this3:ACTED_IN]->(this4:Movie)
-                            RETURN count(this4) > $param0 AS var5
-                        }
-                        WITH *
-                        WHERE var5 = true
-                        RETURN count(this2) > 0 AS var6
-                    }
-                    CALL (this1) {
-                        MATCH (this1)<-[:ACTED_IN]-(this2:Actor)
-                        CALL (this2) {
-                            MATCH (this2)-[this7:ACTED_IN]->(this8:Movie)
-                            RETURN count(this8) > $param1 AS var9
-                        }
-                        WITH *
-                        WHERE NOT (var9 = true)
-                        RETURN count(this2) > 0 AS var10
-                    }
-                    CALL (this1) {
-                        MATCH (this1)<-[this11:ACTED_IN]-(this12:Actor)
-                        RETURN avg(size(this12.name)) < $param2 AS var13
-                    }
-                    WITH *
-                    WHERE ((var10 = false AND var6 = true) AND var13 = true)
-                    RETURN count(this1) > 0 AS var14
+              MATCH (this)<-[:ACTED_IN]-(this0:Actor)
+              CALL (this0) {
+                MATCH (this0)-[:ACTED_IN]->(this1:Movie)
+                CALL (this1) {
+                  MATCH (this1)<-[:ACTED_IN]-(this2:Actor)
+                  CALL (this2) {
+                    MATCH (this2)-[this3:ACTED_IN]->(this4:Movie)
+                    RETURN count(this4) > $param0 AS var5
+                  }
+                  WITH *
+                  WHERE var5 = true
+                  RETURN count(this2) > 0 AS var6
                 }
-                CALL (this0) {
-                    MATCH (this0)-[this15:ACTED_IN]->(this16:Movie)
-                    RETURN avg(this16.released) = $param3 AS var17
+                CALL (this1) {
+                  MATCH (this1)<-[:ACTED_IN]-(this2:Actor)
+                  CALL (this2) {
+                    MATCH (this2)-[this7:ACTED_IN]->(this8:Movie)
+                    RETURN count(this8) > $param1 AS var9
+                  }
+                  WITH *
+                  WHERE NOT (var9 = true)
+                  RETURN count(this2) > 0 AS var10
+                }
+                CALL (this1) {
+                  MATCH (this1)<-[this11:ACTED_IN]-(this12:Actor)
+                  RETURN avg(size(this12.name)) < $param2 AS var13
                 }
                 WITH *
-                WHERE (var14 = true AND var17 = true)
-                RETURN count(this0) = 1 AS var18
+                WHERE ((var10 = false AND var6 = true) AND var13 = true)
+                RETURN count(this1) > 0 AS var14
+              }
+              CALL (this0) {
+                MATCH (this0)-[this15:ACTED_IN]->(this16:Movie)
+                RETURN avg(this16.released) = $param3 AS var17
+              }
+              WITH *
+              WHERE (var14 = true AND var17 = true)
+              RETURN count(this0) = 1 AS var18
             }
             CALL (this) {
-                MATCH (this)<-[this19:ACTED_IN]-(this20:Actor)
-                RETURN avg(size(this20.name)) >= $param4 AS var21
+              MATCH (this)<-[this19:ACTED_IN]-(this20:Actor)
+              RETURN avg(size(this20.name)) >= $param4 AS var21
             }
             WITH *
             WHERE (var18 = true AND var21 = true)
@@ -370,30 +370,30 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
             "CYPHER 5
             MATCH (this:Actor)
             CALL (this) {
-                MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                CALL (this1, this0) {
-                    MATCH (this1)<-[this2:ACTED_IN]-(this3:Actor)
-                    CALL (this3) {
-                        MATCH (this3)-[this4:ACTED_IN]->(this5:Movie)
-                        RETURN count(this5) > $param0 AS var6
-                    }
-                    WITH *
-                    WHERE var6 = true
-                    RETURN count(this3) > 0 AS var7
-                }
-                CALL (this1, this0) {
-                    MATCH (this1)<-[this2:ACTED_IN]-(this3:Actor)
-                    CALL (this3) {
-                        MATCH (this3)-[this8:ACTED_IN]->(this9:Movie)
-                        RETURN count(this9) > $param1 AS var10
-                    }
-                    WITH *
-                    WHERE NOT (var10 = true)
-                    RETURN count(this3) > 0 AS var11
+              MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+              CALL (this1, this0) {
+                MATCH (this1)<-[this2:ACTED_IN]-(this3:Actor)
+                CALL (this3) {
+                  MATCH (this3)-[this4:ACTED_IN]->(this5:Movie)
+                  RETURN count(this5) > $param0 AS var6
                 }
                 WITH *
-                WHERE (var11 = false AND var7 = true)
-                RETURN count(this1) > 0 AS var12
+                WHERE var6 = true
+                RETURN count(this3) > 0 AS var7
+              }
+              CALL (this1, this0) {
+                MATCH (this1)<-[this2:ACTED_IN]-(this3:Actor)
+                CALL (this3) {
+                  MATCH (this3)-[this8:ACTED_IN]->(this9:Movie)
+                  RETURN count(this9) > $param1 AS var10
+                }
+                WITH *
+                WHERE NOT (var10 = true)
+                RETURN count(this3) > 0 AS var11
+              }
+              WITH *
+              WHERE (var11 = false AND var7 = true)
+              RETURN count(this1) > 0 AS var12
             }
             WITH *
             WHERE var12 = true
@@ -438,34 +438,34 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
             "CYPHER 5
             MATCH (this:Actor)
             CALL (this) {
-                MATCH (this)-[:ACTED_IN]->(this0:Movie)
-                CALL (this0) {
-                    MATCH (this0)<-[this1:ACTED_IN]-(this2:Actor)
-                    CALL (this2) {
-                        MATCH (this2)-[this3:ACTED_IN]->(this4:Movie)
-                        RETURN count(this4) > $param0 AS var5
-                    }
-                    WITH *
-                    WHERE var5 = true
-                    RETURN count(this2) > 0 AS var6
-                }
-                CALL (this0) {
-                    MATCH (this0)<-[this1:ACTED_IN]-(this2:Actor)
-                    CALL (this2) {
-                        MATCH (this2)-[this7:ACTED_IN]->(this8:Movie)
-                        RETURN count(this8) > $param1 AS var9
-                    }
-                    WITH *
-                    WHERE NOT (var9 = true)
-                    RETURN count(this2) > 0 AS var10
-                }
-                CALL (this0) {
-                    MATCH (this0)<-[this11:ACTED_IN]-(this12:Actor)
-                    RETURN count(this12) = $param2 AS var13
+              MATCH (this)-[:ACTED_IN]->(this0:Movie)
+              CALL (this0) {
+                MATCH (this0)<-[this1:ACTED_IN]-(this2:Actor)
+                CALL (this2) {
+                  MATCH (this2)-[this3:ACTED_IN]->(this4:Movie)
+                  RETURN count(this4) > $param0 AS var5
                 }
                 WITH *
-                WHERE ((var10 = false AND var6 = true) AND var13 = true)
-                RETURN count(this0) > 0 AS var14
+                WHERE var5 = true
+                RETURN count(this2) > 0 AS var6
+              }
+              CALL (this0) {
+                MATCH (this0)<-[this1:ACTED_IN]-(this2:Actor)
+                CALL (this2) {
+                  MATCH (this2)-[this7:ACTED_IN]->(this8:Movie)
+                  RETURN count(this8) > $param1 AS var9
+                }
+                WITH *
+                WHERE NOT (var9 = true)
+                RETURN count(this2) > 0 AS var10
+              }
+              CALL (this0) {
+                MATCH (this0)<-[this11:ACTED_IN]-(this12:Actor)
+                RETURN count(this12) = $param2 AS var13
+              }
+              WITH *
+              WHERE ((var10 = false AND var6 = true) AND var13 = true)
+              RETURN count(this0) > 0 AS var14
             }
             WITH *
             WHERE var14 = true
@@ -523,36 +523,36 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                CALL (this1, this0) {
-                    MATCH (this1)-[this2:ACTED_IN]->(this3:Movie)
-                    CALL (this3, this2) {
-                        MATCH (this3)<-[this4:ACTED_IN]-(this5:Actor)
-                        CALL (this5) {
-                            MATCH (this5)-[this6:ACTED_IN]->(this7:Movie)
-                            RETURN count(this7) > $param0 AS var8
-                        }
-                        WITH *
-                        WHERE var8 = true
-                        RETURN count(this5) > 0 AS var9
-                    }
-                    CALL (this3, this2) {
-                        MATCH (this3)<-[this4:ACTED_IN]-(this5:Actor)
-                        CALL (this5) {
-                            MATCH (this5)-[this10:ACTED_IN]->(this11:Movie)
-                            RETURN count(this11) > $param1 AS var12
-                        }
-                        WITH *
-                        WHERE NOT (var12 = true)
-                        RETURN count(this5) > 0 AS var13
-                    }
-                    WITH *
-                    WHERE (var13 = false AND var9 = true)
-                    RETURN count(this3) > 0 AS var14
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              CALL (this1, this0) {
+                MATCH (this1)-[this2:ACTED_IN]->(this3:Movie)
+                CALL (this3, this2) {
+                  MATCH (this3)<-[this4:ACTED_IN]-(this5:Actor)
+                  CALL (this5) {
+                    MATCH (this5)-[this6:ACTED_IN]->(this7:Movie)
+                    RETURN count(this7) > $param0 AS var8
+                  }
+                  WITH *
+                  WHERE var8 = true
+                  RETURN count(this5) > 0 AS var9
+                }
+                CALL (this3, this2) {
+                  MATCH (this3)<-[this4:ACTED_IN]-(this5:Actor)
+                  CALL (this5) {
+                    MATCH (this5)-[this10:ACTED_IN]->(this11:Movie)
+                    RETURN count(this11) > $param1 AS var12
+                  }
+                  WITH *
+                  WHERE NOT (var12 = true)
+                  RETURN count(this5) > 0 AS var13
                 }
                 WITH *
-                WHERE var14 = true
-                RETURN count(this1) > 0 AS var15
+                WHERE (var13 = false AND var9 = true)
+                RETURN count(this3) > 0 AS var14
+              }
+              WITH *
+              WHERE var14 = true
+              RETURN count(this1) > 0 AS var15
             }
             WITH *
             WHERE var15 = true
@@ -609,48 +609,48 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                CALL (this1, this0) {
-                    MATCH (this1)-[this2:ACTED_IN]->(this3:Movie)
-                    CALL (this3, this2) {
-                        MATCH (this3)<-[this4:ACTED_IN]-(this5:Actor)
-                        CALL (this5) {
-                            MATCH (this5)-[this6:ACTED_IN]->(this7:Movie)
-                            RETURN count(this7) > $param0 AS var8
-                        }
-                        WITH *
-                        WHERE var8 = true
-                        RETURN count(this5) > 0 AS var9
-                    }
-                    CALL (this3, this2) {
-                        MATCH (this3)<-[this4:ACTED_IN]-(this5:Actor)
-                        CALL (this5) {
-                            MATCH (this5)-[this10:ACTED_IN]->(this11:Movie)
-                            RETURN count(this11) > $param1 AS var12
-                        }
-                        WITH *
-                        WHERE NOT (var12 = true)
-                        RETURN count(this5) > 0 AS var13
-                    }
-                    CALL (this3, this2) {
-                        MATCH (this3)<-[this14:ACTED_IN]-(this15:Actor)
-                        RETURN avg(size(this15.name)) < $param2 AS var16
-                    }
-                    WITH *
-                    WHERE ((var13 = false AND var9 = true) AND var16 = true)
-                    RETURN count(this3) > 0 AS var17
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              CALL (this1, this0) {
+                MATCH (this1)-[this2:ACTED_IN]->(this3:Movie)
+                CALL (this3, this2) {
+                  MATCH (this3)<-[this4:ACTED_IN]-(this5:Actor)
+                  CALL (this5) {
+                    MATCH (this5)-[this6:ACTED_IN]->(this7:Movie)
+                    RETURN count(this7) > $param0 AS var8
+                  }
+                  WITH *
+                  WHERE var8 = true
+                  RETURN count(this5) > 0 AS var9
                 }
-                CALL (this1, this0) {
-                    MATCH (this1)-[this18:ACTED_IN]->(this19:Movie)
-                    RETURN avg(this19.released) = $param3 AS var20
+                CALL (this3, this2) {
+                  MATCH (this3)<-[this4:ACTED_IN]-(this5:Actor)
+                  CALL (this5) {
+                    MATCH (this5)-[this10:ACTED_IN]->(this11:Movie)
+                    RETURN count(this11) > $param1 AS var12
+                  }
+                  WITH *
+                  WHERE NOT (var12 = true)
+                  RETURN count(this5) > 0 AS var13
+                }
+                CALL (this3, this2) {
+                  MATCH (this3)<-[this14:ACTED_IN]-(this15:Actor)
+                  RETURN avg(size(this15.name)) < $param2 AS var16
                 }
                 WITH *
-                WHERE (var17 = true AND var20 = true)
-                RETURN count(this1) > 0 AS var21
+                WHERE ((var13 = false AND var9 = true) AND var16 = true)
+                RETURN count(this3) > 0 AS var17
+              }
+              CALL (this1, this0) {
+                MATCH (this1)-[this18:ACTED_IN]->(this19:Movie)
+                RETURN avg(this19.released) = $param3 AS var20
+              }
+              WITH *
+              WHERE (var17 = true AND var20 = true)
+              RETURN count(this1) > 0 AS var21
             }
             CALL (this) {
-                MATCH (this)<-[this22:ACTED_IN]-(this23:Actor)
-                RETURN avg(size(this23.name)) >= $param4 AS var24
+              MATCH (this)<-[this22:ACTED_IN]-(this23:Actor)
+              RETURN avg(size(this23.name)) >= $param4 AS var24
             }
             WITH *
             WHERE (var21 = true AND var24 = true)
@@ -695,30 +695,30 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
             "CYPHER 5
             MATCH (this:Actor)
             CALL (this) {
-                MATCH (this)-[:ACTED_IN]->(this0:Movie)
-                CALL (this0) {
-                    MATCH (this0)<-[this1:ACTED_IN]-(this2:Actor)
-                    CALL (this2) {
-                        MATCH (this2)-[this3:ACTED_IN]->(this4:Movie)
-                        RETURN count(this4) > $param0 AS var5
-                    }
-                    WITH *
-                    WHERE var5 = true
-                    RETURN count(this2) > 0 AS var6
-                }
-                CALL (this0) {
-                    MATCH (this0)<-[this1:ACTED_IN]-(this2:Actor)
-                    CALL (this2) {
-                        MATCH (this2)-[this7:ACTED_IN]->(this8:Movie)
-                        RETURN count(this8) > $param1 AS var9
-                    }
-                    WITH *
-                    WHERE NOT (var9 = true)
-                    RETURN count(this2) > 0 AS var10
+              MATCH (this)-[:ACTED_IN]->(this0:Movie)
+              CALL (this0) {
+                MATCH (this0)<-[this1:ACTED_IN]-(this2:Actor)
+                CALL (this2) {
+                  MATCH (this2)-[this3:ACTED_IN]->(this4:Movie)
+                  RETURN count(this4) > $param0 AS var5
                 }
                 WITH *
-                WHERE (var10 = false AND var6 = true)
-                RETURN count(this0) > 0 AS var11
+                WHERE var5 = true
+                RETURN count(this2) > 0 AS var6
+              }
+              CALL (this0) {
+                MATCH (this0)<-[this1:ACTED_IN]-(this2:Actor)
+                CALL (this2) {
+                  MATCH (this2)-[this7:ACTED_IN]->(this8:Movie)
+                  RETURN count(this8) > $param1 AS var9
+                }
+                WITH *
+                WHERE NOT (var9 = true)
+                RETURN count(this2) > 0 AS var10
+              }
+              WITH *
+              WHERE (var10 = false AND var6 = true)
+              RETURN count(this0) > 0 AS var11
             }
             WITH *
             WHERE var11 = true
@@ -760,30 +760,30 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
             "CYPHER 5
             MATCH (this:Actor)
             CALL (this) {
-                MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                CALL (this1, this0) {
-                    MATCH (this1)<-[:ACTED_IN]-(this2:Actor)
-                    CALL (this2) {
-                        MATCH (this2)-[this3:ACTED_IN]->(this4:Movie)
-                        RETURN count(this4) > $param0 AS var5
-                    }
-                    WITH *
-                    WHERE var5 = true
-                    RETURN count(this2) > 0 AS var6
-                }
-                CALL (this1, this0) {
-                    MATCH (this1)<-[:ACTED_IN]-(this2:Actor)
-                    CALL (this2) {
-                        MATCH (this2)-[this7:ACTED_IN]->(this8:Movie)
-                        RETURN count(this8) > $param1 AS var9
-                    }
-                    WITH *
-                    WHERE NOT (var9 = true)
-                    RETURN count(this2) > 0 AS var10
+              MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+              CALL (this1, this0) {
+                MATCH (this1)<-[:ACTED_IN]-(this2:Actor)
+                CALL (this2) {
+                  MATCH (this2)-[this3:ACTED_IN]->(this4:Movie)
+                  RETURN count(this4) > $param0 AS var5
                 }
                 WITH *
-                WHERE (var10 = false AND var6 = true)
-                RETURN count(this1) > 0 AS var11
+                WHERE var5 = true
+                RETURN count(this2) > 0 AS var6
+              }
+              CALL (this1, this0) {
+                MATCH (this1)<-[:ACTED_IN]-(this2:Actor)
+                CALL (this2) {
+                  MATCH (this2)-[this7:ACTED_IN]->(this8:Movie)
+                  RETURN count(this8) > $param1 AS var9
+                }
+                WITH *
+                WHERE NOT (var9 = true)
+                RETURN count(this2) > 0 AS var10
+              }
+              WITH *
+              WHERE (var10 = false AND var6 = true)
+              RETURN count(this1) > 0 AS var11
             }
             WITH *
             WHERE var11 = true
@@ -835,26 +835,26 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                CALL (this1, this0) {
-                    MATCH (this1)-[:ACTED_IN]->(this2:Movie)
-                    CALL (this2) {
-                        MATCH (this2)<-[this3:ACTED_IN]-(this4:Actor)
-                        CALL (this4, this3) {
-                            MATCH (this4)-[this5:ACTED_IN]->(this6:Movie)
-                            RETURN count(this6) > $param0 AS var7
-                        }
-                        WITH *
-                        WHERE var7 = true
-                        RETURN count(this4) > 0 AS var8
-                    }
-                    WITH *
-                    WHERE var8 = false
-                    RETURN count(this2) = 1 AS var9
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              CALL (this1, this0) {
+                MATCH (this1)-[:ACTED_IN]->(this2:Movie)
+                CALL (this2) {
+                  MATCH (this2)<-[this3:ACTED_IN]-(this4:Actor)
+                  CALL (this4, this3) {
+                    MATCH (this4)-[this5:ACTED_IN]->(this6:Movie)
+                    RETURN count(this6) > $param0 AS var7
+                  }
+                  WITH *
+                  WHERE var7 = true
+                  RETURN count(this4) > 0 AS var8
                 }
                 WITH *
-                WHERE var9 = true
-                RETURN count(this1) > 0 AS var10
+                WHERE var8 = false
+                RETURN count(this2) = 1 AS var9
+              }
+              WITH *
+              WHERE var9 = true
+              RETURN count(this1) > 0 AS var10
             }
             WITH *
             WHERE var10 = true
@@ -897,24 +897,24 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
             "CYPHER 5
             MATCH (this:Actor)
             CALL (this) {
-                MATCH (this)-[:ACTED_IN]->(this0:Movie)
-                CALL (this0) {
-                    MATCH (this0)<-[:ACTED_IN]-(this1:Actor)
-                    CALL (this1) {
-                        MATCH (this1)-[this2:ACTED_IN]->(this3:Movie)
-                        RETURN avg(this2.screenTime) <= $param0 AS var4
-                    }
-                    WITH *
-                    WHERE var4 = true
-                    RETURN count(this1) > 0 AS var5
-                }
-                CALL (this0) {
-                    MATCH (this0)<-[this6:ACTED_IN]-(this7:Actor)
-                    RETURN avg(this6.screenTime) <= $param1 AS var8
+              MATCH (this)-[:ACTED_IN]->(this0:Movie)
+              CALL (this0) {
+                MATCH (this0)<-[:ACTED_IN]-(this1:Actor)
+                CALL (this1) {
+                  MATCH (this1)-[this2:ACTED_IN]->(this3:Movie)
+                  RETURN avg(this2.screenTime) <= $param0 AS var4
                 }
                 WITH *
-                WHERE (var5 = false AND var8 = true)
-                RETURN count(this0) = 1 AS var9
+                WHERE var4 = true
+                RETURN count(this1) > 0 AS var5
+              }
+              CALL (this0) {
+                MATCH (this0)<-[this6:ACTED_IN]-(this7:Actor)
+                RETURN avg(this6.screenTime) <= $param1 AS var8
+              }
+              WITH *
+              WHERE (var5 = false AND var8 = true)
+              RETURN count(this0) = 1 AS var9
             }
             WITH *
             WHERE var9 = true
@@ -960,20 +960,20 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
             "CYPHER 5
             MATCH (this:Actor)
             CALL (this) {
-                MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                CALL (this1, this0) {
-                    MATCH (this1)<-[this2:ACTED_IN]-(this3:Actor)
-                    CALL (this3, this2) {
-                        MATCH (this3)-[this4:ACTED_IN]->(this5:Movie)
-                        RETURN count(this5) > $param0 AS var6
-                    }
-                    WITH *
-                    WHERE (var6 = true AND $param1 IN this2.roles)
-                    RETURN count(this3) > 0 AS var7
+              MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+              CALL (this1, this0) {
+                MATCH (this1)<-[this2:ACTED_IN]-(this3:Actor)
+                CALL (this3, this2) {
+                  MATCH (this3)-[this4:ACTED_IN]->(this5:Movie)
+                  RETURN count(this5) > $param0 AS var6
                 }
                 WITH *
-                WHERE (var7 = false AND $param2 IN this0.roles)
-                RETURN count(this1) = 1 AS var8
+                WHERE (var6 = true AND $param1 IN this2.roles)
+                RETURN count(this3) > 0 AS var7
+              }
+              WITH *
+              WHERE (var7 = false AND $param2 IN this0.roles)
+              RETURN count(this1) = 1 AS var8
             }
             WITH *
             WHERE var8 = true
@@ -1022,20 +1022,20 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
             "CYPHER 5
             MATCH (this:Actor)
             CALL (this) {
-                MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                CALL (this1, this0) {
-                    MATCH (this1)<-[this2:ACTED_IN]-(this3:Actor)
-                    CALL (this3, this2) {
-                        MATCH (this3)-[this4:ACTED_IN]->(this5:Movie)
-                        RETURN count(this5) > $param0 AS var6
-                    }
-                    WITH *
-                    WHERE ((this3.name = $param1 AND var6 = true) AND $param2 IN this2.roles)
-                    RETURN count(this3) > 0 AS var7
+              MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+              CALL (this1, this0) {
+                MATCH (this1)<-[this2:ACTED_IN]-(this3:Actor)
+                CALL (this3, this2) {
+                  MATCH (this3)-[this4:ACTED_IN]->(this5:Movie)
+                  RETURN count(this5) > $param0 AS var6
                 }
                 WITH *
-                WHERE var7 = true
-                RETURN count(this1) = 1 AS var8
+                WHERE ((this3.name = $param1 AND var6 = true) AND $param2 IN this2.roles)
+                RETURN count(this3) > 0 AS var7
+              }
+              WITH *
+              WHERE var7 = true
+              RETURN count(this1) = 1 AS var8
             }
             WITH *
             WHERE var8 = true
@@ -1075,36 +1075,36 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
             "CYPHER 5
             MATCH (this:Actor)
             CALL (this) {
-                MATCH (this)-[:ACTED_IN]->(this0:Movie)
-                CALL (this0) {
-                    MATCH (this0)<-[:ACTED_IN]-(this1:Actor)
-                    CALL (this1) {
-                        MATCH (this1)-[this2:ACTED_IN]->(this3:Movie)
-                        RETURN count(this3) > $param0 AS var4
-                    }
-                    WITH *
-                    WHERE (this1.name = $param1 AND var4 = true)
-                    RETURN count(this1) > 0 AS var5
+              MATCH (this)-[:ACTED_IN]->(this0:Movie)
+              CALL (this0) {
+                MATCH (this0)<-[:ACTED_IN]-(this1:Actor)
+                CALL (this1) {
+                  MATCH (this1)-[this2:ACTED_IN]->(this3:Movie)
+                  RETURN count(this3) > $param0 AS var4
                 }
                 WITH *
-                WHERE var5 = true
-                RETURN count(this0) > 0 AS var6
+                WHERE (this1.name = $param1 AND var4 = true)
+                RETURN count(this1) > 0 AS var5
+              }
+              WITH *
+              WHERE var5 = true
+              RETURN count(this0) > 0 AS var6
             }
             CALL (this) {
-                MATCH (this)-[:ACTED_IN]->(this0:Movie)
-                CALL (this0) {
-                    MATCH (this0)<-[:ACTED_IN]-(this7:Actor)
-                    CALL (this7) {
-                        MATCH (this7)-[this8:ACTED_IN]->(this9:Movie)
-                        RETURN count(this9) > $param2 AS var10
-                    }
-                    WITH *
-                    WHERE (this7.name = $param3 AND var10 = true)
-                    RETURN count(this7) > 0 AS var11
+              MATCH (this)-[:ACTED_IN]->(this0:Movie)
+              CALL (this0) {
+                MATCH (this0)<-[:ACTED_IN]-(this7:Actor)
+                CALL (this7) {
+                  MATCH (this7)-[this8:ACTED_IN]->(this9:Movie)
+                  RETURN count(this9) > $param2 AS var10
                 }
                 WITH *
-                WHERE NOT (var11 = true)
-                RETURN count(this0) > 0 AS var12
+                WHERE (this7.name = $param3 AND var10 = true)
+                RETURN count(this7) > 0 AS var11
+              }
+              WITH *
+              WHERE NOT (var11 = true)
+              RETURN count(this0) > 0 AS var12
             }
             WITH *
             WHERE (var12 = false AND var6 = true)
@@ -1154,36 +1154,36 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
             "CYPHER 5
             MATCH (this:Actor)
             CALL (this) {
-                MATCH (this)-[:ACTED_IN]->(this0:Movie)
-                CALL (this0) {
-                    MATCH (this0)<-[:ACTED_IN]-(this1:Actor)
-                    CALL (this1) {
-                        MATCH (this1)-[this2:ACTED_IN]->(this3:Movie)
-                        RETURN count(this3) > $param0 AS var4
-                    }
-                    WITH *
-                    WHERE (this1.name = $param1 OR var4 = true)
-                    RETURN count(this1) > 0 AS var5
+              MATCH (this)-[:ACTED_IN]->(this0:Movie)
+              CALL (this0) {
+                MATCH (this0)<-[:ACTED_IN]-(this1:Actor)
+                CALL (this1) {
+                  MATCH (this1)-[this2:ACTED_IN]->(this3:Movie)
+                  RETURN count(this3) > $param0 AS var4
                 }
                 WITH *
-                WHERE var5 = true
-                RETURN count(this0) > 0 AS var6
+                WHERE (this1.name = $param1 OR var4 = true)
+                RETURN count(this1) > 0 AS var5
+              }
+              WITH *
+              WHERE var5 = true
+              RETURN count(this0) > 0 AS var6
             }
             CALL (this) {
-                MATCH (this)-[:ACTED_IN]->(this0:Movie)
-                CALL (this0) {
-                    MATCH (this0)<-[:ACTED_IN]-(this7:Actor)
-                    CALL (this7) {
-                        MATCH (this7)-[this8:ACTED_IN]->(this9:Movie)
-                        RETURN count(this9) > $param2 AS var10
-                    }
-                    WITH *
-                    WHERE (this7.name = $param3 OR var10 = true)
-                    RETURN count(this7) > 0 AS var11
+              MATCH (this)-[:ACTED_IN]->(this0:Movie)
+              CALL (this0) {
+                MATCH (this0)<-[:ACTED_IN]-(this7:Actor)
+                CALL (this7) {
+                  MATCH (this7)-[this8:ACTED_IN]->(this9:Movie)
+                  RETURN count(this9) > $param2 AS var10
                 }
                 WITH *
-                WHERE NOT (var11 = true)
-                RETURN count(this0) > 0 AS var12
+                WHERE (this7.name = $param3 OR var10 = true)
+                RETURN count(this7) > 0 AS var11
+              }
+              WITH *
+              WHERE NOT (var11 = true)
+              RETURN count(this0) > 0 AS var12
             }
             WITH *
             WHERE (var12 = false AND var6 = true)
@@ -1233,36 +1233,36 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
             "CYPHER 5
             MATCH (this:Actor)
             CALL (this) {
-                MATCH (this)-[:ACTED_IN]->(this0:Movie)
-                CALL (this0) {
-                    MATCH (this0)<-[:ACTED_IN]-(this1:Actor)
-                    CALL (this1) {
-                        MATCH (this1)-[this2:ACTED_IN]->(this3:Movie)
-                        RETURN count(this3) > $param0 AS var4
-                    }
-                    WITH *
-                    WHERE (this1.name = $param1 AND var4 = true)
-                    RETURN count(this1) > 0 AS var5
+              MATCH (this)-[:ACTED_IN]->(this0:Movie)
+              CALL (this0) {
+                MATCH (this0)<-[:ACTED_IN]-(this1:Actor)
+                CALL (this1) {
+                  MATCH (this1)-[this2:ACTED_IN]->(this3:Movie)
+                  RETURN count(this3) > $param0 AS var4
                 }
                 WITH *
-                WHERE var5 = true
-                RETURN count(this0) > 0 AS var6
+                WHERE (this1.name = $param1 AND var4 = true)
+                RETURN count(this1) > 0 AS var5
+              }
+              WITH *
+              WHERE var5 = true
+              RETURN count(this0) > 0 AS var6
             }
             CALL (this) {
-                MATCH (this)-[:ACTED_IN]->(this0:Movie)
-                CALL (this0) {
-                    MATCH (this0)<-[:ACTED_IN]-(this7:Actor)
-                    CALL (this7) {
-                        MATCH (this7)-[this8:ACTED_IN]->(this9:Movie)
-                        RETURN count(this9) > $param2 AS var10
-                    }
-                    WITH *
-                    WHERE (this7.name = $param3 AND var10 = true)
-                    RETURN count(this7) > 0 AS var11
+              MATCH (this)-[:ACTED_IN]->(this0:Movie)
+              CALL (this0) {
+                MATCH (this0)<-[:ACTED_IN]-(this7:Actor)
+                CALL (this7) {
+                  MATCH (this7)-[this8:ACTED_IN]->(this9:Movie)
+                  RETURN count(this9) > $param2 AS var10
                 }
                 WITH *
-                WHERE NOT (var11 = true)
-                RETURN count(this0) > 0 AS var12
+                WHERE (this7.name = $param3 AND var10 = true)
+                RETURN count(this7) > 0 AS var11
+              }
+              WITH *
+              WHERE NOT (var11 = true)
+              RETURN count(this0) > 0 AS var12
             }
             WITH *
             WHERE (var12 = false AND var6 = true)
@@ -1319,25 +1319,24 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
             "CYPHER 5
             MATCH (this:Actor)
             CALL (this) {
-                MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                CALL (this1, this0) {
-                    MATCH (this1)<-[this2:ACTED_IN]-(this3:Actor)
-                    CALL (this3, this2) {
-                        MATCH (this3)-[this4:ACTED_IN]->(this5:Movie)
-                        RETURN count(this5) > $param0 AS var6
-                    }
-                    WITH *
-                    WHERE (var6 = true AND $param1 IN this2.roles)
-                    RETURN count(this3) > 0 AS var7
+              MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+              CALL (this1, this0) {
+                MATCH (this1)<-[this2:ACTED_IN]-(this3:Actor)
+                CALL (this3, this2) {
+                  MATCH (this3)-[this4:ACTED_IN]->(this5:Movie)
+                  RETURN count(this5) > $param0 AS var6
                 }
                 WITH *
-                WHERE (var7 = false AND $param2 IN this0.roles)
-                RETURN count(this1) = 1 AS var8
+                WHERE (var6 = true AND $param1 IN this2.roles)
+                RETURN count(this3) > 0 AS var7
+              }
+              WITH *
+              WHERE (var7 = false AND $param2 IN this0.roles)
+              RETURN count(this1) = 1 AS var8
             }
             WITH *
             WHERE var8 = true
-            SET
-                this.name = $param3
+            SET this.name = $param3
             WITH this
             RETURN this { .name } AS this"
         `);
@@ -1385,20 +1384,20 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
             "CYPHER 5
             MATCH (this:Actor)
             CALL (this) {
-                MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                CALL (this1, this0) {
-                    MATCH (this1)<-[this2:ACTED_IN]-(this3:Actor)
-                    CALL (this3, this2) {
-                        MATCH (this3)-[this4:ACTED_IN]->(this5:Movie)
-                        RETURN count(this5) > $param0 AS var6
-                    }
-                    WITH *
-                    WHERE ((this3.name = $param1 AND var6 = true) AND $param2 IN this2.roles)
-                    RETURN count(this3) > 0 AS var7
+              MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+              CALL (this1, this0) {
+                MATCH (this1)<-[this2:ACTED_IN]-(this3:Actor)
+                CALL (this3, this2) {
+                  MATCH (this3)-[this4:ACTED_IN]->(this5:Movie)
+                  RETURN count(this5) > $param0 AS var6
                 }
                 WITH *
-                WHERE var7 = true
-                RETURN count(this1) = 1 AS var8
+                WHERE ((this3.name = $param1 AND var6 = true) AND $param2 IN this2.roles)
+                RETURN count(this3) > 0 AS var7
+              }
+              WITH *
+              WHERE var7 = true
+              RETURN count(this1) = 1 AS var8
             }
             WITH *
             WHERE var8 = true

--- a/packages/graphql/tests/tck/issues/2812.test.ts
+++ b/packages/graphql/tests/tck/issues/2812.test.ts
@@ -87,35 +87,34 @@ describe("https://github.com/neo4j/graphql/issues/2812", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Movie)
+              CREATE (create_this1:Movie)
+              SET create_this1.id = create_var0.id
+              WITH create_this1, create_var0
+              CALL (create_this1, create_var0) {
+                UNWIND create_var0.actors.create AS create_var2
+                CREATE (create_this3:Actor)
                 SET
-                    create_this1.id = create_var0.id
-                WITH create_this1, create_var0
-                CALL (create_this1, create_var0) {
-                    UNWIND create_var0.actors.create AS create_var2
-                    CREATE (create_this3:Actor)
-                    SET
-                        create_this3.id = randomUUID(),
-                        create_this3.name = create_var2.node.name,
-                        create_this3.nodeCreatedBy = create_var2.node.nodeCreatedBy,
-                        create_this3.fieldA = create_var2.node.fieldA,
-                        create_this3.fieldB = create_var2.node.fieldB
-                    MERGE (create_this1)<-[create_this4:ACTED_IN]-(create_this3)
-                    WITH *
-                    CALL apoc.util.validate((create_var2.node.fieldA IS NOT NULL AND NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $create_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    CALL apoc.util.validate((create_var2.node.fieldB IS NOT NULL AND NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $create_param4 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    RETURN collect(NULL) AS create_var5
-                }
+                  create_this3.id = randomUUID(),
+                  create_this3.name = create_var2.node.name,
+                  create_this3.nodeCreatedBy = create_var2.node.nodeCreatedBy,
+                  create_this3.fieldA = create_var2.node.fieldA,
+                  create_this3.fieldB = create_var2.node.fieldB
+                MERGE (create_this1)<-[create_this4:ACTED_IN]-(create_this3)
                 WITH *
-                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $create_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                RETURN create_this1
+                CALL apoc.util.validate((create_var2.node.fieldA IS NOT NULL AND NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $create_param3 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
+                CALL apoc.util.validate((create_var2.node.fieldB IS NOT NULL AND NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $create_param4 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
+                RETURN collect(NULL) AS create_var5
+              }
+              WITH *
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $create_param5 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
+              RETURN create_this1
             }
             CALL (create_this1) {
-                MATCH (create_this1)<-[create_this6:ACTED_IN]-(create_this7:Actor)
-                WITH DISTINCT create_this7
-                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND create_this7.nodeCreatedBy = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                WITH create_this7 { .name } AS create_this7
-                RETURN collect(create_this7) AS create_var8
+              MATCH (create_this1)<-[create_this6:ACTED_IN]-(create_this7:Actor)
+              WITH DISTINCT create_this7
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND create_this7.nodeCreatedBy = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
+              WITH create_this7 { .name } AS create_this7
+              RETURN collect(create_this7) AS create_var8
             }
             RETURN collect(create_this1 { .id, actors: create_var8 }) AS data"
         `);
@@ -197,35 +196,34 @@ describe("https://github.com/neo4j/graphql/issues/2812", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Movie)
+              CREATE (create_this1:Movie)
+              SET create_this1.id = create_var0.id
+              WITH create_this1, create_var0
+              CALL (create_this1, create_var0) {
+                UNWIND create_var0.actors.create AS create_var2
+                CREATE (create_this3:Actor)
                 SET
-                    create_this1.id = create_var0.id
-                WITH create_this1, create_var0
-                CALL (create_this1, create_var0) {
-                    UNWIND create_var0.actors.create AS create_var2
-                    CREATE (create_this3:Actor)
-                    SET
-                        create_this3.id = randomUUID(),
-                        create_this3.name = create_var2.node.name,
-                        create_this3.nodeCreatedBy = create_var2.node.nodeCreatedBy,
-                        create_this3.fieldA = create_var2.node.fieldA,
-                        create_this3.fieldB = create_var2.node.fieldB
-                    MERGE (create_this1)<-[create_this4:ACTED_IN]-(create_this3)
-                    WITH *
-                    CALL apoc.util.validate((create_var2.node.fieldA IS NOT NULL AND NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $create_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    CALL apoc.util.validate((create_var2.node.fieldB IS NOT NULL AND NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $create_param4 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    RETURN collect(NULL) AS create_var5
-                }
+                  create_this3.id = randomUUID(),
+                  create_this3.name = create_var2.node.name,
+                  create_this3.nodeCreatedBy = create_var2.node.nodeCreatedBy,
+                  create_this3.fieldA = create_var2.node.fieldA,
+                  create_this3.fieldB = create_var2.node.fieldB
+                MERGE (create_this1)<-[create_this4:ACTED_IN]-(create_this3)
                 WITH *
-                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $create_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                RETURN create_this1
+                CALL apoc.util.validate((create_var2.node.fieldA IS NOT NULL AND NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $create_param3 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
+                CALL apoc.util.validate((create_var2.node.fieldB IS NOT NULL AND NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $create_param4 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
+                RETURN collect(NULL) AS create_var5
+              }
+              WITH *
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $create_param5 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
+              RETURN create_this1
             }
             CALL (create_this1) {
-                MATCH (create_this1)<-[create_this6:ACTED_IN]-(create_this7:Actor)
-                WITH DISTINCT create_this7
-                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND create_this7.nodeCreatedBy = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                WITH create_this7 { .name } AS create_this7
-                RETURN collect(create_this7) AS create_var8
+              MATCH (create_this1)<-[create_this6:ACTED_IN]-(create_this7:Actor)
+              WITH DISTINCT create_this7
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND create_this7.nodeCreatedBy = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
+              WITH create_this7 { .name } AS create_this7
+              RETURN collect(create_this7) AS create_var8
             }
             RETURN collect(create_this1 { .id, actors: create_var8 }) AS data"
         `);
@@ -305,33 +303,32 @@ describe("https://github.com/neo4j/graphql/issues/2812", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Movie)
+              CREATE (create_this1:Movie)
+              SET create_this1.id = create_var0.id
+              WITH create_this1, create_var0
+              CALL (create_this1, create_var0) {
+                UNWIND create_var0.actors.create AS create_var2
+                CREATE (create_this3:Actor)
                 SET
-                    create_this1.id = create_var0.id
-                WITH create_this1, create_var0
-                CALL (create_this1, create_var0) {
-                    UNWIND create_var0.actors.create AS create_var2
-                    CREATE (create_this3:Actor)
-                    SET
-                        create_this3.id = randomUUID(),
-                        create_this3.name = create_var2.node.name,
-                        create_this3.nodeCreatedBy = create_var2.node.nodeCreatedBy
-                    MERGE (create_this1)<-[create_this4:ACTED_IN]-(create_this3)
-                    WITH *
-                    CALL apoc.util.validate((create_var2.node.fieldA IS NOT NULL AND NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $create_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    CALL apoc.util.validate((create_var2.node.fieldB IS NOT NULL AND NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $create_param4 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    RETURN collect(NULL) AS create_var5
-                }
+                  create_this3.id = randomUUID(),
+                  create_this3.name = create_var2.node.name,
+                  create_this3.nodeCreatedBy = create_var2.node.nodeCreatedBy
+                MERGE (create_this1)<-[create_this4:ACTED_IN]-(create_this3)
                 WITH *
-                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $create_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                RETURN create_this1
+                CALL apoc.util.validate((create_var2.node.fieldA IS NOT NULL AND NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $create_param3 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
+                CALL apoc.util.validate((create_var2.node.fieldB IS NOT NULL AND NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $create_param4 IN $jwt.roles))), '@neo4j/graphql/FORBIDDEN', [])
+                RETURN collect(NULL) AS create_var5
+              }
+              WITH *
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $create_param5 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
+              RETURN create_this1
             }
             CALL (create_this1) {
-                MATCH (create_this1)<-[create_this6:ACTED_IN]-(create_this7:Actor)
-                WITH DISTINCT create_this7
-                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND create_this7.nodeCreatedBy = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                WITH create_this7 { .name } AS create_this7
-                RETURN collect(create_this7) AS create_var8
+              MATCH (create_this1)<-[create_this6:ACTED_IN]-(create_this7:Actor)
+              WITH DISTINCT create_this7
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND create_this7.nodeCreatedBy = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
+              WITH create_this7 { .name } AS create_this7
+              RETURN collect(create_this7) AS create_var8
             }
             RETURN collect(create_this1 { .id, actors: create_var8 }) AS data"
         `);

--- a/packages/graphql/tests/tck/issues/288.test.ts
+++ b/packages/graphql/tests/tck/issues/288.test.ts
@@ -60,11 +60,11 @@ describe("#288", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:USER)
-                SET
-                    create_this1.USERID = create_var0.USERID,
-                    create_this1.COMPANYID = create_var0.COMPANYID
-                RETURN create_this1
+              CREATE (create_this1:USER)
+              SET
+                create_this1.USERID = create_var0.USERID,
+                create_this1.COMPANYID = create_var0.COMPANYID
+              RETURN create_this1
             }
             RETURN collect(create_this1 { .USERID, .COMPANYID }) AS data"
         `);
@@ -100,8 +100,7 @@ describe("#288", () => {
             MATCH (this:USER)
             WITH *
             WHERE this.USERID = $param0
-            SET
-                this.COMPANYID = $param1
+            SET this.COMPANYID = $param1
             WITH this
             RETURN this { .USERID, .COMPANYID } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/2925.test.ts
+++ b/packages/graphql/tests/tck/issues/2925.test.ts
@@ -58,8 +58,8 @@ describe("https://github.com/neo4j/graphql/issues/2925", () => {
             "CYPHER 5
             MATCH (this:User)
             WHERE EXISTS {
-                MATCH (this)-[:HAS_GROUP]->(this0:Group)
-                WHERE this0.name IN $param0
+              MATCH (this)-[:HAS_GROUP]->(this0:Group)
+              WHERE this0.name IN $param0
             }
             RETURN this { .name } AS this"
         `);
@@ -88,11 +88,11 @@ describe("https://github.com/neo4j/graphql/issues/2925", () => {
             "CYPHER 5
             MATCH (this:Group)
             WHERE EXISTS {
-                MATCH (this)<-[:HAS_GROUP]-(this0:User)
-                WHERE EXISTS {
-                    MATCH (this0)-[:HAS_GROUP]->(this1:Group)
-                    WHERE this1.name IN $param0
-                }
+              MATCH (this)<-[:HAS_GROUP]-(this0:User)
+              WHERE EXISTS {
+                MATCH (this0)-[:HAS_GROUP]->(this1:Group)
+                WHERE this1.name IN $param0
+              }
             }
             RETURN this { .name } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/3394.test.ts
+++ b/packages/graphql/tests/tck/issues/3394.test.ts
@@ -84,11 +84,11 @@ describe("https://github.com/neo4j/graphql/issues/3394", () => {
             "CYPHER 5
             MATCH (this:Employee)
             CALL (this) {
-                MATCH (this)-[this0:CAN_ACCESS]->(this1:Product)
-                WITH DISTINCT this1
-                WITH this1 { .description, id: this1.fg_item_id, partNumber: this1.fg_item } AS this1
-                ORDER BY this1.partNumber DESC
-                RETURN collect(this1) AS var2
+              MATCH (this)-[this0:CAN_ACCESS]->(this1:Product)
+              WITH DISTINCT this1
+              WITH this1 { .description, id: this1.fg_item_id, partNumber: this1.fg_item } AS this1
+              ORDER BY this1.partNumber DESC
+              RETURN collect(this1) AS var2
             }
             RETURN this { products: var2 } AS this"
         `);
@@ -116,15 +116,15 @@ describe("https://github.com/neo4j/graphql/issues/3394", () => {
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
                 "CYPHER 5
                 MATCH (this0:Product)
-                WITH collect({ node: this0 }) AS edges
+                WITH collect({node: this0}) AS edges
                 CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this0
-                    WITH *
-                    ORDER BY this0.fg_item DESC
-                    RETURN collect({ node: { id: this0.fg_item_id, partNumber: this0.fg_item, description: this0.description, __resolveType: \\"Product\\" } }) AS var1
+                  UNWIND edges AS edge
+                  WITH edge.node AS this0
+                  WITH *
+                  ORDER BY this0.fg_item DESC
+                  RETURN collect({node: {id: this0.fg_item_id, partNumber: this0.fg_item, description: this0.description, __resolveType: 'Product'}}) AS var1
                 }
-                RETURN { edges: var1 } AS this"
+                RETURN {edges: var1} AS this"
             `);
 
             expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -153,16 +153,16 @@ describe("https://github.com/neo4j/graphql/issues/3394", () => {
                 "CYPHER 5
                 MATCH (this:Employee)
                 CALL (this) {
-                    MATCH (this)-[this0:CAN_ACCESS]->(this1:Product)
-                    WITH collect({ node: this1, relationship: this0 }) AS edges
-                    CALL (edges) {
-                        UNWIND edges AS edge
-                        WITH edge.node AS this1, edge.relationship AS this0
-                        WITH *
-                        ORDER BY this1.fg_item DESC
-                        RETURN collect({ node: { id: this1.fg_item_id, partNumber: this1.fg_item, description: this1.description, __resolveType: \\"Product\\" } }) AS var2
-                    }
-                    RETURN { edges: var2 } AS var3
+                  MATCH (this)-[this0:CAN_ACCESS]->(this1:Product)
+                  WITH collect({node: this1, relationship: this0}) AS edges
+                  CALL (edges) {
+                    UNWIND edges AS edge
+                    WITH edge.node AS this1, edge.relationship AS this0
+                    WITH *
+                    ORDER BY this1.fg_item DESC
+                    RETURN collect({node: {id: this1.fg_item_id, partNumber: this1.fg_item, description: this1.description, __resolveType: 'Product'}}) AS var2
+                  }
+                  RETURN {edges: var2} AS var3
                 }
                 RETURN this { productsConnection: var3 } AS this"
             `);

--- a/packages/graphql/tests/tck/issues/360.test.ts
+++ b/packages/graphql/tests/tck/issues/360.test.ts
@@ -66,7 +66,7 @@ describe("#360", () => {
             "CYPHER 5
             MATCH (this:Event)
             WHERE (this.start >= datetime($param0) AND this.start <= datetime($param1))
-            RETURN this { .activity, start: apoc.date.convertFormat(toString(this.start), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\") } AS this"
+            RETURN this { .activity, start: apoc.date.convertFormat(toString(this.start), 'iso_zoned_date_time', 'iso_offset_date_time') } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -103,7 +103,7 @@ describe("#360", () => {
             "CYPHER 5
             MATCH (this:Event)
             WHERE (this.start >= datetime($param0) OR this.start <= datetime($param1))
-            RETURN this { .activity, start: apoc.date.convertFormat(toString(this.start), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\") } AS this"
+            RETURN this { .activity, start: apoc.date.convertFormat(toString(this.start), 'iso_zoned_date_time', 'iso_offset_date_time') } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/issues/3765.test.ts
+++ b/packages/graphql/tests/tck/issues/3765.test.ts
@@ -69,16 +69,16 @@ describe("https://github.com/neo4j/graphql/issues/3765", () => {
                     "CYPHER 5
                     MATCH (this:Post)
                     CALL (this) {
-                        MATCH (this)<-[this0:LIKES]-(this1:User)
-                        RETURN count(this1) > $param0 AS var2
+                      MATCH (this)<-[this0:LIKES]-(this1:User)
+                      RETURN count(this1) > $param0 AS var2
                     }
                     CALL (this) {
-                        MATCH (this)<-[this3:LIKES]-(this4:User)
-                        RETURN count(this4) > $param1 AS var5
+                      MATCH (this)<-[this3:LIKES]-(this4:User)
+                      RETURN count(this4) > $param1 AS var5
                     }
                     CALL (this) {
-                        MATCH (this)<-[this6:LIKES]-(this7:User)
-                        RETURN count(this7) < $param2 AS var8
+                      MATCH (this)<-[this6:LIKES]-(this7:User)
+                      RETURN count(this7) < $param2 AS var8
                     }
                     WITH *
                     WHERE (var2 = true AND (var5 = true AND var8 = true))
@@ -118,16 +118,16 @@ describe("https://github.com/neo4j/graphql/issues/3765", () => {
                     "CYPHER 5
                     MATCH (this:Post)
                     CALL (this) {
-                        MATCH (this)<-[this0:LIKES]-(this1:User)
-                        RETURN count(this1) > $param0 AS var2
+                      MATCH (this)<-[this0:LIKES]-(this1:User)
+                      RETURN count(this1) > $param0 AS var2
                     }
                     CALL (this) {
-                        MATCH (this)<-[this3:LIKES]-(this4:User)
-                        RETURN count(this4) > $param1 AS var5
+                      MATCH (this)<-[this3:LIKES]-(this4:User)
+                      RETURN count(this4) > $param1 AS var5
                     }
                     CALL (this) {
-                        MATCH (this)<-[this6:LIKES]-(this7:User)
-                        RETURN count(this7) < $param2 AS var8
+                      MATCH (this)<-[this6:LIKES]-(this7:User)
+                      RETURN count(this7) < $param2 AS var8
                     }
                     WITH *
                     WHERE (var2 = true AND (var5 = true AND var8 = true))
@@ -174,16 +174,16 @@ describe("https://github.com/neo4j/graphql/issues/3765", () => {
                     "CYPHER 5
                     MATCH (this:Post)
                     CALL (this) {
-                        MATCH (this)<-[this0:LIKES]-(this1:User)
-                        RETURN count(this1) > $param0 AS var2
+                      MATCH (this)<-[this0:LIKES]-(this1:User)
+                      RETURN count(this1) > $param0 AS var2
                     }
                     CALL (this) {
-                        MATCH (this)<-[this3:LIKES]-(this4:User)
-                        RETURN count(this4) > $param1 AS var5
+                      MATCH (this)<-[this3:LIKES]-(this4:User)
+                      RETURN count(this4) > $param1 AS var5
                     }
                     CALL (this) {
-                        MATCH (this)<-[this6:LIKES]-(this7:User)
-                        RETURN count(this7) < $param2 AS var8
+                      MATCH (this)<-[this6:LIKES]-(this7:User)
+                      RETURN count(this7) < $param2 AS var8
                     }
                     WITH *
                     WHERE (var2 = true AND (var5 = true OR var8 = true))
@@ -230,20 +230,20 @@ describe("https://github.com/neo4j/graphql/issues/3765", () => {
                     "CYPHER 5
                     MATCH (this:Post)
                     CALL (this) {
-                        MATCH (this)<-[this0:LIKES]-(this1:User)
-                        RETURN count(this1) > $param0 AS var2
+                      MATCH (this)<-[this0:LIKES]-(this1:User)
+                      RETURN count(this1) > $param0 AS var2
                     }
                     CALL (this) {
-                        MATCH (this)<-[this3:LIKES]-(this4:User)
-                        RETURN count(this4) > $param1 AS var5
+                      MATCH (this)<-[this3:LIKES]-(this4:User)
+                      RETURN count(this4) > $param1 AS var5
                     }
                     CALL (this) {
-                        MATCH (this)<-[this6:LIKES]-(this7:User)
-                        RETURN count(this7) <= $param2 AS var8
+                      MATCH (this)<-[this6:LIKES]-(this7:User)
+                      RETURN count(this7) <= $param2 AS var8
                     }
                     CALL (this) {
-                        MATCH (this)<-[this9:LIKES]-(this10:User)
-                        RETURN count(this10) < $param3 AS var11
+                      MATCH (this)<-[this9:LIKES]-(this10:User)
+                      RETURN count(this10) < $param3 AS var11
                     }
                     WITH *
                     WHERE (var2 = true AND ((var5 = true AND var8 = true) OR var11 = true))
@@ -297,20 +297,20 @@ describe("https://github.com/neo4j/graphql/issues/3765", () => {
                     "CYPHER 5
                     MATCH (this:Post)
                     CALL (this) {
-                        MATCH (this)<-[this0:LIKES]-(this1:User)
-                        RETURN count(this1) > $param0 AS var2
+                      MATCH (this)<-[this0:LIKES]-(this1:User)
+                      RETURN count(this1) > $param0 AS var2
                     }
                     CALL (this) {
-                        MATCH (this)<-[this3:LIKES]-(this4:User)
-                        RETURN count(this4) > $param1 AS var5
+                      MATCH (this)<-[this3:LIKES]-(this4:User)
+                      RETURN count(this4) > $param1 AS var5
                     }
                     CALL (this) {
-                        MATCH (this)<-[this6:LIKES]-(this7:User)
-                        RETURN count(this7) <= $param2 AS var8
+                      MATCH (this)<-[this6:LIKES]-(this7:User)
+                      RETURN count(this7) <= $param2 AS var8
                     }
                     CALL (this) {
-                        MATCH (this)<-[this9:LIKES]-(this10:User)
-                        RETURN count(this10) < $param3 AS var11
+                      MATCH (this)<-[this9:LIKES]-(this10:User)
+                      RETURN count(this10) < $param3 AS var11
                     }
                     WITH *
                     WHERE (var2 = true AND ((var5 = true AND var8 = true) OR var11 = true))
@@ -368,16 +368,16 @@ describe("https://github.com/neo4j/graphql/issues/3765", () => {
                     "CYPHER 5
                     MATCH (this:Post)
                     CALL (this) {
-                        MATCH (this)<-[this0:LIKES]-(this1:User)
-                        RETURN count(this1) > $param0 AS var2
+                      MATCH (this)<-[this0:LIKES]-(this1:User)
+                      RETURN count(this1) > $param0 AS var2
                     }
                     CALL (this) {
-                        MATCH (this)<-[this3:LIKES]-(this4:User)
-                        RETURN min(size(this4.name)) > $param1 AS var5
+                      MATCH (this)<-[this3:LIKES]-(this4:User)
+                      RETURN min(size(this4.name)) > $param1 AS var5
                     }
                     CALL (this) {
-                        MATCH (this)<-[this6:LIKES]-(this7:User)
-                        RETURN min(size(this7.name)) < $param2 AS var8
+                      MATCH (this)<-[this6:LIKES]-(this7:User)
+                      RETURN min(size(this7.name)) < $param2 AS var8
                     }
                     WITH *
                     WHERE (var2 = true AND (var5 = true AND var8 = true))
@@ -424,16 +424,16 @@ describe("https://github.com/neo4j/graphql/issues/3765", () => {
                     "CYPHER 5
                     MATCH (this:Post)
                     CALL (this) {
-                        MATCH (this)<-[this0:LIKES]-(this1:User)
-                        RETURN count(this1) > $param0 AS var2
+                      MATCH (this)<-[this0:LIKES]-(this1:User)
+                      RETURN count(this1) > $param0 AS var2
                     }
                     CALL (this) {
-                        MATCH (this)<-[this3:LIKES]-(this4:User)
-                        RETURN min(size(this4.name)) > $param1 AS var5
+                      MATCH (this)<-[this3:LIKES]-(this4:User)
+                      RETURN min(size(this4.name)) > $param1 AS var5
                     }
                     CALL (this) {
-                        MATCH (this)<-[this6:LIKES]-(this7:User)
-                        RETURN min(size(this7.name)) < $param2 AS var8
+                      MATCH (this)<-[this6:LIKES]-(this7:User)
+                      RETURN min(size(this7.name)) < $param2 AS var8
                     }
                     WITH *
                     WHERE (var2 = true AND (var5 = true AND var8 = true))
@@ -485,16 +485,16 @@ describe("https://github.com/neo4j/graphql/issues/3765", () => {
                     "CYPHER 5
                     MATCH (this:Post)
                     CALL (this) {
-                        MATCH (this)<-[this0:LIKES]-(this1:User)
-                        RETURN count(this1) > $param0 AS var2
+                      MATCH (this)<-[this0:LIKES]-(this1:User)
+                      RETURN count(this1) > $param0 AS var2
                     }
                     CALL (this) {
-                        MATCH (this)<-[this3:LIKES]-(this4:User)
-                        RETURN min(size(this4.name)) > $param1 AS var5
+                      MATCH (this)<-[this3:LIKES]-(this4:User)
+                      RETURN min(size(this4.name)) > $param1 AS var5
                     }
                     CALL (this) {
-                        MATCH (this)<-[this6:LIKES]-(this7:User)
-                        RETURN min(size(this7.name)) < $param2 AS var8
+                      MATCH (this)<-[this6:LIKES]-(this7:User)
+                      RETURN min(size(this7.name)) < $param2 AS var8
                     }
                     WITH *
                     WHERE (var2 = true AND (var5 = true OR var8 = true))
@@ -546,20 +546,20 @@ describe("https://github.com/neo4j/graphql/issues/3765", () => {
                     "CYPHER 5
                     MATCH (this:Post)
                     CALL (this) {
-                        MATCH (this)<-[this0:LIKES]-(this1:User)
-                        RETURN count(this1) > $param0 AS var2
+                      MATCH (this)<-[this0:LIKES]-(this1:User)
+                      RETURN count(this1) > $param0 AS var2
                     }
                     CALL (this) {
-                        MATCH (this)<-[this3:LIKES]-(this4:User)
-                        RETURN min(size(this4.name)) > $param1 AS var5
+                      MATCH (this)<-[this3:LIKES]-(this4:User)
+                      RETURN min(size(this4.name)) > $param1 AS var5
                     }
                     CALL (this) {
-                        MATCH (this)<-[this6:LIKES]-(this7:User)
-                        RETURN min(size(this7.name)) < $param2 AS var8
+                      MATCH (this)<-[this6:LIKES]-(this7:User)
+                      RETURN min(size(this7.name)) < $param2 AS var8
                     }
                     CALL (this) {
-                        MATCH (this)<-[this9:LIKES]-(this10:User)
-                        RETURN min(size(this10.name)) >= $param3 AS var11
+                      MATCH (this)<-[this9:LIKES]-(this10:User)
+                      RETURN min(size(this10.name)) >= $param3 AS var11
                     }
                     WITH *
                     WHERE (var2 = true AND ((var5 = true AND var8 = true) OR var11 = true))
@@ -617,32 +617,32 @@ describe("https://github.com/neo4j/graphql/issues/3765", () => {
                     "CYPHER 5
                     MATCH (this:Post)
                     CALL (this) {
-                        MATCH (this)<-[this0:LIKES]-(this1:User)
-                        RETURN count(this1) > $param0 AS var2
+                      MATCH (this)<-[this0:LIKES]-(this1:User)
+                      RETURN count(this1) > $param0 AS var2
                     }
                     CALL (this) {
-                        MATCH (this)<-[this3:LIKES]-(this4:User)
-                        RETURN avg(size(this4.name)) > $param1 AS var5
+                      MATCH (this)<-[this3:LIKES]-(this4:User)
+                      RETURN avg(size(this4.name)) > $param1 AS var5
                     }
                     CALL (this) {
-                        MATCH (this)<-[this6:LIKES]-(this7:User)
-                        RETURN min(size(this6.someProp)) < $param2 AS var8
+                      MATCH (this)<-[this6:LIKES]-(this7:User)
+                      RETURN min(size(this6.someProp)) < $param2 AS var8
                     }
                     CALL (this) {
-                        MATCH (this)<-[this9:LIKES]-(this10:User)
-                        RETURN max(size(this9.someProp)) > $param3 AS var11
+                      MATCH (this)<-[this9:LIKES]-(this10:User)
+                      RETURN max(size(this9.someProp)) > $param3 AS var11
                     }
                     CALL (this) {
-                        MATCH (this)<-[this12:LIKES]-(this13:User)
-                        RETURN min(size(this13.name)) > $param4 AS var14
+                      MATCH (this)<-[this12:LIKES]-(this13:User)
+                      RETURN min(size(this13.name)) > $param4 AS var14
                     }
                     CALL (this) {
-                        MATCH (this)<-[this15:LIKES]-(this16:User)
-                        RETURN min(size(this15.someProp)) > $param5 AS var17
+                      MATCH (this)<-[this15:LIKES]-(this16:User)
+                      RETURN min(size(this15.someProp)) > $param5 AS var17
                     }
                     CALL (this) {
-                        MATCH (this)<-[this18:LIKES]-(this19:User)
-                        RETURN max(size(this18.someProp)) < $param6 AS var20
+                      MATCH (this)<-[this18:LIKES]-(this19:User)
+                      RETURN max(size(this18.someProp)) < $param6 AS var20
                     }
                     WITH *
                     WHERE (var2 = true AND ((var5 = true AND (var8 = true AND var11 = true)) OR var14 = true) AND (var17 = true AND var20 = true))
@@ -786,8 +786,8 @@ describe("https://github.com/neo4j/graphql/issues/3765", () => {
                 "CYPHER 5
                 MATCH (this:Post)
                 WHERE EXISTS {
-                    MATCH (this)<-[:LIKES]-(this0:User)
-                    WHERE (this0.name = $param0 AND this0.otherName = $param1)
+                  MATCH (this)<-[:LIKES]-(this0:User)
+                  WHERE (this0.name = $param0 AND this0.otherName = $param1)
                 }
                 RETURN this { .content } AS this"
             `);
@@ -815,14 +815,14 @@ describe("https://github.com/neo4j/graphql/issues/3765", () => {
                 "CYPHER 5
                 MATCH (this:Post)
                 WHERE ((EXISTS {
-                    MATCH (this)<-[:LIKES]-(this0:User)
-                    WHERE this0.otherName = $param0
+                  MATCH (this)<-[:LIKES]-(this0:User)
+                  WHERE this0.otherName = $param0
                 } AND NOT (EXISTS {
-                    MATCH (this)<-[:LIKES]-(this0:User)
-                    WHERE NOT (this0.otherName = $param0)
+                  MATCH (this)<-[:LIKES]-(this0:User)
+                  WHERE NOT (this0.otherName = $param0)
                 })) AND EXISTS {
-                    MATCH (this)<-[:LIKES]-(this1:User)
-                    WHERE this1.name = $param1
+                  MATCH (this)<-[:LIKES]-(this1:User)
+                  WHERE this1.name = $param1
                 })
                 RETURN this { .content } AS this"
             `);
@@ -858,17 +858,17 @@ describe("https://github.com/neo4j/graphql/issues/3765", () => {
                 "CYPHER 5
                 MATCH (this:Post)
                 WHERE (EXISTS {
-                    MATCH (this)<-[:LIKES]-(this0:User)
-                    WHERE this0.name = $param0
+                  MATCH (this)<-[:LIKES]-(this0:User)
+                  WHERE this0.name = $param0
                 } OR (EXISTS {
-                    MATCH (this)<-[:LIKES]-(this1:User)
-                    WHERE this1.otherName = $param1
+                  MATCH (this)<-[:LIKES]-(this1:User)
+                  WHERE this1.otherName = $param1
                 } AND NOT (EXISTS {
-                    MATCH (this)<-[:LIKES]-(this1:User)
-                    WHERE NOT (this1.otherName = $param1)
+                  MATCH (this)<-[:LIKES]-(this1:User)
+                  WHERE NOT (this1.otherName = $param1)
                 })) OR EXISTS {
-                    MATCH (this)<-[:LIKES]-(this2:User)
-                    WHERE this2.otherName = $param2
+                  MATCH (this)<-[:LIKES]-(this2:User)
+                  WHERE this2.otherName = $param2
                 })
                 RETURN this { .content } AS this"
             `);

--- a/packages/graphql/tests/tck/issues/387.test.ts
+++ b/packages/graphql/tests/tck/issues/387.test.ts
@@ -84,38 +84,38 @@ describe("https://github.com/neo4j/graphql/issues/387", () => {
             "CYPHER 5
             MATCH (this:Place)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    return '' + '' as result
-                }
-                WITH result AS this0
-                RETURN this0 AS var1
+              CALL (this) {
+                WITH this AS this
+                return '' + '' as result
+              }
+              WITH result AS this0
+              RETURN this0 AS var1
             }
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    return '' + '' as result
-                }
-                WITH result AS this2
-                RETURN this2 AS var3
+              CALL (this) {
+                WITH this AS this
+                return '' + '' as result
+              }
+              WITH result AS this2
+              RETURN this2 AS var3
             }
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    return ['' + ''] as result
-                }
-                UNWIND result AS var4
-                WITH var4 AS this5
-                RETURN collect(this5) AS var6
+              CALL (this) {
+                WITH this AS this
+                return ['' + ''] as result
+              }
+              UNWIND result AS var4
+              WITH var4 AS this5
+              RETURN collect(this5) AS var6
             }
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    return ['' + ''] as result
-                }
-                UNWIND result AS var7
-                WITH var7 AS this8
-                RETURN collect(this8) AS var9
+              CALL (this) {
+                WITH this AS this
+                return ['' + ''] as result
+              }
+              UNWIND result AS var7
+              WITH var7 AS this8
+              RETURN collect(this8) AS var9
             }
             RETURN this { url_works: var1, url_fails: var3, url_array_works: var6, url_array_fails: var9 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/4001.test.ts
+++ b/packages/graphql/tests/tck/issues/4001.test.ts
@@ -71,14 +71,14 @@ describe("https://github.com/neo4j/graphql/issues/4001", () => {
             "CYPHER 5
             MATCH (this:Serie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (n:Video) RETURN n
-                    SKIP toInteger($param0.offset) LIMIT toInteger($param0.limit)
-                }
-                WITH n AS this0
-                WITH this0 { .id } AS this0
-                RETURN collect(this0) AS var1
+              CALL (this) {
+                WITH this AS this
+                MATCH (n:Video) RETURN n
+                SKIP toInteger($param0.offset) LIMIT toInteger($param0.limit)
+              }
+              WITH n AS this0
+              WITH this0 { .id } AS this0
+              RETURN collect(this0) AS var1
             }
             RETURN this { allEpisodes: var1 } AS this"
         `);
@@ -123,14 +123,14 @@ describe("https://github.com/neo4j/graphql/issues/4001", () => {
             "CYPHER 5
             MATCH (this:Serie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (n:Video) RETURN n
-                    SKIP toInteger($param0.offset) LIMIT toInteger($param0.limit)
-                }
-                WITH n AS this0
-                WITH this0 { .id } AS this0
-                RETURN collect(this0) AS var1
+              CALL (this) {
+                WITH this AS this
+                MATCH (n:Video) RETURN n
+                SKIP toInteger($param0.offset) LIMIT toInteger($param0.limit)
+              }
+              WITH n AS this0
+              WITH this0 { .id } AS this0
+              RETURN collect(this0) AS var1
             }
             RETURN this { allEpisodes: var1 } AS this"
         `);
@@ -168,14 +168,14 @@ describe("https://github.com/neo4j/graphql/issues/4001", () => {
             "CYPHER 5
             MATCH (this:Serie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (n:Video) RETURN n
-                    SKIP toInteger($param0.offset) LIMIT toInteger($param0.limit)
-                }
-                WITH n AS this0
-                WITH this0 { .id } AS this0
-                RETURN collect(this0) AS var1
+              CALL (this) {
+                WITH this AS this
+                MATCH (n:Video) RETURN n
+                SKIP toInteger($param0.offset) LIMIT toInteger($param0.limit)
+              }
+              WITH n AS this0
+              WITH this0 { .id } AS this0
+              RETURN collect(this0) AS var1
             }
             RETURN this { allEpisodes: var1 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/4004.test.ts
+++ b/packages/graphql/tests/tck/issues/4004.test.ts
@@ -65,14 +65,14 @@ describe("https://github.com/neo4j/graphql/issues/4004", () => {
             "CYPHER 5
             MATCH (this:Series)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH(this)<-[:IN_SERIES]-(episode:Episode)
-                    RETURN episode as n LIMIT $param0[0]
-                }
-                WITH n AS this0
-                WITH this0 { .id } AS this0
-                RETURN collect(this0) AS var1
+              CALL (this) {
+                WITH this AS this
+                MATCH(this)<-[:IN_SERIES]-(episode:Episode)
+                RETURN episode as n LIMIT $param0[0]
+              }
+              WITH n AS this0
+              WITH this0 { .id } AS this0
+              RETURN collect(this0) AS var1
             }
             RETURN this { allEpisodes: var1 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/4007.test.ts
+++ b/packages/graphql/tests/tck/issues/4007.test.ts
@@ -63,14 +63,14 @@ describe("https://github.com/neo4j/graphql/issues/4007", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ node: { na: this1.name, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({node: {na: this1.name, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { t: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/4015.test.ts
+++ b/packages/graphql/tests/tck/issues/4015.test.ts
@@ -67,14 +67,14 @@ describe("https://github.com/neo4j/graphql/issues/4015", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ node: { surname: this1.surname, name: this1.name, __resolveType: \\"Actor\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({node: {surname: this1.surname, name: this1.name, __resolveType: 'Actor'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { actorsConnection: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/4095.test.ts
+++ b/packages/graphql/tests/tck/issues/4095.test.ts
@@ -80,15 +80,15 @@ describe("https://github.com/neo4j/graphql/issues/4095", () => {
             "CYPHER 5
             MATCH (this:Family)
             CALL (this) {
-                CALL (this) {
-                    MATCH (this)<-[this0:MEMBER_OF]-(this1:Person)
-                    WHERE ($isAuthenticated = true AND EXISTS {
-                        MATCH (this1)<-[:CREATOR_OF]-(this2:User)
-                        WHERE ($jwt.uid IS NOT NULL AND this2.id = $jwt.uid)
-                    })
-                    RETURN { nodes: count(DISTINCT this1) } AS var3
-                }
-                RETURN { aggregate: { count: var3 } } AS var4
+              CALL (this) {
+                MATCH (this)<-[this0:MEMBER_OF]-(this1:Person)
+                WHERE ($isAuthenticated = true AND EXISTS {
+                  MATCH (this1)<-[:CREATOR_OF]-(this2:User)
+                  WHERE ($jwt.uid IS NOT NULL AND this2.id = $jwt.uid)
+                })
+                RETURN {nodes: count(DISTINCT this1)} AS var3
+              }
+              RETURN {aggregate: {count: var3}} AS var4
             }
             RETURN this { .id, membersConnection: var4 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/4115.test.ts
+++ b/packages/graphql/tests/tck/issues/4115.test.ts
@@ -103,21 +103,21 @@ describe("https://github.com/neo4j/graphql/issues/4115", () => {
             "CYPHER 5
             MATCH (this:Family)
             CALL (this) {
-                CALL (this) {
-                    MATCH (this)<-[this0:MEMBER_OF]-(this1:Person)
-                    WHERE ($isAuthenticated = true AND (EXISTS {
-                        MATCH (this1)<-[:CREATOR_OF]-(this2:User)
-                        WHERE ($jwt.uid IS NOT NULL AND this2.id = $jwt.uid)
-                    } AND EXISTS {
-                        MATCH (this1)-[:MEMBER_OF]->(this3:Family)
-                        WHERE EXISTS {
-                            MATCH (this3)<-[:CREATOR_OF]-(this4:User)
-                            WHERE ($param2 IS NOT NULL AND $param2 IN this4.roles)
-                        }
-                    }))
-                    RETURN { nodes: count(DISTINCT this1) } AS var5
-                }
-                RETURN { aggregate: { count: var5 } } AS var6
+              CALL (this) {
+                MATCH (this)<-[this0:MEMBER_OF]-(this1:Person)
+                WHERE ($isAuthenticated = true AND (EXISTS {
+                  MATCH (this1)<-[:CREATOR_OF]-(this2:User)
+                  WHERE ($jwt.uid IS NOT NULL AND this2.id = $jwt.uid)
+                } AND EXISTS {
+                  MATCH (this1)-[:MEMBER_OF]->(this3:Family)
+                  WHERE EXISTS {
+                    MATCH (this3)<-[:CREATOR_OF]-(this4:User)
+                    WHERE ($param2 IS NOT NULL AND $param2 IN this4.roles)
+                  }
+                }))
+                RETURN {nodes: count(DISTINCT this1)} AS var5
+              }
+              RETURN {aggregate: {count: var5}} AS var6
             }
             RETURN this { .id, membersConnection: var6 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/4116.test.ts
+++ b/packages/graphql/tests/tck/issues/4116.test.ts
@@ -94,18 +94,18 @@ describe("https://github.com/neo4j/graphql/issues/4116", () => {
             "CYPHER 5
             MATCH (this:Family)
             CALL (this) {
-                CALL (this) {
-                    MATCH (this)<-[this0:MEMBER_OF]-(this1:Person)
-                    WHERE ($isAuthenticated = true AND EXISTS {
-                        MATCH (this1)-[:MEMBER_OF]->(this2:Family)
-                        WHERE EXISTS {
-                            MATCH (this2)<-[:CREATOR_OF]-(this3:User)
-                            WHERE ($param1 IS NOT NULL AND $param1 IN this3.roles)
-                        }
-                    })
-                    RETURN { nodes: count(DISTINCT this1) } AS var4
-                }
-                RETURN { aggregate: { count: var4 } } AS var5
+              CALL (this) {
+                MATCH (this)<-[this0:MEMBER_OF]-(this1:Person)
+                WHERE ($isAuthenticated = true AND EXISTS {
+                  MATCH (this1)-[:MEMBER_OF]->(this2:Family)
+                  WHERE EXISTS {
+                    MATCH (this2)<-[:CREATOR_OF]-(this3:User)
+                    WHERE ($param1 IS NOT NULL AND $param1 IN this3.roles)
+                  }
+                })
+                RETURN {nodes: count(DISTINCT this1)} AS var4
+              }
+              RETURN {aggregate: {count: var4}} AS var5
             }
             RETURN this { .id, membersConnection: var5 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/4170.test.ts
+++ b/packages/graphql/tests/tck/issues/4170.test.ts
@@ -164,85 +164,81 @@ describe("https://github.com/neo4j/graphql/issues/4170", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                CREATE (this0:Tenant)
-                SET
-                    this0.id = randomUUID()
-                WITH *
-                CREATE (this1:Settings)
-                WITH *
-                CREATE (this2:OpeningDay)
-                WITH *
-                CREATE (this3:OpeningHoursInterval)
-                MERGE (this2)-[this4:HAS_OPEN_INTERVALS]->(this3)
-                SET
-                    this3.name = $param0,
-                    this3.updatedBy = $param1
-                MERGE (this1)-[this5:VALID_OPENING_DAYS]->(this2)
-                SET
-                    this2.id = randomUUID()
-                MERGE (this0)-[this6:HAS_SETTINGS]->(this1)
-                SET
-                    this1.id = randomUUID()
-                WITH *
-                CREATE (this7:User)
-                MERGE (this0)<-[this8:ADMIN_IN]-(this7)
-                SET
-                    this7.userId = $param2
-                WITH *
-                CALL (*) {
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                        MATCH (this0)<-[:ADMIN_IN]-(this9:User)
-                        WHERE ($jwt.id IS NOT NULL AND this9.userId = $jwt.id)
-                    }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                }
-                CALL (*) {
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                        MATCH (this1)<-[:HAS_SETTINGS]-(this10:Tenant)
-                        WHERE EXISTS {
-                            MATCH (this10)<-[:ADMIN_IN]-(this11:User)
-                            WHERE ($jwt.id IS NOT NULL AND this11.userId = $jwt.id)
-                        }
-                    }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                }
-                CALL (*) {
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                        MATCH (this2)<-[:VALID_GARAGES]-(this12:Settings)
-                        WHERE EXISTS {
-                            MATCH (this12)<-[:HAS_SETTINGS]-(this13:Tenant)
-                            WHERE EXISTS {
-                                MATCH (this13)<-[:ADMIN_IN]-(this14:User)
-                                WHERE ($jwt.id IS NOT NULL AND this14.userId = $jwt.id)
-                            }
-                        }
-                    }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                }
-                CALL (*) {
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                        MATCH (this3)<-[:HAS_OPEN_INTERVALS]-(this15:OpeningDay)
-                        WHERE EXISTS {
-                            MATCH (this15)<-[:VALID_GARAGES]-(this16:Settings)
-                            WHERE EXISTS {
-                                MATCH (this16)<-[:HAS_SETTINGS]-(this17:Tenant)
-                                WHERE EXISTS {
-                                    MATCH (this17)<-[:ADMIN_IN]-(this18:User)
-                                    WHERE ($jwt.id IS NOT NULL AND this18.userId = $jwt.id)
-                                }
-                            }
-                        }
-                    }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                }
-                RETURN this0 AS this
+              CREATE (this0:Tenant)
+              SET this0.id = randomUUID()
+              WITH *
+              CREATE (this1:Settings)
+              WITH *
+              CREATE (this2:OpeningDay)
+              WITH *
+              CREATE (this3:OpeningHoursInterval)
+              MERGE (this2)-[this4:HAS_OPEN_INTERVALS]->(this3)
+              SET
+                this3.name = $param0,
+                this3.updatedBy = $param1
+              MERGE (this1)-[this5:VALID_OPENING_DAYS]->(this2)
+              SET this2.id = randomUUID()
+              MERGE (this0)-[this6:HAS_SETTINGS]->(this1)
+              SET this1.id = randomUUID()
+              WITH *
+              CREATE (this7:User)
+              MERGE (this0)<-[this8:ADMIN_IN]-(this7)
+              SET this7.userId = $param2
+              WITH *
+              CALL (*) {
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
+                  MATCH (this0)<-[:ADMIN_IN]-(this9:User)
+                  WHERE ($jwt.id IS NOT NULL AND this9.userId = $jwt.id)
+                }), '@neo4j/graphql/FORBIDDEN', [])
+              }
+              CALL (*) {
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
+                  MATCH (this1)<-[:HAS_SETTINGS]-(this10:Tenant)
+                  WHERE EXISTS {
+                    MATCH (this10)<-[:ADMIN_IN]-(this11:User)
+                    WHERE ($jwt.id IS NOT NULL AND this11.userId = $jwt.id)
+                  }
+                }), '@neo4j/graphql/FORBIDDEN', [])
+              }
+              CALL (*) {
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
+                  MATCH (this2)<-[:VALID_GARAGES]-(this12:Settings)
+                  WHERE EXISTS {
+                    MATCH (this12)<-[:HAS_SETTINGS]-(this13:Tenant)
+                    WHERE EXISTS {
+                      MATCH (this13)<-[:ADMIN_IN]-(this14:User)
+                      WHERE ($jwt.id IS NOT NULL AND this14.userId = $jwt.id)
+                    }
+                  }
+                }), '@neo4j/graphql/FORBIDDEN', [])
+              }
+              CALL (*) {
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
+                  MATCH (this3)<-[:HAS_OPEN_INTERVALS]-(this15:OpeningDay)
+                  WHERE EXISTS {
+                    MATCH (this15)<-[:VALID_GARAGES]-(this16:Settings)
+                    WHERE EXISTS {
+                      MATCH (this16)<-[:HAS_SETTINGS]-(this17:Tenant)
+                      WHERE EXISTS {
+                        MATCH (this17)<-[:ADMIN_IN]-(this18:User)
+                        WHERE ($jwt.id IS NOT NULL AND this18.userId = $jwt.id)
+                      }
+                    }
+                  }
+                }), '@neo4j/graphql/FORBIDDEN', [])
+              }
+              RETURN this0 AS this
             }
             WITH this
             CALL (this) {
-                CALL (this) {
-                    MATCH (this)<-[this19:ADMIN_IN]-(this20:User)
-                    WITH DISTINCT this20
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.id IS NOT NULL AND this20.userId = $jwt.id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    WITH this20 { .userId } AS this20
-                    RETURN collect(this20) AS var21
-                }
-                RETURN this { .id, admins: var21 } AS var22
+              CALL (this) {
+                MATCH (this)<-[this19:ADMIN_IN]-(this20:User)
+                WITH DISTINCT this20
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.id IS NOT NULL AND this20.userId = $jwt.id)), '@neo4j/graphql/FORBIDDEN', [])
+                WITH this20 { .userId } AS this20
+                RETURN collect(this20) AS var21
+              }
+              RETURN this { .id, admins: var21 } AS var22
             }
             RETURN collect(var22) AS data"
         `);

--- a/packages/graphql/tests/tck/issues/4214.test.ts
+++ b/packages/graphql/tests/tck/issues/4214.test.ts
@@ -172,68 +172,68 @@ describe("https://github.com/neo4j/graphql/issues/4214", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                CREATE (this0:TransactionItem)
-                SET
-                    this0.name = $param0,
-                    this0.price = $param1,
-                    this0.quantity = $param2
+              CREATE (this0:TransactionItem)
+              SET
+                this0.name = $param0,
+                this0.price = $param1,
+                this0.quantity = $param2
+              WITH *
+              CALL (this0) {
+                MATCH (this1:Transaction)
+                WHERE ((($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles)) OR ($isAuthenticated = true AND (($jwt.roles IS NOT NULL AND $param6 IN $jwt.roles) OR ($jwt.roles IS NOT NULL AND $param7 IN $jwt.roles)) AND EXISTS {
+                  MATCH (this1)-[:TRANSACTION]->(this2:Store)
+                  WHERE ($jwt.store IS NOT NULL AND this2.id = $jwt.store)
+                })) AND this1.id = $param8)
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND (($jwt.roles IS NOT NULL AND $param9 IN $jwt.roles) OR ($jwt.roles IS NOT NULL AND $param10 IN $jwt.roles)) AND EXISTS {
+                  MATCH (this1)-[:TRANSACTION]->(this3:Store)
+                  WHERE ($jwt.store IS NOT NULL AND this3.id = $jwt.store)
+                }), '@neo4j/graphql/FORBIDDEN', [])
+                CREATE (this0)-[this4:ITEM_TRANSACTED]->(this1)
                 WITH *
-                CALL (this0) {
-                    MATCH (this1:Transaction)
-                    WHERE ((($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles)) OR ($isAuthenticated = true AND (($jwt.roles IS NOT NULL AND $param6 IN $jwt.roles) OR ($jwt.roles IS NOT NULL AND $param7 IN $jwt.roles)) AND EXISTS {
-                        MATCH (this1)-[:TRANSACTION]->(this2:Store)
-                        WHERE ($jwt.store IS NOT NULL AND this2.id = $jwt.store)
-                    })) AND this1.id = $param8)
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND (($jwt.roles IS NOT NULL AND $param9 IN $jwt.roles) OR ($jwt.roles IS NOT NULL AND $param10 IN $jwt.roles)) AND EXISTS {
-                        MATCH (this1)-[:TRANSACTION]->(this3:Store)
-                        WHERE ($jwt.store IS NOT NULL AND this3.id = $jwt.store)
-                    }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    CREATE (this0)-[this4:ITEM_TRANSACTED]->(this1)
-                    WITH *
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND (($jwt.roles IS NOT NULL AND $param11 IN $jwt.roles) OR ($jwt.roles IS NOT NULL AND $param12 IN $jwt.roles)) AND EXISTS {
-                        MATCH (this1)-[:TRANSACTION]->(this5:Store)
-                        WHERE ($jwt.store IS NOT NULL AND this5.id = $jwt.store)
-                    }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    WITH *
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND (($jwt.roles IS NOT NULL AND $param13 IN $jwt.roles) OR ($jwt.roles IS NOT NULL AND $param14 IN $jwt.roles)) AND EXISTS {
-                        MATCH (this0)-[:ITEM_TRANSACTED]->(this6:Transaction)
-                        WHERE EXISTS {
-                            MATCH (this6)-[:TRANSACTION]->(this7:Store)
-                            WHERE ($jwt.store IS NOT NULL AND this7.id = $jwt.store)
-                        }
-                    }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                }
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND (($jwt.roles IS NOT NULL AND $param11 IN $jwt.roles) OR ($jwt.roles IS NOT NULL AND $param12 IN $jwt.roles)) AND EXISTS {
+                  MATCH (this1)-[:TRANSACTION]->(this5:Store)
+                  WHERE ($jwt.store IS NOT NULL AND this5.id = $jwt.store)
+                }), '@neo4j/graphql/FORBIDDEN', [])
                 WITH *
-                CALL (*) {
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND (($jwt.roles IS NOT NULL AND $param15 IN $jwt.roles) OR ($jwt.roles IS NOT NULL AND $param16 IN $jwt.roles)) AND EXISTS {
-                        MATCH (this0)-[:ITEM_TRANSACTED]->(this8:Transaction)
-                        WHERE EXISTS {
-                            MATCH (this8)-[:TRANSACTION]->(this9:Store)
-                            WHERE ($jwt.store IS NOT NULL AND this9.id = $jwt.store)
-                        }
-                    }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                }
-                RETURN this0 AS this
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND (($jwt.roles IS NOT NULL AND $param13 IN $jwt.roles) OR ($jwt.roles IS NOT NULL AND $param14 IN $jwt.roles)) AND EXISTS {
+                  MATCH (this0)-[:ITEM_TRANSACTED]->(this6:Transaction)
+                  WHERE EXISTS {
+                    MATCH (this6)-[:TRANSACTION]->(this7:Store)
+                    WHERE ($jwt.store IS NOT NULL AND this7.id = $jwt.store)
+                  }
+                }), '@neo4j/graphql/FORBIDDEN', [])
+              }
+              WITH *
+              CALL (*) {
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND (($jwt.roles IS NOT NULL AND $param15 IN $jwt.roles) OR ($jwt.roles IS NOT NULL AND $param16 IN $jwt.roles)) AND EXISTS {
+                  MATCH (this0)-[:ITEM_TRANSACTED]->(this8:Transaction)
+                  WHERE EXISTS {
+                    MATCH (this8)-[:TRANSACTION]->(this9:Store)
+                    WHERE ($jwt.store IS NOT NULL AND this9.id = $jwt.store)
+                  }
+                }), '@neo4j/graphql/FORBIDDEN', [])
+              }
+              RETURN this0 AS this
             }
             WITH this
             CALL (this) {
-                CALL (this) {
-                    MATCH (this)-[this10:ITEM_TRANSACTED]->(this11:Transaction)
-                    WHERE (($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param17 IN $jwt.roles)) OR ($isAuthenticated = true AND (($jwt.roles IS NOT NULL AND $param18 IN $jwt.roles) OR ($jwt.roles IS NOT NULL AND $param19 IN $jwt.roles)) AND EXISTS {
-                        MATCH (this11)-[:TRANSACTION]->(this12:Store)
-                        WHERE ($jwt.store IS NOT NULL AND this12.id = $jwt.store)
-                    }))
-                    WITH DISTINCT this11
-                    CALL (this11) {
-                        MATCH (this11)-[this13:TRANSACTION]->(this14:Store)
-                        WITH DISTINCT this14
-                        WITH this14 { .name } AS this14
-                        RETURN collect(this14) AS var15
-                    }
-                    WITH this11 { .id, store: var15 } AS this11
-                    RETURN collect(this11) AS var16
+              CALL (this) {
+                MATCH (this)-[this10:ITEM_TRANSACTED]->(this11:Transaction)
+                WHERE (($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param17 IN $jwt.roles)) OR ($isAuthenticated = true AND (($jwt.roles IS NOT NULL AND $param18 IN $jwt.roles) OR ($jwt.roles IS NOT NULL AND $param19 IN $jwt.roles)) AND EXISTS {
+                  MATCH (this11)-[:TRANSACTION]->(this12:Store)
+                  WHERE ($jwt.store IS NOT NULL AND this12.id = $jwt.store)
+                }))
+                WITH DISTINCT this11
+                CALL (this11) {
+                  MATCH (this11)-[this13:TRANSACTION]->(this14:Store)
+                  WITH DISTINCT this14
+                  WITH this14 { .name } AS this14
+                  RETURN collect(this14) AS var15
                 }
-                RETURN this { .name, transaction: var16 } AS var17
+                WITH this11 { .id, store: var15 } AS this11
+                RETURN collect(this11) AS var16
+              }
+              RETURN this { .name, transaction: var16 } AS var17
             }
             RETURN collect(var17) AS data"
         `);

--- a/packages/graphql/tests/tck/issues/4223.test.ts
+++ b/packages/graphql/tests/tck/issues/4223.test.ts
@@ -192,103 +192,99 @@ describe("https://github.com/neo4j/graphql/issues/4223", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                CREATE (this0:Tenant)
-                SET
-                    this0.id = randomUUID()
-                WITH *
-                CREATE (this1:Settings)
-                WITH *
-                CREATE (this2:OpeningDay)
-                WITH *
-                CREATE (this3:OpeningHoursInterval)
-                MERGE (this2)-[this4:HAS_OPEN_INTERVALS]->(this3)
-                SET
-                    this3.name = $param0,
-                    this3.updatedBy = $param1
-                MERGE (this1)-[this5:VALID_OPENING_DAYS]->(this2)
-                SET
-                    this2.id = randomUUID()
-                WITH *
-                CREATE (this6:MyWorkspace)
-                MERGE (this1)-[this7:HAS_WORKSPACE_SETTINGS]->(this6)
-                SET
-                    this6.workspace = $param2,
-                    this6.updatedBy = $param3
-                MERGE (this0)<-[this8:VEHICLECARD_OWNER]-(this1)
-                SET
-                    this1.id = randomUUID()
-                WITH *
-                CREATE (this9:User)
-                MERGE (this0)<-[this10:ADMIN_IN]-(this9)
-                SET
-                    this9.userId = $param4
-                WITH *
-                CALL (*) {
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                        MATCH (this0)<-[:ADMIN_IN]-(this11:User)
-                        WHERE ($jwt.id IS NOT NULL AND this11.userId = $jwt.id)
-                    }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                }
-                CALL (*) {
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                        MATCH (this1)<-[:HAS_SETTINGS]-(this12:Tenant)
-                        WHERE EXISTS {
-                            MATCH (this12)<-[:ADMIN_IN]-(this13:User)
-                            WHERE ($jwt.id IS NOT NULL AND this13.userId = $jwt.id)
-                        }
-                    }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                }
-                CALL (*) {
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                        MATCH (this2)<-[:VALID_GARAGES]-(this14:Settings)
-                        WHERE EXISTS {
-                            MATCH (this14)<-[:HAS_SETTINGS]-(this15:Tenant)
-                            WHERE EXISTS {
-                                MATCH (this15)<-[:ADMIN_IN]-(this16:User)
-                                WHERE ($jwt.id IS NOT NULL AND this16.userId = $jwt.id)
-                            }
-                        }
-                    }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                }
-                CALL (*) {
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                        MATCH (this3)<-[:HAS_OPEN_INTERVALS]-(this17:OpeningDay)
-                        WHERE EXISTS {
-                            MATCH (this17)<-[:VALID_GARAGES]-(this18:Settings)
-                            WHERE EXISTS {
-                                MATCH (this18)<-[:HAS_SETTINGS]-(this19:Tenant)
-                                WHERE EXISTS {
-                                    MATCH (this19)<-[:ADMIN_IN]-(this20:User)
-                                    WHERE ($jwt.id IS NOT NULL AND this20.userId = $jwt.id)
-                                }
-                            }
-                        }
-                    }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                }
-                CALL (*) {
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                        MATCH (this6)<-[:HAS_WORKSPACE_SETTINGS]-(this21:Settings)
-                        WHERE EXISTS {
-                            MATCH (this21)<-[:HAS_SETTINGS]-(this22:Tenant)
-                            WHERE EXISTS {
-                                MATCH (this22)<-[:ADMIN_IN]-(this23:User)
-                                WHERE ($jwt.id IS NOT NULL AND this23.userId = $jwt.id)
-                            }
-                        }
-                    }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                }
-                RETURN this0 AS this
+              CREATE (this0:Tenant)
+              SET this0.id = randomUUID()
+              WITH *
+              CREATE (this1:Settings)
+              WITH *
+              CREATE (this2:OpeningDay)
+              WITH *
+              CREATE (this3:OpeningHoursInterval)
+              MERGE (this2)-[this4:HAS_OPEN_INTERVALS]->(this3)
+              SET
+                this3.name = $param0,
+                this3.updatedBy = $param1
+              MERGE (this1)-[this5:VALID_OPENING_DAYS]->(this2)
+              SET this2.id = randomUUID()
+              WITH *
+              CREATE (this6:MyWorkspace)
+              MERGE (this1)-[this7:HAS_WORKSPACE_SETTINGS]->(this6)
+              SET
+                this6.workspace = $param2,
+                this6.updatedBy = $param3
+              MERGE (this0)<-[this8:VEHICLECARD_OWNER]-(this1)
+              SET this1.id = randomUUID()
+              WITH *
+              CREATE (this9:User)
+              MERGE (this0)<-[this10:ADMIN_IN]-(this9)
+              SET this9.userId = $param4
+              WITH *
+              CALL (*) {
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
+                  MATCH (this0)<-[:ADMIN_IN]-(this11:User)
+                  WHERE ($jwt.id IS NOT NULL AND this11.userId = $jwt.id)
+                }), '@neo4j/graphql/FORBIDDEN', [])
+              }
+              CALL (*) {
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
+                  MATCH (this1)<-[:HAS_SETTINGS]-(this12:Tenant)
+                  WHERE EXISTS {
+                    MATCH (this12)<-[:ADMIN_IN]-(this13:User)
+                    WHERE ($jwt.id IS NOT NULL AND this13.userId = $jwt.id)
+                  }
+                }), '@neo4j/graphql/FORBIDDEN', [])
+              }
+              CALL (*) {
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
+                  MATCH (this2)<-[:VALID_GARAGES]-(this14:Settings)
+                  WHERE EXISTS {
+                    MATCH (this14)<-[:HAS_SETTINGS]-(this15:Tenant)
+                    WHERE EXISTS {
+                      MATCH (this15)<-[:ADMIN_IN]-(this16:User)
+                      WHERE ($jwt.id IS NOT NULL AND this16.userId = $jwt.id)
+                    }
+                  }
+                }), '@neo4j/graphql/FORBIDDEN', [])
+              }
+              CALL (*) {
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
+                  MATCH (this3)<-[:HAS_OPEN_INTERVALS]-(this17:OpeningDay)
+                  WHERE EXISTS {
+                    MATCH (this17)<-[:VALID_GARAGES]-(this18:Settings)
+                    WHERE EXISTS {
+                      MATCH (this18)<-[:HAS_SETTINGS]-(this19:Tenant)
+                      WHERE EXISTS {
+                        MATCH (this19)<-[:ADMIN_IN]-(this20:User)
+                        WHERE ($jwt.id IS NOT NULL AND this20.userId = $jwt.id)
+                      }
+                    }
+                  }
+                }), '@neo4j/graphql/FORBIDDEN', [])
+              }
+              CALL (*) {
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
+                  MATCH (this6)<-[:HAS_WORKSPACE_SETTINGS]-(this21:Settings)
+                  WHERE EXISTS {
+                    MATCH (this21)<-[:HAS_SETTINGS]-(this22:Tenant)
+                    WHERE EXISTS {
+                      MATCH (this22)<-[:ADMIN_IN]-(this23:User)
+                      WHERE ($jwt.id IS NOT NULL AND this23.userId = $jwt.id)
+                    }
+                  }
+                }), '@neo4j/graphql/FORBIDDEN', [])
+              }
+              RETURN this0 AS this
             }
             WITH this
             CALL (this) {
-                CALL (this) {
-                    MATCH (this)<-[this24:ADMIN_IN]-(this25:User)
-                    WITH DISTINCT this25
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.id IS NOT NULL AND this25.userId = $jwt.id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    WITH this25 { .userId } AS this25
-                    RETURN collect(this25) AS var26
-                }
-                RETURN this { .id, admins: var26 } AS var27
+              CALL (this) {
+                MATCH (this)<-[this24:ADMIN_IN]-(this25:User)
+                WITH DISTINCT this25
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.id IS NOT NULL AND this25.userId = $jwt.id)), '@neo4j/graphql/FORBIDDEN', [])
+                WITH this25 { .userId } AS this25
+                RETURN collect(this25) AS var26
+              }
+              RETURN this { .id, admins: var26 } AS var27
             }
             RETURN collect(var27) AS data"
         `);

--- a/packages/graphql/tests/tck/issues/4239.test.ts
+++ b/packages/graphql/tests/tck/issues/4239.test.ts
@@ -83,7 +83,7 @@ describe("https://github.com/neo4j/graphql/issues/4239", () => {
             "CYPHER 5
             MATCH (this:Movie)
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND size([(this)<-[this1:DIRECTED]-(this0:Person) WHERE ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub) | 1]) > 0), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND size([(this)<-[this1:DIRECTED]-(this0:Person) WHERE ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub) | 1]) > 0), '@neo4j/graphql/FORBIDDEN', [])
             RETURN this { .title } AS this"
         `);
 
@@ -140,9 +140,9 @@ describe("https://github.com/neo4j/graphql/issues/4239", () => {
             MATCH (this:Movie)
             WITH *
             CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                MATCH (this)<-[:DIRECTED]-(this0:Person)
-                WHERE ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)
-            }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+              MATCH (this)<-[:DIRECTED]-(this0:Person)
+              WHERE ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)
+            }), '@neo4j/graphql/FORBIDDEN', [])
             RETURN this { .title } AS this"
         `);
 
@@ -204,9 +204,9 @@ describe("https://github.com/neo4j/graphql/issues/4239", () => {
             MATCH (this:Movie)
             WITH *
             CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                MATCH (this)<-[this0:DIRECTED]-(this1:Person)
-                WHERE ($jwt.sub IS NOT NULL AND this1.id = $jwt.sub)
-            }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+              MATCH (this)<-[this0:DIRECTED]-(this1:Person)
+              WHERE ($jwt.sub IS NOT NULL AND this1.id = $jwt.sub)
+            }), '@neo4j/graphql/FORBIDDEN', [])
             RETURN this { .title } AS this"
         `);
 

--- a/packages/graphql/tests/tck/issues/4268.test.ts
+++ b/packages/graphql/tests/tck/issues/4268.test.ts
@@ -61,7 +61,7 @@ describe("https://github.com/neo4j/graphql/issues/4268", () => {
             "CYPHER 5
             MATCH (this:Movie)
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND (($jwt.roles IS NOT NULL AND $jwt.roles = $param2) OR ($jwt.roles IS NOT NULL AND $jwt.roles = $param3))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND (($jwt.roles IS NOT NULL AND $jwt.roles = $param2) OR ($jwt.roles IS NOT NULL AND $jwt.roles = $param3))), '@neo4j/graphql/FORBIDDEN', [])
             RETURN this { .title } AS this"
         `);
 
@@ -132,7 +132,7 @@ describe("https://github.com/neo4j/graphql/issues/4268", () => {
             "CYPHER 5
             MATCH (this:Movie)
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ((($jwt.roles IS NOT NULL AND $jwt.roles = $param2) OR ($jwt.roles IS NOT NULL AND $jwt.roles = $param3)) OR (($jwt.roles IS NOT NULL AND $jwt.roles = $param4) OR ($jwt.roles IS NOT NULL AND $jwt.roles = $param5)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ((($jwt.roles IS NOT NULL AND $jwt.roles = $param2) OR ($jwt.roles IS NOT NULL AND $jwt.roles = $param3)) OR (($jwt.roles IS NOT NULL AND $jwt.roles = $param4) OR ($jwt.roles IS NOT NULL AND $jwt.roles = $param5)))), '@neo4j/graphql/FORBIDDEN', [])
             RETURN this { .title } AS this"
         `);
 
@@ -198,7 +198,7 @@ describe("https://github.com/neo4j/graphql/issues/4268", () => {
             "CYPHER 5
             MATCH (this:Movie)
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND (($jwt.roles IS NOT NULL AND $jwt.roles = $param2) AND ($jwt.roles IS NOT NULL AND $jwt.roles = $param3))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND (($jwt.roles IS NOT NULL AND $jwt.roles = $param2) AND ($jwt.roles IS NOT NULL AND $jwt.roles = $param3))), '@neo4j/graphql/FORBIDDEN', [])
             RETURN this { .title } AS this"
         `);
 
@@ -269,7 +269,7 @@ describe("https://github.com/neo4j/graphql/issues/4268", () => {
             "CYPHER 5
             MATCH (this:Movie)
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ((($jwt.roles IS NOT NULL AND $jwt.roles = $param2) AND ($jwt.roles IS NOT NULL AND $jwt.roles = $param3)) AND (($jwt.roles IS NOT NULL AND $jwt.roles = $param4) AND ($jwt.roles IS NOT NULL AND $jwt.roles = $param5)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND ((($jwt.roles IS NOT NULL AND $jwt.roles = $param2) AND ($jwt.roles IS NOT NULL AND $jwt.roles = $param3)) AND (($jwt.roles IS NOT NULL AND $jwt.roles = $param4) AND ($jwt.roles IS NOT NULL AND $jwt.roles = $param5)))), '@neo4j/graphql/FORBIDDEN', [])
             RETURN this { .title } AS this"
         `);
 
@@ -328,7 +328,7 @@ describe("https://github.com/neo4j/graphql/issues/4268", () => {
             "CYPHER 5
             MATCH (this:Movie)
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND NOT ($jwt.roles IS NOT NULL AND $jwt.roles = $param2)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND NOT ($jwt.roles IS NOT NULL AND $jwt.roles = $param2)), '@neo4j/graphql/FORBIDDEN', [])
             RETURN this { .title } AS this"
         `);
 
@@ -386,7 +386,7 @@ describe("https://github.com/neo4j/graphql/issues/4268", () => {
             "CYPHER 5
             MATCH (this:Movie)
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND NOT (NOT ($jwt.roles IS NOT NULL AND $jwt.roles = $param2))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND NOT (NOT ($jwt.roles IS NOT NULL AND $jwt.roles = $param2))), '@neo4j/graphql/FORBIDDEN', [])
             RETURN this { .title } AS this"
         `);
 

--- a/packages/graphql/tests/tck/issues/4287.test.ts
+++ b/packages/graphql/tests/tck/issues/4287.test.ts
@@ -70,25 +70,25 @@ describe("https://github.com/neo4j/graphql/issues/4287", () => {
             "CYPHER 5
             MATCH (this:Actor)
             CALL (this) {
+              CALL (this) {
                 CALL (this) {
-                    CALL (this) {
-                        WITH this
-                        MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                        WHERE (this1.title = $param0 OR this1.title = $param1)
-                        WITH { node: { __resolveType: \\"Movie\\", __id: id(this1), title: this1.title } } AS edge
-                        RETURN edge
-                        UNION
-                        WITH this
-                        MATCH (this)-[this2:ACTED_IN]->(this3:Series)
-                        WHERE (this3.title = $param2 OR this3.title = $param3)
-                        WITH { node: { __resolveType: \\"Series\\", __id: id(this3), title: this3.title } } AS edge
-                        RETURN edge
-                    }
-                    RETURN collect(edge) AS edges
+                  WITH this
+                  MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+                  WHERE (this1.title = $param0 OR this1.title = $param1)
+                  WITH {node: {__resolveType: 'Movie', __id: elementId(this1), title: this1.title}} AS edge
+                  RETURN edge
+                  UNION
+                  WITH this
+                  MATCH (this)-[this2:ACTED_IN]->(this3:Series)
+                  WHERE (this3.title = $param2 OR this3.title = $param3)
+                  WITH {node: {__resolveType: 'Series', __id: elementId(this3), title: this3.title}} AS edge
+                  RETURN edge
                 }
-                WITH edges
-                WITH edges, size(edges) AS totalCount
-                RETURN { edges: edges, totalCount: totalCount } AS var4
+                RETURN collect(edge) AS edges
+              }
+              WITH edges
+              WITH edges, size(edges) AS totalCount
+              RETURN {edges: edges, totalCount: totalCount} AS var4
             }
             RETURN this { actedInConnection: var4 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/4292.test.ts
+++ b/packages/graphql/tests/tck/issues/4292.test.ts
@@ -214,77 +214,77 @@ describe("https://github.com/neo4j/graphql/issues/4292", () => {
             MATCH (this:Group)
             WHERE this.id = $param0
             CALL (this) {
-                MATCH (this)<-[this0:MEMBER_OF]-(this1:Person)
-                WITH DISTINCT this1
-                WITH *
-                CALL apoc.util.validate(NOT ($isAuthenticated = true AND (EXISTS {
-                    MATCH (this1)<-[:CREATOR_OF]-(this2:User)
-                    WHERE ($jwt.uid IS NOT NULL AND this2.id = $jwt.uid)
-                } OR EXISTS {
-                    MATCH (this1)-[:MEMBER_OF]->(this3:Group)
-                    WHERE EXISTS {
-                        MATCH (this3)<-[:ADMIN_OF]-(this4:Admin)
-                        WHERE EXISTS {
-                            MATCH (this4)-[:IS_USER]->(this5:User)
-                            WHERE ($jwt.uid IS NOT NULL AND this5.id = $jwt.uid)
-                        }
-                    }
-                } OR EXISTS {
-                    MATCH (this1)-[:MEMBER_OF]->(this6:Group)
-                    WHERE EXISTS {
-                        MATCH (this6)<-[:CONTRIBUTOR_TO]-(this7:Contributor)
-                        WHERE EXISTS {
-                            MATCH (this7)-[:IS_USER]->(this8:User)
-                            WHERE ($jwt.uid IS NOT NULL AND this8.id = $jwt.uid)
-                        }
-                    }
-                } OR EXISTS {
-                    MATCH (this1)-[:MEMBER_OF]->(this9:Group)
-                    WHERE EXISTS {
-                        MATCH (this9)<-[:CREATOR_OF]-(this10:User)
-                        WHERE ($jwt.uid IS NOT NULL AND this10.id = $jwt.uid)
-                    }
-                })), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                CALL (this1) {
-                    MATCH (this1)-[this11:PARTNER_OF]-(this12:Person)
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND (EXISTS {
-                        MATCH (this12)<-[:CREATOR_OF]-(this13:User)
-                        WHERE ($jwt.uid IS NOT NULL AND this13.id = $jwt.uid)
-                    } OR EXISTS {
-                        MATCH (this12)-[:MEMBER_OF]->(this14:Group)
-                        WHERE EXISTS {
-                            MATCH (this14)<-[:ADMIN_OF]-(this15:Admin)
-                            WHERE EXISTS {
-                                MATCH (this15)-[:IS_USER]->(this16:User)
-                                WHERE ($jwt.uid IS NOT NULL AND this16.id = $jwt.uid)
-                            }
-                        }
-                    } OR EXISTS {
-                        MATCH (this12)-[:MEMBER_OF]->(this17:Group)
-                        WHERE EXISTS {
-                            MATCH (this17)<-[:CONTRIBUTOR_TO]-(this18:Contributor)
-                            WHERE EXISTS {
-                                MATCH (this18)-[:IS_USER]->(this19:User)
-                                WHERE ($jwt.uid IS NOT NULL AND this19.id = $jwt.uid)
-                            }
-                        }
-                    } OR EXISTS {
-                        MATCH (this12)-[:MEMBER_OF]->(this20:Group)
-                        WHERE EXISTS {
-                            MATCH (this20)<-[:CREATOR_OF]-(this21:User)
-                            WHERE ($jwt.uid IS NOT NULL AND this21.id = $jwt.uid)
-                        }
-                    })), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    WITH collect({ node: this12, relationship: this11 }) AS edges
-                    CALL (edges) {
-                        UNWIND edges AS edge
-                        WITH edge.node AS this12, edge.relationship AS this11
-                        RETURN collect({ properties: { active: this11.active, firstDay: this11.firstDay, lastDay: this11.lastDay, __resolveType: \\"PartnerOf\\" }, node: { __id: id(this12), __resolveType: \\"Person\\" } }) AS var22
-                    }
-                    RETURN { edges: var22 } AS var23
+              MATCH (this)<-[this0:MEMBER_OF]-(this1:Person)
+              WITH DISTINCT this1
+              WITH *
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND (EXISTS {
+                MATCH (this1)<-[:CREATOR_OF]-(this2:User)
+                WHERE ($jwt.uid IS NOT NULL AND this2.id = $jwt.uid)
+              } OR EXISTS {
+                MATCH (this1)-[:MEMBER_OF]->(this3:Group)
+                WHERE EXISTS {
+                  MATCH (this3)<-[:ADMIN_OF]-(this4:Admin)
+                  WHERE EXISTS {
+                    MATCH (this4)-[:IS_USER]->(this5:User)
+                    WHERE ($jwt.uid IS NOT NULL AND this5.id = $jwt.uid)
+                  }
                 }
-                WITH this1 { .id, .name, partnersConnection: var23 } AS this1
-                RETURN collect(this1) AS var24
+              } OR EXISTS {
+                MATCH (this1)-[:MEMBER_OF]->(this6:Group)
+                WHERE EXISTS {
+                  MATCH (this6)<-[:CONTRIBUTOR_TO]-(this7:Contributor)
+                  WHERE EXISTS {
+                    MATCH (this7)-[:IS_USER]->(this8:User)
+                    WHERE ($jwt.uid IS NOT NULL AND this8.id = $jwt.uid)
+                  }
+                }
+              } OR EXISTS {
+                MATCH (this1)-[:MEMBER_OF]->(this9:Group)
+                WHERE EXISTS {
+                  MATCH (this9)<-[:CREATOR_OF]-(this10:User)
+                  WHERE ($jwt.uid IS NOT NULL AND this10.id = $jwt.uid)
+                }
+              })), '@neo4j/graphql/FORBIDDEN', [])
+              CALL (this1) {
+                MATCH (this1)-[this11:PARTNER_OF]-(this12:Person)
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND (EXISTS {
+                  MATCH (this12)<-[:CREATOR_OF]-(this13:User)
+                  WHERE ($jwt.uid IS NOT NULL AND this13.id = $jwt.uid)
+                } OR EXISTS {
+                  MATCH (this12)-[:MEMBER_OF]->(this14:Group)
+                  WHERE EXISTS {
+                    MATCH (this14)<-[:ADMIN_OF]-(this15:Admin)
+                    WHERE EXISTS {
+                      MATCH (this15)-[:IS_USER]->(this16:User)
+                      WHERE ($jwt.uid IS NOT NULL AND this16.id = $jwt.uid)
+                    }
+                  }
+                } OR EXISTS {
+                  MATCH (this12)-[:MEMBER_OF]->(this17:Group)
+                  WHERE EXISTS {
+                    MATCH (this17)<-[:CONTRIBUTOR_TO]-(this18:Contributor)
+                    WHERE EXISTS {
+                      MATCH (this18)-[:IS_USER]->(this19:User)
+                      WHERE ($jwt.uid IS NOT NULL AND this19.id = $jwt.uid)
+                    }
+                  }
+                } OR EXISTS {
+                  MATCH (this12)-[:MEMBER_OF]->(this20:Group)
+                  WHERE EXISTS {
+                    MATCH (this20)<-[:CREATOR_OF]-(this21:User)
+                    WHERE ($jwt.uid IS NOT NULL AND this21.id = $jwt.uid)
+                  }
+                })), '@neo4j/graphql/FORBIDDEN', [])
+                WITH collect({node: this12, relationship: this11}) AS edges
+                CALL (edges) {
+                  UNWIND edges AS edge
+                  WITH edge.node AS this12, edge.relationship AS this11
+                  RETURN collect({properties: {active: this11.active, firstDay: this11.firstDay, lastDay: this11.lastDay, __resolveType: 'PartnerOf'}, node: {__id: elementId(this12), __resolveType: 'Person'}}) AS var22
+                }
+                RETURN {edges: var22} AS var23
+              }
+              WITH this1 { .id, .name, partnersConnection: var23 } AS this1
+              RETURN collect(this1) AS var24
             }
             RETURN this { .id, .name, members: var24 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/433.test.ts
+++ b/packages/graphql/tests/tck/issues/433.test.ts
@@ -64,14 +64,14 @@ describe("#413", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)-[this0:ACTED_IN]->(this1:Person)
-                WITH collect({ node: this1, relationship: this0 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ node: { name: this1.name, __resolveType: \\"Person\\" } }) AS var2
-                }
-                RETURN { edges: var2 } AS var3
+              MATCH (this)-[this0:ACTED_IN]->(this1:Person)
+              WITH collect({node: this1, relationship: this0}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this1, edge.relationship AS this0
+                RETURN collect({node: {name: this1.name, __resolveType: 'Person'}}) AS var2
+              }
+              RETURN {edges: var2} AS var3
             }
             RETURN this { .title, actorsConnection: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/4405.test.ts
+++ b/packages/graphql/tests/tck/issues/4405.test.ts
@@ -61,7 +61,7 @@ describe("https://github.com/neo4j/graphql/issues/4405", () => {
             "CYPHER 5
             MATCH (this:Actor)
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND size([(this)-[this1:ACTED_IN]->(this0:Movie) WHERE ($param1 IS NOT NULL AND this0.title IN $param1) | 1]) > 0), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND size([(this)-[this1:ACTED_IN]->(this0:Movie) WHERE ($param1 IS NOT NULL AND this0.title IN $param1) | 1]) > 0), '@neo4j/graphql/FORBIDDEN', [])
             RETURN this { .name } AS this"
         `);
 
@@ -127,7 +127,7 @@ describe("https://github.com/neo4j/graphql/issues/4405", () => {
             "CYPHER 5
             MATCH (this:Actor)
             WITH *
-            CALL apoc.util.validate(NOT ($isAuthenticated = true AND size([(this)-[this1:ACTED_IN]->(this0:Movie) WHERE (($param1 IS NOT NULL AND this0.title IN $param1) OR ($param2 IS NOT NULL AND this0.title IN $param2)) | 1]) > 0), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ($isAuthenticated = true AND size([(this)-[this1:ACTED_IN]->(this0:Movie) WHERE (($param1 IS NOT NULL AND this0.title IN $param1) OR ($param2 IS NOT NULL AND this0.title IN $param2)) | 1]) > 0), '@neo4j/graphql/FORBIDDEN', [])
             RETURN this { .name } AS this"
         `);
 

--- a/packages/graphql/tests/tck/issues/4432.test.ts
+++ b/packages/graphql/tests/tck/issues/4432.test.ts
@@ -72,29 +72,29 @@ describe("https://github.com/neo4j/graphql/issues/4532", () => {
             "CYPHER 5
             MATCH (this:Inventory)
             CALL (this) {
+              CALL (this) {
                 CALL (this) {
-                    CALL (this) {
-                        WITH this
-                        MATCH (this)-[this0:HasChildren]->(this1:Image)
-                        WITH { properties: { order: this0.order, __resolveType: \\"InventoryChildRelation\\" }, node: { __resolveType: \\"Image\\", __id: id(this1), id: this1.id } } AS edge
-                        RETURN edge
-                        UNION
-                        WITH this
-                        MATCH (this)-[this2:HasChildren]->(this3:Video)
-                        WITH { properties: { order: this2.order, __resolveType: \\"InventoryChildRelation\\" }, node: { __resolveType: \\"Video\\", __id: id(this3), id: this3.id } } AS edge
-                        RETURN edge
-                    }
-                    RETURN collect(edge) AS edges
+                  WITH this
+                  MATCH (this)-[this0:HasChildren]->(this1:Image)
+                  WITH {properties: {order: this0.order, __resolveType: 'InventoryChildRelation'}, node: {__resolveType: 'Image', __id: elementId(this1), id: this1.id}} AS edge
+                  RETURN edge
+                  UNION
+                  WITH this
+                  MATCH (this)-[this2:HasChildren]->(this3:Video)
+                  WITH {properties: {order: this2.order, __resolveType: 'InventoryChildRelation'}, node: {__resolveType: 'Video', __id: elementId(this3), id: this3.id}} AS edge
+                  RETURN edge
                 }
-                WITH edges
-                WITH edges, size(edges) AS totalCount
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge
-                    ORDER BY edge.properties.order ASC
-                    RETURN collect(edge) AS var4
-                }
-                RETURN { edges: var4, totalCount: totalCount } AS var5
+                RETURN collect(edge) AS edges
+              }
+              WITH edges
+              WITH edges, size(edges) AS totalCount
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge
+                ORDER BY edge.properties.order ASC
+                RETURN collect(edge) AS var4
+              }
+              RETURN {edges: var4, totalCount: totalCount} AS var5
             }
             RETURN this { .id, childrenConnection: var5 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/4583.test.ts
+++ b/packages/graphql/tests/tck/issues/4583.test.ts
@@ -90,30 +90,27 @@ describe("https://github.com/neo4j/graphql/issues/4583", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                CREATE (this0:Actor)
-                SET
-                    this0.name = $param0
-                WITH *
-                CALL (this0) {
-                    MATCH (this1:Movie)
-                    WHERE (this1.title = $param1 AND this1:Movie)
-                    CREATE (this0)-[this2:ACTED_IN]->(this1)
-                    SET
-                        this2.screenTime = $param2
-                }
-                WITH *
-                CALL (this0) {
-                    MATCH (this3:Series)
-                    WHERE (this3.title = $param3 AND this3:Movie)
-                    CREATE (this0)-[this4:ACTED_IN]->(this3)
-                    SET
-                        this4.screenTime = $param4
-                }
-                RETURN this0 AS this
+              CREATE (this0:Actor)
+              SET this0.name = $param0
+              WITH *
+              CALL (this0) {
+                MATCH (this1:Movie)
+                WHERE (this1.title = $param1 AND this1:Movie)
+                CREATE (this0)-[this2:ACTED_IN]->(this1)
+                SET this2.screenTime = $param2
+              }
+              WITH *
+              CALL (this0) {
+                MATCH (this3:Series)
+                WHERE (this3.title = $param3 AND this3:Movie)
+                CREATE (this0)-[this4:ACTED_IN]->(this3)
+                SET this4.screenTime = $param4
+              }
+              RETURN this0 AS this
             }
             WITH this
             CALL (this) {
-                RETURN this { .name } AS var5
+              RETURN this { .name } AS var5
             }
             RETURN collect(var5) AS data"
         `);
@@ -163,30 +160,27 @@ describe("https://github.com/neo4j/graphql/issues/4583", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                CREATE (this0:Actor)
-                SET
-                    this0.name = $param0
-                WITH *
-                CALL (this0) {
-                    MATCH (this1:Movie)
-                    WHERE (this1.title = $param1 OR this1:Movie)
-                    CREATE (this0)-[this2:ACTED_IN]->(this1)
-                    SET
-                        this2.screenTime = $param2
-                }
-                WITH *
-                CALL (this0) {
-                    MATCH (this3:Series)
-                    WHERE (this3.title = $param3 OR this3:Movie)
-                    CREATE (this0)-[this4:ACTED_IN]->(this3)
-                    SET
-                        this4.screenTime = $param4
-                }
-                RETURN this0 AS this
+              CREATE (this0:Actor)
+              SET this0.name = $param0
+              WITH *
+              CALL (this0) {
+                MATCH (this1:Movie)
+                WHERE (this1.title = $param1 OR this1:Movie)
+                CREATE (this0)-[this2:ACTED_IN]->(this1)
+                SET this2.screenTime = $param2
+              }
+              WITH *
+              CALL (this0) {
+                MATCH (this3:Series)
+                WHERE (this3.title = $param3 OR this3:Movie)
+                CREATE (this0)-[this4:ACTED_IN]->(this3)
+                SET this4.screenTime = $param4
+              }
+              RETURN this0 AS this
             }
             WITH this
             CALL (this) {
-                RETURN this { .name } AS var5
+              RETURN this { .name } AS var5
             }
             RETURN collect(var5) AS data"
         `);
@@ -242,44 +236,39 @@ describe("https://github.com/neo4j/graphql/issues/4583", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                CREATE (this0:Actor)
-                SET
-                    this0.name = $param0
-                WITH *
-                CALL (this0) {
-                    MATCH (this1:Movie)
-                    WHERE (this1.title = $param1 AND this1:Movie)
-                    CALL (this1) {
-                        MATCH (this2:Actor)
-                        WHERE this2.name = $param2
-                        CREATE (this1)<-[this3:ACTED_IN]-(this2)
-                        SET
-                            this3.screenTime = $param3
-                    }
-                    CREATE (this0)-[this4:ACTED_IN]->(this1)
-                    SET
-                        this4.screenTime = $param4
+              CREATE (this0:Actor)
+              SET this0.name = $param0
+              WITH *
+              CALL (this0) {
+                MATCH (this1:Movie)
+                WHERE (this1.title = $param1 AND this1:Movie)
+                CALL (this1) {
+                  MATCH (this2:Actor)
+                  WHERE this2.name = $param2
+                  CREATE (this1)<-[this3:ACTED_IN]-(this2)
+                  SET this3.screenTime = $param3
                 }
-                WITH *
-                CALL (this0) {
-                    MATCH (this5:Series)
-                    WHERE (this5.title = $param5 AND this5:Movie)
-                    CALL (this5) {
-                        MATCH (this6:Actor)
-                        WHERE this6.name = $param6
-                        CREATE (this5)<-[this7:ACTED_IN]-(this6)
-                        SET
-                            this7.episodeNr = $param7
-                    }
-                    CREATE (this0)-[this8:ACTED_IN]->(this5)
-                    SET
-                        this8.screenTime = $param8
+                CREATE (this0)-[this4:ACTED_IN]->(this1)
+                SET this4.screenTime = $param4
+              }
+              WITH *
+              CALL (this0) {
+                MATCH (this5:Series)
+                WHERE (this5.title = $param5 AND this5:Movie)
+                CALL (this5) {
+                  MATCH (this6:Actor)
+                  WHERE this6.name = $param6
+                  CREATE (this5)<-[this7:ACTED_IN]-(this6)
+                  SET this7.episodeNr = $param7
                 }
-                RETURN this0 AS this
+                CREATE (this0)-[this8:ACTED_IN]->(this5)
+                SET this8.screenTime = $param8
+              }
+              RETURN this0 AS this
             }
             WITH this
             CALL (this) {
-                RETURN this { .name } AS var9
+              RETURN this { .name } AS var9
             }
             RETURN collect(var9) AS data"
         `);

--- a/packages/graphql/tests/tck/issues/4704.test.ts
+++ b/packages/graphql/tests/tck/issues/4704.test.ts
@@ -87,56 +87,56 @@ describe("https://github.com/neo4j/graphql/issues/4704", () => {
             "CYPHER 5
             MATCH (this:Actor)
             WHERE ((EXISTS {
-                MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                WHERE (EXISTS {
-                    MATCH (this1)<-[this2:ACTED_IN]-(this3:Actor)
-                    WHERE this3.name = $param0
-                } AND NOT (EXISTS {
-                    MATCH (this1)<-[this2:ACTED_IN]-(this3:Actor)
-                    WHERE NOT (this3.name = $param0)
-                }))
+              MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+              WHERE (EXISTS {
+                MATCH (this1)<-[this2:ACTED_IN]-(this3:Actor)
+                WHERE this3.name = $param0
+              } AND NOT (EXISTS {
+                MATCH (this1)<-[this2:ACTED_IN]-(this3:Actor)
+                WHERE NOT (this3.name = $param0)
+              }))
             } AND NOT (EXISTS {
-                MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                WHERE NOT (EXISTS {
-                    MATCH (this1)<-[this2:ACTED_IN]-(this3:Actor)
-                    WHERE this3.name = $param0
-                } AND NOT (EXISTS {
-                    MATCH (this1)<-[this2:ACTED_IN]-(this3:Actor)
-                    WHERE NOT (this3.name = $param0)
-                }))
+              MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+              WHERE NOT (EXISTS {
+                MATCH (this1)<-[this2:ACTED_IN]-(this3:Actor)
+                WHERE this3.name = $param0
+              } AND NOT (EXISTS {
+                MATCH (this1)<-[this2:ACTED_IN]-(this3:Actor)
+                WHERE NOT (this3.name = $param0)
+              }))
             })) AND (EXISTS {
-                MATCH (this)-[this4:ACTED_IN]->(this5:Series)
-                WHERE (EXISTS {
-                    MATCH (this5)<-[this6:STARRED_IN]-(this7:Actor)
-                    WHERE this7.name = $param1
-                } AND NOT (EXISTS {
-                    MATCH (this5)<-[this6:STARRED_IN]-(this7:Actor)
-                    WHERE NOT (this7.name = $param1)
-                }))
+              MATCH (this)-[this4:ACTED_IN]->(this5:Series)
+              WHERE (EXISTS {
+                MATCH (this5)<-[this6:STARRED_IN]-(this7:Actor)
+                WHERE this7.name = $param1
+              } AND NOT (EXISTS {
+                MATCH (this5)<-[this6:STARRED_IN]-(this7:Actor)
+                WHERE NOT (this7.name = $param1)
+              }))
             } AND NOT (EXISTS {
-                MATCH (this)-[this4:ACTED_IN]->(this5:Series)
-                WHERE NOT (EXISTS {
-                    MATCH (this5)<-[this6:STARRED_IN]-(this7:Actor)
-                    WHERE this7.name = $param1
-                } AND NOT (EXISTS {
-                    MATCH (this5)<-[this6:STARRED_IN]-(this7:Actor)
-                    WHERE NOT (this7.name = $param1)
-                }))
+              MATCH (this)-[this4:ACTED_IN]->(this5:Series)
+              WHERE NOT (EXISTS {
+                MATCH (this5)<-[this6:STARRED_IN]-(this7:Actor)
+                WHERE this7.name = $param1
+              } AND NOT (EXISTS {
+                MATCH (this5)<-[this6:STARRED_IN]-(this7:Actor)
+                WHERE NOT (this7.name = $param1)
+              }))
             })))
             CALL (this) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this)-[this8:ACTED_IN]->(this9:Movie)
-                    WITH this9 { .title, __resolveType: \\"Movie\\", __id: id(this9) } AS var10
-                    RETURN var10
-                    UNION
-                    WITH *
-                    MATCH (this)-[this11:ACTED_IN]->(this12:Series)
-                    WITH this12 { .title, __resolveType: \\"Series\\", __id: id(this12) } AS var10
-                    RETURN var10
-                }
-                WITH var10
-                RETURN collect(var10) AS var10
+              CALL (*) {
+                WITH *
+                MATCH (this)-[this8:ACTED_IN]->(this9:Movie)
+                WITH this9 { .title, __resolveType: 'Movie', __id: elementId(this9) } AS var10
+                RETURN var10
+                UNION
+                WITH *
+                MATCH (this)-[this11:ACTED_IN]->(this12:Series)
+                WITH this12 { .title, __resolveType: 'Series', __id: elementId(this12) } AS var10
+                RETURN var10
+              }
+              WITH var10
+              RETURN collect(var10) AS var10
             }
             RETURN this { actedIn: var10 } AS this"
         `);
@@ -175,19 +175,19 @@ describe("https://github.com/neo4j/graphql/issues/4704", () => {
             MATCH (this:Actor)
             WHERE (single(this1 IN [(this)-[this3:ACTED_IN]->(this1:Movie) WHERE single(this0 IN [(this1)<-[this2:ACTED_IN]-(this0:Actor) WHERE this0.name = $param0 | 1] WHERE true) | 1] WHERE true) XOR single(this5 IN [(this)-[this7:ACTED_IN]->(this5:Series) WHERE single(this4 IN [(this5)<-[this6:STARRED_IN]-(this4:Actor) WHERE this4.name = $param1 | 1] WHERE true) | 1] WHERE true))
             CALL (this) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this)-[this8:ACTED_IN]->(this9:Movie)
-                    WITH this9 { .title, __resolveType: \\"Movie\\", __id: id(this9) } AS var10
-                    RETURN var10
-                    UNION
-                    WITH *
-                    MATCH (this)-[this11:ACTED_IN]->(this12:Series)
-                    WITH this12 { .title, __resolveType: \\"Series\\", __id: id(this12) } AS var10
-                    RETURN var10
-                }
-                WITH var10
-                RETURN collect(var10) AS var10
+              CALL (*) {
+                WITH *
+                MATCH (this)-[this8:ACTED_IN]->(this9:Movie)
+                WITH this9 { .title, __resolveType: 'Movie', __id: elementId(this9) } AS var10
+                RETURN var10
+                UNION
+                WITH *
+                MATCH (this)-[this11:ACTED_IN]->(this12:Series)
+                WITH this12 { .title, __resolveType: 'Series', __id: elementId(this12) } AS var10
+                RETURN var10
+              }
+              WITH var10
+              RETURN collect(var10) AS var10
             }
             RETURN this { actedIn: var10 } AS this"
         `);
@@ -223,32 +223,32 @@ describe("https://github.com/neo4j/graphql/issues/4704", () => {
             "CYPHER 5
             MATCH (this:Actor)
             WHERE (NOT (EXISTS {
-                MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                WHERE NOT (EXISTS {
-                    MATCH (this1)<-[this2:ACTED_IN]-(this3:Actor)
-                    WHERE this3.name = $param0
-                })
+              MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+              WHERE NOT (EXISTS {
+                MATCH (this1)<-[this2:ACTED_IN]-(this3:Actor)
+                WHERE this3.name = $param0
+              })
             }) AND NOT (EXISTS {
-                MATCH (this)-[this4:ACTED_IN]->(this5:Series)
-                WHERE NOT (EXISTS {
-                    MATCH (this5)<-[this6:STARRED_IN]-(this7:Actor)
-                    WHERE this7.name = $param1
-                })
+              MATCH (this)-[this4:ACTED_IN]->(this5:Series)
+              WHERE NOT (EXISTS {
+                MATCH (this5)<-[this6:STARRED_IN]-(this7:Actor)
+                WHERE this7.name = $param1
+              })
             }))
             CALL (this) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this)-[this8:ACTED_IN]->(this9:Movie)
-                    WITH this9 { .title, __resolveType: \\"Movie\\", __id: id(this9) } AS var10
-                    RETURN var10
-                    UNION
-                    WITH *
-                    MATCH (this)-[this11:ACTED_IN]->(this12:Series)
-                    WITH this12 { .title, __resolveType: \\"Series\\", __id: id(this12) } AS var10
-                    RETURN var10
-                }
-                WITH var10
-                RETURN collect(var10) AS var10
+              CALL (*) {
+                WITH *
+                MATCH (this)-[this8:ACTED_IN]->(this9:Movie)
+                WITH this9 { .title, __resolveType: 'Movie', __id: elementId(this9) } AS var10
+                RETURN var10
+                UNION
+                WITH *
+                MATCH (this)-[this11:ACTED_IN]->(this12:Series)
+                WITH this12 { .title, __resolveType: 'Series', __id: elementId(this12) } AS var10
+                RETURN var10
+              }
+              WITH var10
+              RETURN collect(var10) AS var10
             }
             RETURN this { actedIn: var10 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/4741.test.ts
+++ b/packages/graphql/tests/tck/issues/4741.test.ts
@@ -64,25 +64,25 @@ describe("https://github.com/neo4j/graphql/issues/4741", () => {
             "CYPHER 5
             MATCH (this0:Opportunity)
             CALL (this0) {
-                MATCH (this0)-[this1:HAS_LIST]->(this2:ListOli)
-                RETURN count(this2) > $param0 AS var3
+              MATCH (this0)-[this1:HAS_LIST]->(this2:ListOli)
+              RETURN count(this2) > $param0 AS var3
             }
             WITH *
             WHERE var3 = true
-            WITH collect({ node: this0 }) AS edges
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                WITH *
-                LIMIT $param1
-                CALL (this0) {
-                    MATCH (this0)-[this4:HAS_LIST]->(this5:ListOli)
-                    WITH count(this5) AS totalCount
-                    RETURN { totalCount: totalCount } AS var6
-                }
-                RETURN collect({ node: { country: this0.country, listsOlisConnection: var6, __resolveType: \\"Opportunity\\" } }) AS var7
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              WITH *
+              LIMIT $param1
+              CALL (this0) {
+                MATCH (this0)-[this4:HAS_LIST]->(this5:ListOli)
+                WITH count(this5) AS totalCount
+                RETURN {totalCount: totalCount} AS var6
+              }
+              RETURN collect({node: {country: this0.country, listsOlisConnection: var6, __resolveType: 'Opportunity'}}) AS var7
             }
-            RETURN { edges: var7 } AS this"
+            RETURN {edges: var7} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/issues/4814.test.ts
+++ b/packages/graphql/tests/tck/issues/4814.test.ts
@@ -73,53 +73,53 @@ describe("https://github.com/neo4j/graphql/issues/4814", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL (*) {
-                MATCH (this0:AStep)
-                WHERE this0.id = $param0
+              MATCH (this0:AStep)
+              WHERE this0.id = $param0
+              CALL (this0) {
                 CALL (this0) {
-                    CALL (this0) {
-                        CALL (this0) {
-                            WITH this0
-                            MATCH (this0)-[this1:FOLLOWED_BY]->(this2:AStep)
-                            WITH { node: { __resolveType: \\"AStep\\", __id: id(this2), id: this2.id } } AS edge
-                            RETURN edge
-                            UNION
-                            WITH this0
-                            MATCH (this0)-[this3:FOLLOWED_BY]->(this4:BStep)
-                            WITH { node: { __resolveType: \\"BStep\\", __id: id(this4), id: this4.id } } AS edge
-                            RETURN edge
-                        }
-                        RETURN collect(edge) AS edges
-                    }
-                    WITH edges
-                    WITH edges, size(edges) AS totalCount
-                    RETURN { edges: edges, totalCount: totalCount } AS var5
+                  CALL (this0) {
+                    WITH this0
+                    MATCH (this0)-[this1:FOLLOWED_BY]->(this2:AStep)
+                    WITH {node: {__resolveType: 'AStep', __id: elementId(this2), id: this2.id}} AS edge
+                    RETURN edge
+                    UNION
+                    WITH this0
+                    MATCH (this0)-[this3:FOLLOWED_BY]->(this4:BStep)
+                    WITH {node: {__resolveType: 'BStep', __id: elementId(this4), id: this4.id}} AS edge
+                    RETURN edge
+                  }
+                  RETURN collect(edge) AS edges
                 }
-                WITH this0 { nextsConnection: var5, __resolveType: \\"AStep\\", __id: id(this0) } AS this
-                RETURN this
-                UNION
-                MATCH (this6:BStep)
-                WHERE this6.id = $param1
+                WITH edges
+                WITH edges, size(edges) AS totalCount
+                RETURN {edges: edges, totalCount: totalCount} AS var5
+              }
+              WITH this0 { nextsConnection: var5, __resolveType: 'AStep', __id: elementId(this0) } AS this
+              RETURN this
+              UNION
+              MATCH (this6:BStep)
+              WHERE this6.id = $param1
+              CALL (this6) {
                 CALL (this6) {
-                    CALL (this6) {
-                        CALL (this6) {
-                            WITH this6
-                            MATCH (this6)-[this7:FOLLOWED_BY]->(this8:AStep)
-                            WITH { node: { __resolveType: \\"AStep\\", __id: id(this8), id: this8.id } } AS edge
-                            RETURN edge
-                            UNION
-                            WITH this6
-                            MATCH (this6)-[this9:FOLLOWED_BY]->(this10:BStep)
-                            WITH { node: { __resolveType: \\"BStep\\", __id: id(this10), id: this10.id } } AS edge
-                            RETURN edge
-                        }
-                        RETURN collect(edge) AS edges
-                    }
-                    WITH edges
-                    WITH edges, size(edges) AS totalCount
-                    RETURN { edges: edges, totalCount: totalCount } AS var11
+                  CALL (this6) {
+                    WITH this6
+                    MATCH (this6)-[this7:FOLLOWED_BY]->(this8:AStep)
+                    WITH {node: {__resolveType: 'AStep', __id: elementId(this8), id: this8.id}} AS edge
+                    RETURN edge
+                    UNION
+                    WITH this6
+                    MATCH (this6)-[this9:FOLLOWED_BY]->(this10:BStep)
+                    WITH {node: {__resolveType: 'BStep', __id: elementId(this10), id: this10.id}} AS edge
+                    RETURN edge
+                  }
+                  RETURN collect(edge) AS edges
                 }
-                WITH this6 { nextsConnection: var11, __resolveType: \\"BStep\\", __id: id(this6) } AS this
-                RETURN this
+                WITH edges
+                WITH edges, size(edges) AS totalCount
+                RETURN {edges: edges, totalCount: totalCount} AS var11
+              }
+              WITH this6 { nextsConnection: var11, __resolveType: 'BStep', __id: elementId(this6) } AS this
+              RETURN this
             }
             WITH this
             RETURN this AS this"
@@ -155,53 +155,53 @@ describe("https://github.com/neo4j/graphql/issues/4814", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL (*) {
-                MATCH (this0:AStep)
-                WHERE this0.id = $param0
+              MATCH (this0:AStep)
+              WHERE this0.id = $param0
+              CALL (this0) {
                 CALL (this0) {
-                    CALL (this0) {
-                        CALL (this0) {
-                            WITH this0
-                            MATCH (this0)<-[this1:FOLLOWED_BY]-(this2:AStep)
-                            WITH { node: { __resolveType: \\"AStep\\", __id: id(this2), id: this2.id } } AS edge
-                            RETURN edge
-                            UNION
-                            WITH this0
-                            MATCH (this0)<-[this3:FOLLOWED_BY]-(this4:BStep)
-                            WITH { node: { __resolveType: \\"BStep\\", __id: id(this4), id: this4.id } } AS edge
-                            RETURN edge
-                        }
-                        RETURN collect(edge) AS edges
-                    }
-                    WITH edges
-                    WITH edges, size(edges) AS totalCount
-                    RETURN { edges: edges, totalCount: totalCount } AS var5
+                  CALL (this0) {
+                    WITH this0
+                    MATCH (this0)<-[this1:FOLLOWED_BY]-(this2:AStep)
+                    WITH {node: {__resolveType: 'AStep', __id: elementId(this2), id: this2.id}} AS edge
+                    RETURN edge
+                    UNION
+                    WITH this0
+                    MATCH (this0)<-[this3:FOLLOWED_BY]-(this4:BStep)
+                    WITH {node: {__resolveType: 'BStep', __id: elementId(this4), id: this4.id}} AS edge
+                    RETURN edge
+                  }
+                  RETURN collect(edge) AS edges
                 }
-                WITH this0 { prevsConnection: var5, __resolveType: \\"AStep\\", __id: id(this0) } AS this
-                RETURN this
-                UNION
-                MATCH (this6:BStep)
-                WHERE this6.id = $param1
+                WITH edges
+                WITH edges, size(edges) AS totalCount
+                RETURN {edges: edges, totalCount: totalCount} AS var5
+              }
+              WITH this0 { prevsConnection: var5, __resolveType: 'AStep', __id: elementId(this0) } AS this
+              RETURN this
+              UNION
+              MATCH (this6:BStep)
+              WHERE this6.id = $param1
+              CALL (this6) {
                 CALL (this6) {
-                    CALL (this6) {
-                        CALL (this6) {
-                            WITH this6
-                            MATCH (this6)<-[this7:FOLLOWED_BY]-(this8:AStep)
-                            WITH { node: { __resolveType: \\"AStep\\", __id: id(this8), id: this8.id } } AS edge
-                            RETURN edge
-                            UNION
-                            WITH this6
-                            MATCH (this6)<-[this9:FOLLOWED_BY]-(this10:BStep)
-                            WITH { node: { __resolveType: \\"BStep\\", __id: id(this10), id: this10.id } } AS edge
-                            RETURN edge
-                        }
-                        RETURN collect(edge) AS edges
-                    }
-                    WITH edges
-                    WITH edges, size(edges) AS totalCount
-                    RETURN { edges: edges, totalCount: totalCount } AS var11
+                  CALL (this6) {
+                    WITH this6
+                    MATCH (this6)<-[this7:FOLLOWED_BY]-(this8:AStep)
+                    WITH {node: {__resolveType: 'AStep', __id: elementId(this8), id: this8.id}} AS edge
+                    RETURN edge
+                    UNION
+                    WITH this6
+                    MATCH (this6)<-[this9:FOLLOWED_BY]-(this10:BStep)
+                    WITH {node: {__resolveType: 'BStep', __id: elementId(this10), id: this10.id}} AS edge
+                    RETURN edge
+                  }
+                  RETURN collect(edge) AS edges
                 }
-                WITH this6 { prevsConnection: var11, __resolveType: \\"BStep\\", __id: id(this6) } AS this
-                RETURN this
+                WITH edges
+                WITH edges, size(edges) AS totalCount
+                RETURN {edges: edges, totalCount: totalCount} AS var11
+              }
+              WITH this6 { prevsConnection: var11, __resolveType: 'BStep', __id: elementId(this6) } AS this
+              RETURN this
             }
             WITH this
             RETURN this AS this"
@@ -233,45 +233,45 @@ describe("https://github.com/neo4j/graphql/issues/4814", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL (*) {
-                MATCH (this0:AStep)
-                WHERE this0.id = $param0
-                CALL (this0) {
-                    CALL (*) {
-                        WITH *
-                        MATCH (this0)-[this1:FOLLOWED_BY]->(this2:AStep)
-                        WITH this2 { .id, __resolveType: \\"AStep\\", __id: id(this2) } AS var3
-                        RETURN var3
-                        UNION
-                        WITH *
-                        MATCH (this0)-[this4:FOLLOWED_BY]->(this5:BStep)
-                        WITH this5 { .id, __resolveType: \\"BStep\\", __id: id(this5) } AS var3
-                        RETURN var3
-                    }
-                    WITH var3
-                    RETURN collect(var3) AS var3
+              MATCH (this0:AStep)
+              WHERE this0.id = $param0
+              CALL (this0) {
+                CALL (*) {
+                  WITH *
+                  MATCH (this0)-[this1:FOLLOWED_BY]->(this2:AStep)
+                  WITH this2 { .id, __resolveType: 'AStep', __id: elementId(this2) } AS var3
+                  RETURN var3
+                  UNION
+                  WITH *
+                  MATCH (this0)-[this4:FOLLOWED_BY]->(this5:BStep)
+                  WITH this5 { .id, __resolveType: 'BStep', __id: elementId(this5) } AS var3
+                  RETURN var3
                 }
-                WITH this0 { nexts: var3, __resolveType: \\"AStep\\", __id: id(this0) } AS this
-                RETURN this
-                UNION
-                MATCH (this6:BStep)
-                WHERE this6.id = $param1
-                CALL (this6) {
-                    CALL (*) {
-                        WITH *
-                        MATCH (this6)-[this7:FOLLOWED_BY]->(this8:AStep)
-                        WITH this8 { .id, __resolveType: \\"AStep\\", __id: id(this8) } AS var9
-                        RETURN var9
-                        UNION
-                        WITH *
-                        MATCH (this6)-[this10:FOLLOWED_BY]->(this11:BStep)
-                        WITH this11 { .id, __resolveType: \\"BStep\\", __id: id(this11) } AS var9
-                        RETURN var9
-                    }
-                    WITH var9
-                    RETURN collect(var9) AS var9
+                WITH var3
+                RETURN collect(var3) AS var3
+              }
+              WITH this0 { nexts: var3, __resolveType: 'AStep', __id: elementId(this0) } AS this
+              RETURN this
+              UNION
+              MATCH (this6:BStep)
+              WHERE this6.id = $param1
+              CALL (this6) {
+                CALL (*) {
+                  WITH *
+                  MATCH (this6)-[this7:FOLLOWED_BY]->(this8:AStep)
+                  WITH this8 { .id, __resolveType: 'AStep', __id: elementId(this8) } AS var9
+                  RETURN var9
+                  UNION
+                  WITH *
+                  MATCH (this6)-[this10:FOLLOWED_BY]->(this11:BStep)
+                  WITH this11 { .id, __resolveType: 'BStep', __id: elementId(this11) } AS var9
+                  RETURN var9
                 }
-                WITH this6 { nexts: var9, __resolveType: \\"BStep\\", __id: id(this6) } AS this
-                RETURN this
+                WITH var9
+                RETURN collect(var9) AS var9
+              }
+              WITH this6 { nexts: var9, __resolveType: 'BStep', __id: elementId(this6) } AS this
+              RETURN this
             }
             WITH this
             RETURN this AS this"
@@ -303,45 +303,45 @@ describe("https://github.com/neo4j/graphql/issues/4814", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL (*) {
-                MATCH (this0:AStep)
-                WHERE this0.id = $param0
-                CALL (this0) {
-                    CALL (*) {
-                        WITH *
-                        MATCH (this0)<-[this1:FOLLOWED_BY]-(this2:AStep)
-                        WITH this2 { .id, __resolveType: \\"AStep\\", __id: id(this2) } AS var3
-                        RETURN var3
-                        UNION
-                        WITH *
-                        MATCH (this0)<-[this4:FOLLOWED_BY]-(this5:BStep)
-                        WITH this5 { .id, __resolveType: \\"BStep\\", __id: id(this5) } AS var3
-                        RETURN var3
-                    }
-                    WITH var3
-                    RETURN collect(var3) AS var3
+              MATCH (this0:AStep)
+              WHERE this0.id = $param0
+              CALL (this0) {
+                CALL (*) {
+                  WITH *
+                  MATCH (this0)<-[this1:FOLLOWED_BY]-(this2:AStep)
+                  WITH this2 { .id, __resolveType: 'AStep', __id: elementId(this2) } AS var3
+                  RETURN var3
+                  UNION
+                  WITH *
+                  MATCH (this0)<-[this4:FOLLOWED_BY]-(this5:BStep)
+                  WITH this5 { .id, __resolveType: 'BStep', __id: elementId(this5) } AS var3
+                  RETURN var3
                 }
-                WITH this0 { prevs: var3, __resolveType: \\"AStep\\", __id: id(this0) } AS this
-                RETURN this
-                UNION
-                MATCH (this6:BStep)
-                WHERE this6.id = $param1
-                CALL (this6) {
-                    CALL (*) {
-                        WITH *
-                        MATCH (this6)<-[this7:FOLLOWED_BY]-(this8:AStep)
-                        WITH this8 { .id, __resolveType: \\"AStep\\", __id: id(this8) } AS var9
-                        RETURN var9
-                        UNION
-                        WITH *
-                        MATCH (this6)<-[this10:FOLLOWED_BY]-(this11:BStep)
-                        WITH this11 { .id, __resolveType: \\"BStep\\", __id: id(this11) } AS var9
-                        RETURN var9
-                    }
-                    WITH var9
-                    RETURN collect(var9) AS var9
+                WITH var3
+                RETURN collect(var3) AS var3
+              }
+              WITH this0 { prevs: var3, __resolveType: 'AStep', __id: elementId(this0) } AS this
+              RETURN this
+              UNION
+              MATCH (this6:BStep)
+              WHERE this6.id = $param1
+              CALL (this6) {
+                CALL (*) {
+                  WITH *
+                  MATCH (this6)<-[this7:FOLLOWED_BY]-(this8:AStep)
+                  WITH this8 { .id, __resolveType: 'AStep', __id: elementId(this8) } AS var9
+                  RETURN var9
+                  UNION
+                  WITH *
+                  MATCH (this6)<-[this10:FOLLOWED_BY]-(this11:BStep)
+                  WITH this11 { .id, __resolveType: 'BStep', __id: elementId(this11) } AS var9
+                  RETURN var9
                 }
-                WITH this6 { prevs: var9, __resolveType: \\"BStep\\", __id: id(this6) } AS this
-                RETURN this
+                WITH var9
+                RETURN collect(var9) AS var9
+              }
+              WITH this6 { prevs: var9, __resolveType: 'BStep', __id: elementId(this6) } AS this
+              RETURN this
             }
             WITH this
             RETURN this AS this"

--- a/packages/graphql/tests/tck/issues/4831.test.ts
+++ b/packages/graphql/tests/tck/issues/4831.test.ts
@@ -54,12 +54,12 @@ describe("https://github.com/neo4j/graphql/issues/4831", () => {
                 "CYPHER 5
                 MATCH (this:Test)
                 CALL (this) {
-                    CALL (this) {
-                        WITH this AS this
-                        RETURN $param0 as value
-                    }
-                    WITH value AS this0
-                    RETURN this0 AS var1
+                  CALL (this) {
+                    WITH this AS this
+                    RETURN $param0 as value
+                  }
+                  WITH value AS this0
+                  RETURN this0 AS var1
                 }
                 RETURN this { testBoolean: var1 } AS this"
             `);
@@ -86,12 +86,12 @@ describe("https://github.com/neo4j/graphql/issues/4831", () => {
                 "CYPHER 5
                 MATCH (this:Test)
                 CALL (this) {
-                    CALL (this) {
-                        WITH this AS this
-                        RETURN $param0 as value
-                    }
-                    WITH value AS this0
-                    RETURN this0 AS var1
+                  CALL (this) {
+                    WITH this AS this
+                    RETURN $param0 as value
+                  }
+                  WITH value AS this0
+                  RETURN this0 AS var1
                 }
                 RETURN this { testBoolean: var1 } AS this"
             `);
@@ -118,12 +118,12 @@ describe("https://github.com/neo4j/graphql/issues/4831", () => {
                 "CYPHER 5
                 MATCH (this:Test)
                 CALL (this) {
-                    CALL (this) {
-                        WITH this AS this
-                        RETURN NULL as value
-                    }
-                    WITH value AS this0
-                    RETURN this0 AS var1
+                  CALL (this) {
+                    WITH this AS this
+                    RETURN NULL as value
+                  }
+                  WITH value AS this0
+                  RETURN this0 AS var1
                 }
                 RETURN this { testBoolean: var1 } AS this"
             `);
@@ -146,12 +146,12 @@ describe("https://github.com/neo4j/graphql/issues/4831", () => {
                 "CYPHER 5
                 MATCH (this:Test)
                 CALL (this) {
-                    CALL (this) {
-                        WITH this AS this
-                        RETURN NULL as value
-                    }
-                    WITH value AS this0
-                    RETURN this0 AS var1
+                  CALL (this) {
+                    WITH this AS this
+                    RETURN NULL as value
+                  }
+                  WITH value AS this0
+                  RETURN this0 AS var1
                 }
                 RETURN this { testBoolean: var1 } AS this"
             `);
@@ -176,12 +176,12 @@ describe("https://github.com/neo4j/graphql/issues/4831", () => {
                 "CYPHER 5
                 MATCH (this:Test)
                 CALL (this) {
-                    CALL (this) {
-                        WITH this AS this
-                        RETURN $param0 as value
-                    }
-                    WITH value AS this0
-                    RETURN this0 AS var1
+                  CALL (this) {
+                    WITH this AS this
+                    RETURN $param0 as value
+                  }
+                  WITH value AS this0
+                  RETURN this0 AS var1
                 }
                 RETURN this { testString: var1 } AS this"
             `);
@@ -208,12 +208,12 @@ describe("https://github.com/neo4j/graphql/issues/4831", () => {
                 "CYPHER 5
                 MATCH (this:Test)
                 CALL (this) {
-                    CALL (this) {
-                        WITH this AS this
-                        RETURN $param0 as value
-                    }
-                    WITH value AS this0
-                    RETURN this0 AS var1
+                  CALL (this) {
+                    WITH this AS this
+                    RETURN $param0 as value
+                  }
+                  WITH value AS this0
+                  RETURN this0 AS var1
                 }
                 RETURN this { testString: var1 } AS this"
             `);
@@ -240,12 +240,12 @@ describe("https://github.com/neo4j/graphql/issues/4831", () => {
                 "CYPHER 5
                 MATCH (this:Test)
                 CALL (this) {
-                    CALL (this) {
-                        WITH this AS this
-                        RETURN NULL as value
-                    }
-                    WITH value AS this0
-                    RETURN this0 AS var1
+                  CALL (this) {
+                    WITH this AS this
+                    RETURN NULL as value
+                  }
+                  WITH value AS this0
+                  RETURN this0 AS var1
                 }
                 RETURN this { testString: var1 } AS this"
             `);
@@ -268,12 +268,12 @@ describe("https://github.com/neo4j/graphql/issues/4831", () => {
                 "CYPHER 5
                 MATCH (this:Test)
                 CALL (this) {
-                    CALL (this) {
-                        WITH this AS this
-                        RETURN NULL as value
-                    }
-                    WITH value AS this0
-                    RETURN this0 AS var1
+                  CALL (this) {
+                    WITH this AS this
+                    RETURN NULL as value
+                  }
+                  WITH value AS this0
+                  RETURN this0 AS var1
                 }
                 RETURN this { testString: var1 } AS this"
             `);

--- a/packages/graphql/tests/tck/issues/4838.test.ts
+++ b/packages/graphql/tests/tck/issues/4838.test.ts
@@ -58,16 +58,16 @@ describe("https://github.com/neo4j/graphql/issues/4838", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Test)
-                RETURN create_this1
+              CREATE (create_this1:Test)
+              RETURN create_this1
             }
             CALL (create_this1) {
-                CALL (create_this1) {
-                    WITH create_this1 AS this
-                    RETURN true AS value
-                }
-                WITH value AS create_this2
-                RETURN create_this2 AS create_var3
+              CALL (create_this1) {
+                WITH create_this1 AS this
+                RETURN true AS value
+              }
+              WITH value AS create_this2
+              RETURN create_this2 AS create_var3
             }
             RETURN collect(create_this1 { test: create_var3 }) AS data"
         `);
@@ -100,29 +100,29 @@ describe("https://github.com/neo4j/graphql/issues/4838", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:ParentTest)
-                WITH create_this1, create_var0
-                CALL (create_this1, create_var0) {
-                    UNWIND create_var0.tests.create AS create_var2
-                    CREATE (create_this3:Test)
-                    MERGE (create_this1)-[create_this4:REL]->(create_this3)
-                    RETURN collect(NULL) AS create_var5
-                }
-                RETURN create_this1
+              CREATE (create_this1:ParentTest)
+              WITH create_this1, create_var0
+              CALL (create_this1, create_var0) {
+                UNWIND create_var0.tests.create AS create_var2
+                CREATE (create_this3:Test)
+                MERGE (create_this1)-[create_this4:REL]->(create_this3)
+                RETURN collect(NULL) AS create_var5
+              }
+              RETURN create_this1
             }
             CALL (create_this1) {
-                MATCH (create_this1)-[create_this6:REL]->(create_this7:Test)
-                WITH DISTINCT create_this7
+              MATCH (create_this1)-[create_this6:REL]->(create_this7:Test)
+              WITH DISTINCT create_this7
+              CALL (create_this7) {
                 CALL (create_this7) {
-                    CALL (create_this7) {
-                        WITH create_this7 AS this
-                        RETURN true AS value
-                    }
-                    WITH value AS create_this8
-                    RETURN create_this8 AS create_var9
+                  WITH create_this7 AS this
+                  RETURN true AS value
                 }
-                WITH create_this7 { test: create_var9 } AS create_this7
-                RETURN collect(create_this7) AS create_var10
+                WITH value AS create_this8
+                RETURN create_this8 AS create_var9
+              }
+              WITH create_this7 { test: create_var9 } AS create_this7
+              RETURN collect(create_this7) AS create_var10
             }
             RETURN collect(create_this1 { tests: create_var10 }) AS data"
         `);

--- a/packages/graphql/tests/tck/issues/487.test.ts
+++ b/packages/graphql/tests/tck/issues/487.test.ts
@@ -88,40 +88,40 @@ describe("https://github.com/neo4j/graphql/issues/487", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (node)
-                WHERE
-                    \\"Book\\" IN labels(node) OR
-                    \\"Movie\\" IN labels(node)
-                RETURN node
+              MATCH (node)
+              WHERE
+                  \\"Book\\" IN labels(node) OR
+                  \\"Movie\\" IN labels(node)
+              RETURN node
             }
             WITH node AS this0
             CALL (this0) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this0)
-                    WHERE this0:Book
-                    CALL (this0) {
-                        MATCH (this0)<-[this1:WROTE]-(this2:Author)
-                        WITH DISTINCT this2
-                        WITH this2 { .id } AS this2
-                        RETURN collect(this2) AS var3
-                    }
-                    WITH this0 { .id, author: var3, __resolveType: \\"Book\\", __id: id(this0) } AS var4
-                    RETURN var4
-                    UNION
-                    WITH *
-                    MATCH (this0)
-                    WHERE this0:Movie
-                    CALL (this0) {
-                        MATCH (this0)<-[this5:DIRECTED]-(this6:Director)
-                        WITH DISTINCT this6
-                        WITH this6 { .id } AS this6
-                        RETURN collect(this6) AS var7
-                    }
-                    WITH this0 { .id, director: var7, __resolveType: \\"Movie\\", __id: id(this0) } AS var4
-                    RETURN var4
+              CALL (*) {
+                WITH *
+                MATCH (this0)
+                WHERE this0:Book
+                CALL (this0) {
+                  MATCH (this0)<-[this1:WROTE]-(this2:Author)
+                  WITH DISTINCT this2
+                  WITH this2 { .id } AS this2
+                  RETURN collect(this2) AS var3
                 }
+                WITH this0 { .id, author: var3, __resolveType: 'Book', __id: elementId(this0) } AS var4
                 RETURN var4
+                UNION
+                WITH *
+                MATCH (this0)
+                WHERE this0:Movie
+                CALL (this0) {
+                  MATCH (this0)<-[this5:DIRECTED]-(this6:Director)
+                  WITH DISTINCT this6
+                  WITH this6 { .id } AS this6
+                  RETURN collect(this6) AS var7
+                }
+                WITH this0 { .id, director: var7, __resolveType: 'Movie', __id: elementId(this0) } AS var4
+                RETURN var4
+              }
+              RETURN var4
             }
             RETURN var4 AS this0"
         `);
@@ -197,40 +197,40 @@ describe("https://github.com/neo4j/graphql/issues/487", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (node)
-                WHERE
-                    \\"Book\\" IN labels(node) OR
-                    \\"Movie\\" IN labels(node)
-                RETURN node
+              MATCH (node)
+              WHERE
+                  \\"Book\\" IN labels(node) OR
+                  \\"Movie\\" IN labels(node)
+              RETURN node
             }
             WITH node AS this0
             CALL (this0) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this0)
-                    WHERE this0:Book
-                    CALL (this0) {
-                        MATCH (this0)<-[this1:WROTE]-(this2:Author)
-                        WITH DISTINCT this2
-                        WITH this2 { .id } AS this2
-                        RETURN collect(this2) AS var3
-                    }
-                    WITH this0 { .id, author: var3, __resolveType: \\"Book\\", __id: id(this0) } AS var4
-                    RETURN var4
-                    UNION
-                    WITH *
-                    MATCH (this0)
-                    WHERE this0:Movie
-                    CALL (this0) {
-                        MATCH (this0)<-[this5:DIRECTED]-(this6:Director)
-                        WITH DISTINCT this6
-                        WITH this6 { .id } AS this6
-                        RETURN collect(this6) AS var7
-                    }
-                    WITH this0 { .id, director: var7, __resolveType: \\"Movie\\", __id: id(this0) } AS var4
-                    RETURN var4
+              CALL (*) {
+                WITH *
+                MATCH (this0)
+                WHERE this0:Book
+                CALL (this0) {
+                  MATCH (this0)<-[this1:WROTE]-(this2:Author)
+                  WITH DISTINCT this2
+                  WITH this2 { .id } AS this2
+                  RETURN collect(this2) AS var3
                 }
+                WITH this0 { .id, author: var3, __resolveType: 'Book', __id: elementId(this0) } AS var4
                 RETURN var4
+                UNION
+                WITH *
+                MATCH (this0)
+                WHERE this0:Movie
+                CALL (this0) {
+                  MATCH (this0)<-[this5:DIRECTED]-(this6:Director)
+                  WITH DISTINCT this6
+                  WITH this6 { .id } AS this6
+                  RETURN collect(this6) AS var7
+                }
+                WITH this0 { .id, director: var7, __resolveType: 'Movie', __id: elementId(this0) } AS var4
+                RETURN var4
+              }
+              RETURN var4
             }
             RETURN var4 AS this0"
         `);

--- a/packages/graphql/tests/tck/issues/488.test.ts
+++ b/packages/graphql/tests/tck/issues/488.test.ts
@@ -75,28 +75,28 @@ describe("https://github.com/neo4j/graphql/issues/488", () => {
             "CYPHER 5
             MATCH (this:Journalist)
             WHERE EXISTS {
-                MATCH (this)-[this0:HAS_KEYWORD]->(this1:Emoji)
-                WHERE this1.type = $param0
+              MATCH (this)-[this0:HAS_KEYWORD]->(this1:Emoji)
+              WHERE this1.type = $param0
             }
             CALL (this) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this)-[this2:HAS_KEYWORD]->(this3:Emoji)
-                    WITH this3 { .id, .type, __resolveType: \\"Emoji\\", __id: id(this3) } AS var4
-                    RETURN var4
-                    UNION
-                    WITH *
-                    MATCH (this)-[this5:HAS_KEYWORD]->(this6:Hashtag)
-                    WITH this6 { __resolveType: \\"Hashtag\\", __id: id(this6) } AS var4
-                    RETURN var4
-                    UNION
-                    WITH *
-                    MATCH (this)-[this7:HAS_KEYWORD]->(this8:Text)
-                    WITH this8 { __resolveType: \\"Text\\", __id: id(this8) } AS var4
-                    RETURN var4
-                }
-                WITH var4
-                RETURN collect(var4) AS var4
+              CALL (*) {
+                WITH *
+                MATCH (this)-[this2:HAS_KEYWORD]->(this3:Emoji)
+                WITH this3 { .id, .type, __resolveType: 'Emoji', __id: elementId(this3) } AS var4
+                RETURN var4
+                UNION
+                WITH *
+                MATCH (this)-[this5:HAS_KEYWORD]->(this6:Hashtag)
+                WITH this6 { __resolveType: 'Hashtag', __id: elementId(this6) } AS var4
+                RETURN var4
+                UNION
+                WITH *
+                MATCH (this)-[this7:HAS_KEYWORD]->(this8:Text)
+                WITH this8 { __resolveType: 'Text', __id: elementId(this8) } AS var4
+                RETURN var4
+              }
+              WITH var4
+              RETURN collect(var4) AS var4
             }
             RETURN this { .name, keywords: var4 } AS this"
         `);
@@ -129,28 +129,28 @@ describe("https://github.com/neo4j/graphql/issues/488", () => {
             "CYPHER 5
             MATCH (this:Journalist)
             WHERE NOT (EXISTS {
-                MATCH (this)-[this0:HAS_KEYWORD]->(this1:Emoji)
-                WHERE this1.type = $param0
+              MATCH (this)-[this0:HAS_KEYWORD]->(this1:Emoji)
+              WHERE this1.type = $param0
             })
             CALL (this) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this)-[this2:HAS_KEYWORD]->(this3:Emoji)
-                    WITH this3 { .id, .type, __resolveType: \\"Emoji\\", __id: id(this3) } AS var4
-                    RETURN var4
-                    UNION
-                    WITH *
-                    MATCH (this)-[this5:HAS_KEYWORD]->(this6:Hashtag)
-                    WITH this6 { __resolveType: \\"Hashtag\\", __id: id(this6) } AS var4
-                    RETURN var4
-                    UNION
-                    WITH *
-                    MATCH (this)-[this7:HAS_KEYWORD]->(this8:Text)
-                    WITH this8 { __resolveType: \\"Text\\", __id: id(this8) } AS var4
-                    RETURN var4
-                }
-                WITH var4
-                RETURN collect(var4) AS var4
+              CALL (*) {
+                WITH *
+                MATCH (this)-[this2:HAS_KEYWORD]->(this3:Emoji)
+                WITH this3 { .id, .type, __resolveType: 'Emoji', __id: elementId(this3) } AS var4
+                RETURN var4
+                UNION
+                WITH *
+                MATCH (this)-[this5:HAS_KEYWORD]->(this6:Hashtag)
+                WITH this6 { __resolveType: 'Hashtag', __id: elementId(this6) } AS var4
+                RETURN var4
+                UNION
+                WITH *
+                MATCH (this)-[this7:HAS_KEYWORD]->(this8:Text)
+                WITH this8 { __resolveType: 'Text', __id: elementId(this8) } AS var4
+                RETURN var4
+              }
+              WITH var4
+              RETURN collect(var4) AS var4
             }
             RETURN this { .name, keywords: var4 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/5023.test.ts
+++ b/packages/graphql/tests/tck/issues/5023.test.ts
@@ -144,101 +144,101 @@ describe("https://github.com/neo4j/graphql/issues/5023", () => {
             WITH *
             WITH *
             CALL (*) {
-                MATCH (this)-[this0:HAS_SETTINGS]->(this1:Settings)
-                WITH *
-                WITH *
-                CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                    MATCH (this1)<-[:HAS_SETTINGS]-(this2:Tenant)
-                    WHERE EXISTS {
-                        MATCH (this2)<-[:ADMIN_IN]-(this3:User)
-                        WHERE ($jwt.id IS NOT NULL AND this3.userId = $jwt.id)
-                    }
-                }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                WITH *
-                WITH *
-                CALL (*) {
-                    OPTIONAL MATCH (this1)-[this4:HAS_OPENING_HOURS]->(this5:OpeningDay)
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                        MATCH (this5)<-[:HAS_OPENING_HOURS]-(this6:Settings)
-                        WHERE EXISTS {
-                            MATCH (this6)<-[:HAS_SETTINGS]-(this7:Tenant)
-                            WHERE EXISTS {
-                                MATCH (this7)<-[:ADMIN_IN]-(this8:User)
-                                WHERE ($jwt.id IS NOT NULL AND this8.userId = $jwt.id)
-                            }
-                        }
-                    }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    WITH this4, collect(DISTINCT this5) AS var9
-                    CALL (var9) {
-                        UNWIND var9 AS var10
-                        DETACH DELETE var10
-                    }
+              MATCH (this)-[this0:HAS_SETTINGS]->(this1:Settings)
+              WITH *
+              WITH *
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
+                MATCH (this1)<-[:HAS_SETTINGS]-(this2:Tenant)
+                WHERE EXISTS {
+                  MATCH (this2)<-[:ADMIN_IN]-(this3:User)
+                  WHERE ($jwt.id IS NOT NULL AND this3.userId = $jwt.id)
                 }
-                WITH *
+              }), '@neo4j/graphql/FORBIDDEN', [])
+              WITH *
+              WITH *
+              CALL (*) {
+                OPTIONAL MATCH (this1)-[this4:HAS_OPENING_HOURS]->(this5:OpeningDay)
                 CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                    MATCH (this1)<-[:HAS_SETTINGS]-(this11:Tenant)
+                  MATCH (this5)<-[:HAS_OPENING_HOURS]-(this6:Settings)
+                  WHERE EXISTS {
+                    MATCH (this6)<-[:HAS_SETTINGS]-(this7:Tenant)
                     WHERE EXISTS {
-                        MATCH (this11)<-[:ADMIN_IN]-(this12:User)
-                        WHERE ($jwt.id IS NOT NULL AND this12.userId = $jwt.id)
+                      MATCH (this7)<-[:ADMIN_IN]-(this8:User)
+                      WHERE ($jwt.id IS NOT NULL AND this8.userId = $jwt.id)
                     }
-                }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                  }
+                }), '@neo4j/graphql/FORBIDDEN', [])
+                WITH this4, collect(DISTINCT this5) AS var9
+                CALL (var9) {
+                  UNWIND var9 AS var10
+                  DETACH DELETE var10
+                }
+              }
+              WITH *
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
+                MATCH (this1)<-[:HAS_SETTINGS]-(this11:Tenant)
+                WHERE EXISTS {
+                  MATCH (this11)<-[:ADMIN_IN]-(this12:User)
+                  WHERE ($jwt.id IS NOT NULL AND this12.userId = $jwt.id)
+                }
+              }), '@neo4j/graphql/FORBIDDEN', [])
             }
             WITH this
             WITH *
             CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                MATCH (this)<-[:ADMIN_IN]-(this13:User)
-                WHERE ($jwt.id IS NOT NULL AND this13.userId = $jwt.id)
-            }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+              MATCH (this)<-[:ADMIN_IN]-(this13:User)
+              WHERE ($jwt.id IS NOT NULL AND this13.userId = $jwt.id)
+            }), '@neo4j/graphql/FORBIDDEN', [])
             CALL (this) {
-                MATCH (this)-[this14:HAS_SETTINGS]->(this15:Settings)
-                WITH DISTINCT this15
+              MATCH (this)-[this14:HAS_SETTINGS]->(this15:Settings)
+              WITH DISTINCT this15
+              WITH *
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
+                MATCH (this15)<-[:HAS_SETTINGS]-(this16:Tenant)
+                WHERE EXISTS {
+                  MATCH (this16)<-[:ADMIN_IN]-(this17:User)
+                  WHERE ($jwt.id IS NOT NULL AND this17.userId = $jwt.id)
+                }
+              }), '@neo4j/graphql/FORBIDDEN', [])
+              CALL (this15) {
+                MATCH (this15)-[this18:HAS_OPENING_HOURS]->(this19:OpeningDay)
+                WITH DISTINCT this19
                 WITH *
                 CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                    MATCH (this15)<-[:HAS_SETTINGS]-(this16:Tenant)
+                  MATCH (this19)<-[:HAS_OPENING_HOURS]-(this20:Settings)
+                  WHERE EXISTS {
+                    MATCH (this20)<-[:HAS_SETTINGS]-(this21:Tenant)
                     WHERE EXISTS {
-                        MATCH (this16)<-[:ADMIN_IN]-(this17:User)
-                        WHERE ($jwt.id IS NOT NULL AND this17.userId = $jwt.id)
+                      MATCH (this21)<-[:ADMIN_IN]-(this22:User)
+                      WHERE ($jwt.id IS NOT NULL AND this22.userId = $jwt.id)
                     }
-                }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                CALL (this15) {
-                    MATCH (this15)-[this18:HAS_OPENING_HOURS]->(this19:OpeningDay)
-                    WITH DISTINCT this19
-                    WITH *
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                        MATCH (this19)<-[:HAS_OPENING_HOURS]-(this20:Settings)
+                  }
+                }), '@neo4j/graphql/FORBIDDEN', [])
+                CALL (this19) {
+                  MATCH (this19)-[this23:HAS_OPEN_INTERVALS]->(this24:OpeningHoursInterval)
+                  WITH DISTINCT this24
+                  WITH *
+                  CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
+                    MATCH (this24)<-[:HAS_OPEN_INTERVALS]-(this25:OpeningDay)
+                    WHERE EXISTS {
+                      MATCH (this25)<-[:HAS_OPENING_HOURS]-(this26:Settings)
+                      WHERE EXISTS {
+                        MATCH (this26)<-[:HAS_SETTINGS]-(this27:Tenant)
                         WHERE EXISTS {
-                            MATCH (this20)<-[:HAS_SETTINGS]-(this21:Tenant)
-                            WHERE EXISTS {
-                                MATCH (this21)<-[:ADMIN_IN]-(this22:User)
-                                WHERE ($jwt.id IS NOT NULL AND this22.userId = $jwt.id)
-                            }
+                          MATCH (this27)<-[:ADMIN_IN]-(this28:User)
+                          WHERE ($jwt.id IS NOT NULL AND this28.userId = $jwt.id)
                         }
-                    }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    CALL (this19) {
-                        MATCH (this19)-[this23:HAS_OPEN_INTERVALS]->(this24:OpeningHoursInterval)
-                        WITH DISTINCT this24
-                        WITH *
-                        CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                            MATCH (this24)<-[:HAS_OPEN_INTERVALS]-(this25:OpeningDay)
-                            WHERE EXISTS {
-                                MATCH (this25)<-[:HAS_OPENING_HOURS]-(this26:Settings)
-                                WHERE EXISTS {
-                                    MATCH (this26)<-[:HAS_SETTINGS]-(this27:Tenant)
-                                    WHERE EXISTS {
-                                        MATCH (this27)<-[:ADMIN_IN]-(this28:User)
-                                        WHERE ($jwt.id IS NOT NULL AND this28.userId = $jwt.id)
-                                    }
-                                }
-                            }
-                        }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                        WITH this24 { .name } AS this24
-                        RETURN collect(this24) AS var29
+                      }
                     }
-                    WITH this19 { open: var29 } AS this19
-                    RETURN collect(this19) AS var30
+                  }), '@neo4j/graphql/FORBIDDEN', [])
+                  WITH this24 { .name } AS this24
+                  RETURN collect(this24) AS var29
                 }
-                WITH this15 { extendedOpeningHours: var30 } AS this15
-                RETURN collect(this15) AS var31
+                WITH this19 { open: var29 } AS this19
+                RETURN collect(this19) AS var30
+              }
+              WITH this15 { extendedOpeningHours: var30 } AS this15
+              RETURN collect(this15) AS var31
             }
             RETURN this { settings: var31 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/5030.test.ts
+++ b/packages/graphql/tests/tck/issues/5030.test.ts
@@ -64,7 +64,7 @@ describe("https://github.com/neo4j/graphql/issues/5030", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (m:Movie) RETURN m as this
+              MATCH (m:Movie) RETURN m as this
             }
             WITH this AS this0
             WITH this0 { .title } AS this0

--- a/packages/graphql/tests/tck/issues/505.test.ts
+++ b/packages/graphql/tests/tck/issues/505.test.ts
@@ -124,33 +124,33 @@ describe("https://github.com/neo4j/graphql/issues/505", () => {
             MATCH (this:User)
             WHERE this.id = $param0
             CALL (this) {
-                MATCH (this)-[this0:CREATED_PAGE]->(this1:Page)
-                WITH DISTINCT this1
-                WITH *
-                WHERE ($isAuthenticated = true AND (EXISTS {
-                    MATCH (this1)<-[:CREATED_PAGE]-(this2:User)
-                    WHERE ($jwt.sub IS NOT NULL AND this2.authId = $jwt.sub)
-                } OR (($param3 IS NOT NULL AND this1.shared = $param3) AND (EXISTS {
-                    MATCH (this1)<-[:HAS_PAGE]-(this3:Workspace)
-                    WHERE (EXISTS {
-                        MATCH (this3)<-[:MEMBER_OF]-(this4:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this4.authId = $jwt.sub)
-                    } OR EXISTS {
-                        MATCH (this3)-[:HAS_ADMIN]->(this5:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this5.authId = $jwt.sub)
-                    })
-                } AND NOT (EXISTS {
-                    MATCH (this1)<-[:HAS_PAGE]-(this3:Workspace)
-                    WHERE NOT (EXISTS {
-                        MATCH (this3)<-[:MEMBER_OF]-(this4:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this4.authId = $jwt.sub)
-                    } OR EXISTS {
-                        MATCH (this3)-[:HAS_ADMIN]->(this5:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this5.authId = $jwt.sub)
-                    })
-                })))))
-                WITH this1 { .id } AS this1
-                RETURN collect(this1) AS var6
+              MATCH (this)-[this0:CREATED_PAGE]->(this1:Page)
+              WITH DISTINCT this1
+              WITH *
+              WHERE ($isAuthenticated = true AND (EXISTS {
+                MATCH (this1)<-[:CREATED_PAGE]-(this2:User)
+                WHERE ($jwt.sub IS NOT NULL AND this2.authId = $jwt.sub)
+              } OR (($param3 IS NOT NULL AND this1.shared = $param3) AND (EXISTS {
+                MATCH (this1)<-[:HAS_PAGE]-(this3:Workspace)
+                WHERE (EXISTS {
+                  MATCH (this3)<-[:MEMBER_OF]-(this4:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this4.authId = $jwt.sub)
+                } OR EXISTS {
+                  MATCH (this3)-[:HAS_ADMIN]->(this5:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this5.authId = $jwt.sub)
+                })
+              } AND NOT (EXISTS {
+                MATCH (this1)<-[:HAS_PAGE]-(this3:Workspace)
+                WHERE NOT (EXISTS {
+                  MATCH (this3)<-[:MEMBER_OF]-(this4:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this4.authId = $jwt.sub)
+                } OR EXISTS {
+                  MATCH (this3)-[:HAS_ADMIN]->(this5:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this5.authId = $jwt.sub)
+                })
+              })))))
+              WITH this1 { .id } AS this1
+              RETURN collect(this1) AS var6
             }
             RETURN this { .id, .authId, createdPages: var6 } AS this"
         `);
@@ -184,40 +184,40 @@ describe("https://github.com/neo4j/graphql/issues/505", () => {
             MATCH (this:Workspace)
             WITH *
             WHERE (this.id = $param0 AND ($isAuthenticated = true AND (EXISTS {
-                MATCH (this)<-[:MEMBER_OF]-(this0:User)
-                WHERE ($jwt.sub IS NOT NULL AND this0.authId = $jwt.sub)
+              MATCH (this)<-[:MEMBER_OF]-(this0:User)
+              WHERE ($jwt.sub IS NOT NULL AND this0.authId = $jwt.sub)
             } OR EXISTS {
-                MATCH (this)-[:HAS_ADMIN]->(this1:User)
-                WHERE ($jwt.sub IS NOT NULL AND this1.authId = $jwt.sub)
+              MATCH (this)-[:HAS_ADMIN]->(this1:User)
+              WHERE ($jwt.sub IS NOT NULL AND this1.authId = $jwt.sub)
             })))
             CALL (this) {
-                MATCH (this)-[this2:HAS_PAGE]->(this3:Page)
-                WITH DISTINCT this3
-                WITH *
-                WHERE ($isAuthenticated = true AND (EXISTS {
-                    MATCH (this3)<-[:CREATED_PAGE]-(this4:User)
-                    WHERE ($jwt.sub IS NOT NULL AND this4.authId = $jwt.sub)
-                } OR (($param3 IS NOT NULL AND this3.shared = $param3) AND (EXISTS {
-                    MATCH (this3)<-[:HAS_PAGE]-(this5:Workspace)
-                    WHERE (EXISTS {
-                        MATCH (this5)<-[:MEMBER_OF]-(this6:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this6.authId = $jwt.sub)
-                    } OR EXISTS {
-                        MATCH (this5)-[:HAS_ADMIN]->(this7:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this7.authId = $jwt.sub)
-                    })
-                } AND NOT (EXISTS {
-                    MATCH (this3)<-[:HAS_PAGE]-(this5:Workspace)
-                    WHERE NOT (EXISTS {
-                        MATCH (this5)<-[:MEMBER_OF]-(this6:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this6.authId = $jwt.sub)
-                    } OR EXISTS {
-                        MATCH (this5)-[:HAS_ADMIN]->(this7:User)
-                        WHERE ($jwt.sub IS NOT NULL AND this7.authId = $jwt.sub)
-                    })
-                })))))
-                WITH this3 { .id } AS this3
-                RETURN collect(this3) AS var8
+              MATCH (this)-[this2:HAS_PAGE]->(this3:Page)
+              WITH DISTINCT this3
+              WITH *
+              WHERE ($isAuthenticated = true AND (EXISTS {
+                MATCH (this3)<-[:CREATED_PAGE]-(this4:User)
+                WHERE ($jwt.sub IS NOT NULL AND this4.authId = $jwt.sub)
+              } OR (($param3 IS NOT NULL AND this3.shared = $param3) AND (EXISTS {
+                MATCH (this3)<-[:HAS_PAGE]-(this5:Workspace)
+                WHERE (EXISTS {
+                  MATCH (this5)<-[:MEMBER_OF]-(this6:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this6.authId = $jwt.sub)
+                } OR EXISTS {
+                  MATCH (this5)-[:HAS_ADMIN]->(this7:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this7.authId = $jwt.sub)
+                })
+              } AND NOT (EXISTS {
+                MATCH (this3)<-[:HAS_PAGE]-(this5:Workspace)
+                WHERE NOT (EXISTS {
+                  MATCH (this5)<-[:MEMBER_OF]-(this6:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this6.authId = $jwt.sub)
+                } OR EXISTS {
+                  MATCH (this5)-[:HAS_ADMIN]->(this7:User)
+                  WHERE ($jwt.sub IS NOT NULL AND this7.authId = $jwt.sub)
+                })
+              })))))
+              WITH this3 { .id } AS this3
+              RETURN collect(this3) AS var8
             }
             RETURN this { .id, pages: var8 } AS this"
         `);
@@ -248,32 +248,32 @@ describe("https://github.com/neo4j/graphql/issues/505", () => {
             MATCH (this:Page)
             WITH *
             WHERE ((EXISTS {
-                MATCH (this)<-[:HAS_PAGE]-(this0:Workspace)
-                WHERE this0.id = $param0
+              MATCH (this)<-[:HAS_PAGE]-(this0:Workspace)
+              WHERE this0.id = $param0
             } AND NOT (EXISTS {
-                MATCH (this)<-[:HAS_PAGE]-(this0:Workspace)
-                WHERE NOT (this0.id = $param0)
+              MATCH (this)<-[:HAS_PAGE]-(this0:Workspace)
+              WHERE NOT (this0.id = $param0)
             })) AND ($isAuthenticated = true AND (EXISTS {
-                MATCH (this)<-[:CREATED_PAGE]-(this1:User)
-                WHERE ($jwt.sub IS NOT NULL AND this1.authId = $jwt.sub)
+              MATCH (this)<-[:CREATED_PAGE]-(this1:User)
+              WHERE ($jwt.sub IS NOT NULL AND this1.authId = $jwt.sub)
             } OR (($param3 IS NOT NULL AND this.shared = $param3) AND (EXISTS {
-                MATCH (this)<-[:HAS_PAGE]-(this2:Workspace)
-                WHERE (EXISTS {
-                    MATCH (this2)<-[:MEMBER_OF]-(this3:User)
-                    WHERE ($jwt.sub IS NOT NULL AND this3.authId = $jwt.sub)
-                } OR EXISTS {
-                    MATCH (this2)-[:HAS_ADMIN]->(this4:User)
-                    WHERE ($jwt.sub IS NOT NULL AND this4.authId = $jwt.sub)
-                })
+              MATCH (this)<-[:HAS_PAGE]-(this2:Workspace)
+              WHERE (EXISTS {
+                MATCH (this2)<-[:MEMBER_OF]-(this3:User)
+                WHERE ($jwt.sub IS NOT NULL AND this3.authId = $jwt.sub)
+              } OR EXISTS {
+                MATCH (this2)-[:HAS_ADMIN]->(this4:User)
+                WHERE ($jwt.sub IS NOT NULL AND this4.authId = $jwt.sub)
+              })
             } AND NOT (EXISTS {
-                MATCH (this)<-[:HAS_PAGE]-(this2:Workspace)
-                WHERE NOT (EXISTS {
-                    MATCH (this2)<-[:MEMBER_OF]-(this3:User)
-                    WHERE ($jwt.sub IS NOT NULL AND this3.authId = $jwt.sub)
-                } OR EXISTS {
-                    MATCH (this2)-[:HAS_ADMIN]->(this4:User)
-                    WHERE ($jwt.sub IS NOT NULL AND this4.authId = $jwt.sub)
-                })
+              MATCH (this)<-[:HAS_PAGE]-(this2:Workspace)
+              WHERE NOT (EXISTS {
+                MATCH (this2)<-[:MEMBER_OF]-(this3:User)
+                WHERE ($jwt.sub IS NOT NULL AND this3.authId = $jwt.sub)
+              } OR EXISTS {
+                MATCH (this2)-[:HAS_ADMIN]->(this4:User)
+                WHERE ($jwt.sub IS NOT NULL AND this4.authId = $jwt.sub)
+              })
             }))))))
             RETURN this { .id } AS this"
         `);
@@ -304,26 +304,26 @@ describe("https://github.com/neo4j/graphql/issues/505", () => {
             MATCH (this:Page)
             WITH *
             WHERE ($isAuthenticated = true AND (EXISTS {
-                MATCH (this)<-[:CREATED_PAGE]-(this0:User)
-                WHERE ($jwt.sub IS NOT NULL AND this0.authId = $jwt.sub)
+              MATCH (this)<-[:CREATED_PAGE]-(this0:User)
+              WHERE ($jwt.sub IS NOT NULL AND this0.authId = $jwt.sub)
             } OR (($param2 IS NOT NULL AND this.shared = $param2) AND (EXISTS {
-                MATCH (this)<-[:HAS_PAGE]-(this1:Workspace)
-                WHERE (EXISTS {
-                    MATCH (this1)<-[:MEMBER_OF]-(this2:User)
-                    WHERE ($jwt.sub IS NOT NULL AND this2.authId = $jwt.sub)
-                } OR EXISTS {
-                    MATCH (this1)-[:HAS_ADMIN]->(this3:User)
-                    WHERE ($jwt.sub IS NOT NULL AND this3.authId = $jwt.sub)
-                })
+              MATCH (this)<-[:HAS_PAGE]-(this1:Workspace)
+              WHERE (EXISTS {
+                MATCH (this1)<-[:MEMBER_OF]-(this2:User)
+                WHERE ($jwt.sub IS NOT NULL AND this2.authId = $jwt.sub)
+              } OR EXISTS {
+                MATCH (this1)-[:HAS_ADMIN]->(this3:User)
+                WHERE ($jwt.sub IS NOT NULL AND this3.authId = $jwt.sub)
+              })
             } AND NOT (EXISTS {
-                MATCH (this)<-[:HAS_PAGE]-(this1:Workspace)
-                WHERE NOT (EXISTS {
-                    MATCH (this1)<-[:MEMBER_OF]-(this2:User)
-                    WHERE ($jwt.sub IS NOT NULL AND this2.authId = $jwt.sub)
-                } OR EXISTS {
-                    MATCH (this1)-[:HAS_ADMIN]->(this3:User)
-                    WHERE ($jwt.sub IS NOT NULL AND this3.authId = $jwt.sub)
-                })
+              MATCH (this)<-[:HAS_PAGE]-(this1:Workspace)
+              WHERE NOT (EXISTS {
+                MATCH (this1)<-[:MEMBER_OF]-(this2:User)
+                WHERE ($jwt.sub IS NOT NULL AND this2.authId = $jwt.sub)
+              } OR EXISTS {
+                MATCH (this1)-[:HAS_ADMIN]->(this3:User)
+                WHERE ($jwt.sub IS NOT NULL AND this3.authId = $jwt.sub)
+              })
             })))))
             RETURN this { .id } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/5080.test.ts
+++ b/packages/graphql/tests/tck/issues/5080.test.ts
@@ -127,22 +127,22 @@ describe("https://github.com/neo4j/graphql/issues/5080", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH(s:Car)
-                WHERE (s.id = $param0.carId)
-                REMOVE s:Car
-                SET s:DeletedCar
-                SET s.reason = $param0.reason
-                RETURN s AS s
+              MATCH(s:Car)
+              WHERE (s.id = $param0.carId)
+              REMOVE s:Car
+              SET s:DeletedCar
+              SET s.reason = $param0.reason
+              RETURN s AS s
             }
             WITH s AS this0
             WITH *
             CALL apoc.util.validate(NOT ($isAuthenticated = true AND EXISTS {
-                MATCH (this0)-[:OWNED_BY]->(this1:Tenant)
-                WHERE EXISTS {
-                    MATCH (this1)<-[:ADMIN_IN]-(this2:User)
-                    WHERE ($jwt.id IS NOT NULL AND this2.userId = $jwt.id)
-                }
-            }), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+              MATCH (this0)-[:OWNED_BY]->(this1:Tenant)
+              WHERE EXISTS {
+                MATCH (this1)<-[:ADMIN_IN]-(this2:User)
+                WHERE ($jwt.id IS NOT NULL AND this2.userId = $jwt.id)
+              }
+            }), '@neo4j/graphql/FORBIDDEN', [])
             WITH this0 { .id } AS this0
             RETURN this0 AS this"
         `);

--- a/packages/graphql/tests/tck/issues/5143.test.ts
+++ b/packages/graphql/tests/tck/issues/5143.test.ts
@@ -81,18 +81,18 @@ describe("https://github.com/neo4j/graphql/issues/5143", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MATCH (video:Video)
-                RETURN video
-                LIMIT 1
+              MATCH (video:Video)
+              RETURN video
+              LIMIT 1
             }
             WITH video AS this0
             WITH *
             WHERE ($isAuthenticated = true AND (EXISTS {
-                MATCH (this0)<-[:PUBLISHER]-(this1:User)
-                WHERE ($jwt.sub IS NOT NULL AND this1.id = $jwt.sub)
+              MATCH (this0)<-[:PUBLISHER]-(this1:User)
+              WHERE ($jwt.sub IS NOT NULL AND this1.id = $jwt.sub)
             } AND NOT (EXISTS {
-                MATCH (this0)<-[:PUBLISHER]-(this1:User)
-                WHERE NOT ($jwt.sub IS NOT NULL AND this1.id = $jwt.sub)
+              MATCH (this0)<-[:PUBLISHER]-(this1:User)
+              WHERE NOT ($jwt.sub IS NOT NULL AND this1.id = $jwt.sub)
             })))
             WITH this0 { .id } AS this0
             RETURN this0 AS this"

--- a/packages/graphql/tests/tck/issues/5270.test.ts
+++ b/packages/graphql/tests/tck/issues/5270.test.ts
@@ -97,16 +97,16 @@ describe("https://github.com/neo4j/graphql/issues/5270", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                OPTIONAL MATCH (u:User {id: $jwt.sub}) RETURN u
+              OPTIONAL MATCH (u:User {id: $jwt.sub}) RETURN u
             }
             WITH u AS this0
             WITH *
             WHERE ($isAuthenticated = true AND NOT (EXISTS {
-                MATCH (this0)-[:HAS_BLOCKED]->(this1:UserBlockedUser)
-                WHERE EXISTS {
-                    MATCH (this1)-[:IS_BLOCKING]->(this2:User)
-                    WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
-                }
+              MATCH (this0)-[:HAS_BLOCKED]->(this1:UserBlockedUser)
+              WHERE EXISTS {
+                MATCH (this1)-[:IS_BLOCKING]->(this2:User)
+                WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)
+              }
             }))
             WITH this0 { .id } AS this0
             RETURN this0 AS this"

--- a/packages/graphql/tests/tck/issues/5467.test.ts
+++ b/packages/graphql/tests/tck/issues/5467.test.ts
@@ -68,8 +68,8 @@ describe("https://github.com/neo4j/graphql/issues/5467", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                MERGE (t:Test {name: $param0}) SET t.groups = $param1
-                return t
+              MERGE (t:Test {name: $param0}) SET t.groups = $param1
+              return t
             }
             WITH t AS this0
             WITH this0 { .name, .groups } AS this0

--- a/packages/graphql/tests/tck/issues/5515.test.ts
+++ b/packages/graphql/tests/tck/issues/5515.test.ts
@@ -89,11 +89,11 @@ describe("https://github.com/neo4j/graphql/issues/5515", () => {
             "CYPHER 5
             MATCH (this:Category)
             WHERE (this.id = $param0 AND ($isAuthenticated = true AND EXISTS {
-                MATCH (this)<-[:HAS_CATEGORY]-(this0:Cabinet)
-                WHERE EXISTS {
-                    MATCH (this0)<-[:HAS_CABINET]-(this1:User)
-                    WHERE ($jwt.sub IS NOT NULL AND this1.id = $jwt.sub)
-                }
+              MATCH (this)<-[:HAS_CATEGORY]-(this0:Cabinet)
+              WHERE EXISTS {
+                MATCH (this0)<-[:HAS_CABINET]-(this1:User)
+                WHERE ($jwt.sub IS NOT NULL AND this1.id = $jwt.sub)
+              }
             }))
             DETACH DELETE this"
         `);

--- a/packages/graphql/tests/tck/issues/5599.test.ts
+++ b/packages/graphql/tests/tck/issues/5599.test.ts
@@ -70,13 +70,13 @@ describe("https://github.com/neo4j/graphql/issues/5599", () => {
             WITH *
             WITH *
             CALL (*) {
-                OPTIONAL MATCH (this)<-[this0:ACTED_IN]-(this1:LeadActor)
-                WHERE this1.name = $param0
-                WITH this0, collect(DISTINCT this1) AS var2
-                CALL (var2) {
-                    UNWIND var2 AS var3
-                    DETACH DELETE var3
-                }
+              OPTIONAL MATCH (this)<-[this0:ACTED_IN]-(this1:LeadActor)
+              WHERE this1.name = $param0
+              WITH this0, collect(DISTINCT this1) AS var2
+              CALL (var2) {
+                UNWIND var2 AS var3
+                DETACH DELETE var3
+              }
             }
             WITH this
             RETURN this { .title } AS this"
@@ -115,23 +115,23 @@ describe("https://github.com/neo4j/graphql/issues/5599", () => {
             WITH *
             WITH *
             CALL (*) {
-                OPTIONAL MATCH (this)<-[this0:ACTED_IN]-(this1:LeadActor)
-                WHERE this1.name = $param0
-                WITH this0, collect(DISTINCT this1) AS var2
-                CALL (var2) {
-                    UNWIND var2 AS var3
-                    DETACH DELETE var3
-                }
+              OPTIONAL MATCH (this)<-[this0:ACTED_IN]-(this1:LeadActor)
+              WHERE this1.name = $param0
+              WITH this0, collect(DISTINCT this1) AS var2
+              CALL (var2) {
+                UNWIND var2 AS var3
+                DETACH DELETE var3
+              }
             }
             WITH *
             CALL (*) {
-                OPTIONAL MATCH (this)<-[this4:ACTED_IN]-(this5:Extra)
-                WHERE this5.name = $param1
-                WITH this4, collect(DISTINCT this5) AS var6
-                CALL (var6) {
-                    UNWIND var6 AS var7
-                    DETACH DELETE var7
-                }
+              OPTIONAL MATCH (this)<-[this4:ACTED_IN]-(this5:Extra)
+              WHERE this5.name = $param1
+              WITH this4, collect(DISTINCT this5) AS var6
+              CALL (var6) {
+                UNWIND var6 AS var7
+                DETACH DELETE var7
+              }
             }
             WITH this
             RETURN this { .title } AS this"

--- a/packages/graphql/tests/tck/issues/582.test.ts
+++ b/packages/graphql/tests/tck/issues/582.test.ts
@@ -77,11 +77,11 @@ describe("#582", () => {
             "CYPHER 5
             MATCH (this:Entity)
             WHERE (this.type = $param0 AND EXISTS {
-                MATCH (this)-[this0:EDGE]->(this1:Entity)
-                WHERE (this1.type = $param1 AND EXISTS {
-                    MATCH (this1)<-[this2:EDGE]-(this3:Entity)
-                    WHERE this3.type = $param2
-                })
+              MATCH (this)-[this0:EDGE]->(this1:Entity)
+              WHERE (this1.type = $param1 AND EXISTS {
+                MATCH (this1)<-[this2:EDGE]-(this3:Entity)
+                WHERE this3.type = $param2
+              })
             })
             RETURN this { .type } AS this"
         `);
@@ -137,14 +137,14 @@ describe("#582", () => {
             "CYPHER 5
             MATCH (this:Entity)
             WHERE (this.type = $param0 AND EXISTS {
-                MATCH (this)-[this0:EDGE]->(this1:Entity)
-                WHERE (this1.type = $param1 AND EXISTS {
-                    MATCH (this1)<-[this2:EDGE]-(this3:Entity)
-                    WHERE (this3.type = $param2 AND EXISTS {
-                        MATCH (this3)-[this4:EDGE]->(this5:Entity)
-                        WHERE this5.type = $param3
-                    })
+              MATCH (this)-[this0:EDGE]->(this1:Entity)
+              WHERE (this1.type = $param1 AND EXISTS {
+                MATCH (this1)<-[this2:EDGE]-(this3:Entity)
+                WHERE (this3.type = $param2 AND EXISTS {
+                  MATCH (this3)-[this4:EDGE]->(this5:Entity)
+                  WHERE this5.type = $param3
                 })
+              })
             })
             RETURN this { .type } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/583.test.ts
+++ b/packages/graphql/tests/tck/issues/583.test.ts
@@ -82,24 +82,24 @@ describe("https://github.com/neo4j/graphql/issues/583", () => {
             "CYPHER 5
             MATCH (this:Actor)
             CALL (this) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                    WITH this1 { .title, .awardsGiven, __resolveType: \\"Movie\\", __id: id(this1) } AS var2
-                    RETURN var2
-                    UNION
-                    WITH *
-                    MATCH (this)-[this3:ACTED_IN]->(this4:Series)
-                    WITH this4 { .title, .awardsGiven, __resolveType: \\"Series\\", __id: id(this4) } AS var2
-                    RETURN var2
-                    UNION
-                    WITH *
-                    MATCH (this)-[this5:ACTED_IN]->(this6:ShortFilm)
-                    WITH this6 { .title, __resolveType: \\"ShortFilm\\", __id: id(this6) } AS var2
-                    RETURN var2
-                }
-                WITH var2
-                RETURN collect(var2) AS var2
+              CALL (*) {
+                WITH *
+                MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+                WITH this1 { .title, .awardsGiven, __resolveType: 'Movie', __id: elementId(this1) } AS var2
+                RETURN var2
+                UNION
+                WITH *
+                MATCH (this)-[this3:ACTED_IN]->(this4:Series)
+                WITH this4 { .title, .awardsGiven, __resolveType: 'Series', __id: elementId(this4) } AS var2
+                RETURN var2
+                UNION
+                WITH *
+                MATCH (this)-[this5:ACTED_IN]->(this6:ShortFilm)
+                WITH this6 { .title, __resolveType: 'ShortFilm', __id: elementId(this6) } AS var2
+                RETURN var2
+              }
+              WITH var2
+              RETURN collect(var2) AS var2
             }
             RETURN this { .name, actedIn: var2 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/6005.test.ts
+++ b/packages/graphql/tests/tck/issues/6005.test.ts
@@ -62,9 +62,9 @@ describe("https://github.com/neo4j/graphql/issues/6005", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WITH DISTINCT this1
-                RETURN count(this1) = $param0 AS var2
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WITH DISTINCT this1
+              RETURN count(this1) = $param0 AS var2
             }
             WITH *
             WHERE var2 = true
@@ -97,17 +97,17 @@ describe("https://github.com/neo4j/graphql/issues/6005", () => {
             "CYPHER 5
             MATCH (this:Actor)
             CALL (this) {
-                MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                WITH DISTINCT this1
-                CALL (this1) {
-                    MATCH (this1)<-[this2:ACTED_IN]-(this3:Actor)
-                    WITH DISTINCT this3
-                    RETURN count(this3) = $param0 AS var4
-                }
-                WITH *
-                WHERE var4 = true
-                WITH this1 { .title } AS this1
-                RETURN collect(this1) AS var5
+              MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+              WITH DISTINCT this1
+              CALL (this1) {
+                MATCH (this1)<-[this2:ACTED_IN]-(this3:Actor)
+                WITH DISTINCT this3
+                RETURN count(this3) = $param0 AS var4
+              }
+              WITH *
+              WHERE var4 = true
+              WITH this1 { .title } AS this1
+              RETURN collect(this1) AS var5
             }
             RETURN this { movies: var5 } AS this"
         `);
@@ -140,19 +140,19 @@ describe("https://github.com/neo4j/graphql/issues/6005", () => {
             "CYPHER 5
             MATCH (this0:Movie)
             CALL (this0) {
-                MATCH (this0)<-[this1:ACTED_IN]-(this2:Actor)
-                WITH DISTINCT this2
-                RETURN count(this2) = $param0 AS var3
+              MATCH (this0)<-[this1:ACTED_IN]-(this2:Actor)
+              WITH DISTINCT this2
+              RETURN count(this2) = $param0 AS var3
             }
             WITH *
             WHERE var3 = true
-            WITH collect({ node: this0 }) AS edges
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var4
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              RETURN collect({node: {title: this0.title, __resolveType: 'Movie'}}) AS var4
             }
-            RETURN { edges: var4 } AS this"
+            RETURN {edges: var4} AS this"
         `);
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
                         "{
@@ -190,30 +190,30 @@ describe("https://github.com/neo4j/graphql/issues/6005", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             MATCH (this0:Actor)
-            WITH collect({ node: this0 }) AS edges
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                CALL (this0) {
-                    MATCH (this0)-[this1:ACTED_IN]->(this2:Movie)
-                    CALL (this2, this1) {
-                        MATCH (this2)<-[this3:ACTED_IN]-(this4:Actor)
-                        WITH DISTINCT this4
-                        RETURN count(this4) = $param0 AS var5
-                    }
-                    WITH *
-                    WHERE var5 = true
-                    WITH collect({ node: this2, relationship: this1 }) AS edges
-                    CALL (edges) {
-                        UNWIND edges AS edge
-                        WITH edge.node AS this2, edge.relationship AS this1
-                        RETURN collect({ node: { title: this2.title, __resolveType: \\"Movie\\" } }) AS var6
-                    }
-                    RETURN { edges: var6 } AS var7
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              CALL (this0) {
+                MATCH (this0)-[this1:ACTED_IN]->(this2:Movie)
+                CALL (this2, this1) {
+                  MATCH (this2)<-[this3:ACTED_IN]-(this4:Actor)
+                  WITH DISTINCT this4
+                  RETURN count(this4) = $param0 AS var5
                 }
-                RETURN collect({ node: { moviesConnection: var7, __resolveType: \\"Actor\\" } }) AS var8
+                WITH *
+                WHERE var5 = true
+                WITH collect({node: this2, relationship: this1}) AS edges
+                CALL (edges) {
+                  UNWIND edges AS edge
+                  WITH edge.node AS this2, edge.relationship AS this1
+                  RETURN collect({node: {title: this2.title, __resolveType: 'Movie'}}) AS var6
+                }
+                RETURN {edges: var6} AS var7
+              }
+              RETURN collect({node: {moviesConnection: var7, __resolveType: 'Actor'}}) AS var8
             }
-            RETURN { edges: var8 } AS this"
+            RETURN {edges: var8} AS this"
         `);
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
                 "{

--- a/packages/graphql/tests/tck/issues/6031.test.ts
+++ b/packages/graphql/tests/tck/issues/6031.test.ts
@@ -74,22 +74,22 @@ describe("https://github.com/neo4j/graphql/issues/6031", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL () {
-                CALL () {
-                    MATCH (this0:Series)
-                    WHERE this0:Movie
-                    WITH { node: { __resolveType: \\"Series\\", __id: id(this0), title: this0.title } } AS edge
-                    RETURN edge
-                    UNION
-                    MATCH (this1:Movie)
-                    WHERE this1:Movie
-                    WITH { node: { __resolveType: \\"Movie\\", __id: id(this1), title: this1.title } } AS edge
-                    RETURN edge
-                }
-                RETURN collect(edge) AS edges
+              CALL () {
+                MATCH (this0:Series)
+                WHERE this0:Movie
+                WITH {node: {__resolveType: 'Series', __id: elementId(this0), title: this0.title}} AS edge
+                RETURN edge
+                UNION
+                MATCH (this1:Movie)
+                WHERE this1:Movie
+                WITH {node: {__resolveType: 'Movie', __id: elementId(this1), title: this1.title}} AS edge
+                RETURN edge
+              }
+              RETURN collect(edge) AS edges
             }
             WITH edges
             WITH edges, size(edges) AS totalCount
-            RETURN { edges: edges, totalCount: totalCount } AS this"
+            RETURN {edges: edges, totalCount: totalCount} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -120,34 +120,34 @@ describe("https://github.com/neo4j/graphql/issues/6031", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             MATCH (this0:Actor)
-            WITH collect({ node: this0 }) AS edges
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              CALL (this0) {
                 CALL (this0) {
-                    CALL (this0) {
-                        CALL (this0) {
-                            WITH this0
-                            MATCH (this0)-[this1:ACTED_IN]->(this2:Series)
-                            WHERE this2:Movie
-                            WITH { node: { __resolveType: \\"Series\\", __id: id(this2), title: this2.title } } AS edge
-                            RETURN edge
-                            UNION
-                            WITH this0
-                            MATCH (this0)-[this3:ACTED_IN]->(this4:Movie)
-                            WHERE this4:Movie
-                            WITH { node: { __resolveType: \\"Movie\\", __id: id(this4), title: this4.title } } AS edge
-                            RETURN edge
-                        }
-                        RETURN collect(edge) AS edges
-                    }
-                    WITH edges
-                    WITH edges, size(edges) AS totalCount
-                    RETURN { edges: edges, totalCount: totalCount } AS var5
+                  CALL (this0) {
+                    WITH this0
+                    MATCH (this0)-[this1:ACTED_IN]->(this2:Series)
+                    WHERE this2:Movie
+                    WITH {node: {__resolveType: 'Series', __id: elementId(this2), title: this2.title}} AS edge
+                    RETURN edge
+                    UNION
+                    WITH this0
+                    MATCH (this0)-[this3:ACTED_IN]->(this4:Movie)
+                    WHERE this4:Movie
+                    WITH {node: {__resolveType: 'Movie', __id: elementId(this4), title: this4.title}} AS edge
+                    RETURN edge
+                  }
+                  RETURN collect(edge) AS edges
                 }
-                RETURN collect({ node: { name: this0.name, productionsConnection: var5, __resolveType: \\"Actor\\" } }) AS var6
+                WITH edges
+                WITH edges, size(edges) AS totalCount
+                RETURN {edges: edges, totalCount: totalCount} AS var5
+              }
+              RETURN collect({node: {name: this0.name, productionsConnection: var5, __resolveType: 'Actor'}}) AS var6
             }
-            RETURN { edges: var6 } AS this"
+            RETURN {edges: var6} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);

--- a/packages/graphql/tests/tck/issues/630.test.ts
+++ b/packages/graphql/tests/tck/issues/630.test.ts
@@ -69,19 +69,19 @@ describe("Cypher directive", () => {
             "CYPHER 5
             MATCH (this:Actor)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (m:Movie {title: NULL})
-                    RETURN m
-                }
-                WITH m AS this0
-                CALL (this0) {
-                    MATCH (this0)<-[this1:ACTED_IN]-(this2:Actor)
-                    WITH count(this2) AS totalCount
-                    RETURN { totalCount: totalCount } AS var3
-                }
-                WITH this0 { actorsConnection: var3 } AS this0
-                RETURN collect(this0) AS var4
+              CALL (this) {
+                WITH this AS this
+                MATCH (m:Movie {title: NULL})
+                RETURN m
+              }
+              WITH m AS this0
+              CALL (this0) {
+                MATCH (this0)<-[this1:ACTED_IN]-(this2:Actor)
+                WITH count(this2) AS totalCount
+                RETURN {totalCount: totalCount} AS var3
+              }
+              WITH this0 { actorsConnection: var3 } AS this0
+              RETURN collect(this0) AS var4
             }
             RETURN this { movies: var4 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/6491.test.ts
+++ b/packages/graphql/tests/tck/issues/6491.test.ts
@@ -66,27 +66,27 @@ describe("https://github.com/neo4j/graphql/issues/6491", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL (*) {
-                MATCH (this0:SVG:VectorGraphic)
+              MATCH (this0:SVG&VectorGraphic)
+              CALL (this0) {
                 CALL (this0) {
-                    CALL (this0) {
-                        WITH this0 AS this
-                        RETURN this['name'] = 'test' AS result
-                    }
-                    WITH result AS this1
-                    RETURN this1 AS var2
+                  WITH this0 AS this
+                  RETURN this['name'] = 'test' AS result
                 }
-                WITH *
-                WHERE var2 = $param0
+                WITH result AS this1
+                RETURN this1 AS var2
+              }
+              WITH *
+              WHERE var2 = $param0
+              CALL (this0) {
                 CALL (this0) {
-                    CALL (this0) {
-                        WITH this0 AS this
-                        RETURN this['name'] = 'test' AS result
-                    }
-                    WITH result AS this3
-                    RETURN this3 AS var4
+                  WITH this0 AS this
+                  RETURN this['name'] = 'test' AS result
                 }
-                WITH this0 { .name, cypherTest: var4, __resolveType: \\"SVG\\", __id: id(this0) } AS this
-                RETURN this
+                WITH result AS this3
+                RETURN this3 AS var4
+              }
+              WITH this0 { .name, cypherTest: var4, __resolveType: 'SVG', __id: elementId(this0) } AS this
+              RETURN this
             }
             WITH this
             RETURN this AS this"

--- a/packages/graphql/tests/tck/issues/6618.test.ts
+++ b/packages/graphql/tests/tck/issues/6618.test.ts
@@ -52,7 +52,7 @@ describe("https://github.com/neo4j/graphql/issues/6618", () => {
             "CYPHER 5
             MATCH (this0:ProductInstance)
             WITH count(this0) AS totalCount
-            RETURN { totalCount: totalCount } AS this"
+            RETURN {totalCount: totalCount} AS this"
         `);
 
         expect(formatCypher(result.cypher)).not.toContain("collect");
@@ -73,7 +73,7 @@ describe("https://github.com/neo4j/graphql/issues/6618", () => {
             "CYPHER 5
             MATCH (this0:Asset)
             WITH count(this0) AS totalCount
-            RETURN { totalCount: totalCount } AS this"
+            RETURN {totalCount: totalCount} AS this"
         `);
     });
 });

--- a/packages/graphql/tests/tck/issues/6620.test.ts
+++ b/packages/graphql/tests/tck/issues/6620.test.ts
@@ -209,11 +209,11 @@ describe("https://github.com/neo4j/graphql/issues/6620", () => {
             WHERE this.name = $param0
             WITH *
             CALL (*) {
-                CALL (this) {
-                    MATCH (this0:CarManufacturer)
-                    WHERE ((this0.accessibleBy IS NULL OR ($jwt.permission_CarManufacturer_node_CREATE_RELATIONSHIP IS NOT NULL AND this0.accessibleBy IN $jwt.permission_CarManufacturer_node_CREATE_RELATIONSHIP)) AND this0.name = $param2)
-                    CREATE (this)<-[this1:CAR_IS_PRODUCED_BY_CARMANUFACTURER]-(this0)
-                }
+              CALL (this) {
+                MATCH (this0:CarManufacturer)
+                WHERE ((this0.accessibleBy IS NULL OR ($jwt.permission_CarManufacturer_node_CREATE_RELATIONSHIP IS NOT NULL AND this0.accessibleBy IN $jwt.permission_CarManufacturer_node_CREATE_RELATIONSHIP)) AND this0.name = $param2)
+                CREATE (this)<-[this1:CAR_IS_PRODUCED_BY_CARMANUFACTURER]-(this0)
+              }
             }
             FINISH"
         `);
@@ -243,15 +243,14 @@ describe("https://github.com/neo4j/graphql/issues/6620", () => {
             MATCH (this:Car)
             WITH *
             WHERE (this.name = $param0 AND (this.accessibleBy IS NULL OR ($jwt.permission_Car_node_UPDATE IS NOT NULL AND this.accessibleBy IN $jwt.permission_Car_node_UPDATE)))
-            SET
-                this.name = $param2
+            SET this.name = $param2
             WITH *
             CALL (*) {
-                CALL (this) {
-                    MATCH (this0:CarManufacturer)
-                    WHERE ((this0.accessibleBy IS NULL OR ($jwt.permission_CarManufacturer_node_CREATE_RELATIONSHIP IS NOT NULL AND this0.accessibleBy IN $jwt.permission_CarManufacturer_node_CREATE_RELATIONSHIP)) AND this0.name = $param3)
-                    CREATE (this)<-[this1:CAR_IS_PRODUCED_BY_CARMANUFACTURER]-(this0)
-                }
+              CALL (this) {
+                MATCH (this0:CarManufacturer)
+                WHERE ((this0.accessibleBy IS NULL OR ($jwt.permission_CarManufacturer_node_CREATE_RELATIONSHIP IS NOT NULL AND this0.accessibleBy IN $jwt.permission_CarManufacturer_node_CREATE_RELATIONSHIP)) AND this0.name = $param3)
+                CREATE (this)<-[this1:CAR_IS_PRODUCED_BY_CARMANUFACTURER]-(this0)
+              }
             }
             FINISH"
         `);
@@ -447,16 +446,16 @@ describe("https://github.com/neo4j/graphql/issues/6620 validate", () => {
             WHERE this.name = $param0
             WITH *
             CALL (*) {
-                CALL (this) {
-                    MATCH (this0:CarManufacturer)
-                    WHERE this0.name = $param1
-                    CALL apoc.util.validate(NOT (this0.accessibleBy IS NULL OR ($jwt.permission_CarManufacturer_node_CREATE_RELATIONSHIP IS NOT NULL AND this0.accessibleBy IN $jwt.permission_CarManufacturer_node_CREATE_RELATIONSHIP)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    CREATE (this)<-[this1:CAR_IS_PRODUCED_BY_CARMANUFACTURER]-(this0)
-                    WITH *
-                    CALL apoc.util.validate(NOT (this0.accessibleBy IS NULL OR ($jwt.permission_CarManufacturer_node_CREATE_RELATIONSHIP IS NOT NULL AND this0.accessibleBy IN $jwt.permission_CarManufacturer_node_CREATE_RELATIONSHIP)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    WITH *
-                    CALL apoc.util.validate(NOT (this.accessibleBy IS NULL OR ($jwt.permission_Car_node_CREATE_RELATIONSHIP IS NOT NULL AND this.accessibleBy IN $jwt.permission_Car_node_CREATE_RELATIONSHIP)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                }
+              CALL (this) {
+                MATCH (this0:CarManufacturer)
+                WHERE this0.name = $param1
+                CALL apoc.util.validate(NOT (this0.accessibleBy IS NULL OR ($jwt.permission_CarManufacturer_node_CREATE_RELATIONSHIP IS NOT NULL AND this0.accessibleBy IN $jwt.permission_CarManufacturer_node_CREATE_RELATIONSHIP)), '@neo4j/graphql/FORBIDDEN', [])
+                CREATE (this)<-[this1:CAR_IS_PRODUCED_BY_CARMANUFACTURER]-(this0)
+                WITH *
+                CALL apoc.util.validate(NOT (this0.accessibleBy IS NULL OR ($jwt.permission_CarManufacturer_node_CREATE_RELATIONSHIP IS NOT NULL AND this0.accessibleBy IN $jwt.permission_CarManufacturer_node_CREATE_RELATIONSHIP)), '@neo4j/graphql/FORBIDDEN', [])
+                WITH *
+                CALL apoc.util.validate(NOT (this.accessibleBy IS NULL OR ($jwt.permission_Car_node_CREATE_RELATIONSHIP IS NOT NULL AND this.accessibleBy IN $jwt.permission_Car_node_CREATE_RELATIONSHIP)), '@neo4j/graphql/FORBIDDEN', [])
+              }
             }
             FINISH"
         `);
@@ -487,25 +486,24 @@ describe("https://github.com/neo4j/graphql/issues/6620 validate", () => {
             WITH *
             WHERE this.name = $param0
             WITH *
-            CALL apoc.util.validate(NOT (this.accessibleBy IS NULL OR ($jwt.permission_Car_node_UPDATE IS NOT NULL AND this.accessibleBy IN $jwt.permission_Car_node_UPDATE)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT (this.accessibleBy IS NULL OR ($jwt.permission_Car_node_UPDATE IS NOT NULL AND this.accessibleBy IN $jwt.permission_Car_node_UPDATE)), '@neo4j/graphql/FORBIDDEN', [])
             WITH *
-            SET
-                this.name = $param2
+            SET this.name = $param2
             WITH *
             CALL (*) {
-                CALL (this) {
-                    MATCH (this0:CarManufacturer)
-                    WHERE this0.name = $param3
-                    CALL apoc.util.validate(NOT (this0.accessibleBy IS NULL OR ($jwt.permission_CarManufacturer_node_CREATE_RELATIONSHIP IS NOT NULL AND this0.accessibleBy IN $jwt.permission_CarManufacturer_node_CREATE_RELATIONSHIP)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    CREATE (this)<-[this1:CAR_IS_PRODUCED_BY_CARMANUFACTURER]-(this0)
-                    WITH *
-                    CALL apoc.util.validate(NOT (this0.accessibleBy IS NULL OR ($jwt.permission_CarManufacturer_node_CREATE_RELATIONSHIP IS NOT NULL AND this0.accessibleBy IN $jwt.permission_CarManufacturer_node_CREATE_RELATIONSHIP)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    WITH *
-                    CALL apoc.util.validate(NOT (this.accessibleBy IS NULL OR ($jwt.permission_Car_node_CREATE_RELATIONSHIP IS NOT NULL AND this.accessibleBy IN $jwt.permission_Car_node_CREATE_RELATIONSHIP)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                }
+              CALL (this) {
+                MATCH (this0:CarManufacturer)
+                WHERE this0.name = $param3
+                CALL apoc.util.validate(NOT (this0.accessibleBy IS NULL OR ($jwt.permission_CarManufacturer_node_CREATE_RELATIONSHIP IS NOT NULL AND this0.accessibleBy IN $jwt.permission_CarManufacturer_node_CREATE_RELATIONSHIP)), '@neo4j/graphql/FORBIDDEN', [])
+                CREATE (this)<-[this1:CAR_IS_PRODUCED_BY_CARMANUFACTURER]-(this0)
+                WITH *
+                CALL apoc.util.validate(NOT (this0.accessibleBy IS NULL OR ($jwt.permission_CarManufacturer_node_CREATE_RELATIONSHIP IS NOT NULL AND this0.accessibleBy IN $jwt.permission_CarManufacturer_node_CREATE_RELATIONSHIP)), '@neo4j/graphql/FORBIDDEN', [])
+                WITH *
+                CALL apoc.util.validate(NOT (this.accessibleBy IS NULL OR ($jwt.permission_Car_node_CREATE_RELATIONSHIP IS NOT NULL AND this.accessibleBy IN $jwt.permission_Car_node_CREATE_RELATIONSHIP)), '@neo4j/graphql/FORBIDDEN', [])
+              }
             }
             WITH *
-            CALL apoc.util.validate(NOT (this.accessibleBy IS NULL OR ($jwt.permission_Car_node_UPDATE IS NOT NULL AND this.accessibleBy IN $jwt.permission_Car_node_UPDATE)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT (this.accessibleBy IS NULL OR ($jwt.permission_Car_node_UPDATE IS NOT NULL AND this.accessibleBy IN $jwt.permission_Car_node_UPDATE)), '@neo4j/graphql/FORBIDDEN', [])
             FINISH"
         `);
     });

--- a/packages/graphql/tests/tck/issues/832.test.ts
+++ b/packages/graphql/tests/tck/issues/832.test.ts
@@ -85,69 +85,69 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                CREATE (this0:Interaction)
-                SET
-                    this0.id = randomUUID(),
-                    this0.kind = $param0
-                WITH *
-                CALL (this0) {
-                    MATCH (this1:Person)
-                    WHERE this1.id IN $param1
-                    CREATE (this0)<-[this2:ACTED_IN]-(this1)
-                }
-                WITH *
-                CALL (this0) {
-                    MATCH (this3:Place)
-                    WHERE this3.id IN $param2
-                    CREATE (this0)<-[this4:ACTED_IN]-(this3)
-                }
-                WITH *
-                CALL (this0) {
-                    MATCH (this5:Person)
-                    WHERE this5.id IN $param3
-                    CREATE (this0)-[this6:ACTED_IN]->(this5)
-                }
-                WITH *
-                CALL (this0) {
-                    MATCH (this7:Place)
-                    WHERE this7.id IN $param4
-                    CREATE (this0)-[this8:ACTED_IN]->(this7)
-                }
-                RETURN this0 AS this
-                UNION
-                CREATE (this9:Interaction)
-                SET
-                    this9.id = randomUUID(),
-                    this9.kind = $param5
-                WITH *
-                CALL (this9) {
-                    MATCH (this10:Person)
-                    WHERE this10.id IN $param6
-                    CREATE (this9)<-[this11:ACTED_IN]-(this10)
-                }
-                WITH *
-                CALL (this9) {
-                    MATCH (this12:Place)
-                    WHERE this12.id IN $param7
-                    CREATE (this9)<-[this13:ACTED_IN]-(this12)
-                }
-                WITH *
-                CALL (this9) {
-                    MATCH (this14:Person)
-                    WHERE this14.id IN $param8
-                    CREATE (this9)-[this15:ACTED_IN]->(this14)
-                }
-                WITH *
-                CALL (this9) {
-                    MATCH (this16:Place)
-                    WHERE this16.id IN $param9
-                    CREATE (this9)-[this17:ACTED_IN]->(this16)
-                }
-                RETURN this9 AS this
+              CREATE (this0:Interaction)
+              SET
+                this0.id = randomUUID(),
+                this0.kind = $param0
+              WITH *
+              CALL (this0) {
+                MATCH (this1:Person)
+                WHERE this1.id IN $param1
+                CREATE (this0)<-[this2:ACTED_IN]-(this1)
+              }
+              WITH *
+              CALL (this0) {
+                MATCH (this3:Place)
+                WHERE this3.id IN $param2
+                CREATE (this0)<-[this4:ACTED_IN]-(this3)
+              }
+              WITH *
+              CALL (this0) {
+                MATCH (this5:Person)
+                WHERE this5.id IN $param3
+                CREATE (this0)-[this6:ACTED_IN]->(this5)
+              }
+              WITH *
+              CALL (this0) {
+                MATCH (this7:Place)
+                WHERE this7.id IN $param4
+                CREATE (this0)-[this8:ACTED_IN]->(this7)
+              }
+              RETURN this0 AS this
+              UNION
+              CREATE (this9:Interaction)
+              SET
+                this9.id = randomUUID(),
+                this9.kind = $param5
+              WITH *
+              CALL (this9) {
+                MATCH (this10:Person)
+                WHERE this10.id IN $param6
+                CREATE (this9)<-[this11:ACTED_IN]-(this10)
+              }
+              WITH *
+              CALL (this9) {
+                MATCH (this12:Place)
+                WHERE this12.id IN $param7
+                CREATE (this9)<-[this13:ACTED_IN]-(this12)
+              }
+              WITH *
+              CALL (this9) {
+                MATCH (this14:Person)
+                WHERE this14.id IN $param8
+                CREATE (this9)-[this15:ACTED_IN]->(this14)
+              }
+              WITH *
+              CALL (this9) {
+                MATCH (this16:Place)
+                WHERE this16.id IN $param9
+                CREATE (this9)-[this17:ACTED_IN]->(this16)
+              }
+              RETURN this9 AS this
             }
             WITH this
             CALL (this) {
-                RETURN this { .id } AS var18
+              RETURN this { .id } AS var18
             }
             RETURN collect(var18) AS data"
         `);
@@ -215,39 +215,39 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                CREATE (this0:Interaction)
-                SET
-                    this0.id = randomUUID(),
-                    this0.kind = $param0
-                WITH *
-                CALL (this0) {
-                    MATCH (this1:Person)
-                    WHERE this1.id IN $param1
-                    CREATE (this0)<-[this2:ACTED_IN]-(this1)
-                }
-                WITH *
-                CALL (this0) {
-                    MATCH (this3:Place)
-                    WHERE this3.id IN $param2
-                    CREATE (this0)<-[this4:ACTED_IN]-(this3)
-                }
-                WITH *
-                CALL (this0) {
-                    MATCH (this5:Person)
-                    WHERE this5.id IN $param3
-                    CREATE (this0)-[this6:ACTED_IN]->(this5)
-                }
-                WITH *
-                CALL (this0) {
-                    MATCH (this7:Place)
-                    WHERE this7.id IN $param4
-                    CREATE (this0)-[this8:ACTED_IN]->(this7)
-                }
-                RETURN this0 AS this
+              CREATE (this0:Interaction)
+              SET
+                this0.id = randomUUID(),
+                this0.kind = $param0
+              WITH *
+              CALL (this0) {
+                MATCH (this1:Person)
+                WHERE this1.id IN $param1
+                CREATE (this0)<-[this2:ACTED_IN]-(this1)
+              }
+              WITH *
+              CALL (this0) {
+                MATCH (this3:Place)
+                WHERE this3.id IN $param2
+                CREATE (this0)<-[this4:ACTED_IN]-(this3)
+              }
+              WITH *
+              CALL (this0) {
+                MATCH (this5:Person)
+                WHERE this5.id IN $param3
+                CREATE (this0)-[this6:ACTED_IN]->(this5)
+              }
+              WITH *
+              CALL (this0) {
+                MATCH (this7:Place)
+                WHERE this7.id IN $param4
+                CREATE (this0)-[this8:ACTED_IN]->(this7)
+              }
+              RETURN this0 AS this
             }
             WITH this
             CALL (this) {
-                RETURN this { .id } AS var9
+              RETURN this { .id } AS var9
             }
             RETURN collect(var9) AS data"
         `);
@@ -300,39 +300,39 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                CREATE (this0:Interaction)
-                SET
-                    this0.id = randomUUID(),
-                    this0.kind = $param0
-                WITH *
-                CALL (this0) {
-                    MATCH (this1:Person)
-                    WHERE this1.id IN $param1
-                    CREATE (this0)<-[this2:ACTED_IN]-(this1)
-                }
-                WITH *
-                CALL (this0) {
-                    MATCH (this3:Place)
-                    WHERE this3.id IN $param2
-                    CREATE (this0)<-[this4:ACTED_IN]-(this3)
-                }
-                WITH *
-                CALL (this0) {
-                    MATCH (this5:Person)
-                    WHERE this5.id IN $param3
-                    CREATE (this0)-[this6:ACTED_IN]->(this5)
-                }
-                WITH *
-                CALL (this0) {
-                    MATCH (this7:Place)
-                    WHERE this7.id IN $param4
-                    CREATE (this0)-[this8:ACTED_IN]->(this7)
-                }
-                RETURN this0 AS this
+              CREATE (this0:Interaction)
+              SET
+                this0.id = randomUUID(),
+                this0.kind = $param0
+              WITH *
+              CALL (this0) {
+                MATCH (this1:Person)
+                WHERE this1.id IN $param1
+                CREATE (this0)<-[this2:ACTED_IN]-(this1)
+              }
+              WITH *
+              CALL (this0) {
+                MATCH (this3:Place)
+                WHERE this3.id IN $param2
+                CREATE (this0)<-[this4:ACTED_IN]-(this3)
+              }
+              WITH *
+              CALL (this0) {
+                MATCH (this5:Person)
+                WHERE this5.id IN $param3
+                CREATE (this0)-[this6:ACTED_IN]->(this5)
+              }
+              WITH *
+              CALL (this0) {
+                MATCH (this7:Place)
+                WHERE this7.id IN $param4
+                CREATE (this0)-[this8:ACTED_IN]->(this7)
+              }
+              RETURN this0 AS this
             }
             WITH this
             CALL (this) {
-                RETURN this { .id } AS var9
+              RETURN this { .id } AS var9
             }
             RETURN collect(var9) AS data"
         `);
@@ -396,99 +396,99 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                CREATE (this0:Interaction)
-                SET
-                    this0.id = randomUUID(),
-                    this0.kind = $param0
-                WITH *
-                CALL (this0) {
-                    MATCH (this1:Person)
-                    WHERE this1.id IN $param1
-                    CREATE (this0)<-[this2:ACTED_IN]-(this1)
-                }
-                WITH *
-                CALL (this0) {
-                    MATCH (this3:Place)
-                    WHERE this3.id IN $param2
-                    CREATE (this0)<-[this4:ACTED_IN]-(this3)
-                }
-                WITH *
-                CALL (this0) {
-                    MATCH (this5:Person)
-                    WHERE this5.id IN $param3
-                    CREATE (this0)-[this6:ACTED_IN]->(this5)
-                }
-                WITH *
-                CALL (this0) {
-                    MATCH (this7:Place)
-                    WHERE this7.id IN $param4
-                    CREATE (this0)-[this8:ACTED_IN]->(this7)
-                }
-                RETURN this0 AS this
-                UNION
-                CREATE (this9:Interaction)
-                SET
-                    this9.id = randomUUID(),
-                    this9.kind = $param5
-                WITH *
-                CALL (this9) {
-                    MATCH (this10:Person)
-                    WHERE this10.id IN $param6
-                    CREATE (this9)<-[this11:ACTED_IN]-(this10)
-                }
-                WITH *
-                CALL (this9) {
-                    MATCH (this12:Place)
-                    WHERE this12.id IN $param7
-                    CREATE (this9)<-[this13:ACTED_IN]-(this12)
-                }
-                WITH *
-                CALL (this9) {
-                    MATCH (this14:Person)
-                    WHERE this14.id IN $param8
-                    CREATE (this9)-[this15:ACTED_IN]->(this14)
-                }
-                WITH *
-                CALL (this9) {
-                    MATCH (this16:Place)
-                    WHERE this16.id IN $param9
-                    CREATE (this9)-[this17:ACTED_IN]->(this16)
-                }
-                RETURN this9 AS this
+              CREATE (this0:Interaction)
+              SET
+                this0.id = randomUUID(),
+                this0.kind = $param0
+              WITH *
+              CALL (this0) {
+                MATCH (this1:Person)
+                WHERE this1.id IN $param1
+                CREATE (this0)<-[this2:ACTED_IN]-(this1)
+              }
+              WITH *
+              CALL (this0) {
+                MATCH (this3:Place)
+                WHERE this3.id IN $param2
+                CREATE (this0)<-[this4:ACTED_IN]-(this3)
+              }
+              WITH *
+              CALL (this0) {
+                MATCH (this5:Person)
+                WHERE this5.id IN $param3
+                CREATE (this0)-[this6:ACTED_IN]->(this5)
+              }
+              WITH *
+              CALL (this0) {
+                MATCH (this7:Place)
+                WHERE this7.id IN $param4
+                CREATE (this0)-[this8:ACTED_IN]->(this7)
+              }
+              RETURN this0 AS this
+              UNION
+              CREATE (this9:Interaction)
+              SET
+                this9.id = randomUUID(),
+                this9.kind = $param5
+              WITH *
+              CALL (this9) {
+                MATCH (this10:Person)
+                WHERE this10.id IN $param6
+                CREATE (this9)<-[this11:ACTED_IN]-(this10)
+              }
+              WITH *
+              CALL (this9) {
+                MATCH (this12:Place)
+                WHERE this12.id IN $param7
+                CREATE (this9)<-[this13:ACTED_IN]-(this12)
+              }
+              WITH *
+              CALL (this9) {
+                MATCH (this14:Person)
+                WHERE this14.id IN $param8
+                CREATE (this9)-[this15:ACTED_IN]->(this14)
+              }
+              WITH *
+              CALL (this9) {
+                MATCH (this16:Place)
+                WHERE this16.id IN $param9
+                CREATE (this9)-[this17:ACTED_IN]->(this16)
+              }
+              RETURN this9 AS this
             }
             WITH this
             CALL (this) {
-                CALL (this) {
-                    CALL (*) {
-                        WITH *
-                        MATCH (this)<-[this18:ACTED_IN]-(this19:Person)
-                        WITH this19 { .id, __resolveType: \\"Person\\", __id: id(this19) } AS var20
-                        RETURN var20
-                        UNION
-                        WITH *
-                        MATCH (this)<-[this21:ACTED_IN]-(this22:Place)
-                        WITH this22 { .id, __resolveType: \\"Place\\", __id: id(this22) } AS var20
-                        RETURN var20
-                    }
-                    WITH var20
-                    RETURN collect(var20) AS var20
+              CALL (this) {
+                CALL (*) {
+                  WITH *
+                  MATCH (this)<-[this18:ACTED_IN]-(this19:Person)
+                  WITH this19 { .id, __resolveType: 'Person', __id: elementId(this19) } AS var20
+                  RETURN var20
+                  UNION
+                  WITH *
+                  MATCH (this)<-[this21:ACTED_IN]-(this22:Place)
+                  WITH this22 { .id, __resolveType: 'Place', __id: elementId(this22) } AS var20
+                  RETURN var20
                 }
-                CALL (this) {
-                    CALL (*) {
-                        WITH *
-                        MATCH (this)-[this23:ACTED_IN]->(this24:Person)
-                        WITH this24 { .id, __resolveType: \\"Person\\", __id: id(this24) } AS var25
-                        RETURN var25
-                        UNION
-                        WITH *
-                        MATCH (this)-[this26:ACTED_IN]->(this27:Place)
-                        WITH this27 { .id, __resolveType: \\"Place\\", __id: id(this27) } AS var25
-                        RETURN var25
-                    }
-                    WITH var25
-                    RETURN collect(var25) AS var25
+                WITH var20
+                RETURN collect(var20) AS var20
+              }
+              CALL (this) {
+                CALL (*) {
+                  WITH *
+                  MATCH (this)-[this23:ACTED_IN]->(this24:Person)
+                  WITH this24 { .id, __resolveType: 'Person', __id: elementId(this24) } AS var25
+                  RETURN var25
+                  UNION
+                  WITH *
+                  MATCH (this)-[this26:ACTED_IN]->(this27:Place)
+                  WITH this27 { .id, __resolveType: 'Place', __id: elementId(this27) } AS var25
+                  RETURN var25
                 }
-                RETURN this { .id, subjects: var20, objects: var25 } AS var28
+                WITH var25
+                RETURN collect(var25) AS var25
+              }
+              RETURN this { .id, subjects: var20, objects: var25 } AS var28
             }
             RETURN collect(var28) AS data"
         `);
@@ -556,33 +556,33 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                CREATE (this0:Interaction)
-                SET
-                    this0.id = randomUUID(),
-                    this0.kind = $param0
-                WITH *
-                CALL (this0) {
-                    MATCH (this1:Person)
-                    WHERE this1.id IN $param1
-                    CREATE (this0)<-[this2:ACTED_IN]-(this1)
-                }
-                WITH *
-                CALL (this0) {
-                    MATCH (this3:Place)
-                    WHERE this3.id IN $param2
-                    CREATE (this0)<-[this4:ACTED_IN]-(this3)
-                }
-                RETURN this0 AS this
-                UNION
-                CREATE (this5:Interaction)
-                SET
-                    this5.id = randomUUID(),
-                    this5.kind = $param3
-                RETURN this5 AS this
+              CREATE (this0:Interaction)
+              SET
+                this0.id = randomUUID(),
+                this0.kind = $param0
+              WITH *
+              CALL (this0) {
+                MATCH (this1:Person)
+                WHERE this1.id IN $param1
+                CREATE (this0)<-[this2:ACTED_IN]-(this1)
+              }
+              WITH *
+              CALL (this0) {
+                MATCH (this3:Place)
+                WHERE this3.id IN $param2
+                CREATE (this0)<-[this4:ACTED_IN]-(this3)
+              }
+              RETURN this0 AS this
+              UNION
+              CREATE (this5:Interaction)
+              SET
+                this5.id = randomUUID(),
+                this5.kind = $param3
+              RETURN this5 AS this
             }
             WITH this
             CALL (this) {
-                RETURN this { .id } AS var6
+              RETURN this { .id } AS var6
             }
             RETURN collect(var6) AS data"
         `);

--- a/packages/graphql/tests/tck/issues/847.test.ts
+++ b/packages/graphql/tests/tck/issues/847.test.ts
@@ -69,34 +69,34 @@ describe("https://github.com/neo4j/graphql/issues/847", () => {
             "CYPHER 5
             MATCH (this:Interaction)
             CALL (this) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this)<-[this0:ACTED_IN]-(this1:Person)
-                    WITH this1 { .id, __resolveType: \\"Person\\", __id: id(this1) } AS var2
-                    RETURN var2
-                    UNION
-                    WITH *
-                    MATCH (this)<-[this3:ACTED_IN]-(this4:Place)
-                    WITH this4 { .id, __resolveType: \\"Place\\", __id: id(this4) } AS var2
-                    RETURN var2
-                }
-                WITH var2
-                RETURN collect(var2) AS var2
+              CALL (*) {
+                WITH *
+                MATCH (this)<-[this0:ACTED_IN]-(this1:Person)
+                WITH this1 { .id, __resolveType: 'Person', __id: elementId(this1) } AS var2
+                RETURN var2
+                UNION
+                WITH *
+                MATCH (this)<-[this3:ACTED_IN]-(this4:Place)
+                WITH this4 { .id, __resolveType: 'Place', __id: elementId(this4) } AS var2
+                RETURN var2
+              }
+              WITH var2
+              RETURN collect(var2) AS var2
             }
             CALL (this) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this)-[this5:ACTED_IN]->(this6:Person)
-                    WITH this6 { .id, __resolveType: \\"Person\\", __id: id(this6) } AS var7
-                    RETURN var7
-                    UNION
-                    WITH *
-                    MATCH (this)-[this8:ACTED_IN]->(this9:Place)
-                    WITH this9 { .id, __resolveType: \\"Place\\", __id: id(this9) } AS var7
-                    RETURN var7
-                }
-                WITH var7
-                RETURN collect(var7) AS var7
+              CALL (*) {
+                WITH *
+                MATCH (this)-[this5:ACTED_IN]->(this6:Person)
+                WITH this6 { .id, __resolveType: 'Person', __id: elementId(this6) } AS var7
+                RETURN var7
+                UNION
+                WITH *
+                MATCH (this)-[this8:ACTED_IN]->(this9:Place)
+                WITH this9 { .id, __resolveType: 'Place', __id: elementId(this9) } AS var7
+                RETURN var7
+              }
+              WITH var7
+              RETURN collect(var7) AS var7
             }
             RETURN this { .id, subjects: var2, objects: var7 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/894.test.ts
+++ b/packages/graphql/tests/tck/issues/894.test.ts
@@ -71,20 +71,20 @@ describe("https://github.com/neo4j/graphql/issues/894", () => {
             WHERE this.name = $param0
             WITH *
             CALL (*) {
-                CALL (this) {
-                    MATCH (this0:Organization)
-                    WHERE this0._id = $param1
-                    CREATE (this)-[this1:ACTIVELY_MANAGING]->(this0)
-                }
+              CALL (this) {
+                MATCH (this0:Organization)
+                WHERE this0._id = $param1
+                CREATE (this)-[this1:ACTIVELY_MANAGING]->(this0)
+              }
             }
             WITH *
             CALL (*) {
-                CALL (this) {
-                    OPTIONAL MATCH (this)-[this2:ACTIVELY_MANAGING]->(this3:Organization)
-                    WHERE NOT (this3._id = $param2)
-                    WITH *
-                    DELETE this2
-                }
+              CALL (this) {
+                OPTIONAL MATCH (this)-[this2:ACTIVELY_MANAGING]->(this3:Organization)
+                WHERE NOT (this3._id = $param2)
+                WITH *
+                DELETE this2
+              }
             }
             WITH this
             RETURN this { id: this._id } AS this"

--- a/packages/graphql/tests/tck/issues/901.test.ts
+++ b/packages/graphql/tests/tck/issues/901.test.ts
@@ -96,23 +96,23 @@ describe("https://github.com/neo4j/graphql/issues/901", () => {
             "CYPHER 5
             MATCH (this:Series)
             WHERE (EXISTS {
-                MATCH (this)-[this0:HAS_MANUFACTURER]->(this1:Series)
-                WHERE (this1.name = $param0 AND this0.current = $param1)
+              MATCH (this)-[this0:HAS_MANUFACTURER]->(this1:Series)
+              WHERE (this1.name = $param0 AND this0.current = $param1)
             } OR EXISTS {
-                MATCH (this)-[this2:HAS_BRAND]->(this3:Series)
-                WHERE (this3.name = $param2 AND this2.current = $param3)
+              MATCH (this)-[this2:HAS_BRAND]->(this3:Series)
+              WHERE (this3.name = $param2 AND this2.current = $param3)
             })
             CALL (this) {
-                MATCH (this)-[this4:HAS_BRAND]->(this5:Series)
-                WITH DISTINCT this5
-                WITH this5 { .name } AS this5
-                RETURN collect(this5) AS var6
+              MATCH (this)-[this4:HAS_BRAND]->(this5:Series)
+              WITH DISTINCT this5
+              WITH this5 { .name } AS this5
+              RETURN collect(this5) AS var6
             }
             CALL (this) {
-                MATCH (this)-[this7:HAS_MANUFACTURER]->(this8:Series)
-                WITH DISTINCT this8
-                WITH this8 { .name } AS this8
-                RETURN collect(this8) AS var9
+              MATCH (this)-[this7:HAS_MANUFACTURER]->(this8:Series)
+              WITH DISTINCT this8
+              WITH this8 { .name } AS this8
+              RETURN collect(this8) AS var9
             }
             RETURN this { .name, brand: var6, manufacturer: var9 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/988.test.ts
+++ b/packages/graphql/tests/tck/issues/988.test.ts
@@ -142,34 +142,34 @@ describe("https://github.com/neo4j/graphql/issues/988", () => {
             "CYPHER 5
             MATCH (this:Series)
             WHERE (this.current = $param0 AND ((EXISTS {
-                MATCH (this)-[this0:MANUFACTURER]->(this1:Manufacturer)
-                WHERE (this1.name = $param1 AND this0.current = $param2)
+              MATCH (this)-[this0:MANUFACTURER]->(this1:Manufacturer)
+              WHERE (this1.name = $param1 AND this0.current = $param2)
             } OR EXISTS {
-                MATCH (this)-[this2:MANUFACTURER]->(this3:Manufacturer)
-                WHERE (this3.name = $param3 AND this2.current = $param4)
+              MATCH (this)-[this2:MANUFACTURER]->(this3:Manufacturer)
+              WHERE (this3.name = $param3 AND this2.current = $param4)
             }) AND EXISTS {
-                MATCH (this)-[this4:BRAND]->(this5:Brand)
-                WHERE (this5.name = $param5 AND this4.current = $param6)
+              MATCH (this)-[this4:BRAND]->(this5:Brand)
+              WHERE (this5.name = $param5 AND this4.current = $param6)
             }))
             CALL (this) {
-                MATCH (this)-[this6:MANUFACTURER]->(this7:Manufacturer)
-                WITH collect({ node: this7, relationship: this6 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this7, edge.relationship AS this6
-                    RETURN collect({ properties: { current: this6.current, __resolveType: \\"RelationProps\\" }, node: { name: this7.name, __resolveType: \\"Manufacturer\\" } }) AS var8
-                }
-                RETURN { edges: var8 } AS var9
+              MATCH (this)-[this6:MANUFACTURER]->(this7:Manufacturer)
+              WITH collect({node: this7, relationship: this6}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this7, edge.relationship AS this6
+                RETURN collect({properties: {current: this6.current, __resolveType: 'RelationProps'}, node: {name: this7.name, __resolveType: 'Manufacturer'}}) AS var8
+              }
+              RETURN {edges: var8} AS var9
             }
             CALL (this) {
-                MATCH (this)-[this10:BRAND]->(this11:Brand)
-                WITH collect({ node: this11, relationship: this10 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this11, edge.relationship AS this10
-                    RETURN collect({ properties: { current: this10.current, __resolveType: \\"RelationProps\\" }, node: { name: this11.name, __resolveType: \\"Brand\\" } }) AS var12
-                }
-                RETURN { edges: var12 } AS var13
+              MATCH (this)-[this10:BRAND]->(this11:Brand)
+              WITH collect({node: this11, relationship: this10}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this11, edge.relationship AS this10
+                RETURN collect({properties: {current: this10.current, __resolveType: 'RelationProps'}, node: {name: this11.name, __resolveType: 'Brand'}}) AS var12
+              }
+              RETURN {edges: var12} AS var13
             }
             RETURN this { .name, .current, manufacturerConnection: var9, brandConnection: var13 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/context-variable-not-always-resolved-on-cypher-queries.test.ts
+++ b/packages/graphql/tests/tck/issues/context-variable-not-always-resolved-on-cypher-queries.test.ts
@@ -95,13 +95,13 @@ describe("context-variable-not-always-resolved-on-cypher-queries", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
-            MATCH (this:Exprlabel:test:Resource)
+            MATCH (this:Exprlabel&test&Resource)
             WHERE EXISTS {
-                MATCH (this)-[:realizationOf]->(this0:WorkLabel:test:Resource)
-                WHERE EXISTS {
-                    MATCH (this0)-[:hasResourceType]->(this1:ResourceType)
-                    WHERE this1.uri = $param0
-                }
+              MATCH (this)-[:realizationOf]->(this0:WorkLabel&test&Resource)
+              WHERE EXISTS {
+                MATCH (this0)-[:hasResourceType]->(this1:ResourceType)
+                WHERE this1.uri = $param0
+              }
             }
             WITH *
             LIMIT $param1
@@ -153,30 +153,30 @@ describe("context-variable-not-always-resolved-on-cypher-queries", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
-            MATCH (this:Exprlabel:test:Resource)
+            MATCH (this:Exprlabel&test&Resource)
             WHERE EXISTS {
-                MATCH (this)-[:realizationOf]->(this0:WorkLabel:test:Resource)
-                WHERE EXISTS {
-                    MATCH (this0)-[:hasResourceType]->(this1:ResourceType)
-                    WHERE this1.uri = $param0
-                }
+              MATCH (this)-[:realizationOf]->(this0:WorkLabel&test&Resource)
+              WHERE EXISTS {
+                MATCH (this0)-[:hasResourceType]->(this1:ResourceType)
+                WHERE this1.uri = $param0
+              }
             }
             WITH *
             LIMIT $param1
             CALL (this) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this)-[this2:relToUnion]->(this3:coreRoot:Resource)
-                    WITH this3 { __resolveType: \\"coreRoot\\", __id: id(this3) } AS var4
-                    RETURN var4
-                    UNION
-                    WITH *
-                    MATCH (this)-[this5:relToUnion]->(this6:coreFrag:test:Resource)
-                    WITH this6 { iri: this6.uri, __resolveType: \\"coreFrag\\", __id: id(this6) } AS var4
-                    RETURN var4
-                }
-                WITH var4
-                RETURN collect(var4) AS var4
+              CALL (*) {
+                WITH *
+                MATCH (this)-[this2:relToUnion]->(this3:coreRoot&Resource)
+                WITH this3 { __resolveType: 'coreRoot', __id: elementId(this3) } AS var4
+                RETURN var4
+                UNION
+                WITH *
+                MATCH (this)-[this5:relToUnion]->(this6:coreFrag&test&Resource)
+                WITH this6 { iri: this6.uri, __resolveType: 'coreFrag', __id: elementId(this6) } AS var4
+                RETURN var4
+              }
+              WITH var4
+              RETURN collect(var4) AS var4
             }
             RETURN this { iri: this.uri, relToUnion: var4 } AS this"
         `);
@@ -226,25 +226,25 @@ describe("context-variable-not-always-resolved-on-cypher-queries", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
-            MATCH (this:Exprlabel:test:Resource)
+            MATCH (this:Exprlabel&test&Resource)
             WHERE EXISTS {
-                MATCH (this)-[:realizationOf]->(this0:WorkLabel:test:Resource)
-                WHERE EXISTS {
-                    MATCH (this0)-[:hasResourceType]->(this1:ResourceType)
-                    WHERE this1.uri = $param0
-                }
+              MATCH (this)-[:realizationOf]->(this0:WorkLabel&test&Resource)
+              WHERE EXISTS {
+                MATCH (this0)-[:hasResourceType]->(this1:ResourceType)
+                WHERE this1.uri = $param0
+              }
             }
             WITH *
             LIMIT $param1
             CALL (this) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this)-[this2:relToInterface]->(this3:coreFrag:test:Resource)
-                    WITH this3 { iri: this3.uri, __resolveType: \\"coreFrag\\", __id: id(this3) } AS var4
-                    RETURN var4
-                }
-                WITH var4
-                RETURN collect(var4) AS var4
+              CALL (*) {
+                WITH *
+                MATCH (this)-[this2:relToInterface]->(this3:coreFrag&test&Resource)
+                WITH this3 { iri: this3.uri, __resolveType: 'coreFrag', __id: elementId(this3) } AS var4
+                RETURN var4
+              }
+              WITH var4
+              RETURN collect(var4) AS var4
             }
             RETURN this { iri: this.uri, relToInterface: var4 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/missing-custom-cypher-on-unions.test.ts
+++ b/packages/graphql/tests/tck/issues/missing-custom-cypher-on-unions.test.ts
@@ -153,70 +153,70 @@ describe("Missing custom Cypher on unions", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
-            MATCH (this:HierarchicalComponent:Resource)
+            MATCH (this:HierarchicalComponent&Resource)
             WHERE (this.uri IN $param0 AND EXISTS {
-                MATCH (this)-[:isContained]->(this0:HierarchicalRoot:Resource)
-                WHERE this0.uri = $param1
+              MATCH (this)-[:isContained]->(this0:HierarchicalRoot&Resource)
+              WHERE this0.uri = $param1
             })
             WITH *
             LIMIT $param2
             CALL (this) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this)-[this1:relatesToChild]->(this2:HierarchicalRoot:Resource)
-                    WITH this2 { __resolveType: \\"HierarchicalRoot\\", __id: id(this2) } AS var3
-                    RETURN var3
-                    UNION
-                    WITH *
-                    MATCH (this)-[this4:relatesToChild]->(this5:HierarchicalComponent:Resource)
-                    CALL (this5) {
-                        CALL (this5) {
-                            WITH this5 AS this
-                            MATCH p=(this)<-[:relatesToChild*..10]-(parent:HierarchicalRoot)
-                            WITH p, parent
-                            OPTIONAL MATCH (parent) - [:type] -> (parentType)
-                            WITH p, parent, parentType
-                            UNWIND nodes(p) as pathNode
-                            WITH pathNode, relationships(p) as rels, parent, parentType
-                            WITH pathNode, head([r in rels where endNode(r) = pathNode]) as relation, parent, parentType
-                            OPTIONAL MATCH (pathNode) - [:identifier] -> (pathNodeIdentifier)
-                            OPTIONAL MATCH (pathNode) - [:title] -> (pathNodeTitle)
-                            WITH pathNode, relation, parent, parentType, pathNodeIdentifier, collect({value: pathNodeTitle.value, language: pathNodeTitle.language}) as pathNodeTitles
-                            WITH {
-                            uri: pathNode.uri,
-                            identifier: pathNodeIdentifier.value,
-                            title: pathNodeTitles,
-                            hasSortKey: relation.hasSortKey,
-                            labels: labels(pathNode),
-                            partOf: parent.uri,
-                            partOfType: parentType.uri
-                            } AS obj
-                            RETURN DISTINCT obj as result
-                        }
-                        WITH result AS this6
-                        WITH this6 { .hasSortKey, iri: this6.uri } AS this6
-                        RETURN collect(this6) AS var7
-                    }
-                    WITH this5 { hierarchicalPathNodes: var7, __resolveType: \\"HierarchicalComponent\\", __id: id(this5) } AS var3
-                    RETURN var3
-                    UNION
-                    WITH *
-                    MATCH (this)-[this8:relatesToChild]->(this9:Expression:MyTenant:Resource)
-                    WITH this9 { __resolveType: \\"Expression\\", __id: id(this9) } AS var3
-                    RETURN var3
-                    UNION
-                    WITH *
-                    MATCH (this)-[this10:relatesToChild]->(this11:Work:MyTenant:Resource)
-                    WITH this11 { __resolveType: \\"Work\\", __id: id(this11) } AS var3
-                    RETURN var3
-                    UNION
-                    WITH *
-                    MATCH (this)-[this12:relatesToChild]->(this13:Fragment:MyTenant:Resource)
-                    WITH this13 { __resolveType: \\"Fragment\\", __id: id(this13) } AS var3
-                    RETURN var3
+              CALL (*) {
+                WITH *
+                MATCH (this)-[this1:relatesToChild]->(this2:HierarchicalRoot&Resource)
+                WITH this2 { __resolveType: 'HierarchicalRoot', __id: elementId(this2) } AS var3
+                RETURN var3
+                UNION
+                WITH *
+                MATCH (this)-[this4:relatesToChild]->(this5:HierarchicalComponent&Resource)
+                CALL (this5) {
+                  CALL (this5) {
+                    WITH this5 AS this
+                    MATCH p=(this)<-[:relatesToChild*..10]-(parent:HierarchicalRoot)
+                    WITH p, parent
+                    OPTIONAL MATCH (parent) - [:type] -> (parentType)
+                    WITH p, parent, parentType
+                    UNWIND nodes(p) as pathNode
+                    WITH pathNode, relationships(p) as rels, parent, parentType
+                    WITH pathNode, head([r in rels where endNode(r) = pathNode]) as relation, parent, parentType
+                    OPTIONAL MATCH (pathNode) - [:identifier] -> (pathNodeIdentifier)
+                    OPTIONAL MATCH (pathNode) - [:title] -> (pathNodeTitle)
+                    WITH pathNode, relation, parent, parentType, pathNodeIdentifier, collect({value: pathNodeTitle.value, language: pathNodeTitle.language}) as pathNodeTitles
+                    WITH {
+                    uri: pathNode.uri,
+                    identifier: pathNodeIdentifier.value,
+                    title: pathNodeTitles,
+                    hasSortKey: relation.hasSortKey,
+                    labels: labels(pathNode),
+                    partOf: parent.uri,
+                    partOfType: parentType.uri
+                    } AS obj
+                    RETURN DISTINCT obj as result
+                  }
+                  WITH result AS this6
+                  WITH this6 { .hasSortKey, iri: this6.uri } AS this6
+                  RETURN collect(this6) AS var7
                 }
-                WITH var3
-                RETURN collect(var3) AS var3
+                WITH this5 { hierarchicalPathNodes: var7, __resolveType: 'HierarchicalComponent', __id: elementId(this5) } AS var3
+                RETURN var3
+                UNION
+                WITH *
+                MATCH (this)-[this8:relatesToChild]->(this9:Expression&MyTenant&Resource)
+                WITH this9 { __resolveType: 'Expression', __id: elementId(this9) } AS var3
+                RETURN var3
+                UNION
+                WITH *
+                MATCH (this)-[this10:relatesToChild]->(this11:Work&MyTenant&Resource)
+                WITH this11 { __resolveType: 'Work', __id: elementId(this11) } AS var3
+                RETURN var3
+                UNION
+                WITH *
+                MATCH (this)-[this12:relatesToChild]->(this13:Fragment&MyTenant&Resource)
+                WITH this13 { __resolveType: 'Fragment', __id: elementId(this13) } AS var3
+                RETURN var3
+              }
+              WITH var3
+              RETURN collect(var3) AS var3
             }
             RETURN this { relatesToChild: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/math.test.ts
+++ b/packages/graphql/tests/tck/math.test.ts
@@ -77,12 +77,11 @@ describe("Math operators", () => {
             "CYPHER 5
             MATCH (this:Movie)
             WITH *
-            SET
-                this.viewers = (this.viewers + $param0)
+            SET this.viewers = (this.viewers + $param0)
             WITH *
             CALL (*) {
-                CALL apoc.util.validate(this.viewers IS NULL, \\"Cannot %s %s to Nan\\", [\\"increment\\", $param0])
-                CALL apoc.util.validate((this.viewers + $param0) > ((2 ^ 31) - 1), \\"Overflow: Value returned from operator %s is larger than %s bit\\", [\\"increment\\", 32])
+              CALL apoc.util.validate(this.viewers IS NULL, 'Cannot %s %s to Nan', ['increment', $param0])
+              CALL apoc.util.validate((this.viewers + $param0) > ((2 ^ 31) - 1), 'Overflow: Value returned from operator %s is larger than %s bit', ['increment', 32])
             }
             WITH this
             RETURN this { .id, .viewers } AS this"
@@ -115,12 +114,11 @@ describe("Math operators", () => {
             "CYPHER 5
             MATCH (this:Movie)
             WITH *
-            SET
-                this.revenue = (this.revenue * $param0)
+            SET this.revenue = (this.revenue * $param0)
             WITH *
             CALL (*) {
-                CALL apoc.util.validate(this.revenue IS NULL, \\"Cannot %s %s to Nan\\", [\\"multiply\\", $param0])
-                CALL apoc.util.validate((this.revenue * $param0) > ((2 ^ 63) - 1), \\"Overflow: Value returned from operator %s is larger than %s bit\\", [\\"multiply\\", 64])
+              CALL apoc.util.validate(this.revenue IS NULL, 'Cannot %s %s to Nan', ['multiply', $param0])
+              CALL apoc.util.validate((this.revenue * $param0) > ((2 ^ 63) - 1), 'Overflow: Value returned from operator %s is larger than %s bit', ['multiply', 64])
             }
             WITH this
             RETURN this { .id, .revenue } AS this"
@@ -154,22 +152,21 @@ describe("Math operators", () => {
             WITH *
             WITH *
             CALL (*) {
-                MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                WITH *
-                SET
-                    this1.viewers = (this1.viewers + $param0)
-                WITH *
-                CALL (*) {
-                    CALL apoc.util.validate(this1.viewers IS NULL, \\"Cannot %s %s to Nan\\", [\\"increment\\", $param0])
-                    CALL apoc.util.validate((this1.viewers + $param0) > ((2 ^ 31) - 1), \\"Overflow: Value returned from operator %s is larger than %s bit\\", [\\"increment\\", 32])
-                }
+              MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+              WITH *
+              SET this1.viewers = (this1.viewers + $param0)
+              WITH *
+              CALL (*) {
+                CALL apoc.util.validate(this1.viewers IS NULL, 'Cannot %s %s to Nan', ['increment', $param0])
+                CALL apoc.util.validate((this1.viewers + $param0) > ((2 ^ 31) - 1), 'Overflow: Value returned from operator %s is larger than %s bit', ['increment', 32])
+              }
             }
             WITH this
             CALL (this) {
-                MATCH (this)-[this2:ACTED_IN]->(this3:Movie)
-                WITH DISTINCT this3
-                WITH this3 { .viewers } AS this3
-                RETURN collect(this3) AS var4
+              MATCH (this)-[this2:ACTED_IN]->(this3:Movie)
+              WITH DISTINCT this3
+              WITH this3 { .viewers } AS this3
+              RETURN collect(this3) AS var4
             }
             RETURN this { .name, actedIn: var4 } AS this"
         `);
@@ -212,32 +209,31 @@ describe("Math operators", () => {
             WITH *
             WITH *
             CALL (*) {
-                MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                WITH *
-                SET
-                    this0.pay = (this0.pay + $param0)
-                WITH *
-                CALL (*) {
-                    CALL apoc.util.validate(this0.pay IS NULL, \\"Cannot %s %s to Nan\\", [\\"add\\", $param0])
-                    CALL apoc.util.validate((this0.pay + $param0) > ((2 ^ 63) - 1), \\"Overflow: Value returned from operator %s is larger than %s bit\\", [\\"add\\", 64])
-                }
+              MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+              WITH *
+              SET this0.pay = (this0.pay + $param0)
+              WITH *
+              CALL (*) {
+                CALL apoc.util.validate(this0.pay IS NULL, 'Cannot %s %s to Nan', ['add', $param0])
+                CALL apoc.util.validate((this0.pay + $param0) > ((2 ^ 63) - 1), 'Overflow: Value returned from operator %s is larger than %s bit', ['add', 64])
+              }
             }
             WITH this
             CALL (this) {
-                MATCH (this)-[this2:ACTED_IN]->(this3:Movie)
-                WITH DISTINCT this3
-                WITH this3 { .title } AS this3
-                RETURN collect(this3) AS var4
+              MATCH (this)-[this2:ACTED_IN]->(this3:Movie)
+              WITH DISTINCT this3
+              WITH this3 { .title } AS this3
+              RETURN collect(this3) AS var4
             }
             CALL (this) {
-                MATCH (this)-[this5:ACTED_IN]->(this6:Movie)
-                WITH collect({ node: this6, relationship: this5 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS this6, edge.relationship AS this5
-                    RETURN collect({ properties: { pay: this5.pay, __resolveType: \\"ActedIn\\" }, node: { __id: id(this6), __resolveType: \\"Movie\\" } }) AS var7
-                }
-                RETURN { edges: var7 } AS var8
+              MATCH (this)-[this5:ACTED_IN]->(this6:Movie)
+              WITH collect({node: this6, relationship: this5}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS this6, edge.relationship AS this5
+                RETURN collect({properties: {pay: this5.pay, __resolveType: 'ActedIn'}, node: {__id: elementId(this6), __resolveType: 'Movie'}}) AS var7
+              }
+              RETURN {edges: var7} AS var8
             }
             RETURN this { .name, actedIn: var4, actedInConnection: var8 } AS this"
         `);
@@ -270,26 +266,25 @@ describe("Math operators", () => {
             WITH *
             WITH *
             CALL (*) {
-                MATCH (this)-[this0:MARRIED_WITH]->(this1:Star)
-                WITH *
-                SET
-                    this1.marriageLength = (this1.marriageLength + $param0)
-                WITH *
-                CALL (*) {
-                    CALL apoc.util.validate(this1.marriageLength IS NULL, \\"Cannot %s %s to Nan\\", [\\"increment\\", $param0])
-                    CALL apoc.util.validate((this1.marriageLength + $param0) > ((2 ^ 31) - 1), \\"Overflow: Value returned from operator %s is larger than %s bit\\", [\\"increment\\", 32])
-                }
+              MATCH (this)-[this0:MARRIED_WITH]->(this1:Star)
+              WITH *
+              SET this1.marriageLength = (this1.marriageLength + $param0)
+              WITH *
+              CALL (*) {
+                CALL apoc.util.validate(this1.marriageLength IS NULL, 'Cannot %s %s to Nan', ['increment', $param0])
+                CALL apoc.util.validate((this1.marriageLength + $param0) > ((2 ^ 31) - 1), 'Overflow: Value returned from operator %s is larger than %s bit', ['increment', 32])
+              }
             }
             WITH this
             CALL (this) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this)-[this2:MARRIED_WITH]->(this3:Star)
-                    WITH this3 { .marriageLength, __resolveType: \\"Star\\", __id: id(this3) } AS var4
-                    RETURN var4
-                }
-                WITH var4
-                RETURN collect(var4) AS var4
+              CALL (*) {
+                WITH *
+                MATCH (this)-[this2:MARRIED_WITH]->(this3:Star)
+                WITH this3 { .marriageLength, __resolveType: 'Star', __id: elementId(this3) } AS var4
+                RETURN var4
+              }
+              WITH var4
+              RETURN collect(var4) AS var4
             }
             RETURN this { .name, marriedWith: var4 } AS this"
         `);

--- a/packages/graphql/tests/tck/nested-unions.test.ts
+++ b/packages/graphql/tests/tck/nested-unions.test.ts
@@ -98,50 +98,50 @@ describe("Nested Unions", () => {
             WHERE this.title = $param0
             WITH *
             CALL (*) {
-                CALL (this) {
-                    MATCH (this0:LeadActor)
-                    WHERE this0.name = $param1
-                    CALL (this0) {
-                        MATCH (this1:Movie)
-                        CREATE (this0)-[this2:ACTED_IN]->(this1)
-                    }
-                    CALL (this0) {
-                        MATCH (this3:Series)
-                        CREATE (this0)-[this4:ACTED_IN]->(this3)
-                    }
-                    CREATE (this)<-[this5:ACTED_IN]-(this0)
+              CALL (this) {
+                MATCH (this0:LeadActor)
+                WHERE this0.name = $param1
+                CALL (this0) {
+                  MATCH (this1:Movie)
+                  CREATE (this0)-[this2:ACTED_IN]->(this1)
                 }
+                CALL (this0) {
+                  MATCH (this3:Series)
+                  CREATE (this0)-[this4:ACTED_IN]->(this3)
+                }
+                CREATE (this)<-[this5:ACTED_IN]-(this0)
+              }
             }
             WITH this
             CALL (this) {
-                CALL (*) {
+              CALL (*) {
+                WITH *
+                MATCH (this)<-[this6:ACTED_IN]-(this7:LeadActor)
+                CALL (this7) {
+                  CALL (*) {
                     WITH *
-                    MATCH (this)<-[this6:ACTED_IN]-(this7:LeadActor)
-                    CALL (this7) {
-                        CALL (*) {
-                            WITH *
-                            MATCH (this7)-[this8:ACTED_IN]->(this9:Movie)
-                            WITH this9 { __resolveType: \\"Movie\\", __id: id(this9) } AS var10
-                            RETURN var10
-                            UNION
-                            WITH *
-                            MATCH (this7)-[this11:ACTED_IN]->(this12:Series)
-                            WITH this12 { .name, __resolveType: \\"Series\\", __id: id(this12) } AS var10
-                            RETURN var10
-                        }
-                        WITH var10
-                        RETURN collect(var10) AS var10
-                    }
-                    WITH this7 { .name, actedIn: var10, __resolveType: \\"LeadActor\\", __id: id(this7) } AS var13
-                    RETURN var13
+                    MATCH (this7)-[this8:ACTED_IN]->(this9:Movie)
+                    WITH this9 { __resolveType: 'Movie', __id: elementId(this9) } AS var10
+                    RETURN var10
                     UNION
                     WITH *
-                    MATCH (this)<-[this14:ACTED_IN]-(this15:Extra)
-                    WITH this15 { __resolveType: \\"Extra\\", __id: id(this15) } AS var13
-                    RETURN var13
+                    MATCH (this7)-[this11:ACTED_IN]->(this12:Series)
+                    WITH this12 { .name, __resolveType: 'Series', __id: elementId(this12) } AS var10
+                    RETURN var10
+                  }
+                  WITH var10
+                  RETURN collect(var10) AS var10
                 }
-                WITH var13
-                RETURN collect(var13) AS var13
+                WITH this7 { .name, actedIn: var10, __resolveType: 'LeadActor', __id: elementId(this7) } AS var13
+                RETURN var13
+                UNION
+                WITH *
+                MATCH (this)<-[this14:ACTED_IN]-(this15:Extra)
+                WITH this15 { __resolveType: 'Extra', __id: elementId(this15) } AS var13
+                RETURN var13
+              }
+              WITH var13
+              RETURN collect(var13) AS var13
             }
             RETURN this { .title, actors: var13 } AS this"
         `);
@@ -196,57 +196,57 @@ describe("Nested Unions", () => {
             WHERE this.title = $param0
             WITH *
             CALL (*) {
-                CALL (this) {
-                    OPTIONAL MATCH (this)<-[this0:ACTED_IN]-(this1:LeadActor)
-                    WHERE this1.name = $param1
-                    CALL (this1) {
-                        CALL (this1) {
-                            OPTIONAL MATCH (this1)-[this2:ACTED_IN]->(this3:Movie)
-                            WITH *
-                            DELETE this2
-                        }
-                    }
-                    CALL (this1) {
-                        CALL (this1) {
-                            OPTIONAL MATCH (this1)-[this4:ACTED_IN]->(this5:Series)
-                            WITH *
-                            DELETE this4
-                        }
-                    }
+              CALL (this) {
+                OPTIONAL MATCH (this)<-[this0:ACTED_IN]-(this1:LeadActor)
+                WHERE this1.name = $param1
+                CALL (this1) {
+                  CALL (this1) {
+                    OPTIONAL MATCH (this1)-[this2:ACTED_IN]->(this3:Movie)
                     WITH *
-                    DELETE this0
+                    DELETE this2
+                  }
                 }
+                CALL (this1) {
+                  CALL (this1) {
+                    OPTIONAL MATCH (this1)-[this4:ACTED_IN]->(this5:Series)
+                    WITH *
+                    DELETE this4
+                  }
+                }
+                WITH *
+                DELETE this0
+              }
             }
             WITH this
             CALL (this) {
-                CALL (*) {
+              CALL (*) {
+                WITH *
+                MATCH (this)<-[this6:ACTED_IN]-(this7:LeadActor)
+                CALL (this7) {
+                  CALL (*) {
                     WITH *
-                    MATCH (this)<-[this6:ACTED_IN]-(this7:LeadActor)
-                    CALL (this7) {
-                        CALL (*) {
-                            WITH *
-                            MATCH (this7)-[this8:ACTED_IN]->(this9:Movie)
-                            WITH this9 { __resolveType: \\"Movie\\", __id: id(this9) } AS var10
-                            RETURN var10
-                            UNION
-                            WITH *
-                            MATCH (this7)-[this11:ACTED_IN]->(this12:Series)
-                            WITH this12 { .name, __resolveType: \\"Series\\", __id: id(this12) } AS var10
-                            RETURN var10
-                        }
-                        WITH var10
-                        RETURN collect(var10) AS var10
-                    }
-                    WITH this7 { .name, actedIn: var10, __resolveType: \\"LeadActor\\", __id: id(this7) } AS var13
-                    RETURN var13
+                    MATCH (this7)-[this8:ACTED_IN]->(this9:Movie)
+                    WITH this9 { __resolveType: 'Movie', __id: elementId(this9) } AS var10
+                    RETURN var10
                     UNION
                     WITH *
-                    MATCH (this)<-[this14:ACTED_IN]-(this15:Extra)
-                    WITH this15 { __resolveType: \\"Extra\\", __id: id(this15) } AS var13
-                    RETURN var13
+                    MATCH (this7)-[this11:ACTED_IN]->(this12:Series)
+                    WITH this12 { .name, __resolveType: 'Series', __id: elementId(this12) } AS var10
+                    RETURN var10
+                  }
+                  WITH var10
+                  RETURN collect(var10) AS var10
                 }
-                WITH var13
-                RETURN collect(var13) AS var13
+                WITH this7 { .name, actedIn: var10, __resolveType: 'LeadActor', __id: elementId(this7) } AS var13
+                RETURN var13
+                UNION
+                WITH *
+                MATCH (this)<-[this14:ACTED_IN]-(this15:Extra)
+                WITH this15 { __resolveType: 'Extra', __id: elementId(this15) } AS var13
+                RETURN var13
+              }
+              WITH var13
+              RETURN collect(var13) AS var13
             }
             RETURN this { .title, actors: var13 } AS this"
         `);

--- a/packages/graphql/tests/tck/operations/batch/batch-create-auth.test.ts
+++ b/packages/graphql/tests/tck/operations/batch/batch-create-auth.test.ts
@@ -85,12 +85,11 @@ describe("Batch Create, Auth", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Movie)
-                SET
-                    create_this1.id = create_var0.id
-                WITH *
-                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $create_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                RETURN create_this1
+              CREATE (create_this1:Movie)
+              SET create_this1.id = create_var0.id
+              WITH *
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $create_param3 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
+              RETURN create_this1
             }
             RETURN collect(create_this1 { .id }) AS data"
         `);
@@ -141,31 +140,29 @@ describe("Batch Create, Auth", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Movie)
+              CREATE (create_this1:Movie)
+              SET create_this1.id = create_var0.id
+              WITH create_this1, create_var0
+              CALL (create_this1, create_var0) {
+                UNWIND create_var0.actors.create AS create_var2
+                CREATE (create_this3:Actor)
                 SET
-                    create_this1.id = create_var0.id
-                WITH create_this1, create_var0
-                CALL (create_this1, create_var0) {
-                    UNWIND create_var0.actors.create AS create_var2
-                    CREATE (create_this3:Actor)
-                    SET
-                        create_this3.id = randomUUID(),
-                        create_this3.name = create_var2.node.name
-                    MERGE (create_this1)<-[create_this4:ACTED_IN]-(create_this3)
-                    SET
-                        create_this4.year = create_var2.edge.year
-                    RETURN collect(NULL) AS create_var5
-                }
-                WITH *
-                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $create_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                RETURN create_this1
+                  create_this3.id = randomUUID(),
+                  create_this3.name = create_var2.node.name
+                MERGE (create_this1)<-[create_this4:ACTED_IN]-(create_this3)
+                SET create_this4.year = create_var2.edge.year
+                RETURN collect(NULL) AS create_var5
+              }
+              WITH *
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $create_param3 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
+              RETURN create_this1
             }
             CALL (create_this1) {
-                MATCH (create_this1)<-[create_this6:ACTED_IN]-(create_this7:Actor)
-                WITH DISTINCT create_this7
-                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND create_this7.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                WITH create_this7 { .name } AS create_this7
-                RETURN collect(create_this7) AS create_var8
+              MATCH (create_this1)<-[create_this6:ACTED_IN]-(create_this7:Actor)
+              WITH DISTINCT create_this7
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND create_this7.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
+              WITH create_this7 { .name } AS create_this7
+              RETURN collect(create_this7) AS create_var8
             }
             RETURN collect(create_this1 { .id, actors: create_var8 }) AS data"
         `);

--- a/packages/graphql/tests/tck/operations/batch/batch-create-fields.test.ts
+++ b/packages/graphql/tests/tck/operations/batch/batch-create-fields.test.ts
@@ -80,13 +80,13 @@ describe("Batch Create, Scalar types", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Movie)
-                SET
-                    create_this1.createdAt = datetime(),
-                    create_this1.id = create_var0.id,
-                    create_this1.runningTime = create_var0.runningTime,
-                    create_this1.location = point(create_var0.location)
-                RETURN create_this1
+              CREATE (create_this1:Movie)
+              SET
+                create_this1.createdAt = datetime(),
+                create_this1.id = create_var0.id,
+                create_this1.runningTime = create_var0.runningTime,
+                create_this1.location = point(create_var0.location)
+              RETURN create_this1
             }
             RETURN collect(create_this1 { .id }) AS data"
         `);
@@ -150,42 +150,39 @@ describe("Batch Create, Scalar types", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Movie)
+              CREATE (create_this1:Movie)
+              SET
+                create_this1.createdAt = datetime(),
+                create_this1.id = create_var0.id
+              WITH create_this1, create_var0
+              CALL (create_this1, create_var0) {
+                UNWIND create_var0.actors.create AS create_var2
+                CREATE (create_this3:Actor)
                 SET
-                    create_this1.createdAt = datetime(),
-                    create_this1.id = create_var0.id
-                WITH create_this1, create_var0
-                CALL (create_this1, create_var0) {
-                    UNWIND create_var0.actors.create AS create_var2
-                    CREATE (create_this3:Actor)
-                    SET
-                        create_this3.id = randomUUID(),
-                        create_this3.createdAt = datetime(),
-                        create_this3.name = create_var2.node.name
-                    MERGE (create_this1)<-[create_this4:ACTED_IN]-(create_this3)
-                    SET
-                        create_this4.year = create_var2.edge.year
-                    WITH create_this3, create_var2
-                    CALL (create_this3, create_var2) {
-                        UNWIND create_var2.node.website.create AS create_var5
-                        CREATE (create_this6:Website)
-                        SET
-                            create_this6.address = create_var5.node.address
-                        MERGE (create_this3)-[create_this7:HAS_WEBSITE]->(create_this6)
-                        RETURN collect(NULL) AS create_var8
-                    }
-                    RETURN collect(NULL) AS create_var9
+                  create_this3.id = randomUUID(),
+                  create_this3.createdAt = datetime(),
+                  create_this3.name = create_var2.node.name
+                MERGE (create_this1)<-[create_this4:ACTED_IN]-(create_this3)
+                SET create_this4.year = create_var2.edge.year
+                WITH create_this3, create_var2
+                CALL (create_this3, create_var2) {
+                  UNWIND create_var2.node.website.create AS create_var5
+                  CREATE (create_this6:Website)
+                  SET create_this6.address = create_var5.node.address
+                  MERGE (create_this3)-[create_this7:HAS_WEBSITE]->(create_this6)
+                  RETURN collect(NULL) AS create_var8
                 }
-                WITH create_this1, create_var0
-                CALL (create_this1, create_var0) {
-                    UNWIND create_var0.website.create AS create_var10
-                    CREATE (create_this11:Website)
-                    SET
-                        create_this11.address = create_var10.node.address
-                    MERGE (create_this1)-[create_this12:HAS_WEBSITE]->(create_this11)
-                    RETURN collect(NULL) AS create_var13
-                }
-                RETURN create_this1
+                RETURN collect(NULL) AS create_var9
+              }
+              WITH create_this1, create_var0
+              CALL (create_this1, create_var0) {
+                UNWIND create_var0.website.create AS create_var10
+                CREATE (create_this11:Website)
+                SET create_this11.address = create_var10.node.address
+                MERGE (create_this1)-[create_this12:HAS_WEBSITE]->(create_this11)
+                RETURN collect(NULL) AS create_var13
+              }
+              RETURN create_this1
             }
             RETURN collect(create_this1 { .id }) AS data"
         `);
@@ -262,30 +259,29 @@ describe("Batch Create, Scalar types", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Movie)
+              CREATE (create_this1:Movie)
+              SET
+                create_this1.createdAt = datetime(),
+                create_this1.id = create_var0.id
+              WITH create_this1, create_var0
+              CALL (create_this1, create_var0) {
+                UNWIND create_var0.actors.create AS create_var2
+                CREATE (create_this3:Actor)
                 SET
-                    create_this1.createdAt = datetime(),
-                    create_this1.id = create_var0.id
-                WITH create_this1, create_var0
-                CALL (create_this1, create_var0) {
-                    UNWIND create_var0.actors.create AS create_var2
-                    CREATE (create_this3:Actor)
-                    SET
-                        create_this3.id = randomUUID(),
-                        create_this3.createdAt = datetime(),
-                        create_this3.name = create_var2.node.name
-                    MERGE (create_this1)<-[create_this4:ACTED_IN]-(create_this3)
-                    SET
-                        create_this4.year = create_var2.edge.year
-                    RETURN collect(NULL) AS create_var5
-                }
-                RETURN create_this1
+                  create_this3.id = randomUUID(),
+                  create_this3.createdAt = datetime(),
+                  create_this3.name = create_var2.node.name
+                MERGE (create_this1)<-[create_this4:ACTED_IN]-(create_this3)
+                SET create_this4.year = create_var2.edge.year
+                RETURN collect(NULL) AS create_var5
+              }
+              RETURN create_this1
             }
             CALL (create_this1) {
-                MATCH (create_this1)<-[create_this6:ACTED_IN]-(create_this7:Actor)
-                WITH DISTINCT create_this7
-                WITH create_this7 { .name } AS create_this7
-                RETURN collect(create_this7) AS create_var8
+              MATCH (create_this1)<-[create_this6:ACTED_IN]-(create_this7:Actor)
+              WITH DISTINCT create_this7
+              WITH create_this7 { .name } AS create_this7
+              RETURN collect(create_this7) AS create_var8
             }
             RETURN collect(create_this1 { .id, actors: create_var8 }) AS data"
         `);

--- a/packages/graphql/tests/tck/operations/batch/batch-create-interface.test.ts
+++ b/packages/graphql/tests/tck/operations/batch/batch-create-interface.test.ts
@@ -82,10 +82,9 @@ describe("Batch Create, Interface", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Movie)
-                SET
-                    create_this1.id = create_var0.id
-                RETURN create_this1
+              CREATE (create_this1:Movie)
+              SET create_this1.id = create_var0.id
+              RETURN create_this1
             }
             RETURN collect(create_this1 { .id }) AS data"
         `);
@@ -138,48 +137,46 @@ describe("Batch Create, Interface", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                CREATE (this0:Movie)
-                SET
-                    this0.id = $param0
-                WITH *
-                CREATE (this1:Actor)
-                MERGE (this0)<-[this2:EMPLOYED]-(this1)
-                SET
-                    this1.id = $param1,
-                    this1.name = $param2,
-                    this2.year = $param3
-                RETURN this0 AS this
-                UNION
-                CREATE (this3:Movie)
-                SET
-                    this3.id = $param4
-                WITH *
-                CREATE (this4:Modeler)
-                MERGE (this3)<-[this5:EMPLOYED]-(this4)
-                SET
-                    this4.id = $param5,
-                    this4.name = $param6,
-                    this5.year = $param7
-                RETURN this3 AS this
+              CREATE (this0:Movie)
+              SET this0.id = $param0
+              WITH *
+              CREATE (this1:Actor)
+              MERGE (this0)<-[this2:EMPLOYED]-(this1)
+              SET
+                this1.id = $param1,
+                this1.name = $param2,
+                this2.year = $param3
+              RETURN this0 AS this
+              UNION
+              CREATE (this3:Movie)
+              SET this3.id = $param4
+              WITH *
+              CREATE (this4:Modeler)
+              MERGE (this3)<-[this5:EMPLOYED]-(this4)
+              SET
+                this4.id = $param5,
+                this4.name = $param6,
+                this5.year = $param7
+              RETURN this3 AS this
             }
             WITH this
             CALL (this) {
-                CALL (this) {
-                    CALL (*) {
-                        WITH *
-                        MATCH (this)<-[this6:EMPLOYED]-(this7:Actor)
-                        WITH this7 { .name, __resolveType: \\"Actor\\", __id: id(this7) } AS var8
-                        RETURN var8
-                        UNION
-                        WITH *
-                        MATCH (this)<-[this9:EMPLOYED]-(this10:Modeler)
-                        WITH this10 { .name, __resolveType: \\"Modeler\\", __id: id(this10) } AS var8
-                        RETURN var8
-                    }
-                    WITH var8
-                    RETURN collect(var8) AS var8
+              CALL (this) {
+                CALL (*) {
+                  WITH *
+                  MATCH (this)<-[this6:EMPLOYED]-(this7:Actor)
+                  WITH this7 { .name, __resolveType: 'Actor', __id: elementId(this7) } AS var8
+                  RETURN var8
+                  UNION
+                  WITH *
+                  MATCH (this)<-[this9:EMPLOYED]-(this10:Modeler)
+                  WITH this10 { .name, __resolveType: 'Modeler', __id: elementId(this10) } AS var8
+                  RETURN var8
                 }
-                RETURN this { .id, workers: var8 } AS var11
+                WITH var8
+                RETURN collect(var8) AS var8
+              }
+              RETURN this { .id, workers: var8 } AS var11
             }
             RETURN collect(var11) AS data"
         `);
@@ -243,81 +240,76 @@ describe("Batch Create, Interface", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                CREATE (this0:Movie)
-                SET
-                    this0.id = $param0
-                WITH *
-                CREATE (this1:Actor)
-                MERGE (this0)<-[this2:EMPLOYED]-(this1)
-                SET
-                    this1.id = $param1,
-                    this1.name = $param2,
-                    this2.year = $param3
-                RETURN this0 AS this
-                UNION
-                CREATE (this3:Movie)
-                SET
-                    this3.id = $param4
-                WITH *
-                CREATE (this4:Actor)
-                MERGE (this3)<-[this5:EMPLOYED]-(this4)
-                SET
-                    this4.id = $param5,
-                    this4.name = $param6,
-                    this5.year = $param7
-                RETURN this3 AS this
-                UNION
-                CREATE (this6:Movie)
-                SET
-                    this6.id = $param8
-                WITH *
-                CREATE (this7:Website)
-                MERGE (this6)-[this8:HAS_WEBSITE]->(this7)
-                SET
-                    this7.address = $param9
-                RETURN this6 AS this
-                UNION
-                CREATE (this9:Movie)
-                SET
-                    this9.id = $param10
-                WITH *
-                CALL (this9) {
-                    MATCH (this10:Actor)
-                    WHERE this10.id = $param11
-                    CREATE (this9)<-[this11:EMPLOYED]-(this10)
-                }
-                WITH *
-                CALL (this9) {
-                    MATCH (this12:Modeler)
-                    WHERE this12.id = $param12
-                    CREATE (this9)<-[this13:EMPLOYED]-(this12)
-                }
-                RETURN this9 AS this
+              CREATE (this0:Movie)
+              SET this0.id = $param0
+              WITH *
+              CREATE (this1:Actor)
+              MERGE (this0)<-[this2:EMPLOYED]-(this1)
+              SET
+                this1.id = $param1,
+                this1.name = $param2,
+                this2.year = $param3
+              RETURN this0 AS this
+              UNION
+              CREATE (this3:Movie)
+              SET this3.id = $param4
+              WITH *
+              CREATE (this4:Actor)
+              MERGE (this3)<-[this5:EMPLOYED]-(this4)
+              SET
+                this4.id = $param5,
+                this4.name = $param6,
+                this5.year = $param7
+              RETURN this3 AS this
+              UNION
+              CREATE (this6:Movie)
+              SET this6.id = $param8
+              WITH *
+              CREATE (this7:Website)
+              MERGE (this6)-[this8:HAS_WEBSITE]->(this7)
+              SET this7.address = $param9
+              RETURN this6 AS this
+              UNION
+              CREATE (this9:Movie)
+              SET this9.id = $param10
+              WITH *
+              CALL (this9) {
+                MATCH (this10:Actor)
+                WHERE this10.id = $param11
+                CREATE (this9)<-[this11:EMPLOYED]-(this10)
+              }
+              WITH *
+              CALL (this9) {
+                MATCH (this12:Modeler)
+                WHERE this12.id = $param12
+                CREATE (this9)<-[this13:EMPLOYED]-(this12)
+              }
+              RETURN this9 AS this
             }
             WITH this
             CALL (this) {
-                CALL (this) {
-                    MATCH (this)-[this14:HAS_WEBSITE]->(this15:Website)
-                    WITH DISTINCT this15
-                    WITH this15 { .address } AS this15
-                    RETURN collect(this15) AS var16
+              CALL (this) {
+                MATCH (this)-[this14:HAS_WEBSITE]->(this15:Website)
+                WITH DISTINCT this15
+                WITH this15 { .address } AS this15
+                RETURN collect(this15) AS var16
+              }
+              CALL (this) {
+                CALL (*) {
+                  WITH *
+                  MATCH (this)<-[this17:EMPLOYED]-(this18:Actor)
+                  WITH this18 { .name, __resolveType: 'Actor', __id: elementId(this18) } AS var19
+                  RETURN var19
+                  UNION
+                  WITH *
+                  MATCH (this)<-[this20:EMPLOYED]-(this21:Modeler)
+                  WITH this21 { .name, __resolveType: 'Modeler', __id: elementId(this21) } AS var19
+                  RETURN var19
                 }
-                CALL (this) {
-                    CALL (*) {
-                        WITH *
-                        MATCH (this)<-[this17:EMPLOYED]-(this18:Actor)
-                        WITH this18 { .name, __resolveType: \\"Actor\\", __id: id(this18) } AS var19
-                        RETURN var19
-                        UNION
-                        WITH *
-                        MATCH (this)<-[this20:EMPLOYED]-(this21:Modeler)
-                        WITH this21 { .name, __resolveType: \\"Modeler\\", __id: id(this21) } AS var19
-                        RETURN var19
-                    }
-                    WITH var19
-                    RETURN collect(var19) AS var19
-                }
-                RETURN this { .id, website: var16, workers: var19 } AS var22
+                WITH var19
+                RETURN collect(var19) AS var19
+              }
+              RETURN this { .id, website: var16, workers: var19 } AS var22
             }
             RETURN collect(var22) AS data"
         `);

--- a/packages/graphql/tests/tck/operations/batch/batch-create.test.ts
+++ b/packages/graphql/tests/tck/operations/batch/batch-create.test.ts
@@ -70,10 +70,9 @@ describe("Batch Create", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Movie)
-                SET
-                    create_this1.id = create_var0.id
-                RETURN create_this1
+              CREATE (create_this1:Movie)
+              SET create_this1.id = create_var0.id
+              RETURN create_this1
             }
             RETURN collect(create_this1 { .id }) AS data"
         `);
@@ -127,40 +126,36 @@ describe("Batch Create", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Movie)
+              CREATE (create_this1:Movie)
+              SET create_this1.id = create_var0.id
+              WITH create_this1, create_var0
+              CALL (create_this1, create_var0) {
+                UNWIND create_var0.actors.create AS create_var2
+                CREATE (create_this3:Actor)
                 SET
-                    create_this1.id = create_var0.id
-                WITH create_this1, create_var0
-                CALL (create_this1, create_var0) {
-                    UNWIND create_var0.actors.create AS create_var2
-                    CREATE (create_this3:Actor)
-                    SET
-                        create_this3.id = randomUUID(),
-                        create_this3.name = create_var2.node.name
-                    MERGE (create_this1)<-[create_this4:ACTED_IN]-(create_this3)
-                    SET
-                        create_this4.year = create_var2.edge.year
-                    WITH create_this3, create_var2
-                    CALL (create_this3, create_var2) {
-                        UNWIND create_var2.node.website.create AS create_var5
-                        CREATE (create_this6:Website)
-                        SET
-                            create_this6.address = create_var5.node.address
-                        MERGE (create_this3)-[create_this7:HAS_WEBSITE]->(create_this6)
-                        RETURN collect(NULL) AS create_var8
-                    }
-                    RETURN collect(NULL) AS create_var9
+                  create_this3.id = randomUUID(),
+                  create_this3.name = create_var2.node.name
+                MERGE (create_this1)<-[create_this4:ACTED_IN]-(create_this3)
+                SET create_this4.year = create_var2.edge.year
+                WITH create_this3, create_var2
+                CALL (create_this3, create_var2) {
+                  UNWIND create_var2.node.website.create AS create_var5
+                  CREATE (create_this6:Website)
+                  SET create_this6.address = create_var5.node.address
+                  MERGE (create_this3)-[create_this7:HAS_WEBSITE]->(create_this6)
+                  RETURN collect(NULL) AS create_var8
                 }
-                WITH create_this1, create_var0
-                CALL (create_this1, create_var0) {
-                    UNWIND create_var0.website.create AS create_var10
-                    CREATE (create_this11:Website)
-                    SET
-                        create_this11.address = create_var10.node.address
-                    MERGE (create_this1)-[create_this12:HAS_WEBSITE]->(create_this11)
-                    RETURN collect(NULL) AS create_var13
-                }
-                RETURN create_this1
+                RETURN collect(NULL) AS create_var9
+              }
+              WITH create_this1, create_var0
+              CALL (create_this1, create_var0) {
+                UNWIND create_var0.website.create AS create_var10
+                CREATE (create_this11:Website)
+                SET create_this11.address = create_var10.node.address
+                MERGE (create_this1)-[create_this12:HAS_WEBSITE]->(create_this11)
+                RETURN collect(NULL) AS create_var13
+              }
+              RETURN create_this1
             }
             RETURN collect(create_this1 { .id }) AS data"
         `);
@@ -237,28 +232,26 @@ describe("Batch Create", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Movie)
+              CREATE (create_this1:Movie)
+              SET create_this1.id = create_var0.id
+              WITH create_this1, create_var0
+              CALL (create_this1, create_var0) {
+                UNWIND create_var0.actors.create AS create_var2
+                CREATE (create_this3:Actor)
                 SET
-                    create_this1.id = create_var0.id
-                WITH create_this1, create_var0
-                CALL (create_this1, create_var0) {
-                    UNWIND create_var0.actors.create AS create_var2
-                    CREATE (create_this3:Actor)
-                    SET
-                        create_this3.id = randomUUID(),
-                        create_this3.name = create_var2.node.name
-                    MERGE (create_this1)<-[create_this4:ACTED_IN]-(create_this3)
-                    SET
-                        create_this4.year = create_var2.edge.year
-                    RETURN collect(NULL) AS create_var5
-                }
-                RETURN create_this1
+                  create_this3.id = randomUUID(),
+                  create_this3.name = create_var2.node.name
+                MERGE (create_this1)<-[create_this4:ACTED_IN]-(create_this3)
+                SET create_this4.year = create_var2.edge.year
+                RETURN collect(NULL) AS create_var5
+              }
+              RETURN create_this1
             }
             CALL (create_this1) {
-                MATCH (create_this1)<-[create_this6:ACTED_IN]-(create_this7:Actor)
-                WITH DISTINCT create_this7
-                WITH create_this7 { .name } AS create_this7
-                RETURN collect(create_this7) AS create_var8
+              MATCH (create_this1)<-[create_this6:ACTED_IN]-(create_this7:Actor)
+              WITH DISTINCT create_this7
+              WITH create_this7 { .name } AS create_this7
+              RETURN collect(create_this7) AS create_var8
             }
             RETURN collect(create_this1 { .id, actors: create_var8 }) AS data"
         `);
@@ -331,37 +324,35 @@ describe("Batch Create", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                CREATE (this0:Movie)
-                SET
-                    this0.id = $param0
-                WITH *
-                CALL (this0) {
-                    MATCH (this1:Actor)
-                    WHERE this1.id = $param1
-                    CREATE (this0)<-[this2:ACTED_IN]-(this1)
-                }
-                RETURN this0 AS this
-                UNION
-                CREATE (this3:Movie)
-                SET
-                    this3.id = $param2
-                WITH *
-                CALL (this3) {
-                    MATCH (this4:Actor)
-                    WHERE this4.id = $param3
-                    CREATE (this3)<-[this5:ACTED_IN]-(this4)
-                }
-                RETURN this3 AS this
+              CREATE (this0:Movie)
+              SET this0.id = $param0
+              WITH *
+              CALL (this0) {
+                MATCH (this1:Actor)
+                WHERE this1.id = $param1
+                CREATE (this0)<-[this2:ACTED_IN]-(this1)
+              }
+              RETURN this0 AS this
+              UNION
+              CREATE (this3:Movie)
+              SET this3.id = $param2
+              WITH *
+              CALL (this3) {
+                MATCH (this4:Actor)
+                WHERE this4.id = $param3
+                CREATE (this3)<-[this5:ACTED_IN]-(this4)
+              }
+              RETURN this3 AS this
             }
             WITH this
             CALL (this) {
-                CALL (this) {
-                    MATCH (this)<-[this6:ACTED_IN]-(this7:Actor)
-                    WITH DISTINCT this7
-                    WITH this7 { .name } AS this7
-                    RETURN collect(this7) AS var8
-                }
-                RETURN this { .id, actors: var8 } AS var9
+              CALL (this) {
+                MATCH (this)<-[this6:ACTED_IN]-(this7:Actor)
+                WITH DISTINCT this7
+                WITH this7 { .name } AS this7
+                RETURN collect(this7) AS var8
+              }
+              RETURN this { .id, actors: var8 } AS var9
             }
             RETURN collect(var9) AS data"
         `);

--- a/packages/graphql/tests/tck/operations/connect.test.ts
+++ b/packages/graphql/tests/tck/operations/connect.test.ts
@@ -108,53 +108,53 @@ describe("Cypher Connect", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                CREATE (this0:Product)
-                SET
-                    this0.id = $param0,
-                    this0.name = $param1
-                WITH *
-                CALL (this0) {
-                    MATCH (this1:Color)
-                    WHERE this1.name = $param2
-                    CALL (this1) {
-                        MATCH (this2:Photo)
-                        WHERE this2.id = $param3
-                        CALL (this2) {
-                            MATCH (this3:Color)
-                            WHERE this3.id = $param4
-                            CREATE (this2)-[this4:OF_COLOR]->(this3)
-                        }
-                        CREATE (this1)<-[this5:OF_COLOR]-(this2)
-                    }
-                    CREATE (this0)-[this6:HAS_COLOR]->(this1)
+              CREATE (this0:Product)
+              SET
+                this0.id = $param0,
+                this0.name = $param1
+              WITH *
+              CALL (this0) {
+                MATCH (this1:Color)
+                WHERE this1.name = $param2
+                CALL (this1) {
+                  MATCH (this2:Photo)
+                  WHERE this2.id = $param3
+                  CALL (this2) {
+                    MATCH (this3:Color)
+                    WHERE this3.id = $param4
+                    CREATE (this2)-[this4:OF_COLOR]->(this3)
+                  }
+                  CREATE (this1)<-[this5:OF_COLOR]-(this2)
                 }
-                WITH *
-                CALL (this0) {
-                    MATCH (this7:Photo)
-                    WHERE this7.id = $param5
-                    CALL (this7) {
-                        MATCH (this8:Color)
-                        WHERE this8.name = $param6
-                        CREATE (this7)-[this9:OF_COLOR]->(this8)
-                    }
-                    CREATE (this0)-[this10:HAS_PHOTO]->(this7)
+                CREATE (this0)-[this6:HAS_COLOR]->(this1)
+              }
+              WITH *
+              CALL (this0) {
+                MATCH (this7:Photo)
+                WHERE this7.id = $param5
+                CALL (this7) {
+                  MATCH (this8:Color)
+                  WHERE this8.name = $param6
+                  CREATE (this7)-[this9:OF_COLOR]->(this8)
                 }
-                WITH *
-                CALL (this0) {
-                    MATCH (this11:Photo)
-                    WHERE this11.id = $param7
-                    CALL (this11) {
-                        MATCH (this12:Color)
-                        WHERE this12.name = $param8
-                        CREATE (this11)-[this13:OF_COLOR]->(this12)
-                    }
-                    CREATE (this0)-[this14:HAS_PHOTO]->(this11)
+                CREATE (this0)-[this10:HAS_PHOTO]->(this7)
+              }
+              WITH *
+              CALL (this0) {
+                MATCH (this11:Photo)
+                WHERE this11.id = $param7
+                CALL (this11) {
+                  MATCH (this12:Color)
+                  WHERE this12.name = $param8
+                  CREATE (this11)-[this13:OF_COLOR]->(this12)
                 }
-                RETURN this0 AS this
+                CREATE (this0)-[this14:HAS_PHOTO]->(this11)
+              }
+              RETURN this0 AS this
             }
             WITH this
             CALL (this) {
-                RETURN this { .id } AS var15
+              RETURN this { .id } AS var15
             }
             RETURN collect(var15) AS data"
         `);

--- a/packages/graphql/tests/tck/operations/create.test.ts
+++ b/packages/graphql/tests/tck/operations/create.test.ts
@@ -59,10 +59,9 @@ describe("Cypher Create", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Movie)
-                SET
-                    create_this1.id = create_var0.id
-                RETURN create_this1
+              CREATE (create_this1:Movie)
+              SET create_this1.id = create_var0.id
+              RETURN create_this1
             }
             RETURN collect(create_this1 { .id }) AS data"
         `);
@@ -95,10 +94,9 @@ describe("Cypher Create", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Movie)
-                SET
-                    create_this1.id = create_var0.id
-                RETURN create_this1
+              CREATE (create_this1:Movie)
+              SET create_this1.id = create_var0.id
+              RETURN create_this1
             }
             RETURN collect(create_this1 { .id }) AS data"
         `);
@@ -139,19 +137,17 @@ describe("Cypher Create", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Movie)
-                SET
-                    create_this1.id = create_var0.id
-                WITH create_this1, create_var0
-                CALL (create_this1, create_var0) {
-                    UNWIND create_var0.actors.create AS create_var2
-                    CREATE (create_this3:Actor)
-                    SET
-                        create_this3.name = create_var2.node.name
-                    MERGE (create_this1)<-[create_this4:ACTED_IN]-(create_this3)
-                    RETURN collect(NULL) AS create_var5
-                }
-                RETURN create_this1
+              CREATE (create_this1:Movie)
+              SET create_this1.id = create_var0.id
+              WITH create_this1, create_var0
+              CALL (create_this1, create_var0) {
+                UNWIND create_var0.actors.create AS create_var2
+                CREATE (create_this3:Actor)
+                SET create_this3.name = create_var2.node.name
+                MERGE (create_this1)<-[create_this4:ACTED_IN]-(create_this3)
+                RETURN collect(NULL) AS create_var5
+              }
+              RETURN create_this1
             }
             RETURN collect(create_this1 { .id }) AS data"
         `);
@@ -220,28 +216,25 @@ describe("Cypher Create", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Movie)
-                SET
-                    create_this1.id = create_var0.id
-                WITH create_this1, create_var0
-                CALL (create_this1, create_var0) {
-                    UNWIND create_var0.actors.create AS create_var2
-                    CREATE (create_this3:Actor)
-                    SET
-                        create_this3.name = create_var2.node.name
-                    MERGE (create_this1)<-[create_this4:ACTED_IN]-(create_this3)
-                    WITH create_this3, create_var2
-                    CALL (create_this3, create_var2) {
-                        UNWIND create_var2.node.movies.create AS create_var5
-                        CREATE (create_this6:Movie)
-                        SET
-                            create_this6.id = create_var5.node.id
-                        MERGE (create_this3)-[create_this7:ACTED_IN]->(create_this6)
-                        RETURN collect(NULL) AS create_var8
-                    }
-                    RETURN collect(NULL) AS create_var9
+              CREATE (create_this1:Movie)
+              SET create_this1.id = create_var0.id
+              WITH create_this1, create_var0
+              CALL (create_this1, create_var0) {
+                UNWIND create_var0.actors.create AS create_var2
+                CREATE (create_this3:Actor)
+                SET create_this3.name = create_var2.node.name
+                MERGE (create_this1)<-[create_this4:ACTED_IN]-(create_this3)
+                WITH create_this3, create_var2
+                CALL (create_this3, create_var2) {
+                  UNWIND create_var2.node.movies.create AS create_var5
+                  CREATE (create_this6:Movie)
+                  SET create_this6.id = create_var5.node.id
+                  MERGE (create_this3)-[create_this7:ACTED_IN]->(create_this6)
+                  RETURN collect(NULL) AS create_var8
                 }
-                RETURN create_this1
+                RETURN collect(NULL) AS create_var9
+              }
+              RETURN create_this1
             }
             RETURN collect(create_this1 { .id }) AS data"
         `);
@@ -312,20 +305,19 @@ describe("Cypher Create", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                CREATE (this0:Movie)
-                SET
-                    this0.id = $param0
-                WITH *
-                CALL (this0) {
-                    MATCH (this1:Actor)
-                    WHERE this1.name = $param1
-                    CREATE (this0)<-[this2:ACTED_IN]-(this1)
-                }
-                RETURN this0 AS this
+              CREATE (this0:Movie)
+              SET this0.id = $param0
+              WITH *
+              CALL (this0) {
+                MATCH (this1:Actor)
+                WHERE this1.name = $param1
+                CREATE (this0)<-[this2:ACTED_IN]-(this1)
+              }
+              RETURN this0 AS this
             }
             WITH this
             CALL (this) {
-                RETURN this { .id } AS var3
+              RETURN this { .id } AS var3
             }
             RETURN collect(var3) AS data"
         `);
@@ -356,25 +348,23 @@ describe("Cypher Create", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                CREATE (this0:Movie)
-                SET
-                    this0.id = $param0
-                WITH *
-                CALL (this0) {
-                    MATCH (this1:Actor)
-                    WHERE this1.name = $param1
-                    CREATE (this0)<-[this2:ACTED_IN]-(this1)
-                }
-                RETURN this0 AS this
-                UNION
-                CREATE (this3:Movie)
-                SET
-                    this3.id = $param2
-                RETURN this3 AS this
+              CREATE (this0:Movie)
+              SET this0.id = $param0
+              WITH *
+              CALL (this0) {
+                MATCH (this1:Actor)
+                WHERE this1.name = $param1
+                CREATE (this0)<-[this2:ACTED_IN]-(this1)
+              }
+              RETURN this0 AS this
+              UNION
+              CREATE (this3:Movie)
+              SET this3.id = $param2
+              RETURN this3 AS this
             }
             WITH this
             CALL (this) {
-                RETURN this { .id } AS var4
+              RETURN this { .id } AS var4
             }
             RETURN collect(var4) AS data"
         `);
@@ -414,25 +404,23 @@ describe("Cypher Create", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                CREATE (this0:Movie)
-                SET
-                    this0.id = $param0
-                WITH *
-                CREATE (this1:Actor)
-                MERGE (this0)<-[this2:ACTED_IN]-(this1)
-                SET
-                    this1.name = $param1
-                WITH *
-                CALL (this0) {
-                    MATCH (this3:Actor)
-                    WHERE this3.name = $param2
-                    CREATE (this0)<-[this4:ACTED_IN]-(this3)
-                }
-                RETURN this0 AS this
+              CREATE (this0:Movie)
+              SET this0.id = $param0
+              WITH *
+              CREATE (this1:Actor)
+              MERGE (this0)<-[this2:ACTED_IN]-(this1)
+              SET this1.name = $param1
+              WITH *
+              CALL (this0) {
+                MATCH (this3:Actor)
+                WHERE this3.name = $param2
+                CREATE (this0)<-[this4:ACTED_IN]-(this3)
+              }
+              RETURN this0 AS this
             }
             WITH this
             CALL (this) {
-                RETURN this { .id } AS var5
+              RETURN this { .id } AS var5
             }
             RETURN collect(var5) AS data"
         `);
@@ -472,37 +460,36 @@ describe("Cypher Create", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                CREATE (this0:Actor)
-                SET
-                    this0.name = $param0
-                WITH *
-                CALL (this0) {
-                    MATCH (this1:Movie)
-                    WHERE this1.id = $param1
-                    CREATE (this0)-[this2:ACTED_IN]->(this1)
-                }
-                RETURN this0 AS this
+              CREATE (this0:Actor)
+              SET this0.name = $param0
+              WITH *
+              CALL (this0) {
+                MATCH (this1:Movie)
+                WHERE this1.id = $param1
+                CREATE (this0)-[this2:ACTED_IN]->(this1)
+              }
+              RETURN this0 AS this
             }
             WITH this
             CALL (this) {
-                CALL (this) {
-                    MATCH (this)-[this3:ACTED_IN]->(this4:Movie)
-                    WITH DISTINCT this4
-                    CALL (this4) {
-                        MATCH (this4)<-[this5:ACTED_IN]-(this6:Actor)
-                        WHERE this6.name = $param2
-                        WITH collect({ node: this6, relationship: this5 }) AS edges, count(this6) AS totalCount
-                        CALL (edges) {
-                            UNWIND edges AS edge
-                            WITH edge.node AS this6, edge.relationship AS this5
-                            RETURN collect({ node: { name: this6.name, __resolveType: \\"Actor\\" } }) AS var7
-                        }
-                        RETURN { edges: var7, totalCount: totalCount } AS var8
-                    }
-                    WITH this4 { actorsConnection: var8 } AS this4
-                    RETURN collect(this4) AS var9
+              CALL (this) {
+                MATCH (this)-[this3:ACTED_IN]->(this4:Movie)
+                WITH DISTINCT this4
+                CALL (this4) {
+                  MATCH (this4)<-[this5:ACTED_IN]-(this6:Actor)
+                  WHERE this6.name = $param2
+                  WITH collect({node: this6, relationship: this5}) AS edges, count(this6) AS totalCount
+                  CALL (edges) {
+                    UNWIND edges AS edge
+                    WITH edge.node AS this6, edge.relationship AS this5
+                    RETURN collect({node: {name: this6.name, __resolveType: 'Actor'}}) AS var7
+                  }
+                  RETURN {edges: var7, totalCount: totalCount} AS var8
                 }
-                RETURN this { .name, movies: var9 } AS var10
+                WITH this4 { actorsConnection: var8 } AS this4
+                RETURN collect(this4) AS var9
+              }
+              RETURN this { .name, movies: var9 } AS var10
             }
             RETURN collect(var10) AS data"
         `);

--- a/packages/graphql/tests/tck/operations/delete-interface.test.ts
+++ b/packages/graphql/tests/tck/operations/delete-interface.test.ts
@@ -122,22 +122,22 @@ describe("Cypher Delete - interface", () => {
             WHERE this.name = $param0
             WITH *
             CALL (*) {
-                OPTIONAL MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                WHERE this1.title = $param1
-                WITH this0, collect(DISTINCT this1) AS var2
-                CALL (var2) {
-                    UNWIND var2 AS var3
-                    DETACH DELETE var3
-                }
+              OPTIONAL MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+              WHERE this1.title = $param1
+              WITH this0, collect(DISTINCT this1) AS var2
+              CALL (var2) {
+                UNWIND var2 AS var3
+                DETACH DELETE var3
+              }
             }
             CALL (*) {
-                OPTIONAL MATCH (this)-[this4:ACTED_IN]->(this5:Series)
-                WHERE this5.title = $param2
-                WITH this4, collect(DISTINCT this5) AS var6
-                CALL (var6) {
-                    UNWIND var6 AS var7
-                    DETACH DELETE var7
-                }
+              OPTIONAL MATCH (this)-[this4:ACTED_IN]->(this5:Series)
+              WHERE this5.title = $param2
+              WITH this4, collect(DISTINCT this5) AS var6
+              CALL (var6) {
+                UNWIND var6 AS var7
+                DETACH DELETE var7
+              }
             }
             WITH *
             DETACH DELETE this"
@@ -172,22 +172,22 @@ describe("Cypher Delete - interface", () => {
             WHERE this.name = $param0
             WITH *
             CALL (*) {
-                OPTIONAL MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                WHERE (this1.title = $param1 AND this1:Movie)
-                WITH this0, collect(DISTINCT this1) AS var2
-                CALL (var2) {
-                    UNWIND var2 AS var3
-                    DETACH DELETE var3
-                }
+              OPTIONAL MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+              WHERE (this1.title = $param1 AND this1:Movie)
+              WITH this0, collect(DISTINCT this1) AS var2
+              CALL (var2) {
+                UNWIND var2 AS var3
+                DETACH DELETE var3
+              }
             }
             CALL (*) {
-                OPTIONAL MATCH (this)-[this4:ACTED_IN]->(this5:Series)
-                WHERE (this5.title = $param2 AND this5:Movie)
-                WITH this4, collect(DISTINCT this5) AS var6
-                CALL (var6) {
-                    UNWIND var6 AS var7
-                    DETACH DELETE var7
-                }
+              OPTIONAL MATCH (this)-[this4:ACTED_IN]->(this5:Series)
+              WHERE (this5.title = $param2 AND this5:Movie)
+              WITH this4, collect(DISTINCT this5) AS var6
+              CALL (var6) {
+                UNWIND var6 AS var7
+                DETACH DELETE var7
+              }
             }
             WITH *
             DETACH DELETE this"
@@ -226,22 +226,22 @@ describe("Cypher Delete - interface", () => {
             WHERE this.name = $param0
             WITH *
             CALL (*) {
-                OPTIONAL MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                WHERE (this1.title = $param1 OR this1.title = $param2)
-                WITH this0, collect(DISTINCT this1) AS var2
-                CALL (var2) {
-                    UNWIND var2 AS var3
-                    DETACH DELETE var3
-                }
+              OPTIONAL MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+              WHERE (this1.title = $param1 OR this1.title = $param2)
+              WITH this0, collect(DISTINCT this1) AS var2
+              CALL (var2) {
+                UNWIND var2 AS var3
+                DETACH DELETE var3
+              }
             }
             CALL (*) {
-                OPTIONAL MATCH (this)-[this4:ACTED_IN]->(this5:Series)
-                WHERE (this5.title = $param3 OR this5.title = $param4)
-                WITH this4, collect(DISTINCT this5) AS var6
-                CALL (var6) {
-                    UNWIND var6 AS var7
-                    DETACH DELETE var7
-                }
+              OPTIONAL MATCH (this)-[this4:ACTED_IN]->(this5:Series)
+              WHERE (this5.title = $param3 OR this5.title = $param4)
+              WITH this4, collect(DISTINCT this5) AS var6
+              CALL (var6) {
+                UNWIND var6 AS var7
+                DETACH DELETE var7
+              }
             }
             WITH *
             DETACH DELETE this"
@@ -283,42 +283,42 @@ describe("Cypher Delete - interface", () => {
             WHERE this.name = $param0
             WITH *
             CALL (*) {
-                OPTIONAL MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                WHERE this1.title = $param1
-                WITH *
-                CALL (*) {
-                    OPTIONAL MATCH (this1)<-[this2:ACTED_IN]-(this3:Actor)
-                    WHERE this3.name = $param2
-                    WITH this2, collect(DISTINCT this3) AS var4
-                    CALL (var4) {
-                        UNWIND var4 AS var5
-                        DETACH DELETE var5
-                    }
+              OPTIONAL MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+              WHERE this1.title = $param1
+              WITH *
+              CALL (*) {
+                OPTIONAL MATCH (this1)<-[this2:ACTED_IN]-(this3:Actor)
+                WHERE this3.name = $param2
+                WITH this2, collect(DISTINCT this3) AS var4
+                CALL (var4) {
+                  UNWIND var4 AS var5
+                  DETACH DELETE var5
                 }
-                WITH this0, collect(DISTINCT this1) AS var6
-                CALL (var6) {
-                    UNWIND var6 AS var7
-                    DETACH DELETE var7
-                }
+              }
+              WITH this0, collect(DISTINCT this1) AS var6
+              CALL (var6) {
+                UNWIND var6 AS var7
+                DETACH DELETE var7
+              }
             }
             CALL (*) {
-                OPTIONAL MATCH (this)-[this8:ACTED_IN]->(this9:Series)
-                WHERE this9.title = $param3
-                WITH *
-                CALL (*) {
-                    OPTIONAL MATCH (this9)<-[this10:ACTED_IN]-(this11:Actor)
-                    WHERE this11.name = $param4
-                    WITH this10, collect(DISTINCT this11) AS var12
-                    CALL (var12) {
-                        UNWIND var12 AS var13
-                        DETACH DELETE var13
-                    }
+              OPTIONAL MATCH (this)-[this8:ACTED_IN]->(this9:Series)
+              WHERE this9.title = $param3
+              WITH *
+              CALL (*) {
+                OPTIONAL MATCH (this9)<-[this10:ACTED_IN]-(this11:Actor)
+                WHERE this11.name = $param4
+                WITH this10, collect(DISTINCT this11) AS var12
+                CALL (var12) {
+                  UNWIND var12 AS var13
+                  DETACH DELETE var13
                 }
-                WITH this8, collect(DISTINCT this9) AS var14
-                CALL (var14) {
-                    UNWIND var14 AS var15
-                    DETACH DELETE var15
-                }
+              }
+              WITH this8, collect(DISTINCT this9) AS var14
+              CALL (var14) {
+                UNWIND var14 AS var15
+                DETACH DELETE var15
+              }
             }
             WITH *
             DETACH DELETE this"

--- a/packages/graphql/tests/tck/operations/delete-union.test.ts
+++ b/packages/graphql/tests/tck/operations/delete-union.test.ts
@@ -117,13 +117,13 @@ describe("Cypher Delete - union", () => {
             WHERE this.name = $param0
             WITH *
             CALL (*) {
-                OPTIONAL MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                WHERE this1.title = $param1
-                WITH this0, collect(DISTINCT this1) AS var2
-                CALL (var2) {
-                    UNWIND var2 AS var3
-                    DETACH DELETE var3
-                }
+              OPTIONAL MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+              WHERE this1.title = $param1
+              WITH this0, collect(DISTINCT this1) AS var2
+              CALL (var2) {
+                UNWIND var2 AS var3
+                DETACH DELETE var3
+              }
             }
             WITH *
             DETACH DELETE this"
@@ -164,22 +164,22 @@ describe("Cypher Delete - union", () => {
             WHERE this.name = $param0
             WITH *
             CALL (*) {
-                OPTIONAL MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                WHERE this1.title = $param1
-                WITH this0, collect(DISTINCT this1) AS var2
-                CALL (var2) {
-                    UNWIND var2 AS var3
-                    DETACH DELETE var3
-                }
+              OPTIONAL MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+              WHERE this1.title = $param1
+              WITH this0, collect(DISTINCT this1) AS var2
+              CALL (var2) {
+                UNWIND var2 AS var3
+                DETACH DELETE var3
+              }
             }
             CALL (*) {
-                OPTIONAL MATCH (this)-[this4:ACTED_IN]->(this5:Movie)
-                WHERE this5.title = $param2
-                WITH this4, collect(DISTINCT this5) AS var6
-                CALL (var6) {
-                    UNWIND var6 AS var7
-                    DETACH DELETE var7
-                }
+              OPTIONAL MATCH (this)-[this4:ACTED_IN]->(this5:Movie)
+              WHERE this5.title = $param2
+              WITH this4, collect(DISTINCT this5) AS var6
+              CALL (var6) {
+                UNWIND var6 AS var7
+                DETACH DELETE var7
+              }
             }
             WITH *
             DETACH DELETE this"
@@ -221,23 +221,23 @@ describe("Cypher Delete - union", () => {
             WHERE this.name = $param0
             WITH *
             CALL (*) {
-                OPTIONAL MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                WHERE this1.title = $param1
-                WITH *
-                CALL (*) {
-                    OPTIONAL MATCH (this1)<-[this2:ACTED_IN]-(this3:Actor)
-                    WHERE this3.name = $param2
-                    WITH this2, collect(DISTINCT this3) AS var4
-                    CALL (var4) {
-                        UNWIND var4 AS var5
-                        DETACH DELETE var5
-                    }
+              OPTIONAL MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+              WHERE this1.title = $param1
+              WITH *
+              CALL (*) {
+                OPTIONAL MATCH (this1)<-[this2:ACTED_IN]-(this3:Actor)
+                WHERE this3.name = $param2
+                WITH this2, collect(DISTINCT this3) AS var4
+                CALL (var4) {
+                  UNWIND var4 AS var5
+                  DETACH DELETE var5
                 }
-                WITH this0, collect(DISTINCT this1) AS var6
-                CALL (var6) {
-                    UNWIND var6 AS var7
-                    DETACH DELETE var7
-                }
+              }
+              WITH this0, collect(DISTINCT this1) AS var6
+              CALL (var6) {
+                UNWIND var6 AS var7
+                DETACH DELETE var7
+              }
             }
             WITH *
             DETACH DELETE this"
@@ -281,23 +281,23 @@ describe("Cypher Delete - union", () => {
             WHERE this.name = $param0
             WITH *
             CALL (*) {
-                OPTIONAL MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                WHERE this1.title = $param1
-                WITH *
-                CALL (*) {
-                    OPTIONAL MATCH (this1)<-[this2:WORKED_ON]-(this3:ScreenWriter)
-                    WHERE this3.name = $param2
-                    WITH this2, collect(DISTINCT this3) AS var4
-                    CALL (var4) {
-                        UNWIND var4 AS var5
-                        DETACH DELETE var5
-                    }
+              OPTIONAL MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
+              WHERE this1.title = $param1
+              WITH *
+              CALL (*) {
+                OPTIONAL MATCH (this1)<-[this2:WORKED_ON]-(this3:ScreenWriter)
+                WHERE this3.name = $param2
+                WITH this2, collect(DISTINCT this3) AS var4
+                CALL (var4) {
+                  UNWIND var4 AS var5
+                  DETACH DELETE var5
                 }
-                WITH this0, collect(DISTINCT this1) AS var6
-                CALL (var6) {
-                    UNWIND var6 AS var7
-                    DETACH DELETE var7
-                }
+              }
+              WITH this0, collect(DISTINCT this1) AS var6
+              CALL (var6) {
+                UNWIND var6 AS var7
+                DETACH DELETE var7
+              }
             }
             WITH *
             DETACH DELETE this"

--- a/packages/graphql/tests/tck/operations/delete.test.ts
+++ b/packages/graphql/tests/tck/operations/delete.test.ts
@@ -88,13 +88,13 @@ describe("Cypher Delete", () => {
             WHERE this.id = $param0
             WITH *
             CALL (*) {
-                OPTIONAL MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE this1.name = $param1
-                WITH this0, collect(DISTINCT this1) AS var2
-                CALL (var2) {
-                    UNWIND var2 AS var3
-                    DETACH DELETE var3
-                }
+              OPTIONAL MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE this1.name = $param1
+              WITH this0, collect(DISTINCT this1) AS var2
+              CALL (var2) {
+                UNWIND var2 AS var3
+                DETACH DELETE var3
+              }
             }
             WITH *
             DETACH DELETE this"
@@ -133,22 +133,22 @@ describe("Cypher Delete", () => {
             WHERE this.id = $param0
             WITH *
             CALL (*) {
-                OPTIONAL MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE this1.name = $param1
-                WITH this0, collect(DISTINCT this1) AS var2
-                CALL (var2) {
-                    UNWIND var2 AS var3
-                    DETACH DELETE var3
-                }
+              OPTIONAL MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE this1.name = $param1
+              WITH this0, collect(DISTINCT this1) AS var2
+              CALL (var2) {
+                UNWIND var2 AS var3
+                DETACH DELETE var3
+              }
             }
             CALL (*) {
-                OPTIONAL MATCH (this)<-[this4:ACTED_IN]-(this5:Actor)
-                WHERE this5.name = $param2
-                WITH this4, collect(DISTINCT this5) AS var6
-                CALL (var6) {
-                    UNWIND var6 AS var7
-                    DETACH DELETE var7
-                }
+              OPTIONAL MATCH (this)<-[this4:ACTED_IN]-(this5:Actor)
+              WHERE this5.name = $param2
+              WITH this4, collect(DISTINCT this5) AS var6
+              CALL (var6) {
+                UNWIND var6 AS var7
+                DETACH DELETE var7
+              }
             }
             WITH *
             DETACH DELETE this"
@@ -188,23 +188,23 @@ describe("Cypher Delete", () => {
             WHERE this.id = $param0
             WITH *
             CALL (*) {
-                OPTIONAL MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE this1.name = $param1
-                WITH *
-                CALL (*) {
-                    OPTIONAL MATCH (this1)-[this2:ACTED_IN]->(this3:Movie)
-                    WHERE this3.id = $param2
-                    WITH this2, collect(DISTINCT this3) AS var4
-                    CALL (var4) {
-                        UNWIND var4 AS var5
-                        DETACH DELETE var5
-                    }
+              OPTIONAL MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE this1.name = $param1
+              WITH *
+              CALL (*) {
+                OPTIONAL MATCH (this1)-[this2:ACTED_IN]->(this3:Movie)
+                WHERE this3.id = $param2
+                WITH this2, collect(DISTINCT this3) AS var4
+                CALL (var4) {
+                  UNWIND var4 AS var5
+                  DETACH DELETE var5
                 }
-                WITH this0, collect(DISTINCT this1) AS var6
-                CALL (var6) {
-                    UNWIND var6 AS var7
-                    DETACH DELETE var7
-                }
+              }
+              WITH this0, collect(DISTINCT this1) AS var6
+              CALL (var6) {
+                UNWIND var6 AS var7
+                DETACH DELETE var7
+              }
             }
             WITH *
             DETACH DELETE this"
@@ -249,33 +249,33 @@ describe("Cypher Delete", () => {
             WHERE this.id = $param0
             WITH *
             CALL (*) {
-                OPTIONAL MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE this1.name = $param1
+              OPTIONAL MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE this1.name = $param1
+              WITH *
+              CALL (*) {
+                OPTIONAL MATCH (this1)-[this2:ACTED_IN]->(this3:Movie)
+                WHERE this3.id = $param2
                 WITH *
                 CALL (*) {
-                    OPTIONAL MATCH (this1)-[this2:ACTED_IN]->(this3:Movie)
-                    WHERE this3.id = $param2
-                    WITH *
-                    CALL (*) {
-                        OPTIONAL MATCH (this3)<-[this4:ACTED_IN]-(this5:Actor)
-                        WHERE this5.name = $param3
-                        WITH this4, collect(DISTINCT this5) AS var6
-                        CALL (var6) {
-                            UNWIND var6 AS var7
-                            DETACH DELETE var7
-                        }
-                    }
-                    WITH this2, collect(DISTINCT this3) AS var8
-                    CALL (var8) {
-                        UNWIND var8 AS var9
-                        DETACH DELETE var9
-                    }
+                  OPTIONAL MATCH (this3)<-[this4:ACTED_IN]-(this5:Actor)
+                  WHERE this5.name = $param3
+                  WITH this4, collect(DISTINCT this5) AS var6
+                  CALL (var6) {
+                    UNWIND var6 AS var7
+                    DETACH DELETE var7
+                  }
                 }
-                WITH this0, collect(DISTINCT this1) AS var10
-                CALL (var10) {
-                    UNWIND var10 AS var11
-                    DETACH DELETE var11
+                WITH this2, collect(DISTINCT this3) AS var8
+                CALL (var8) {
+                  UNWIND var8 AS var9
+                  DETACH DELETE var9
                 }
+              }
+              WITH this0, collect(DISTINCT this1) AS var10
+              CALL (var10) {
+                UNWIND var10 AS var11
+                DETACH DELETE var11
+              }
             }
             WITH *
             DETACH DELETE this"

--- a/packages/graphql/tests/tck/operations/disconnect.test.ts
+++ b/packages/graphql/tests/tck/operations/disconnect.test.ts
@@ -108,66 +108,66 @@ describe("Cypher Disconnect", () => {
             MATCH (this:Product)
             WITH *
             SET
-                this.id = $param0,
-                this.name = $param1
+              this.id = $param0,
+              this.name = $param1
             WITH *
             CALL (*) {
-                CALL (this) {
-                    OPTIONAL MATCH (this)-[this0:HAS_COLOR]->(this1:Color)
-                    WHERE this1.name = $param2
-                    CALL (this1) {
-                        CALL (this1) {
-                            OPTIONAL MATCH (this1)<-[this2:OF_COLOR]-(this3:Photo)
-                            WHERE this3.id = $param3
-                            CALL (this3) {
-                                CALL (this3) {
-                                    OPTIONAL MATCH (this3)-[this4:OF_COLOR]->(this5:Color)
-                                    WHERE this5.id = $param4
-                                    WITH *
-                                    DELETE this4
-                                }
-                            }
-                            WITH *
-                            DELETE this2
-                        }
+              CALL (this) {
+                OPTIONAL MATCH (this)-[this0:HAS_COLOR]->(this1:Color)
+                WHERE this1.name = $param2
+                CALL (this1) {
+                  CALL (this1) {
+                    OPTIONAL MATCH (this1)<-[this2:OF_COLOR]-(this3:Photo)
+                    WHERE this3.id = $param3
+                    CALL (this3) {
+                      CALL (this3) {
+                        OPTIONAL MATCH (this3)-[this4:OF_COLOR]->(this5:Color)
+                        WHERE this5.id = $param4
+                        WITH *
+                        DELETE this4
+                      }
                     }
                     WITH *
-                    DELETE this0
+                    DELETE this2
+                  }
                 }
+                WITH *
+                DELETE this0
+              }
             }
             WITH *
             CALL (*) {
-                CALL (this) {
-                    OPTIONAL MATCH (this)-[this6:HAS_PHOTO]->(this7:Photo)
-                    WHERE this7.id = $param5
-                    CALL (this7) {
-                        CALL (this7) {
-                            OPTIONAL MATCH (this7)-[this8:OF_COLOR]->(this9:Color)
-                            WHERE this9.name = $param6
-                            WITH *
-                            DELETE this8
-                        }
-                    }
+              CALL (this) {
+                OPTIONAL MATCH (this)-[this6:HAS_PHOTO]->(this7:Photo)
+                WHERE this7.id = $param5
+                CALL (this7) {
+                  CALL (this7) {
+                    OPTIONAL MATCH (this7)-[this8:OF_COLOR]->(this9:Color)
+                    WHERE this9.name = $param6
                     WITH *
-                    DELETE this6
+                    DELETE this8
+                  }
                 }
+                WITH *
+                DELETE this6
+              }
             }
             WITH *
             CALL (*) {
-                CALL (this) {
-                    OPTIONAL MATCH (this)-[this10:HAS_PHOTO]->(this11:Photo)
-                    WHERE this11.id = $param7
-                    CALL (this11) {
-                        CALL (this11) {
-                            OPTIONAL MATCH (this11)-[this12:OF_COLOR]->(this13:Color)
-                            WHERE this13.name = $param8
-                            WITH *
-                            DELETE this12
-                        }
-                    }
+              CALL (this) {
+                OPTIONAL MATCH (this)-[this10:HAS_PHOTO]->(this11:Photo)
+                WHERE this11.id = $param7
+                CALL (this11) {
+                  CALL (this11) {
+                    OPTIONAL MATCH (this11)-[this12:OF_COLOR]->(this13:Color)
+                    WHERE this13.name = $param8
                     WITH *
-                    DELETE this10
+                    DELETE this12
+                  }
                 }
+                WITH *
+                DELETE this10
+              }
             }
             WITH this
             RETURN this { .id } AS this"

--- a/packages/graphql/tests/tck/operations/update.test.ts
+++ b/packages/graphql/tests/tck/operations/update.test.ts
@@ -65,8 +65,7 @@ describe("Cypher Update", () => {
             MATCH (this:Movie)
             WITH *
             WHERE this.id = $param0
-            SET
-                this.id = $param1
+            SET this.id = $param1
             WITH this
             RETURN this { .id } AS this"
         `);
@@ -112,11 +111,10 @@ describe("Cypher Update", () => {
             WHERE this.id = $param0
             WITH *
             CALL (*) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WITH *
-                WHERE this1.name = $param1
-                SET
-                    this1.name = $param2
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WITH *
+              WHERE this1.name = $param1
+              SET this1.name = $param2
             }
             WITH this
             RETURN this { .id } AS this"
@@ -173,19 +171,17 @@ describe("Cypher Update", () => {
             WHERE this.id = $param0
             WITH *
             CALL (*) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WITH *
+              WHERE this1.name = $param1
+              SET this1.name = $param2
+              WITH *
+              CALL (*) {
+                MATCH (this1)-[this2:ACTED_IN]->(this3:Movie)
                 WITH *
-                WHERE this1.name = $param1
-                SET
-                    this1.name = $param2
-                WITH *
-                CALL (*) {
-                    MATCH (this1)-[this2:ACTED_IN]->(this3:Movie)
-                    WITH *
-                    WHERE this3.id = $param3
-                    SET
-                        this3.title = $param4
-                }
+                WHERE this3.id = $param3
+                SET this3.title = $param4
+              }
             }
             WITH this
             RETURN this { .id } AS this"
@@ -225,11 +221,11 @@ describe("Cypher Update", () => {
             WHERE this.id = $param0
             WITH *
             CALL (*) {
-                CALL (this) {
-                    MATCH (this0:Actor)
-                    WHERE this0.name = $param1
-                    CREATE (this)<-[this1:ACTED_IN]-(this0)
-                }
+              CALL (this) {
+                MATCH (this0:Actor)
+                WHERE this0.name = $param1
+                CREATE (this)<-[this1:ACTED_IN]-(this0)
+              }
             }
             WITH this
             RETURN this { .id } AS this"
@@ -273,19 +269,19 @@ describe("Cypher Update", () => {
             WHERE this.id = $param0
             WITH *
             CALL (*) {
-                CALL (this) {
-                    MATCH (this0:Actor)
-                    WHERE this0.name = $param1
-                    CREATE (this)<-[this1:ACTED_IN]-(this0)
-                }
+              CALL (this) {
+                MATCH (this0:Actor)
+                WHERE this0.name = $param1
+                CREATE (this)<-[this1:ACTED_IN]-(this0)
+              }
             }
             WITH *
             CALL (*) {
-                CALL (this) {
-                    MATCH (this2:Actor)
-                    WHERE this2.name = $param2
-                    CREATE (this)<-[this3:ACTED_IN]-(this2)
-                }
+              CALL (this) {
+                MATCH (this2:Actor)
+                WHERE this2.name = $param2
+                CREATE (this)<-[this3:ACTED_IN]-(this2)
+              }
             }
             WITH this
             RETURN this { .id } AS this"
@@ -323,12 +319,12 @@ describe("Cypher Update", () => {
             WHERE this.id = $param0
             WITH *
             CALL (*) {
-                CALL (this) {
-                    OPTIONAL MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                    WHERE this1.name = $param1
-                    WITH *
-                    DELETE this0
-                }
+              CALL (this) {
+                OPTIONAL MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+                WHERE this1.name = $param1
+                WITH *
+                DELETE this0
+              }
             }
             WITH this
             RETURN this { .id } AS this"
@@ -372,21 +368,21 @@ describe("Cypher Update", () => {
             WHERE this.id = $param0
             WITH *
             CALL (*) {
-                CALL (this) {
-                    OPTIONAL MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                    WHERE this1.name = $param1
-                    WITH *
-                    DELETE this0
-                }
+              CALL (this) {
+                OPTIONAL MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+                WHERE this1.name = $param1
+                WITH *
+                DELETE this0
+              }
             }
             WITH *
             CALL (*) {
-                CALL (this) {
-                    OPTIONAL MATCH (this)<-[this2:ACTED_IN]-(this3:Actor)
-                    WHERE this3.name = $param2
-                    WITH *
-                    DELETE this2
-                }
+              CALL (this) {
+                OPTIONAL MATCH (this)<-[this2:ACTED_IN]-(this3:Actor)
+                WHERE this3.name = $param2
+                WITH *
+                DELETE this2
+              }
             }
             WITH this
             RETURN this { .id } AS this"
@@ -428,18 +424,18 @@ describe("Cypher Update", () => {
             WHERE this.name = $param0
             WITH *
             CALL (*) {
-                CREATE (this0:Movie)
-                MERGE (this)-[this1:ACTED_IN]->(this0)
-                SET
-                    this0.id = $param1,
-                    this0.title = $param2
+              CREATE (this0:Movie)
+              MERGE (this)-[this1:ACTED_IN]->(this0)
+              SET
+                this0.id = $param1,
+                this0.title = $param2
             }
             WITH this
             CALL (this) {
-                MATCH (this)-[this2:ACTED_IN]->(this3:Movie)
-                WITH DISTINCT this3
-                WITH this3 { .id, .title } AS this3
-                RETURN collect(this3) AS var4
+              MATCH (this)-[this2:ACTED_IN]->(this3:Movie)
+              WITH DISTINCT this3
+              WITH this3 { .id, .title } AS this3
+              RETURN collect(this3) AS var4
             }
             RETURN this { .name, movies: var4 } AS this"
         `);
@@ -480,18 +476,18 @@ describe("Cypher Update", () => {
             WHERE this.name = $param0
             WITH *
             CALL (*) {
-                CREATE (this0:Movie)
-                MERGE (this)-[this1:ACTED_IN]->(this0)
-                SET
-                    this0.id = $param1,
-                    this0.title = $param2
+              CREATE (this0:Movie)
+              MERGE (this)-[this1:ACTED_IN]->(this0)
+              SET
+                this0.id = $param1,
+                this0.title = $param2
             }
             WITH this
             CALL (this) {
-                MATCH (this)-[this2:ACTED_IN]->(this3:Movie)
-                WITH DISTINCT this3
-                WITH this3 { .id, .title } AS this3
-                RETURN collect(this3) AS var4
+              MATCH (this)-[this2:ACTED_IN]->(this3:Movie)
+              WITH DISTINCT this3
+              WITH this3 { .id, .title } AS this3
+              RETURN collect(this3) AS var4
             }
             RETURN this { .name, movies: var4 } AS this"
         `);
@@ -539,26 +535,26 @@ describe("Cypher Update", () => {
             WHERE this.name = $param0
             WITH *
             CALL (*) {
-                CREATE (this0:Movie)
-                MERGE (this)-[this1:ACTED_IN]->(this0)
-                SET
-                    this0.id = $param1,
-                    this0.title = $param2
+              CREATE (this0:Movie)
+              MERGE (this)-[this1:ACTED_IN]->(this0)
+              SET
+                this0.id = $param1,
+                this0.title = $param2
             }
             WITH *
             CALL (*) {
-                CREATE (this2:Movie)
-                MERGE (this)-[this3:ACTED_IN]->(this2)
-                SET
-                    this2.id = $param3,
-                    this2.title = $param4
+              CREATE (this2:Movie)
+              MERGE (this)-[this3:ACTED_IN]->(this2)
+              SET
+                this2.id = $param3,
+                this2.title = $param4
             }
             WITH this
             CALL (this) {
-                MATCH (this)-[this4:ACTED_IN]->(this5:Movie)
-                WITH DISTINCT this5
-                WITH this5 { .id, .title } AS this5
-                RETURN collect(this5) AS var6
+              MATCH (this)-[this4:ACTED_IN]->(this5:Movie)
+              WITH DISTINCT this5
+              WITH this5 { .id, .title } AS this5
+              RETURN collect(this5) AS var6
             }
             RETURN this { .name, movies: var6 } AS this"
         `);
@@ -603,13 +599,13 @@ describe("Cypher Update", () => {
             WHERE this.id = $param0
             WITH *
             CALL (*) {
-                OPTIONAL MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE (this1.name = $param1 AND this0.screenTime = $param2)
-                WITH this0, collect(DISTINCT this1) AS var2
-                CALL (var2) {
-                    UNWIND var2 AS var3
-                    DETACH DELETE var3
-                }
+              OPTIONAL MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE (this1.name = $param1 AND this0.screenTime = $param2)
+              WITH this0, collect(DISTINCT this1) AS var2
+              CALL (var2) {
+                UNWIND var2 AS var3
+                DETACH DELETE var3
+              }
             }
             WITH this
             RETURN this { .id } AS this"
@@ -658,21 +654,20 @@ describe("Cypher Update", () => {
             WHERE this.id = $param0
             WITH *
             CALL (*) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WITH *
-                WHERE this1.name = $param1
-                SET
-                    this1.name = $param2
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WITH *
+              WHERE this1.name = $param1
+              SET this1.name = $param2
             }
             WITH *
             CALL (*) {
-                OPTIONAL MATCH (this)<-[this2:ACTED_IN]-(this3:Actor)
-                WHERE this3.name = $param3
-                WITH this2, collect(DISTINCT this3) AS var4
-                CALL (var4) {
-                    UNWIND var4 AS var5
-                    DETACH DELETE var5
-                }
+              OPTIONAL MATCH (this)<-[this2:ACTED_IN]-(this3:Actor)
+              WHERE this3.name = $param3
+              WITH this2, collect(DISTINCT this3) AS var4
+              CALL (var4) {
+                UNWIND var4 AS var5
+                DETACH DELETE var5
+              }
             }
             WITH this
             RETURN this { .id } AS this"
@@ -711,13 +706,13 @@ describe("Cypher Update", () => {
             WHERE this.id = $param0
             WITH *
             CALL (*) {
-                OPTIONAL MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE this1.name = $param1
-                WITH this0, collect(DISTINCT this1) AS var2
-                CALL (var2) {
-                    UNWIND var2 AS var3
-                    DETACH DELETE var3
-                }
+              OPTIONAL MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE this1.name = $param1
+              WITH this0, collect(DISTINCT this1) AS var2
+              CALL (var2) {
+                UNWIND var2 AS var3
+                DETACH DELETE var3
+              }
             }
             WITH this
             RETURN this { .id } AS this"
@@ -761,23 +756,23 @@ describe("Cypher Update", () => {
             WHERE this.id = $param0
             WITH *
             CALL (*) {
-                OPTIONAL MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE this1.name = $param1
-                WITH *
-                CALL (*) {
-                    OPTIONAL MATCH (this1)-[this2:ACTED_IN]->(this3:Movie)
-                    WHERE this3.id = $param2
-                    WITH this2, collect(DISTINCT this3) AS var4
-                    CALL (var4) {
-                        UNWIND var4 AS var5
-                        DETACH DELETE var5
-                    }
+              OPTIONAL MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE this1.name = $param1
+              WITH *
+              CALL (*) {
+                OPTIONAL MATCH (this1)-[this2:ACTED_IN]->(this3:Movie)
+                WHERE this3.id = $param2
+                WITH this2, collect(DISTINCT this3) AS var4
+                CALL (var4) {
+                  UNWIND var4 AS var5
+                  DETACH DELETE var5
                 }
-                WITH this0, collect(DISTINCT this1) AS var6
-                CALL (var6) {
-                    UNWIND var6 AS var7
-                    DETACH DELETE var7
-                }
+              }
+              WITH this0, collect(DISTINCT this1) AS var6
+              CALL (var6) {
+                UNWIND var6 AS var7
+                DETACH DELETE var7
+              }
             }
             WITH this
             RETURN this { .id } AS this"

--- a/packages/graphql/tests/tck/pagination/cypher-connection-pagination.test.ts
+++ b/packages/graphql/tests/tck/pagination/cypher-connection-pagination.test.ts
@@ -107,24 +107,24 @@ describe("Cypher Connection pagination", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             MATCH (this0:Movie)
-            WITH collect({ node: this0 }) AS edges
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              CALL (this0) {
                 CALL (this0) {
-                    CALL (this0) {
-                        WITH this0 AS this
-                        MATCH (this)-[:HAS_GENRE]->(genre:Genre)
-                        RETURN count(DISTINCT genre) as result
-                    }
-                    WITH result AS this1
-                    RETURN this1 AS var2
+                  WITH this0 AS this
+                  MATCH (this)-[:HAS_GENRE]->(genre:Genre)
+                  RETURN count(DISTINCT genre) as result
                 }
-                WITH *
-                ORDER BY var2 DESC
-                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var3
+                WITH result AS this1
+                RETURN this1 AS var2
+              }
+              WITH *
+              ORDER BY var2 DESC
+              RETURN collect({node: {title: this0.title, __resolveType: 'Movie'}}) AS var3
             }
-            RETURN { edges: var3 } AS this"
+            RETURN {edges: var3} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -148,24 +148,24 @@ describe("Cypher Connection pagination", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             MATCH (this0:Movie)
-            WITH collect({ node: this0 }) AS edges
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              CALL (this0) {
                 CALL (this0) {
-                    CALL (this0) {
-                        WITH this0 AS this
-                        MATCH (this)-[:HAS_GENRE]->(genre:Genre)
-                        RETURN count(DISTINCT genre) as result
-                    }
-                    WITH result AS this1
-                    RETURN this1 AS var2
+                  WITH this0 AS this
+                  MATCH (this)-[:HAS_GENRE]->(genre:Genre)
+                  RETURN count(DISTINCT genre) as result
                 }
-                WITH *
-                ORDER BY var2 DESC
-                RETURN collect({ node: { totalGenres: var2, __resolveType: \\"Movie\\" } }) AS var3
+                WITH result AS this1
+                RETURN this1 AS var2
+              }
+              WITH *
+              ORDER BY var2 DESC
+              RETURN collect({node: {totalGenres: var2, __resolveType: 'Movie'}}) AS var3
             }
-            RETURN { edges: var3 } AS this"
+            RETURN {edges: var3} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -190,32 +190,32 @@ describe("Cypher Connection pagination", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             MATCH (this0:Movie)
-            WITH collect({ node: this0 }) AS edges
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              CALL (this0) {
                 CALL (this0) {
-                    CALL (this0) {
-                        WITH this0 AS this
-                        MATCH (actor:Actor)-[:ACTED_IN]->(this) RETURN count(actor) as count
-                    }
-                    WITH count AS this1
-                    RETURN this1 AS var2
+                  WITH this0 AS this
+                  MATCH (actor:Actor)-[:ACTED_IN]->(this) RETURN count(actor) as count
                 }
+                WITH count AS this1
+                RETURN this1 AS var2
+              }
+              CALL (this0) {
                 CALL (this0) {
-                    CALL (this0) {
-                        WITH this0 AS this
-                        MATCH (this)-[:HAS_GENRE]->(genre:Genre)
-                        RETURN count(DISTINCT genre) as result
-                    }
-                    WITH result AS this3
-                    RETURN this3 AS var4
+                  WITH this0 AS this
+                  MATCH (this)-[:HAS_GENRE]->(genre:Genre)
+                  RETURN count(DISTINCT genre) as result
                 }
-                WITH *
-                ORDER BY var2 DESC, var4 ASC
-                RETURN collect({ node: { numberOfActors: var2, totalGenres: var4, __resolveType: \\"Movie\\" } }) AS var5
+                WITH result AS this3
+                RETURN this3 AS var4
+              }
+              WITH *
+              ORDER BY var2 DESC, var4 ASC
+              RETURN collect({node: {numberOfActors: var2, totalGenres: var4, __resolveType: 'Movie'}}) AS var5
             }
-            RETURN { edges: var5 } AS this"
+            RETURN {edges: var5} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -247,25 +247,25 @@ describe("Cypher Connection pagination", () => {
             "CYPHER 5
             MATCH (this0:Movie)
             WHERE this0.title = $param0
-            WITH collect({ node: this0 }) AS edges
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              CALL (this0) {
                 CALL (this0) {
-                    CALL (this0) {
-                        WITH this0 AS this
-                        MATCH (actor:Actor)-[:ACTED_IN]->(this) RETURN count(actor) as count
-                    }
-                    WITH count AS this1
-                    RETURN this1 AS var2
+                  WITH this0 AS this
+                  MATCH (actor:Actor)-[:ACTED_IN]->(this) RETURN count(actor) as count
                 }
-                WITH *
-                ORDER BY var2 DESC, this0.title ASC
-                SKIP $param1
-                LIMIT $param2
-                RETURN collect({ node: { id: this0.id, title: this0.title, __resolveType: \\"Movie\\" } }) AS var3
+                WITH count AS this1
+                RETURN this1 AS var2
+              }
+              WITH *
+              ORDER BY var2 DESC, this0.title ASC
+              SKIP $param1
+              LIMIT $param2
+              RETURN collect({node: {id: this0.id, title: this0.title, __resolveType: 'Movie'}}) AS var3
             }
-            RETURN { edges: var3 } AS this"
+            RETURN {edges: var3} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -307,34 +307,34 @@ describe("Cypher Connection pagination", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             MATCH (this0:Movie)
-            WITH collect({ node: this0 }) AS edges
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                CALL (this0) {
-                    MATCH (this0)-[this1:HAS_GENRE]->(this2:Genre)
-                    WITH collect({ node: this2, relationship: this1 }) AS edges
-                    CALL (edges) {
-                        UNWIND edges AS edge
-                        WITH edge.node AS this2, edge.relationship AS this1
-                        CALL (this2) {
-                            CALL (this2) {
-                                WITH this2 AS this
-                                MATCH (this)<-[:HAS_GENRE]-(movie:Movie)
-                                RETURN count(DISTINCT movie) as result
-                            }
-                            WITH result AS this3
-                            RETURN this3 AS var4
-                        }
-                        WITH *
-                        ORDER BY var4 ASC
-                        RETURN collect({ node: { name: this2.name, __resolveType: \\"Genre\\" } }) AS var5
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              CALL (this0) {
+                MATCH (this0)-[this1:HAS_GENRE]->(this2:Genre)
+                WITH collect({node: this2, relationship: this1}) AS edges
+                CALL (edges) {
+                  UNWIND edges AS edge
+                  WITH edge.node AS this2, edge.relationship AS this1
+                  CALL (this2) {
+                    CALL (this2) {
+                      WITH this2 AS this
+                      MATCH (this)<-[:HAS_GENRE]-(movie:Movie)
+                      RETURN count(DISTINCT movie) as result
                     }
-                    RETURN { edges: var5 } AS var6
+                    WITH result AS this3
+                    RETURN this3 AS var4
+                  }
+                  WITH *
+                  ORDER BY var4 ASC
+                  RETURN collect({node: {name: this2.name, __resolveType: 'Genre'}}) AS var5
                 }
-                RETURN collect({ node: { genresConnection: var6, __resolveType: \\"Movie\\" } }) AS var7
+                RETURN {edges: var5} AS var6
+              }
+              RETURN collect({node: {genresConnection: var6, __resolveType: 'Movie'}}) AS var7
             }
-            RETURN { edges: var7 } AS this"
+            RETURN {edges: var7} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -369,34 +369,34 @@ describe("Cypher Connection pagination", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             MATCH (this0:Movie)
-            WITH collect({ node: this0 }) AS edges
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                CALL (this0) {
-                    MATCH (this0)<-[this1:ACTED_IN]-(this2:Actor)
-                    WITH collect({ node: this2, relationship: this1 }) AS edges
-                    CALL (edges) {
-                        UNWIND edges AS edge
-                        WITH edge.node AS this2, edge.relationship AS this1
-                        CALL (this2) {
-                            CALL (this2) {
-                                WITH this2 AS this
-                                MATCH (this)-[r:ACTED_IN]->(:Movie)
-                                RETURN sum(r.screenTime) as sum
-                            }
-                            WITH sum AS this3
-                            RETURN this3 AS var4
-                        }
-                        WITH *
-                        ORDER BY this1.screenTime DESC, var4 ASC
-                        RETURN collect({ properties: { screenTime: this1.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: this2.name, __resolveType: \\"Actor\\" } }) AS var5
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              CALL (this0) {
+                MATCH (this0)<-[this1:ACTED_IN]-(this2:Actor)
+                WITH collect({node: this2, relationship: this1}) AS edges
+                CALL (edges) {
+                  UNWIND edges AS edge
+                  WITH edge.node AS this2, edge.relationship AS this1
+                  CALL (this2) {
+                    CALL (this2) {
+                      WITH this2 AS this
+                      MATCH (this)-[r:ACTED_IN]->(:Movie)
+                      RETURN sum(r.screenTime) as sum
                     }
-                    RETURN { edges: var5 } AS var6
+                    WITH sum AS this3
+                    RETURN this3 AS var4
+                  }
+                  WITH *
+                  ORDER BY this1.screenTime DESC, var4 ASC
+                  RETURN collect({properties: {screenTime: this1.screenTime, __resolveType: 'ActedIn'}, node: {name: this2.name, __resolveType: 'Actor'}}) AS var5
                 }
-                RETURN collect({ node: { actorsConnection: var6, __resolveType: \\"Movie\\" } }) AS var7
+                RETURN {edges: var5} AS var6
+              }
+              RETURN collect({node: {actorsConnection: var6, __resolveType: 'Movie'}}) AS var7
             }
-            RETURN { edges: var7 } AS this"
+            RETURN {edges: var7} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);

--- a/packages/graphql/tests/tck/pagination/cypher-pagination.test.ts
+++ b/packages/graphql/tests/tck/pagination/cypher-pagination.test.ts
@@ -100,13 +100,13 @@ describe("Cypher Sort tests", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:HAS_GENRE]->(genre:Genre)
-                    RETURN count(DISTINCT genre) as result
-                }
-                WITH result AS this0
-                RETURN this0 AS var1
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:HAS_GENRE]->(genre:Genre)
+                RETURN count(DISTINCT genre) as result
+              }
+              WITH result AS this0
+              RETURN this0 AS var1
             }
             WITH *
             ORDER BY var1 DESC
@@ -131,13 +131,13 @@ describe("Cypher Sort tests", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:HAS_GENRE]->(genre:Genre)
-                    RETURN count(DISTINCT genre) as result
-                }
-                WITH result AS this0
-                RETURN this0 AS var1
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:HAS_GENRE]->(genre:Genre)
+                RETURN count(DISTINCT genre) as result
+              }
+              WITH result AS this0
+              RETURN this0 AS var1
             }
             WITH *
             ORDER BY var1 DESC
@@ -163,21 +163,21 @@ describe("Cypher Sort tests", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (actor:Actor)-[:ACTED_IN]->(this) RETURN count(actor) as count
-                }
-                WITH count AS this0
-                RETURN this0 AS var1
+              CALL (this) {
+                WITH this AS this
+                MATCH (actor:Actor)-[:ACTED_IN]->(this) RETURN count(actor) as count
+              }
+              WITH count AS this0
+              RETURN this0 AS var1
             }
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (this)-[:HAS_GENRE]->(genre:Genre)
-                    RETURN count(DISTINCT genre) as result
-                }
-                WITH result AS this2
-                RETURN this2 AS var3
+              CALL (this) {
+                WITH this AS this
+                MATCH (this)-[:HAS_GENRE]->(genre:Genre)
+                RETURN count(DISTINCT genre) as result
+              }
+              WITH result AS this2
+              RETURN this2 AS var3
             }
             WITH *
             ORDER BY var1 DESC, var3 ASC
@@ -209,12 +209,12 @@ describe("Cypher Sort tests", () => {
             MATCH (this:Movie)
             WHERE this.title = $param0
             CALL (this) {
-                CALL (this) {
-                    WITH this AS this
-                    MATCH (actor:Actor)-[:ACTED_IN]->(this) RETURN count(actor) as count
-                }
-                WITH count AS this0
-                RETURN this0 AS var1
+              CALL (this) {
+                WITH this AS this
+                MATCH (actor:Actor)-[:ACTED_IN]->(this) RETURN count(actor) as count
+              }
+              WITH count AS this0
+              RETURN this0 AS var1
             }
             WITH *
             ORDER BY var1 DESC, this.title ASC
@@ -255,20 +255,20 @@ describe("Cypher Sort tests", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)-[this0:HAS_GENRE]->(this1:Genre)
-                WITH DISTINCT this1
+              MATCH (this)-[this0:HAS_GENRE]->(this1:Genre)
+              WITH DISTINCT this1
+              CALL (this1) {
                 CALL (this1) {
-                    CALL (this1) {
-                        WITH this1 AS this
-                        MATCH (this)<-[:HAS_GENRE]-(movie:Movie)
-                        RETURN count(DISTINCT movie) as result
-                    }
-                    WITH result AS this2
-                    RETURN this2 AS var3
+                  WITH this1 AS this
+                  MATCH (this)<-[:HAS_GENRE]-(movie:Movie)
+                  RETURN count(DISTINCT movie) as result
                 }
-                WITH this1 { .name, totalMovies: var3 } AS this1
-                ORDER BY var3 ASC
-                RETURN collect(this1) AS var4
+                WITH result AS this2
+                RETURN this2 AS var3
+              }
+              WITH this1 { .name, totalMovies: var3 } AS this1
+              ORDER BY var3 ASC
+              RETURN collect(this1) AS var4
             }
             RETURN this { genres: var4 } AS this"
         `);

--- a/packages/graphql/tests/tck/pagination/sort.test.ts
+++ b/packages/graphql/tests/tck/pagination/sort.test.ts
@@ -166,11 +166,11 @@ describe("Sort", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)-[this0:HAS_GENRE]->(this1:Genre)
-                WITH DISTINCT this1
-                WITH this1 { .name } AS this1
-                ORDER BY this1.name ASC
-                RETURN collect(this1) AS var2
+              MATCH (this)-[this0:HAS_GENRE]->(this1:Genre)
+              WITH DISTINCT this1
+              WITH this1 { .name } AS this1
+              ORDER BY this1.name ASC
+              RETURN collect(this1) AS var2
             }
             RETURN this { genres: var2 } AS this"
         `);
@@ -195,11 +195,11 @@ describe("Sort", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                MATCH (this)-[this0:HAS_GENRE]->(this1:Genre)
-                WITH DISTINCT this1
-                WITH this1 { .name } AS this1
-                ORDER BY this1.name DESC
-                RETURN collect(this1) AS var2
+              MATCH (this)-[this0:HAS_GENRE]->(this1:Genre)
+              WITH DISTINCT this1
+              WITH this1 { .name } AS this1
+              ORDER BY this1.name DESC
+              RETURN collect(this1) AS var2
             }
             RETURN this { genres: var2 } AS this"
         `);

--- a/packages/graphql/tests/tck/pringles.test.ts
+++ b/packages/graphql/tests/tck/pringles.test.ts
@@ -108,72 +108,72 @@ describe("Cypher Create Pringles", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                CREATE (this0:Product)
-                SET
-                    this0.id = $param0,
-                    this0.name = $param1
-                WITH *
-                CREATE (this1:Size)
-                MERGE (this0)-[this2:HAS_SIZE]->(this1)
-                SET
-                    this1.id = $param2,
-                    this1.name = $param3
-                WITH *
-                CREATE (this3:Size)
-                MERGE (this0)-[this4:HAS_SIZE]->(this3)
-                SET
-                    this3.id = $param4,
-                    this3.name = $param5
-                WITH *
-                CREATE (this5:Color)
-                MERGE (this0)-[this6:HAS_COLOR]->(this5)
-                SET
-                    this5.id = $param6,
-                    this5.name = $param7
-                WITH *
-                CREATE (this7:Color)
-                MERGE (this0)-[this8:HAS_COLOR]->(this7)
-                SET
-                    this7.id = $param8,
-                    this7.name = $param9
-                WITH *
-                CREATE (this9:Photo)
-                MERGE (this0)-[this10:HAS_PHOTO]->(this9)
-                SET
-                    this9.id = $param10,
-                    this9.description = $param11,
-                    this9.url = $param12
-                WITH *
-                CREATE (this11:Photo)
-                WITH *
-                CALL (this11) {
-                    MATCH (this12:Color)
-                    WHERE this12.id = $param13
-                    CREATE (this11)-[this13:OF_COLOR]->(this12)
-                }
-                MERGE (this0)-[this14:HAS_PHOTO]->(this11)
-                SET
-                    this11.id = $param14,
-                    this11.description = $param15,
-                    this11.url = $param16
-                WITH *
-                CREATE (this15:Photo)
-                WITH *
-                CALL (this15) {
-                    MATCH (this16:Color)
-                    WHERE this16.id = $param17
-                    CREATE (this15)-[this17:OF_COLOR]->(this16)
-                }
-                MERGE (this0)-[this18:HAS_PHOTO]->(this15)
-                SET
-                    this15.id = $param18,
-                    this15.description = $param19,
-                    this15.url = $param20
-                RETURN this0 AS this
+              CREATE (this0:Product)
+              SET
+                this0.id = $param0,
+                this0.name = $param1
+              WITH *
+              CREATE (this1:Size)
+              MERGE (this0)-[this2:HAS_SIZE]->(this1)
+              SET
+                this1.id = $param2,
+                this1.name = $param3
+              WITH *
+              CREATE (this3:Size)
+              MERGE (this0)-[this4:HAS_SIZE]->(this3)
+              SET
+                this3.id = $param4,
+                this3.name = $param5
+              WITH *
+              CREATE (this5:Color)
+              MERGE (this0)-[this6:HAS_COLOR]->(this5)
+              SET
+                this5.id = $param6,
+                this5.name = $param7
+              WITH *
+              CREATE (this7:Color)
+              MERGE (this0)-[this8:HAS_COLOR]->(this7)
+              SET
+                this7.id = $param8,
+                this7.name = $param9
+              WITH *
+              CREATE (this9:Photo)
+              MERGE (this0)-[this10:HAS_PHOTO]->(this9)
+              SET
+                this9.id = $param10,
+                this9.description = $param11,
+                this9.url = $param12
+              WITH *
+              CREATE (this11:Photo)
+              WITH *
+              CALL (this11) {
+                MATCH (this12:Color)
+                WHERE this12.id = $param13
+                CREATE (this11)-[this13:OF_COLOR]->(this12)
+              }
+              MERGE (this0)-[this14:HAS_PHOTO]->(this11)
+              SET
+                this11.id = $param14,
+                this11.description = $param15,
+                this11.url = $param16
+              WITH *
+              CREATE (this15:Photo)
+              WITH *
+              CALL (this15) {
+                MATCH (this16:Color)
+                WHERE this16.id = $param17
+                CREATE (this15)-[this17:OF_COLOR]->(this16)
+              }
+              MERGE (this0)-[this18:HAS_PHOTO]->(this15)
+              SET
+                this15.id = $param18,
+                this15.description = $param19,
+                this15.url = $param20
+              RETURN this0 AS this
             }
             WITH this
             CALL (this) {
-                RETURN this { .id } AS var19
+              RETURN this { .id } AS var19
             }
             RETURN collect(var19) AS data"
         `);
@@ -243,28 +243,27 @@ describe("Cypher Create Pringles", () => {
             WHERE this.name = $param0
             WITH *
             CALL (*) {
-                MATCH (this)-[this0:HAS_PHOTO]->(this1:Photo)
-                WITH *
-                WHERE this1.description = $param1
-                SET
-                    this1.description = $param2
-                WITH *
-                CALL (*) {
-                    CALL (this1) {
-                        MATCH (this2:Color)
-                        WHERE this2.name = $param3
-                        CREATE (this1)-[this3:OF_COLOR]->(this2)
-                    }
+              MATCH (this)-[this0:HAS_PHOTO]->(this1:Photo)
+              WITH *
+              WHERE this1.description = $param1
+              SET this1.description = $param2
+              WITH *
+              CALL (*) {
+                CALL (this1) {
+                  MATCH (this2:Color)
+                  WHERE this2.name = $param3
+                  CREATE (this1)-[this3:OF_COLOR]->(this2)
                 }
-                WITH *
-                CALL (*) {
-                    CALL (this1) {
-                        OPTIONAL MATCH (this1)-[this4:OF_COLOR]->(this5:Color)
-                        WHERE this5.name = $param4
-                        WITH *
-                        DELETE this4
-                    }
+              }
+              WITH *
+              CALL (*) {
+                CALL (this1) {
+                  OPTIONAL MATCH (this1)-[this4:OF_COLOR]->(this5:Color)
+                  WHERE this5.name = $param4
+                  WITH *
+                  DELETE this4
                 }
+              }
             }
             WITH this
             RETURN this { .id } AS this"

--- a/packages/graphql/tests/tck/projection.test.ts
+++ b/packages/graphql/tests/tck/projection.test.ts
@@ -90,31 +90,30 @@ describe("Cypher Projection", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Product)
-                SET
-                    create_this1.id = create_var0.id
-                RETURN create_this1
+              CREATE (create_this1:Product)
+              SET create_this1.id = create_var0.id
+              RETURN create_this1
             }
             CALL (create_this1) {
-                MATCH (create_this1)-[create_this2:HAS_PHOTO]->(create_this3:Photo)
-                WHERE create_this3.url = $create_param1
-                WITH DISTINCT create_this3
-                WITH create_this3 { .url, .location } AS create_this3
-                RETURN collect(create_this3) AS create_var4
+              MATCH (create_this1)-[create_this2:HAS_PHOTO]->(create_this3:Photo)
+              WHERE create_this3.url = $create_param1
+              WITH DISTINCT create_this3
+              WITH create_this3 { .url, .location } AS create_this3
+              RETURN collect(create_this3) AS create_var4
             }
             CALL (create_this1) {
-                MATCH (create_this1)-[create_this5:HAS_COLOR]->(create_this6:Color)
-                WHERE create_this6.id = $create_param2
-                WITH DISTINCT create_this6
-                WITH create_this6 { .id } AS create_this6
-                RETURN collect(create_this6) AS create_var7
+              MATCH (create_this1)-[create_this5:HAS_COLOR]->(create_this6:Color)
+              WHERE create_this6.id = $create_param2
+              WITH DISTINCT create_this6
+              WITH create_this6 { .id } AS create_this6
+              RETURN collect(create_this6) AS create_var7
             }
             CALL (create_this1) {
-                MATCH (create_this1)-[create_this8:HAS_SIZE]->(create_this9:Size)
-                WHERE create_this9.name = $create_param3
-                WITH DISTINCT create_this9
-                WITH create_this9 { .name } AS create_this9
-                RETURN collect(create_this9) AS create_var10
+              MATCH (create_this1)-[create_this8:HAS_SIZE]->(create_this9:Size)
+              WHERE create_this9.name = $create_param3
+              WITH DISTINCT create_this9
+              WITH create_this9 { .name } AS create_this9
+              RETURN collect(create_this9) AS create_var10
             }
             RETURN collect(create_this1 { .id, photos: create_var4, colors: create_var7, sizes: create_var10 }) AS data"
         `);

--- a/packages/graphql/tests/tck/rfcs/query-limits.test.ts
+++ b/packages/graphql/tests/tck/rfcs/query-limits.test.ts
@@ -160,11 +160,11 @@ describe("tck/rfcs/query-limits", () => {
                 WITH *
                 LIMIT $param0
                 CALL (this) {
-                    MATCH (this)<-[this0:ACTED_IN]-(this1:Person)
-                    WITH DISTINCT this1
-                    WITH this1 { .id } AS this1
-                    LIMIT $param1
-                    RETURN collect(this1) AS var2
+                  MATCH (this)<-[this0:ACTED_IN]-(this1:Person)
+                  WITH DISTINCT this1
+                  WITH this1 { .id } AS this1
+                  LIMIT $param1
+                  RETURN collect(this1) AS var2
                 }
                 RETURN this { .id, actors: var2 } AS this"
             `);
@@ -207,16 +207,16 @@ describe("tck/rfcs/query-limits", () => {
                 WITH *
                 LIMIT $param0
                 CALL (this) {
-                    MATCH (this)<-[this0:ACTED_IN]-(this1:Person)
-                    WITH collect({ node: this1, relationship: this0 }) AS edges
-                    CALL (edges) {
-                        UNWIND edges AS edge
-                        WITH edge.node AS this1, edge.relationship AS this0
-                        WITH *
-                        LIMIT $param1
-                        RETURN collect({ node: { id: this1.id, __resolveType: \\"Person\\" } }) AS var2
-                    }
-                    RETURN { edges: var2 } AS var3
+                  MATCH (this)<-[this0:ACTED_IN]-(this1:Person)
+                  WITH collect({node: this1, relationship: this0}) AS edges
+                  CALL (edges) {
+                    UNWIND edges AS edge
+                    WITH edge.node AS this1, edge.relationship AS this0
+                    WITH *
+                    LIMIT $param1
+                    RETURN collect({node: {id: this1.id, __resolveType: 'Person'}}) AS var2
+                  }
+                  RETURN {edges: var2} AS var3
                 }
                 RETURN this { .id, actorsConnection: var3 } AS this"
             `);
@@ -259,16 +259,16 @@ describe("tck/rfcs/query-limits", () => {
                 WITH *
                 LIMIT $param0
                 CALL (this) {
-                    MATCH (this)<-[this0:ACTED_IN]-(this1:Person)
-                    WITH collect({ node: this1, relationship: this0 }) AS edges
-                    CALL (edges) {
-                        UNWIND edges AS edge
-                        WITH edge.node AS this1, edge.relationship AS this0
-                        WITH *
-                        LIMIT $param1
-                        RETURN collect({ node: { id: this1.id, __resolveType: \\"Person\\" } }) AS var2
-                    }
-                    RETURN { edges: var2 } AS var3
+                  MATCH (this)<-[this0:ACTED_IN]-(this1:Person)
+                  WITH collect({node: this1, relationship: this0}) AS edges
+                  CALL (edges) {
+                    UNWIND edges AS edge
+                    WITH edge.node AS this1, edge.relationship AS this0
+                    WITH *
+                    LIMIT $param1
+                    RETURN collect({node: {id: this1.id, __resolveType: 'Person'}}) AS var2
+                  }
+                  RETURN {edges: var2} AS var3
                 }
                 RETURN this { .id, actorsConnection: var3 } AS this"
             `);
@@ -309,16 +309,16 @@ describe("tck/rfcs/query-limits", () => {
                 "CYPHER 5
                 MATCH (this:Festival)
                 CALL (this) {
-                    MATCH (this)<-[this0:PART_OF]-(this1:Show)
-                    WITH collect({ node: this1, relationship: this0 }) AS edges
-                    CALL (edges) {
-                        UNWIND edges AS edge
-                        WITH edge.node AS this1, edge.relationship AS this0
-                        WITH *
-                        LIMIT $param0
-                        RETURN collect({ node: { id: this1.id, __resolveType: \\"Show\\" } }) AS var2
-                    }
-                    RETURN { edges: var2 } AS var3
+                  MATCH (this)<-[this0:PART_OF]-(this1:Show)
+                  WITH collect({node: this1, relationship: this0}) AS edges
+                  CALL (edges) {
+                    UNWIND edges AS edge
+                    WITH edge.node AS this1, edge.relationship AS this0
+                    WITH *
+                    LIMIT $param0
+                    RETURN collect({node: {id: this1.id, __resolveType: 'Show'}}) AS var2
+                  }
+                  RETURN {edges: var2} AS var3
                 }
                 RETURN this { .name, showsConnection: var3 } AS this"
             `);
@@ -353,11 +353,11 @@ describe("tck/rfcs/query-limits", () => {
                 WITH *
                 LIMIT $param0
                 CALL (this) {
-                    MATCH (this)<-[this0:ACTED_IN]-(this1:Person)
-                    WITH DISTINCT this1
-                    WITH this1 { .id } AS this1
-                    LIMIT $param1
-                    RETURN collect(this1) AS var2
+                  MATCH (this)<-[this0:ACTED_IN]-(this1:Person)
+                  WITH DISTINCT this1
+                  WITH this1 { .id } AS this1
+                  LIMIT $param1
+                  RETURN collect(this1) AS var2
                 }
                 RETURN this { .id, actors: var2 } AS this"
             `);

--- a/packages/graphql/tests/tck/rfcs/rfc-022.test.ts
+++ b/packages/graphql/tests/tck/rfcs/rfc-022.test.ts
@@ -70,11 +70,11 @@ describe("tck/rfs/022 subquery projection", () => {
                 MATCH (this:Movie)
                 WHERE this.released = $param0
                 CALL (this) {
-                    MATCH (this)<-[this0:ACTED_IN]-(this1:Person)
-                    WHERE this1.name = $param1
-                    WITH DISTINCT this1
-                    WITH this1 { .name } AS this1
-                    RETURN collect(this1) AS var2
+                  MATCH (this)<-[this0:ACTED_IN]-(this1:Person)
+                  WHERE this1.name = $param1
+                  WITH DISTINCT this1
+                  WITH this1 { .name } AS this1
+                  RETURN collect(this1) AS var2
                 }
                 RETURN this { .title, actors: var2 } AS this"
             `);
@@ -113,17 +113,17 @@ describe("tck/rfs/022 subquery projection", () => {
                 MATCH (this:Movie)
                 WHERE this.released = $param0
                 CALL (this) {
-                    MATCH (this)<-[this0:ACTED_IN]-(this1:Person)
-                    WHERE this1.name = $param1
-                    WITH DISTINCT this1
-                    CALL (this1) {
-                        MATCH (this1)-[this2:DIRECTED]->(this3:Movie)
-                        WITH DISTINCT this3
-                        WITH this3 { .title, .released } AS this3
-                        RETURN collect(this3) AS var4
-                    }
-                    WITH this1 { .name, directed: var4 } AS this1
-                    RETURN collect(this1) AS var5
+                  MATCH (this)<-[this0:ACTED_IN]-(this1:Person)
+                  WHERE this1.name = $param1
+                  WITH DISTINCT this1
+                  CALL (this1) {
+                    MATCH (this1)-[this2:DIRECTED]->(this3:Movie)
+                    WITH DISTINCT this3
+                    WITH this3 { .title, .released } AS this3
+                    RETURN collect(this3) AS var4
+                  }
+                  WITH this1 { .name, directed: var4 } AS this1
+                  RETURN collect(this1) AS var5
                 }
                 RETURN this { .title, actors: var5 } AS this"
             `);
@@ -203,13 +203,13 @@ describe("tck/rfs/022 subquery projection", () => {
                 MATCH (this:Movie)
                 WHERE this.released = $param0
                 CALL (this) {
-                    MATCH (this)<-[this0:ACTED_IN]-(this1:Person)
-                    WITH DISTINCT this1
-                    WITH *
-                    WHERE (this1.name = $param1 AND ($isAuthenticated = true AND ($param3 IS NOT NULL AND this1.name = $param3)))
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.test IS NOT NULL AND this1.name = $jwt.test) AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    WITH this1 { .name } AS this1
-                    RETURN collect(this1) AS var2
+                  MATCH (this)<-[this0:ACTED_IN]-(this1:Person)
+                  WITH DISTINCT this1
+                  WITH *
+                  WHERE (this1.name = $param1 AND ($isAuthenticated = true AND ($param3 IS NOT NULL AND this1.name = $param3)))
+                  CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.test IS NOT NULL AND this1.name = $jwt.test) AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles)), '@neo4j/graphql/FORBIDDEN', [])
+                  WITH this1 { .name } AS this1
+                  RETURN collect(this1) AS var2
                 }
                 RETURN this { .title, actors: var2 } AS this"
             `);

--- a/packages/graphql/tests/tck/root-connection.test.ts
+++ b/packages/graphql/tests/tck/root-connection.test.ts
@@ -63,13 +63,13 @@ describe("Root Connection Query tests", () => {
             "CYPHER 5
             MATCH (this0:Movie)
             WHERE this0.title = $param0
-            WITH collect({ node: this0 }) AS edges, count(this0) AS totalCount
+            WITH collect({node: this0}) AS edges, count(this0) AS totalCount
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var1
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              RETURN collect({node: {title: this0.title, __resolveType: 'Movie'}}) AS var1
             }
-            RETURN { edges: var1, totalCount: totalCount } AS this"
+            RETURN {edges: var1, totalCount: totalCount} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -97,16 +97,16 @@ describe("Root Connection Query tests", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             MATCH (this0:Movie)
-            WITH collect({ node: this0 }) AS edges
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                WITH *
-                ORDER BY this0.title ASC
-                LIMIT $param0
-                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var1
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              WITH *
+              ORDER BY this0.title ASC
+              LIMIT $param0
+              RETURN collect({node: {title: this0.title, __resolveType: 'Movie'}}) AS var1
             }
-            RETURN { edges: var1 } AS this"
+            RETURN {edges: var1} AS this"
         `);
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -135,16 +135,16 @@ describe("Root Connection Query tests", () => {
             "CYPHER 5
             MATCH (this0:Movie)
             WHERE this0.title CONTAINS $param0
-            WITH collect({ node: this0 }) AS edges
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                WITH *
-                ORDER BY this0.title ASC
-                LIMIT $param1
-                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var1
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              WITH *
+              ORDER BY this0.title ASC
+              LIMIT $param1
+              RETURN collect({node: {title: this0.title, __resolveType: 'Movie'}}) AS var1
             }
-            RETURN { edges: var1 } AS this"
+            RETURN {edges: var1} AS this"
         `);
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -180,26 +180,26 @@ describe("Root Connection Query tests", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             MATCH (this0:Movie)
-            WITH collect({ node: this0 }) AS edges
+            WITH collect({node: this0}) AS edges
             CALL (edges) {
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                WITH *
-                ORDER BY this0.title ASC
-                LIMIT $param0
-                CALL (this0) {
-                    MATCH (this0)<-[this1:ACTED_IN]-(this2:Actor)
-                    WITH collect({ node: this2, relationship: this1 }) AS edges, count(this2) AS totalCount
-                    CALL (edges) {
-                        UNWIND edges AS edge
-                        WITH edge.node AS this2, edge.relationship AS this1
-                        RETURN collect({ node: { name: this2.name, __resolveType: \\"Actor\\" } }) AS var3
-                    }
-                    RETURN { edges: var3, totalCount: totalCount } AS var4
+              UNWIND edges AS edge
+              WITH edge.node AS this0
+              WITH *
+              ORDER BY this0.title ASC
+              LIMIT $param0
+              CALL (this0) {
+                MATCH (this0)<-[this1:ACTED_IN]-(this2:Actor)
+                WITH collect({node: this2, relationship: this1}) AS edges, count(this2) AS totalCount
+                CALL (edges) {
+                  UNWIND edges AS edge
+                  WITH edge.node AS this2, edge.relationship AS this1
+                  RETURN collect({node: {name: this2.name, __resolveType: 'Actor'}}) AS var3
                 }
-                RETURN collect({ node: { title: this0.title, actorsConnection: var4, __resolveType: \\"Movie\\" } }) AS var5
+                RETURN {edges: var3, totalCount: totalCount} AS var4
+              }
+              RETURN collect({node: {title: this0.title, actorsConnection: var4, __resolveType: 'Movie'}}) AS var5
             }
-            RETURN { edges: var5 } AS this"
+            RETURN {edges: var5} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/subscriptions/create-auth.test.ts
+++ b/packages/graphql/tests/tck/subscriptions/create-auth.test.ts
@@ -71,12 +71,11 @@ describe("Subscriptions metadata on create", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Actor)
-                SET
-                    create_this1.id = create_var0.id
-                WITH *
-                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND create_this1.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                RETURN create_this1
+              CREATE (create_this1:Actor)
+              SET create_this1.id = create_var0.id
+              WITH *
+              CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND create_this1.id = $jwt.sub)), '@neo4j/graphql/FORBIDDEN', [])
+              RETURN create_this1
             }
             RETURN collect(create_this1 { .id }) AS data"
         `);

--- a/packages/graphql/tests/tck/subscriptions/create.test.ts
+++ b/packages/graphql/tests/tck/subscriptions/create.test.ts
@@ -104,31 +104,28 @@ describe("Subscriptions metadata on create", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Movie)
-                SET
-                    create_this1.title = create_var0.title
-                WITH create_this1, create_var0
-                CALL (create_this1, create_var0) {
-                    UNWIND create_var0.actors.create AS create_var2
-                    CREATE (create_this3:Actor)
-                    SET
-                        create_this3.name = create_var2.node.name
-                    MERGE (create_this1)<-[create_this4:ACTED_IN]-(create_this3)
-                    SET
-                        create_this4.screenTime = create_var2.edge.screenTime
-                    RETURN collect(NULL) AS create_var5
-                }
-                RETURN create_this1
+              CREATE (create_this1:Movie)
+              SET create_this1.title = create_var0.title
+              WITH create_this1, create_var0
+              CALL (create_this1, create_var0) {
+                UNWIND create_var0.actors.create AS create_var2
+                CREATE (create_this3:Actor)
+                SET create_this3.name = create_var2.node.name
+                MERGE (create_this1)<-[create_this4:ACTED_IN]-(create_this3)
+                SET create_this4.screenTime = create_var2.edge.screenTime
+                RETURN collect(NULL) AS create_var5
+              }
+              RETURN create_this1
             }
             CALL (create_this1) {
-                MATCH (create_this1)<-[create_this6:ACTED_IN]-(create_this7:Actor)
-                WITH collect({ node: create_this7, relationship: create_this6 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS create_this7, edge.relationship AS create_this6
-                    RETURN collect({ properties: { screenTime: create_this6.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: create_this7.name, __resolveType: \\"Actor\\" } }) AS create_var8
-                }
-                RETURN { edges: create_var8 } AS create_var9
+              MATCH (create_this1)<-[create_this6:ACTED_IN]-(create_this7:Actor)
+              WITH collect({node: create_this7, relationship: create_this6}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS create_this7, edge.relationship AS create_this6
+                RETURN collect({properties: {screenTime: create_this6.screenTime, __resolveType: 'ActedIn'}, node: {name: create_this7.name, __resolveType: 'Actor'}}) AS create_var8
+              }
+              RETURN {edges: create_var8} AS create_var9
             }
             RETURN collect(create_this1 { .title, actorsConnection: create_var9 }) AS data"
         `);
@@ -204,29 +201,27 @@ describe("Subscriptions metadata on create", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Movie)
-                SET
-                    create_this1.title = create_var0.title
-                WITH create_this1, create_var0
-                CALL (create_this1, create_var0) {
-                    UNWIND create_var0.actors.create AS create_var2
-                    CREATE (create_this3:Actor)
-                    SET
-                        create_this3.name = create_var2.node.name
-                    MERGE (create_this1)<-[create_this4:ACTED_IN]-(create_this3)
-                    RETURN collect(NULL) AS create_var5
-                }
-                RETURN create_this1
+              CREATE (create_this1:Movie)
+              SET create_this1.title = create_var0.title
+              WITH create_this1, create_var0
+              CALL (create_this1, create_var0) {
+                UNWIND create_var0.actors.create AS create_var2
+                CREATE (create_this3:Actor)
+                SET create_this3.name = create_var2.node.name
+                MERGE (create_this1)<-[create_this4:ACTED_IN]-(create_this3)
+                RETURN collect(NULL) AS create_var5
+              }
+              RETURN create_this1
             }
             CALL (create_this1) {
-                MATCH (create_this1)<-[create_this6:ACTED_IN]-(create_this7:Actor)
-                WITH collect({ node: create_this7, relationship: create_this6 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS create_this7, edge.relationship AS create_this6
-                    RETURN collect({ node: { name: create_this7.name, __resolveType: \\"Actor\\" } }) AS create_var8
-                }
-                RETURN { edges: create_var8 } AS create_var9
+              MATCH (create_this1)<-[create_this6:ACTED_IN]-(create_this7:Actor)
+              WITH collect({node: create_this7, relationship: create_this6}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS create_this7, edge.relationship AS create_this6
+                RETURN collect({node: {name: create_this7.name, __resolveType: 'Actor'}}) AS create_var8
+              }
+              RETURN {edges: create_var8} AS create_var9
             }
             RETURN collect(create_this1 { .title, actorsConnection: create_var9 }) AS data"
         `);
@@ -320,42 +315,37 @@ describe("Subscriptions metadata on create", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Movie)
-                SET
-                    create_this1.title = create_var0.title
-                WITH create_this1, create_var0
-                CALL (create_this1, create_var0) {
-                    UNWIND create_var0.actors.create AS create_var2
-                    CREATE (create_this3:Actor)
-                    SET
-                        create_this3.name = create_var2.node.name
-                    MERGE (create_this1)<-[create_this4:ACTED_IN]-(create_this3)
-                    SET
-                        create_this4.screenTime = create_var2.edge.screenTime
-                    WITH create_this3, create_var2
-                    CALL (create_this3, create_var2) {
-                        UNWIND create_var2.node.movies.create AS create_var5
-                        CREATE (create_this6:Movie)
-                        SET
-                            create_this6.title = create_var5.node.title
-                        MERGE (create_this3)-[create_this7:ACTED_IN]->(create_this6)
-                        SET
-                            create_this7.screenTime = create_var5.edge.screenTime
-                        RETURN collect(NULL) AS create_var8
-                    }
-                    RETURN collect(NULL) AS create_var9
+              CREATE (create_this1:Movie)
+              SET create_this1.title = create_var0.title
+              WITH create_this1, create_var0
+              CALL (create_this1, create_var0) {
+                UNWIND create_var0.actors.create AS create_var2
+                CREATE (create_this3:Actor)
+                SET create_this3.name = create_var2.node.name
+                MERGE (create_this1)<-[create_this4:ACTED_IN]-(create_this3)
+                SET create_this4.screenTime = create_var2.edge.screenTime
+                WITH create_this3, create_var2
+                CALL (create_this3, create_var2) {
+                  UNWIND create_var2.node.movies.create AS create_var5
+                  CREATE (create_this6:Movie)
+                  SET create_this6.title = create_var5.node.title
+                  MERGE (create_this3)-[create_this7:ACTED_IN]->(create_this6)
+                  SET create_this7.screenTime = create_var5.edge.screenTime
+                  RETURN collect(NULL) AS create_var8
                 }
-                RETURN create_this1
+                RETURN collect(NULL) AS create_var9
+              }
+              RETURN create_this1
             }
             CALL (create_this1) {
-                MATCH (create_this1)<-[create_this10:ACTED_IN]-(create_this11:Actor)
-                WITH collect({ node: create_this11, relationship: create_this10 }) AS edges
-                CALL (edges) {
-                    UNWIND edges AS edge
-                    WITH edge.node AS create_this11, edge.relationship AS create_this10
-                    RETURN collect({ properties: { screenTime: create_this10.screenTime, __resolveType: \\"ActedIn\\" }, node: { name: create_this11.name, __resolveType: \\"Actor\\" } }) AS create_var12
-                }
-                RETURN { edges: create_var12 } AS create_var13
+              MATCH (create_this1)<-[create_this10:ACTED_IN]-(create_this11:Actor)
+              WITH collect({node: create_this11, relationship: create_this10}) AS edges
+              CALL (edges) {
+                UNWIND edges AS edge
+                WITH edge.node AS create_this11, edge.relationship AS create_this10
+                RETURN collect({properties: {screenTime: create_this10.screenTime, __resolveType: 'ActedIn'}, node: {name: create_this11.name, __resolveType: 'Actor'}}) AS create_var12
+              }
+              RETURN {edges: create_var12} AS create_var13
             }
             RETURN collect(create_this1 { .title, actorsConnection: create_var13 }) AS data"
         `);
@@ -469,41 +459,40 @@ describe("Subscriptions metadata on create", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                CREATE (this0:Movie)
-                SET
-                    this0.title = $param0
-                WITH *
-                CREATE (this1:Person)
-                MERGE (this0)<-[this2:DIRECTED]-(this1)
-                SET
-                    this1.name = $param1,
-                    this2.year = $param2
-                WITH *
-                CREATE (this3:Actor)
-                MERGE (this0)<-[this4:DIRECTED]-(this3)
-                SET
-                    this3.name = $param3,
-                    this4.year = $param4
-                RETURN this0 AS this
+              CREATE (this0:Movie)
+              SET this0.title = $param0
+              WITH *
+              CREATE (this1:Person)
+              MERGE (this0)<-[this2:DIRECTED]-(this1)
+              SET
+                this1.name = $param1,
+                this2.year = $param2
+              WITH *
+              CREATE (this3:Actor)
+              MERGE (this0)<-[this4:DIRECTED]-(this3)
+              SET
+                this3.name = $param3,
+                this4.year = $param4
+              RETURN this0 AS this
             }
             WITH this
             CALL (this) {
-                CALL (this) {
-                    CALL (*) {
-                        WITH *
-                        MATCH (this)<-[this5:DIRECTED]-(this6:Person)
-                        WITH this6 { .name, __resolveType: \\"Person\\", __id: id(this6) } AS var7
-                        RETURN var7
-                        UNION
-                        WITH *
-                        MATCH (this)<-[this8:DIRECTED]-(this9:Actor)
-                        WITH this9 { .name, __resolveType: \\"Actor\\", __id: id(this9) } AS var7
-                        RETURN var7
-                    }
-                    WITH var7
-                    RETURN collect(var7) AS var7
+              CALL (this) {
+                CALL (*) {
+                  WITH *
+                  MATCH (this)<-[this5:DIRECTED]-(this6:Person)
+                  WITH this6 { .name, __resolveType: 'Person', __id: elementId(this6) } AS var7
+                  RETURN var7
+                  UNION
+                  WITH *
+                  MATCH (this)<-[this8:DIRECTED]-(this9:Actor)
+                  WITH this9 { .name, __resolveType: 'Actor', __id: elementId(this9) } AS var7
+                  RETURN var7
                 }
-                RETURN this { .title, directors: var7 } AS var10
+                WITH var7
+                RETURN collect(var7) AS var7
+              }
+              RETURN this { .title, directors: var7 } AS var10
             }
             RETURN collect(var10) AS data"
         `);
@@ -610,53 +599,52 @@ describe("Subscriptions metadata on create", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                CREATE (this0:Movie)
-                SET
-                    this0.title = $param0
-                WITH *
-                CREATE (this1:Person)
-                MERGE (this0)<-[this2:DIRECTED]-(this1)
-                SET
-                    this1.name = $param1,
-                    this2.year = $param2
-                WITH *
-                CREATE (this3:Actor)
-                WITH *
-                CREATE (this4:Movie)
-                MERGE (this3)-[this5:ACTED_IN]->(this4)
-                SET
-                    this4.title = $param3,
-                    this5.screenTime = $param4
-                MERGE (this0)<-[this6:DIRECTED]-(this3)
-                SET
-                    this3.name = $param5,
-                    this6.year = $param6
-                RETURN this0 AS this
+              CREATE (this0:Movie)
+              SET this0.title = $param0
+              WITH *
+              CREATE (this1:Person)
+              MERGE (this0)<-[this2:DIRECTED]-(this1)
+              SET
+                this1.name = $param1,
+                this2.year = $param2
+              WITH *
+              CREATE (this3:Actor)
+              WITH *
+              CREATE (this4:Movie)
+              MERGE (this3)-[this5:ACTED_IN]->(this4)
+              SET
+                this4.title = $param3,
+                this5.screenTime = $param4
+              MERGE (this0)<-[this6:DIRECTED]-(this3)
+              SET
+                this3.name = $param5,
+                this6.year = $param6
+              RETURN this0 AS this
             }
             WITH this
             CALL (this) {
-                CALL (this) {
-                    CALL (*) {
-                        WITH *
-                        MATCH (this)<-[this7:DIRECTED]-(this8:Person)
-                        WITH this8 { .name, __resolveType: \\"Person\\", __id: id(this8) } AS var9
-                        RETURN var9
-                        UNION
-                        WITH *
-                        MATCH (this)<-[this10:DIRECTED]-(this11:Actor)
-                        CALL (this11) {
-                            MATCH (this11)-[this12:ACTED_IN]->(this13:Movie)
-                            WITH DISTINCT this13
-                            WITH this13 { .title } AS this13
-                            RETURN collect(this13) AS var14
-                        }
-                        WITH this11 { .name, movies: var14, __resolveType: \\"Actor\\", __id: id(this11) } AS var9
-                        RETURN var9
-                    }
-                    WITH var9
-                    RETURN collect(var9) AS var9
+              CALL (this) {
+                CALL (*) {
+                  WITH *
+                  MATCH (this)<-[this7:DIRECTED]-(this8:Person)
+                  WITH this8 { .name, __resolveType: 'Person', __id: elementId(this8) } AS var9
+                  RETURN var9
+                  UNION
+                  WITH *
+                  MATCH (this)<-[this10:DIRECTED]-(this11:Actor)
+                  CALL (this11) {
+                    MATCH (this11)-[this12:ACTED_IN]->(this13:Movie)
+                    WITH DISTINCT this13
+                    WITH this13 { .title } AS this13
+                    RETURN collect(this13) AS var14
+                  }
+                  WITH this11 { .name, movies: var14, __resolveType: 'Actor', __id: elementId(this11) } AS var9
+                  RETURN var9
                 }
-                RETURN this { .title, directors: var9 } AS var15
+                WITH var9
+                RETURN collect(var9) AS var9
+              }
+              RETURN this { .title, directors: var9 } AS var15
             }
             RETURN collect(var15) AS data"
         `);
@@ -699,10 +687,9 @@ describe("Subscriptions metadata on create", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Movie)
-                SET
-                    create_this1.id = create_var0.id
-                RETURN create_this1
+              CREATE (create_this1:Movie)
+              SET create_this1.id = create_var0.id
+              RETURN create_this1
             }
             RETURN collect(create_this1 { .id }) AS data"
         `);
@@ -735,10 +722,9 @@ describe("Subscriptions metadata on create", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Movie)
-                SET
-                    create_this1.id = create_var0.id
-                RETURN create_this1
+              CREATE (create_this1:Movie)
+              SET create_this1.id = create_var0.id
+              RETURN create_this1
             }
             RETURN collect(create_this1 { .id }) AS data"
         `);
@@ -777,25 +763,23 @@ describe("Subscriptions metadata on create", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Movie)
-                SET
-                    create_this1.id = create_var0.id
-                WITH create_this1, create_var0
-                CALL (create_this1, create_var0) {
-                    UNWIND create_var0.actors.create AS create_var2
-                    CREATE (create_this3:Actor)
-                    SET
-                        create_this3.name = create_var2.node.name
-                    MERGE (create_this1)<-[create_this4:ACTED_IN]-(create_this3)
-                    RETURN collect(NULL) AS create_var5
-                }
-                RETURN create_this1
+              CREATE (create_this1:Movie)
+              SET create_this1.id = create_var0.id
+              WITH create_this1, create_var0
+              CALL (create_this1, create_var0) {
+                UNWIND create_var0.actors.create AS create_var2
+                CREATE (create_this3:Actor)
+                SET create_this3.name = create_var2.node.name
+                MERGE (create_this1)<-[create_this4:ACTED_IN]-(create_this3)
+                RETURN collect(NULL) AS create_var5
+              }
+              RETURN create_this1
             }
             CALL (create_this1) {
-                MATCH (create_this1)<-[create_this6:ACTED_IN]-(create_this7:Actor)
-                WITH DISTINCT create_this7
-                WITH create_this7 { .name } AS create_this7
-                RETURN collect(create_this7) AS create_var8
+              MATCH (create_this1)<-[create_this6:ACTED_IN]-(create_this7:Actor)
+              WITH DISTINCT create_this7
+              WITH create_this7 { .name } AS create_this7
+              RETURN collect(create_this7) AS create_var8
             }
             RETURN collect(create_this1 { .id, actors: create_var8 }) AS data"
         `);
@@ -847,34 +831,31 @@ describe("Subscriptions metadata on create", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Movie)
-                SET
-                    create_this1.id = create_var0.id
-                WITH create_this1, create_var0
-                CALL (create_this1, create_var0) {
-                    UNWIND create_var0.actors.create AS create_var2
-                    CREATE (create_this3:Actor)
-                    SET
-                        create_this3.name = create_var2.node.name
-                    MERGE (create_this1)<-[create_this4:ACTED_IN]-(create_this3)
-                    WITH create_this3, create_var2
-                    CALL (create_this3, create_var2) {
-                        UNWIND create_var2.node.movies.create AS create_var5
-                        CREATE (create_this6:Movie)
-                        SET
-                            create_this6.id = create_var5.node.id
-                        MERGE (create_this3)-[create_this7:ACTED_IN]->(create_this6)
-                        RETURN collect(NULL) AS create_var8
-                    }
-                    RETURN collect(NULL) AS create_var9
+              CREATE (create_this1:Movie)
+              SET create_this1.id = create_var0.id
+              WITH create_this1, create_var0
+              CALL (create_this1, create_var0) {
+                UNWIND create_var0.actors.create AS create_var2
+                CREATE (create_this3:Actor)
+                SET create_this3.name = create_var2.node.name
+                MERGE (create_this1)<-[create_this4:ACTED_IN]-(create_this3)
+                WITH create_this3, create_var2
+                CALL (create_this3, create_var2) {
+                  UNWIND create_var2.node.movies.create AS create_var5
+                  CREATE (create_this6:Movie)
+                  SET create_this6.id = create_var5.node.id
+                  MERGE (create_this3)-[create_this7:ACTED_IN]->(create_this6)
+                  RETURN collect(NULL) AS create_var8
                 }
-                RETURN create_this1
+                RETURN collect(NULL) AS create_var9
+              }
+              RETURN create_this1
             }
             CALL (create_this1) {
-                MATCH (create_this1)<-[create_this10:ACTED_IN]-(create_this11:Actor)
-                WITH DISTINCT create_this11
-                WITH create_this11 { .name } AS create_this11
-                RETURN collect(create_this11) AS create_var12
+              MATCH (create_this1)<-[create_this10:ACTED_IN]-(create_this11:Actor)
+              WITH DISTINCT create_this11
+              WITH create_this11 { .name } AS create_this11
+              RETURN collect(create_this11) AS create_var12
             }
             RETURN collect(create_this1 { .id, actors: create_var12 }) AS data"
         `);
@@ -952,55 +933,51 @@ describe("Subscriptions metadata on create", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Movie)
-                SET
-                    create_this1.id = create_var0.id
-                WITH create_this1, create_var0
-                CALL (create_this1, create_var0) {
-                    UNWIND create_var0.actors.create AS create_var2
-                    CREATE (create_this3:Actor)
-                    SET
-                        create_this3.name = create_var2.node.name
-                    MERGE (create_this1)<-[create_this4:ACTED_IN]-(create_this3)
-                    WITH create_this3, create_var2
-                    CALL (create_this3, create_var2) {
-                        UNWIND create_var2.node.movies.create AS create_var5
-                        CREATE (create_this6:Movie)
-                        SET
-                            create_this6.id = create_var5.node.id
-                        MERGE (create_this3)-[create_this7:ACTED_IN]->(create_this6)
-                        WITH create_this6, create_var5
-                        CALL (create_this6, create_var5) {
-                            UNWIND create_var5.node.actors.create AS create_var8
-                            CREATE (create_this9:Actor)
-                            SET
-                                create_this9.name = create_var8.node.name
-                            MERGE (create_this6)<-[create_this10:ACTED_IN]-(create_this9)
-                            RETURN collect(NULL) AS create_var11
-                        }
-                        RETURN collect(NULL) AS create_var12
-                    }
-                    RETURN collect(NULL) AS create_var13
+              CREATE (create_this1:Movie)
+              SET create_this1.id = create_var0.id
+              WITH create_this1, create_var0
+              CALL (create_this1, create_var0) {
+                UNWIND create_var0.actors.create AS create_var2
+                CREATE (create_this3:Actor)
+                SET create_this3.name = create_var2.node.name
+                MERGE (create_this1)<-[create_this4:ACTED_IN]-(create_this3)
+                WITH create_this3, create_var2
+                CALL (create_this3, create_var2) {
+                  UNWIND create_var2.node.movies.create AS create_var5
+                  CREATE (create_this6:Movie)
+                  SET create_this6.id = create_var5.node.id
+                  MERGE (create_this3)-[create_this7:ACTED_IN]->(create_this6)
+                  WITH create_this6, create_var5
+                  CALL (create_this6, create_var5) {
+                    UNWIND create_var5.node.actors.create AS create_var8
+                    CREATE (create_this9:Actor)
+                    SET create_this9.name = create_var8.node.name
+                    MERGE (create_this6)<-[create_this10:ACTED_IN]-(create_this9)
+                    RETURN collect(NULL) AS create_var11
+                  }
+                  RETURN collect(NULL) AS create_var12
                 }
-                RETURN create_this1
+                RETURN collect(NULL) AS create_var13
+              }
+              RETURN create_this1
             }
             CALL (create_this1) {
-                MATCH (create_this1)<-[create_this14:ACTED_IN]-(create_this15:Actor)
-                WITH DISTINCT create_this15
-                CALL (create_this15) {
-                    MATCH (create_this15)-[create_this16:ACTED_IN]->(create_this17:Movie)
-                    WITH DISTINCT create_this17
-                    CALL (create_this17) {
-                        MATCH (create_this17)<-[create_this18:ACTED_IN]-(create_this19:Actor)
-                        WITH DISTINCT create_this19
-                        WITH create_this19 { .name } AS create_this19
-                        RETURN collect(create_this19) AS create_var20
-                    }
-                    WITH create_this17 { .id, actors: create_var20 } AS create_this17
-                    RETURN collect(create_this17) AS create_var21
+              MATCH (create_this1)<-[create_this14:ACTED_IN]-(create_this15:Actor)
+              WITH DISTINCT create_this15
+              CALL (create_this15) {
+                MATCH (create_this15)-[create_this16:ACTED_IN]->(create_this17:Movie)
+                WITH DISTINCT create_this17
+                CALL (create_this17) {
+                  MATCH (create_this17)<-[create_this18:ACTED_IN]-(create_this19:Actor)
+                  WITH DISTINCT create_this19
+                  WITH create_this19 { .name } AS create_this19
+                  RETURN collect(create_this19) AS create_var20
                 }
-                WITH create_this15 { .name, movies: create_var21 } AS create_this15
-                RETURN collect(create_this15) AS create_var22
+                WITH create_this17 { .id, actors: create_var20 } AS create_this17
+                RETURN collect(create_this17) AS create_var21
+              }
+              WITH create_this15 { .name, movies: create_var21 } AS create_this15
+              RETURN collect(create_this15) AS create_var22
             }
             RETURN collect(create_this1 { .id, actors: create_var22 }) AS data"
         `);
@@ -1071,28 +1048,25 @@ describe("Subscriptions metadata on create", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Movie)
-                SET
-                    create_this1.id = create_var0.id
-                WITH create_this1, create_var0
-                CALL (create_this1, create_var0) {
-                    UNWIND create_var0.actors.create AS create_var2
-                    CREATE (create_this3:Actor)
-                    SET
-                        create_this3.name = create_var2.node.name
-                    MERGE (create_this1)<-[create_this4:ACTED_IN]-(create_this3)
-                    WITH create_this3, create_var2
-                    CALL (create_this3, create_var2) {
-                        UNWIND create_var2.node.movies.create AS create_var5
-                        CREATE (create_this6:Movie)
-                        SET
-                            create_this6.id = create_var5.node.id
-                        MERGE (create_this3)-[create_this7:ACTED_IN]->(create_this6)
-                        RETURN collect(NULL) AS create_var8
-                    }
-                    RETURN collect(NULL) AS create_var9
+              CREATE (create_this1:Movie)
+              SET create_this1.id = create_var0.id
+              WITH create_this1, create_var0
+              CALL (create_this1, create_var0) {
+                UNWIND create_var0.actors.create AS create_var2
+                CREATE (create_this3:Actor)
+                SET create_this3.name = create_var2.node.name
+                MERGE (create_this1)<-[create_this4:ACTED_IN]-(create_this3)
+                WITH create_this3, create_var2
+                CALL (create_this3, create_var2) {
+                  UNWIND create_var2.node.movies.create AS create_var5
+                  CREATE (create_this6:Movie)
+                  SET create_this6.id = create_var5.node.id
+                  MERGE (create_this3)-[create_this7:ACTED_IN]->(create_this6)
+                  RETURN collect(NULL) AS create_var8
                 }
-                RETURN create_this1
+                RETURN collect(NULL) AS create_var9
+              }
+              RETURN create_this1
             }
             RETURN collect(create_this1 { .id }) AS data"
         `);
@@ -1164,12 +1138,11 @@ describe("Subscriptions metadata on create", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Movie)
-                SET
-                    create_this1.id = create_var0.id
-                RETURN create_this1
+              CREATE (create_this1:Movie)
+              SET create_this1.id = create_var0.id
+              RETURN create_this1
             }
-            RETURN \\"Query cannot conclude with CALL\\""
+            RETURN 'Query cannot conclude with CALL'"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/subscriptions/delete.test.ts
+++ b/packages/graphql/tests/tck/subscriptions/delete.test.ts
@@ -91,13 +91,13 @@ describe("Subscriptions metadata on delete", () => {
             WHERE this.id = $param0
             WITH *
             CALL (*) {
-                OPTIONAL MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE this1.name = $param1
-                WITH this0, collect(DISTINCT this1) AS var2
-                CALL (var2) {
-                    UNWIND var2 AS var3
-                    DETACH DELETE var3
-                }
+              OPTIONAL MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE this1.name = $param1
+              WITH this0, collect(DISTINCT this1) AS var2
+              CALL (var2) {
+                UNWIND var2 AS var3
+                DETACH DELETE var3
+              }
             }
             WITH *
             DETACH DELETE this"
@@ -140,33 +140,33 @@ describe("Subscriptions metadata on delete", () => {
             WHERE this.id = $param0
             WITH *
             CALL (*) {
-                OPTIONAL MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WHERE this1.name = $param1
+              OPTIONAL MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WHERE this1.name = $param1
+              WITH *
+              CALL (*) {
+                OPTIONAL MATCH (this1)-[this2:ACTED_IN]->(this3:Movie)
+                WHERE this3.id = $param2
                 WITH *
                 CALL (*) {
-                    OPTIONAL MATCH (this1)-[this2:ACTED_IN]->(this3:Movie)
-                    WHERE this3.id = $param2
-                    WITH *
-                    CALL (*) {
-                        OPTIONAL MATCH (this3)<-[this4:ACTED_IN]-(this5:Actor)
-                        WHERE this5.name = $param3
-                        WITH this4, collect(DISTINCT this5) AS var6
-                        CALL (var6) {
-                            UNWIND var6 AS var7
-                            DETACH DELETE var7
-                        }
-                    }
-                    WITH this2, collect(DISTINCT this3) AS var8
-                    CALL (var8) {
-                        UNWIND var8 AS var9
-                        DETACH DELETE var9
-                    }
+                  OPTIONAL MATCH (this3)<-[this4:ACTED_IN]-(this5:Actor)
+                  WHERE this5.name = $param3
+                  WITH this4, collect(DISTINCT this5) AS var6
+                  CALL (var6) {
+                    UNWIND var6 AS var7
+                    DETACH DELETE var7
+                  }
                 }
-                WITH this0, collect(DISTINCT this1) AS var10
-                CALL (var10) {
-                    UNWIND var10 AS var11
-                    DETACH DELETE var11
+                WITH this2, collect(DISTINCT this3) AS var8
+                CALL (var8) {
+                  UNWIND var8 AS var9
+                  DETACH DELETE var9
                 }
+              }
+              WITH this0, collect(DISTINCT this1) AS var10
+              CALL (var10) {
+                UNWIND var10 AS var11
+                DETACH DELETE var11
+              }
             }
             WITH *
             DETACH DELETE this"

--- a/packages/graphql/tests/tck/subscriptions/update.test.ts
+++ b/packages/graphql/tests/tck/subscriptions/update.test.ts
@@ -64,8 +64,7 @@ describe("Subscriptions metadata on update", () => {
             MATCH (this:Movie)
             WITH *
             WHERE this.id = $param0
-            SET
-                this.id = $param1
+            SET this.id = $param1
             WITH this
             RETURN this { .id } AS this"
         `);
@@ -104,15 +103,13 @@ describe("Subscriptions metadata on update", () => {
             MATCH (this:Movie)
             WITH *
             WHERE this.id = $param0
-            SET
-                this.id = $param1
+            SET this.id = $param1
             WITH *
             CALL (*) {
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WITH *
-                WHERE this1.name = $param2
-                SET
-                    this1.name = $param3
+              MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
+              WITH *
+              WHERE this1.name = $param2
+              SET this1.name = $param3
             }
             WITH this
             RETURN this { .id } AS this"

--- a/packages/graphql/tests/tck/types/date.test.ts
+++ b/packages/graphql/tests/tck/types/date.test.ts
@@ -112,10 +112,9 @@ describe("Cypher Date", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Movie)
-                SET
-                    create_this1.date = create_var0.date
-                RETURN create_this1
+              CREATE (create_this1:Movie)
+              SET create_this1.date = create_var0.date
+              RETURN create_this1
             }
             RETURN collect(create_this1 { .date }) AS data"
         `);
@@ -153,8 +152,7 @@ describe("Cypher Date", () => {
             "CYPHER 5
             MATCH (this:Movie)
             WITH *
-            SET
-                this.date = $param0
+            SET this.date = $param0
             WITH this
             RETURN this { .id, .date } AS this"
         `);

--- a/packages/graphql/tests/tck/types/datetime.test.ts
+++ b/packages/graphql/tests/tck/types/datetime.test.ts
@@ -52,7 +52,7 @@ describe("Cypher DateTime", () => {
             "CYPHER 5
             MATCH (this:Movie)
             WHERE this.datetime = datetime($param0)
-            RETURN this { datetime: apoc.date.convertFormat(toString(this.datetime), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\") } AS this"
+            RETURN this { datetime: apoc.date.convertFormat(toString(this.datetime), 'iso_zoned_date_time', 'iso_offset_date_time') } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -79,12 +79,11 @@ describe("Cypher DateTime", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Movie)
-                SET
-                    create_this1.datetime = datetime(create_var0.datetime)
-                RETURN create_this1
+              CREATE (create_this1:Movie)
+              SET create_this1.datetime = datetime(create_var0.datetime)
+              RETURN create_this1
             }
-            RETURN collect(create_this1 { datetime: apoc.date.convertFormat(toString(create_this1.datetime), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\") }) AS data"
+            RETURN collect(create_this1 { datetime: apoc.date.convertFormat(toString(create_this1.datetime), 'iso_zoned_date_time', 'iso_offset_date_time') }) AS data"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -116,10 +115,9 @@ describe("Cypher DateTime", () => {
             "CYPHER 5
             MATCH (this:Movie)
             WITH *
-            SET
-                this.datetime = datetime($param0)
+            SET this.datetime = datetime($param0)
             WITH this
-            RETURN this { .id, datetime: apoc.date.convertFormat(toString(this.datetime), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\") } AS this"
+            RETURN this { .id, datetime: apoc.date.convertFormat(toString(this.datetime), 'iso_zoned_date_time', 'iso_offset_date_time') } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/types/duration.test.ts
+++ b/packages/graphql/tests/tck/types/duration.test.ts
@@ -114,10 +114,9 @@ describe("Cypher Duration", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Movie)
-                SET
-                    create_this1.duration = create_var0.duration
-                RETURN create_this1
+              CREATE (create_this1:Movie)
+              SET create_this1.duration = create_var0.duration
+              RETURN create_this1
             }
             RETURN collect(create_this1 { .duration }) AS data"
         `);
@@ -156,8 +155,7 @@ describe("Cypher Duration", () => {
             "CYPHER 5
             MATCH (this:Movie)
             WITH *
-            SET
-                this.duration = $param0
+            SET this.duration = $param0
             WITH this
             RETURN this { .id, .duration } AS this"
         `);

--- a/packages/graphql/tests/tck/types/localdatetime.test.ts
+++ b/packages/graphql/tests/tck/types/localdatetime.test.ts
@@ -120,10 +120,9 @@ describe("Cypher LocalDateTime", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Movie)
-                SET
-                    create_this1.localDT = create_var0.localDT
-                RETURN create_this1
+              CREATE (create_this1:Movie)
+              SET create_this1.localDT = create_var0.localDT
+              RETURN create_this1
             }
             RETURN collect(create_this1 { .localDT }) AS data"
         `);
@@ -165,8 +164,7 @@ describe("Cypher LocalDateTime", () => {
             "CYPHER 5
             MATCH (this:Movie)
             WITH *
-            SET
-                this.localDT = $param0
+            SET this.localDT = $param0
             WITH this
             RETURN this { .id, .localDT } AS this"
         `);

--- a/packages/graphql/tests/tck/types/localtime.test.ts
+++ b/packages/graphql/tests/tck/types/localtime.test.ts
@@ -114,10 +114,9 @@ describe("Cypher LocalTime", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Movie)
-                SET
-                    create_this1.time = create_var0.time
-                RETURN create_this1
+              CREATE (create_this1:Movie)
+              SET create_this1.time = create_var0.time
+              RETURN create_this1
             }
             RETURN collect(create_this1 { .time }) AS data"
         `);
@@ -156,8 +155,7 @@ describe("Cypher LocalTime", () => {
             "CYPHER 5
             MATCH (this:Movie)
             WITH *
-            SET
-                this.time = $param0
+            SET this.time = $param0
             WITH this
             RETURN this { .id, .time } AS this"
         `);

--- a/packages/graphql/tests/tck/types/point.test.ts
+++ b/packages/graphql/tests/tck/types/point.test.ts
@@ -337,10 +337,9 @@ describe("Cypher Points", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:PointContainer)
-                SET
-                    create_this1.point = point(create_var0.point)
-                RETURN create_this1
+              CREATE (create_this1:PointContainer)
+              SET create_this1.point = point(create_var0.point)
+              RETURN create_this1
             }
             RETURN collect(create_this1 { .point }) AS data"
         `);
@@ -384,8 +383,7 @@ describe("Cypher Points", () => {
             MATCH (this:PointContainer)
             WITH *
             WHERE this.id = $param0
-            SET
-                this.point = point($param1)
+            SET this.point = point($param1)
             WITH this
             RETURN this { .point } AS this"
         `);

--- a/packages/graphql/tests/tck/types/points.test.ts
+++ b/packages/graphql/tests/tck/types/points.test.ts
@@ -157,10 +157,9 @@ describe("Cypher Points", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:PointContainer)
-                SET
-                    create_this1.points = [create_var2 IN create_var0.points | point(create_var2)]
-                RETURN create_this1
+              CREATE (create_this1:PointContainer)
+              SET create_this1.points = [create_var2 IN create_var0.points | point(create_var2)]
+              RETURN create_this1
             }
             RETURN collect(create_this1 { .points }) AS data"
         `);
@@ -206,8 +205,7 @@ describe("Cypher Points", () => {
             MATCH (this:PointContainer)
             WITH *
             WHERE this.id = $param0
-            SET
-                this.points = [var0 IN $param1 | point(var0)]
+            SET this.points = [var0 IN $param1 | point(var0)]
             WITH this
             RETURN this { .points } AS this"
         `);

--- a/packages/graphql/tests/tck/types/time.test.ts
+++ b/packages/graphql/tests/tck/types/time.test.ts
@@ -104,10 +104,9 @@ describe("Cypher Time", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Movie)
-                SET
-                    create_this1.time = time(create_var0.time)
-                RETURN create_this1
+              CREATE (create_this1:Movie)
+              SET create_this1.time = time(create_var0.time)
+              RETURN create_this1
             }
             RETURN collect(create_this1 { .time }) AS data"
         `);
@@ -141,8 +140,7 @@ describe("Cypher Time", () => {
             "CYPHER 5
             MATCH (this:Movie)
             WITH *
-            SET
-                this.time = time($param0)
+            SET this.time = time($param0)
             WITH this
             RETURN this { .id, .time } AS this"
         `);
@@ -171,10 +169,9 @@ describe("Cypher Time", () => {
             "CYPHER 5
             UNWIND $create_param0 AS create_var0
             CALL (create_var0) {
-                CREATE (create_this1:Movie)
-                SET
-                    create_this1.time = time(create_var0.time)
-                RETURN create_this1
+              CREATE (create_this1:Movie)
+              SET create_this1.time = time(create_var0.time)
+              RETURN create_this1
             }
             RETURN collect(create_this1 { .time }) AS data"
         `);

--- a/packages/graphql/tests/tck/undirected-relationships/query-direction-aggregations.test.ts
+++ b/packages/graphql/tests/tck/undirected-relationships/query-direction-aggregations.test.ts
@@ -55,11 +55,11 @@ describe("QueryDirection in relationships aggregations", () => {
             "CYPHER 5
             MATCH (this:User)
             CALL (this) {
-                CALL (this) {
-                    MATCH (this)-[this0:FRIENDS_WITH]->(this1:User)
-                    RETURN { nodes: count(DISTINCT this1) } AS var2
-                }
-                RETURN { aggregate: { count: var2 } } AS var3
+              CALL (this) {
+                MATCH (this)-[this0:FRIENDS_WITH]->(this1:User)
+                RETURN {nodes: count(DISTINCT this1)} AS var2
+              }
+              RETURN {aggregate: {count: var2}} AS var3
             }
             RETURN this { friendsConnection: var3 } AS this"
         `);
@@ -97,11 +97,11 @@ describe("QueryDirection in relationships aggregations", () => {
             "CYPHER 5
             MATCH (this:User)
             CALL (this) {
-                CALL (this) {
-                    MATCH (this)-[this0:FRIENDS_WITH]-(this1:User)
-                    RETURN { nodes: count(DISTINCT this1) } AS var2
-                }
-                RETURN { aggregate: { count: var2 } } AS var3
+              CALL (this) {
+                MATCH (this)-[this0:FRIENDS_WITH]-(this1:User)
+                RETURN {nodes: count(DISTINCT this1)} AS var2
+              }
+              RETURN {aggregate: {count: var2}} AS var3
             }
             RETURN this { friendsConnection: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/undirected-relationships/query-direction-connection.test.ts
+++ b/packages/graphql/tests/tck/undirected-relationships/query-direction-connection.test.ts
@@ -51,9 +51,9 @@ describe("QueryDirection in relationships connection", () => {
             "CYPHER 5
             MATCH (this:User)
             CALL (this) {
-                MATCH (this)-[this0:FRIENDS_WITH]->(this1:User)
-                WITH count(this1) AS totalCount
-                RETURN { totalCount: totalCount } AS var2
+              MATCH (this)-[this0:FRIENDS_WITH]->(this1:User)
+              WITH count(this1) AS totalCount
+              RETURN {totalCount: totalCount} AS var2
             }
             RETURN this { friendsConnection: var2 } AS this"
         `);
@@ -88,9 +88,9 @@ describe("QueryDirection in relationships connection", () => {
             "CYPHER 5
             MATCH (this:User)
             CALL (this) {
-                MATCH (this)-[this0:FRIENDS_WITH]-(this1:User)
-                WITH count(this1) AS totalCount
-                RETURN { totalCount: totalCount } AS var2
+              MATCH (this)-[this0:FRIENDS_WITH]-(this1:User)
+              WITH count(this1) AS totalCount
+              RETURN {totalCount: totalCount} AS var2
             }
             RETURN this { friendsConnection: var2 } AS this"
         `);

--- a/packages/graphql/tests/tck/undirected-relationships/query-direction.test.ts
+++ b/packages/graphql/tests/tck/undirected-relationships/query-direction.test.ts
@@ -55,10 +55,10 @@ describe("queryDirection in relationships", () => {
                 "CYPHER 5
                 MATCH (this:User)
                 CALL (this) {
-                    MATCH (this)-[this0:FRIENDS_WITH]->(this1:User)
-                    WITH DISTINCT this1
-                    WITH this1 { .name } AS this1
-                    RETURN collect(this1) AS var2
+                  MATCH (this)-[this0:FRIENDS_WITH]->(this1:User)
+                  WITH DISTINCT this1
+                  WITH this1 { .name } AS this1
+                  RETURN collect(this1) AS var2
                 }
                 RETURN this { .name, friends: var2 } AS this"
             `);
@@ -84,14 +84,14 @@ describe("queryDirection in relationships", () => {
                 "CYPHER 5
                 MATCH (this:User)
                 WHERE EXISTS {
-                    MATCH (this)-[:FRIENDS_WITH]->(this0:User)
-                    WHERE this0.name = $param0
+                  MATCH (this)-[:FRIENDS_WITH]->(this0:User)
+                  WHERE this0.name = $param0
                 }
                 CALL (this) {
-                    MATCH (this)-[this1:FRIENDS_WITH]->(this2:User)
-                    WITH DISTINCT this2
-                    WITH this2 { .name } AS this2
-                    RETURN collect(this2) AS var3
+                  MATCH (this)-[this1:FRIENDS_WITH]->(this2:User)
+                  WITH DISTINCT this2
+                  WITH this2 { .name } AS this2
+                  RETURN collect(this2) AS var3
                 }
                 RETURN this { .name, friends: var3 } AS this"
             `);
@@ -127,24 +127,24 @@ describe("queryDirection in relationships", () => {
                 MATCH (this:User)
                 WITH *
                 WHERE EXISTS {
-                    MATCH (this)-[:FRIENDS_WITH]->(this0:User)
-                    WHERE this0.name = $param0
+                  MATCH (this)-[:FRIENDS_WITH]->(this0:User)
+                  WHERE this0.name = $param0
                 }
                 WITH *
                 CALL (*) {
-                    CALL (this) {
-                        OPTIONAL MATCH (this)-[this1:FRIENDS_WITH]->(this2:User)
-                        WHERE this2.name = $param1
-                        WITH *
-                        DELETE this1
-                    }
+                  CALL (this) {
+                    OPTIONAL MATCH (this)-[this1:FRIENDS_WITH]->(this2:User)
+                    WHERE this2.name = $param1
+                    WITH *
+                    DELETE this1
+                  }
                 }
                 WITH this
                 CALL (this) {
-                    MATCH (this)-[this3:FRIENDS_WITH]->(this4:User)
-                    WITH DISTINCT this4
-                    WITH this4 { .name } AS this4
-                    RETURN collect(this4) AS var5
+                  MATCH (this)-[this3:FRIENDS_WITH]->(this4:User)
+                  WITH DISTINCT this4
+                  WITH this4 { .name } AS this4
+                  RETURN collect(this4) AS var5
                 }
                 RETURN this { .name, friends: var5 } AS this"
             `);
@@ -181,25 +181,25 @@ describe("queryDirection in relationships", () => {
                 MATCH (this:User)
                 WITH *
                 WHERE EXISTS {
-                    MATCH (this)-[:FRIENDS_WITH]->(this0:User)
-                    WHERE this0.name = $param0
+                  MATCH (this)-[:FRIENDS_WITH]->(this0:User)
+                  WHERE this0.name = $param0
                 }
                 WITH *
                 CALL (*) {
-                    OPTIONAL MATCH (this)-[this1:FRIENDS_WITH]->(this2:User)
-                    WHERE this2.name = $param1
-                    WITH this1, collect(DISTINCT this2) AS var3
-                    CALL (var3) {
-                        UNWIND var3 AS var4
-                        DETACH DELETE var4
-                    }
+                  OPTIONAL MATCH (this)-[this1:FRIENDS_WITH]->(this2:User)
+                  WHERE this2.name = $param1
+                  WITH this1, collect(DISTINCT this2) AS var3
+                  CALL (var3) {
+                    UNWIND var3 AS var4
+                    DETACH DELETE var4
+                  }
                 }
                 WITH this
                 CALL (this) {
-                    MATCH (this)-[this5:FRIENDS_WITH]->(this6:User)
-                    WITH DISTINCT this6
-                    WITH this6 { .name } AS this6
-                    RETURN collect(this6) AS var7
+                  MATCH (this)-[this5:FRIENDS_WITH]->(this6:User)
+                  WITH DISTINCT this6
+                  WITH this6 { .name } AS this6
+                  RETURN collect(this6) AS var7
                 }
                 RETURN this { .name, friends: var7 } AS this"
             `);
@@ -243,23 +243,22 @@ describe("queryDirection in relationships", () => {
                 MATCH (this:User)
                 WITH *
                 WHERE EXISTS {
-                    MATCH (this)-[:FRIENDS_WITH]->(this0:User)
-                    WHERE this0.name = $param0
+                  MATCH (this)-[:FRIENDS_WITH]->(this0:User)
+                  WHERE this0.name = $param0
                 }
                 WITH *
                 CALL (*) {
-                    MATCH (this)-[this1:FRIENDS_WITH]->(this2:User)
-                    WITH *
-                    WHERE this2.name = $param1
-                    SET
-                        this2.name = $param2
+                  MATCH (this)-[this1:FRIENDS_WITH]->(this2:User)
+                  WITH *
+                  WHERE this2.name = $param1
+                  SET this2.name = $param2
                 }
                 WITH this
                 CALL (this) {
-                    MATCH (this)-[this3:FRIENDS_WITH]->(this4:User)
-                    WITH DISTINCT this4
-                    WITH this4 { .name } AS this4
-                    RETURN collect(this4) AS var5
+                  MATCH (this)-[this3:FRIENDS_WITH]->(this4:User)
+                  WITH DISTINCT this4
+                  WITH this4 { .name } AS this4
+                  RETURN collect(this4) AS var5
                 }
                 RETURN this { .name, friends: var5 } AS this"
             `);
@@ -291,18 +290,18 @@ describe("queryDirection in relationships", () => {
                 "CYPHER 5
                 MATCH (this:User)
                 WHERE EXISTS {
-                    MATCH (this)-[:FRIENDS_WITH]->(this0:User)
-                    WHERE this0.name = $param0
+                  MATCH (this)-[:FRIENDS_WITH]->(this0:User)
+                  WHERE this0.name = $param0
                 }
                 WITH *
                 CALL (*) {
-                    OPTIONAL MATCH (this)-[this1:FRIENDS_WITH]->(this2:User)
-                    WHERE this2.name = $param1
-                    WITH this1, collect(DISTINCT this2) AS var3
-                    CALL (var3) {
-                        UNWIND var3 AS var4
-                        DETACH DELETE var4
-                    }
+                  OPTIONAL MATCH (this)-[this1:FRIENDS_WITH]->(this2:User)
+                  WHERE this2.name = $param1
+                  WITH this1, collect(DISTINCT this2) AS var3
+                  CALL (var3) {
+                    UNWIND var3 AS var4
+                    DETACH DELETE var4
+                  }
                 }
                 WITH *
                 DETACH DELETE this"
@@ -351,10 +350,10 @@ describe("queryDirection in relationships", () => {
                 "CYPHER 5
                 MATCH (this:User)
                 CALL (this) {
-                    MATCH (this)-[this0:FRIENDS_WITH]-(this1:User)
-                    WITH DISTINCT this1
-                    WITH this1 { .name } AS this1
-                    RETURN collect(this1) AS var2
+                  MATCH (this)-[this0:FRIENDS_WITH]-(this1:User)
+                  WITH DISTINCT this1
+                  WITH this1 { .name } AS this1
+                  RETURN collect(this1) AS var2
                 }
                 RETURN this { .name, friends: var2 } AS this"
             `);
@@ -380,14 +379,14 @@ describe("queryDirection in relationships", () => {
                 "CYPHER 5
                 MATCH (this:User)
                 WHERE EXISTS {
-                    MATCH (this)-[:FRIENDS_WITH]-(this0:User)
-                    WHERE this0.name = $param0
+                  MATCH (this)-[:FRIENDS_WITH]-(this0:User)
+                  WHERE this0.name = $param0
                 }
                 CALL (this) {
-                    MATCH (this)-[this1:FRIENDS_WITH]-(this2:User)
-                    WITH DISTINCT this2
-                    WITH this2 { .name } AS this2
-                    RETURN collect(this2) AS var3
+                  MATCH (this)-[this1:FRIENDS_WITH]-(this2:User)
+                  WITH DISTINCT this2
+                  WITH this2 { .name } AS this2
+                  RETURN collect(this2) AS var3
                 }
                 RETURN this { .name, friends: var3 } AS this"
             `);
@@ -423,24 +422,24 @@ describe("queryDirection in relationships", () => {
                 MATCH (this:User)
                 WITH *
                 WHERE EXISTS {
-                    MATCH (this)-[:FRIENDS_WITH]-(this0:User)
-                    WHERE this0.name = $param0
+                  MATCH (this)-[:FRIENDS_WITH]-(this0:User)
+                  WHERE this0.name = $param0
                 }
                 WITH *
                 CALL (*) {
-                    CALL (this) {
-                        OPTIONAL MATCH (this)-[this1:FRIENDS_WITH]-(this2:User)
-                        WHERE this2.name = $param1
-                        WITH *
-                        DELETE this1
-                    }
+                  CALL (this) {
+                    OPTIONAL MATCH (this)-[this1:FRIENDS_WITH]-(this2:User)
+                    WHERE this2.name = $param1
+                    WITH *
+                    DELETE this1
+                  }
                 }
                 WITH this
                 CALL (this) {
-                    MATCH (this)-[this3:FRIENDS_WITH]-(this4:User)
-                    WITH DISTINCT this4
-                    WITH this4 { .name } AS this4
-                    RETURN collect(this4) AS var5
+                  MATCH (this)-[this3:FRIENDS_WITH]-(this4:User)
+                  WITH DISTINCT this4
+                  WITH this4 { .name } AS this4
+                  RETURN collect(this4) AS var5
                 }
                 RETURN this { .name, friends: var5 } AS this"
             `);
@@ -477,25 +476,25 @@ describe("queryDirection in relationships", () => {
                 MATCH (this:User)
                 WITH *
                 WHERE EXISTS {
-                    MATCH (this)-[:FRIENDS_WITH]-(this0:User)
-                    WHERE this0.name = $param0
+                  MATCH (this)-[:FRIENDS_WITH]-(this0:User)
+                  WHERE this0.name = $param0
                 }
                 WITH *
                 CALL (*) {
-                    OPTIONAL MATCH (this)-[this1:FRIENDS_WITH]-(this2:User)
-                    WHERE this2.name = $param1
-                    WITH this1, collect(DISTINCT this2) AS var3
-                    CALL (var3) {
-                        UNWIND var3 AS var4
-                        DETACH DELETE var4
-                    }
+                  OPTIONAL MATCH (this)-[this1:FRIENDS_WITH]-(this2:User)
+                  WHERE this2.name = $param1
+                  WITH this1, collect(DISTINCT this2) AS var3
+                  CALL (var3) {
+                    UNWIND var3 AS var4
+                    DETACH DELETE var4
+                  }
                 }
                 WITH this
                 CALL (this) {
-                    MATCH (this)-[this5:FRIENDS_WITH]-(this6:User)
-                    WITH DISTINCT this6
-                    WITH this6 { .name } AS this6
-                    RETURN collect(this6) AS var7
+                  MATCH (this)-[this5:FRIENDS_WITH]-(this6:User)
+                  WITH DISTINCT this6
+                  WITH this6 { .name } AS this6
+                  RETURN collect(this6) AS var7
                 }
                 RETURN this { .name, friends: var7 } AS this"
             `);
@@ -539,23 +538,22 @@ describe("queryDirection in relationships", () => {
                 MATCH (this:User)
                 WITH *
                 WHERE EXISTS {
-                    MATCH (this)-[:FRIENDS_WITH]-(this0:User)
-                    WHERE this0.name = $param0
+                  MATCH (this)-[:FRIENDS_WITH]-(this0:User)
+                  WHERE this0.name = $param0
                 }
                 WITH *
                 CALL (*) {
-                    MATCH (this)-[this1:FRIENDS_WITH]-(this2:User)
-                    WITH *
-                    WHERE this2.name = $param1
-                    SET
-                        this2.name = $param2
+                  MATCH (this)-[this1:FRIENDS_WITH]-(this2:User)
+                  WITH *
+                  WHERE this2.name = $param1
+                  SET this2.name = $param2
                 }
                 WITH this
                 CALL (this) {
-                    MATCH (this)-[this3:FRIENDS_WITH]-(this4:User)
-                    WITH DISTINCT this4
-                    WITH this4 { .name } AS this4
-                    RETURN collect(this4) AS var5
+                  MATCH (this)-[this3:FRIENDS_WITH]-(this4:User)
+                  WITH DISTINCT this4
+                  WITH this4 { .name } AS this4
+                  RETURN collect(this4) AS var5
                 }
                 RETURN this { .name, friends: var5 } AS this"
             `);
@@ -587,18 +585,18 @@ describe("queryDirection in relationships", () => {
                 "CYPHER 5
                 MATCH (this:User)
                 WHERE EXISTS {
-                    MATCH (this)-[:FRIENDS_WITH]-(this0:User)
-                    WHERE this0.name = $param0
+                  MATCH (this)-[:FRIENDS_WITH]-(this0:User)
+                  WHERE this0.name = $param0
                 }
                 WITH *
                 CALL (*) {
-                    OPTIONAL MATCH (this)-[this1:FRIENDS_WITH]-(this2:User)
-                    WHERE this2.name = $param1
-                    WITH this1, collect(DISTINCT this2) AS var3
-                    CALL (var3) {
-                        UNWIND var3 AS var4
-                        DETACH DELETE var4
-                    }
+                  OPTIONAL MATCH (this)-[this1:FRIENDS_WITH]-(this2:User)
+                  WHERE this2.name = $param1
+                  WITH this1, collect(DISTINCT this2) AS var3
+                  CALL (var3) {
+                    UNWIND var3 AS var4
+                    DETACH DELETE var4
+                  }
                 }
                 WITH *
                 DETACH DELETE this"

--- a/packages/graphql/tests/tck/union.test.ts
+++ b/packages/graphql/tests/tck/union.test.ts
@@ -79,20 +79,20 @@ describe("Cypher Union", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this)-[this0:SEARCH]->(this1:Genre)
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.jwtAllowedNamesExample IS NOT NULL AND this1.name = $jwt.jwtAllowedNamesExample)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    WITH this1 { .name, __resolveType: \\"Genre\\", __id: id(this1) } AS var2
-                    RETURN var2
-                    UNION
-                    WITH *
-                    MATCH (this)-[this3:SEARCH]->(this4:Movie)
-                    WITH this4 { .title, __resolveType: \\"Movie\\", __id: id(this4) } AS var2
-                    RETURN var2
-                }
-                WITH var2
-                RETURN collect(var2) AS var2
+              CALL (*) {
+                WITH *
+                MATCH (this)-[this0:SEARCH]->(this1:Genre)
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.jwtAllowedNamesExample IS NOT NULL AND this1.name = $jwt.jwtAllowedNamesExample)), '@neo4j/graphql/FORBIDDEN', [])
+                WITH this1 { .name, __resolveType: 'Genre', __id: elementId(this1) } AS var2
+                RETURN var2
+                UNION
+                WITH *
+                MATCH (this)-[this3:SEARCH]->(this4:Movie)
+                WITH this4 { .title, __resolveType: 'Movie', __id: elementId(this4) } AS var2
+                RETURN var2
+              }
+              WITH var2
+              RETURN collect(var2) AS var2
             }
             RETURN this { search: var2 } AS this"
         `);
@@ -128,20 +128,20 @@ describe("Cypher Union", () => {
             "CYPHER 5
             MATCH (this:Movie)
             CALL (this) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this)-[this0:SEARCH]->(this1:Genre)
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.jwtAllowedNamesExample IS NOT NULL AND this1.name = $jwt.jwtAllowedNamesExample)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    WITH this1 { .name, __resolveType: \\"Genre\\", __id: id(this1) } AS var2
-                    RETURN var2
-                    UNION
-                    WITH *
-                    MATCH (this)-[this3:SEARCH]->(this4:Movie)
-                    WITH this4 { __resolveType: \\"Movie\\", __id: id(this4) } AS var2
-                    RETURN var2
-                }
-                WITH var2
-                RETURN collect(var2) AS var2
+              CALL (*) {
+                WITH *
+                MATCH (this)-[this0:SEARCH]->(this1:Genre)
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.jwtAllowedNamesExample IS NOT NULL AND this1.name = $jwt.jwtAllowedNamesExample)), '@neo4j/graphql/FORBIDDEN', [])
+                WITH this1 { .name, __resolveType: 'Genre', __id: elementId(this1) } AS var2
+                RETURN var2
+                UNION
+                WITH *
+                MATCH (this)-[this3:SEARCH]->(this4:Movie)
+                WITH this4 { __resolveType: 'Movie', __id: elementId(this4) } AS var2
+                RETURN var2
+              }
+              WITH var2
+              RETURN collect(var2) AS var2
             }
             RETURN this { search: var2 } AS this"
         `);
@@ -185,24 +185,24 @@ describe("Cypher Union", () => {
             MATCH (this:Movie)
             WHERE this.title = $param0
             CALL (this) {
-                CALL (*) {
-                    WITH *
-                    MATCH (this)-[this0:SEARCH]->(this1:Genre)
-                    WHERE this1.name = $param1
-                    CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.jwtAllowedNamesExample IS NOT NULL AND this1.name = $jwt.jwtAllowedNamesExample)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    WITH this1 { .name, __resolveType: \\"Genre\\", __id: id(this1) } AS var2
-                    RETURN var2
-                    UNION
-                    WITH *
-                    MATCH (this)-[this3:SEARCH]->(this4:Movie)
-                    WHERE this4.title = $param4
-                    WITH this4 { .title, __resolveType: \\"Movie\\", __id: id(this4) } AS var2
-                    RETURN var2
-                }
-                WITH var2
-                SKIP $param5
-                LIMIT $param6
-                RETURN collect(var2) AS var2
+              CALL (*) {
+                WITH *
+                MATCH (this)-[this0:SEARCH]->(this1:Genre)
+                WHERE this1.name = $param1
+                CALL apoc.util.validate(NOT ($isAuthenticated = true AND ($jwt.jwtAllowedNamesExample IS NOT NULL AND this1.name = $jwt.jwtAllowedNamesExample)), '@neo4j/graphql/FORBIDDEN', [])
+                WITH this1 { .name, __resolveType: 'Genre', __id: elementId(this1) } AS var2
+                RETURN var2
+                UNION
+                WITH *
+                MATCH (this)-[this3:SEARCH]->(this4:Movie)
+                WHERE this4.title = $param4
+                WITH this4 { .title, __resolveType: 'Movie', __id: elementId(this4) } AS var2
+                RETURN var2
+              }
+              WITH var2
+              SKIP $param5
+              LIMIT $param6
+              RETURN collect(var2) AS var2
             }
             RETURN this { search: var2 } AS this"
         `);
@@ -248,19 +248,17 @@ describe("Cypher Union", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                CREATE (this0:Movie)
-                SET
-                    this0.title = $param0
-                WITH *
-                CREATE (this1:Genre)
-                MERGE (this0)-[this2:SEARCH]->(this1)
-                SET
-                    this1.name = $param1
-                RETURN this0 AS this
+              CREATE (this0:Movie)
+              SET this0.title = $param0
+              WITH *
+              CREATE (this1:Genre)
+              MERGE (this0)-[this2:SEARCH]->(this1)
+              SET this1.name = $param1
+              RETURN this0 AS this
             }
             WITH this
             CALL (this) {
-                RETURN this { .title } AS var3
+              RETURN this { .title } AS var3
             }
             RETURN collect(var3) AS data"
         `);
@@ -293,10 +291,9 @@ describe("Cypher Union", () => {
             WITH *
             WITH *
             CALL (*) {
-                CREATE (this0:Genre)
-                MERGE (this)-[this1:SEARCH]->(this0)
-                SET
-                    this0.name = $param0
+              CREATE (this0:Genre)
+              MERGE (this)-[this1:SEARCH]->(this0)
+              SET this0.name = $param0
             }
             WITH this
             RETURN this { .title } AS this"
@@ -333,20 +330,19 @@ describe("Cypher Union", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
             CALL {
-                CREATE (this0:Movie)
-                SET
-                    this0.title = $param0
-                WITH *
-                CALL (this0) {
-                    MATCH (this1:Genre)
-                    WHERE this1.name = $param1
-                    CREATE (this0)-[this2:SEARCH]->(this1)
-                }
-                RETURN this0 AS this
+              CREATE (this0:Movie)
+              SET this0.title = $param0
+              WITH *
+              CALL (this0) {
+                MATCH (this1:Genre)
+                WHERE this1.name = $param1
+                CREATE (this0)-[this2:SEARCH]->(this1)
+              }
+              RETURN this0 AS this
             }
             WITH this
             CALL (this) {
-                RETURN this { .title } AS var3
+              RETURN this { .title } AS var3
             }
             RETURN collect(var3) AS data"
         `);
@@ -392,11 +388,10 @@ describe("Cypher Union", () => {
             WHERE this.title = $param0
             WITH *
             CALL (*) {
-                MATCH (this)-[this0:SEARCH]->(this1:Genre)
-                WITH *
-                WHERE this1.name = $param1
-                SET
-                    this1.name = $param2
+              MATCH (this)-[this0:SEARCH]->(this1:Genre)
+              WITH *
+              WHERE this1.name = $param1
+              SET this1.name = $param2
             }
             WITH this
             RETURN this { .title } AS this"
@@ -435,12 +430,12 @@ describe("Cypher Union", () => {
             WHERE this.title = $param0
             WITH *
             CALL (*) {
-                CALL (this) {
-                    OPTIONAL MATCH (this)-[this0:SEARCH]->(this1:Genre)
-                    WHERE this1.name = $param1
-                    WITH *
-                    DELETE this0
-                }
+              CALL (this) {
+                OPTIONAL MATCH (this)-[this0:SEARCH]->(this1:Genre)
+                WHERE this1.name = $param1
+                WITH *
+                DELETE this0
+              }
             }
             WITH this
             RETURN this { .title } AS this"
@@ -478,11 +473,11 @@ describe("Cypher Union", () => {
             WHERE this.title = $param0
             WITH *
             CALL (*) {
-                CALL (this) {
-                    MATCH (this0:Genre)
-                    WHERE this0.name = $param1
-                    CREATE (this)-[this1:SEARCH]->(this0)
-                }
+              CALL (this) {
+                MATCH (this0:Genre)
+                WHERE this0.name = $param1
+                CREATE (this)-[this1:SEARCH]->(this0)
+              }
             }
             WITH this
             RETURN this { .title } AS this"
@@ -520,13 +515,13 @@ describe("Cypher Union", () => {
             WHERE this.title = $param0
             WITH *
             CALL (*) {
-                OPTIONAL MATCH (this)-[this0:SEARCH]->(this1:Genre)
-                WHERE this1.name = $param1
-                WITH this0, collect(DISTINCT this1) AS var2
-                CALL (var2) {
-                    UNWIND var2 AS var3
-                    DETACH DELETE var3
-                }
+              OPTIONAL MATCH (this)-[this0:SEARCH]->(this1:Genre)
+              WHERE this1.name = $param1
+              WITH this0, collect(DISTINCT this1) AS var2
+              CALL (var2) {
+                UNWIND var2 AS var3
+                DETACH DELETE var3
+              }
             }
             WITH this
             RETURN this { .title } AS this"

--- a/packages/introspector/jest.config.js
+++ b/packages/introspector/jest.config.js
@@ -5,11 +5,19 @@ module.exports = {
     displayName: "@neo4j/introspector",
     roots: ["<rootDir>/packages/introspector/src/", "<rootDir>/packages/introspector/tests/"],
     coverageDirectory: "<rootDir>/packages/introspector/coverage/",
+    // @neo4j/cypher-builder is ESM-only; allow Jest to transform it to CJS
+    transformIgnorePatterns: ["/node_modules/(?!@neo4j/cypher-builder)"],
     transform: {
         "^.+\\.ts$": [
             "ts-jest",
             {
                 tsconfig: "<rootDir>/packages/introspector/tsconfig.json",
+            },
+        ],
+        "node_modules/@neo4j/cypher-builder/.+\\.js$": [
+            "ts-jest",
+            {
+                tsconfig: "<rootDir>/packages/graphql/tsconfig.json",
             },
         ],
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2791,10 +2791,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@neo4j/cypher-builder@file:./neo4j-cypher-builder-3.0.0.tgz::locator=%40neo4j%2Fgraphql%40workspace%3Apackages%2Fgraphql":
+"@neo4j/cypher-builder@npm:3.0.0":
   version: 3.0.0
-  resolution: "@neo4j/cypher-builder@file:./neo4j-cypher-builder-3.0.0.tgz#./neo4j-cypher-builder-3.0.0.tgz::hash=a9f205&locator=%40neo4j%2Fgraphql%40workspace%3Apackages%2Fgraphql"
-  checksum: 10c0/72d5ccf5e0c999b6b770e0f11dbf7b78cfc14edfdaa9836a2b04d032f7234b90187f5f26ab6ae125cac91d7cb58949c243a297f267f309c0130af708ce9229d4
+  resolution: "@neo4j/cypher-builder@npm:3.0.0"
+  checksum: 10c0/63a48b16b563161140364ff030fbd9309d3dda2044851beeb6f7d2bf8152086f8bce2534e00c78787a099f2295549898b7414a2fb3dfd36de4f363a52fa33db4
   languageName: node
   linkType: hard
 
@@ -2816,7 +2816,7 @@ __metadata:
     "@graphql-tools/resolvers-composition": "npm:^7.0.0"
     "@graphql-tools/schema": "npm:^10.0.0"
     "@graphql-tools/utils": "npm:11.0.0"
-    "@neo4j/cypher-builder": "file:./neo4j-cypher-builder-3.0.0.tgz"
+    "@neo4j/cypher-builder": "npm:3.0.0"
     "@types/is-uuid": "npm:1.0.2"
     "@types/jest": "npm:30.0.0"
     "@types/jsonwebtoken": "npm:9.0.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2791,10 +2791,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@neo4j/cypher-builder@npm:2.12.0":
-  version: 2.12.0
-  resolution: "@neo4j/cypher-builder@npm:2.12.0"
-  checksum: 10c0/f5d6356c24d4ddb60f3abe8e2348fba3f6b7e20ed4651647b7a0495141e01c3c0c0e87a1a57e120335b3fe6f0d1f64fff8f11e67ed093fe4802206f2896c619b
+"@neo4j/cypher-builder@file:./neo4j-cypher-builder-3.0.0.tgz::locator=%40neo4j%2Fgraphql%40workspace%3Apackages%2Fgraphql":
+  version: 3.0.0
+  resolution: "@neo4j/cypher-builder@file:./neo4j-cypher-builder-3.0.0.tgz#./neo4j-cypher-builder-3.0.0.tgz::hash=a9f205&locator=%40neo4j%2Fgraphql%40workspace%3Apackages%2Fgraphql"
+  checksum: 10c0/72d5ccf5e0c999b6b770e0f11dbf7b78cfc14edfdaa9836a2b04d032f7234b90187f5f26ab6ae125cac91d7cb58949c243a297f267f309c0130af708ce9229d4
   languageName: node
   linkType: hard
 
@@ -2816,7 +2816,7 @@ __metadata:
     "@graphql-tools/resolvers-composition": "npm:^7.0.0"
     "@graphql-tools/schema": "npm:^10.0.0"
     "@graphql-tools/utils": "npm:11.0.0"
-    "@neo4j/cypher-builder": "npm:2.12.0"
+    "@neo4j/cypher-builder": "file:./neo4j-cypher-builder-3.0.0.tgz"
     "@types/is-uuid": "npm:1.0.2"
     "@types/jest": "npm:30.0.0"
     "@types/jsonwebtoken": "npm:9.0.10"


### PR DESCRIPTION
# Description

Update Cypher builder to v3 following the [migration guide](https://neo4j.com/docs/cypher-builder/current/migration-guide-3/)

Notable changes:

* [apoc is no longer supported](https://neo4j.com/docs/cypher-builder/current/migration-guide-3/#_removed_support_for_apoc), so a few helper functions have been proted into `apocwrapper` keep using apoc
* jest doesn't support esm very well, so the config has been updated to be able to use the esm-only cypher-builder@3
* tck tests have been changed, due to the new [formatting](https://neo4j.com/docs/cypher-builder/current/migration-guide-3/#_changed_cypher_formatting)