### PR TITLE
update cypher-builder to 3.0.1

### DIFF
--- a/.changeset/seven-points-mate.md
+++ b/.changeset/seven-points-mate.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+Update cypher-builder dependency to avoid using module system instead of cjs

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -85,7 +85,7 @@
         "@graphql-tools/resolvers-composition": "^7.0.0",
         "@graphql-tools/schema": "^10.0.0",
         "@graphql-tools/utils": "11.0.0",
-        "@neo4j/cypher-builder": "3.0.0",
+        "@neo4j/cypher-builder": "3.0.1",
         "camelcase": "^6.3.0",
         "debug": "^4.3.4",
         "dot-prop": "^6.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2796,10 +2796,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@neo4j/cypher-builder@npm:3.0.0":
-  version: 3.0.0
-  resolution: "@neo4j/cypher-builder@npm:3.0.0"
-  checksum: 10c0/63a48b16b563161140364ff030fbd9309d3dda2044851beeb6f7d2bf8152086f8bce2534e00c78787a099f2295549898b7414a2fb3dfd36de4f363a52fa33db4
+"@neo4j/cypher-builder@npm:3.0.1":
+  version: 3.0.1
+  resolution: "@neo4j/cypher-builder@npm:3.0.1"
+  checksum: 10c0/36d2f9c2b075aa6f89435ba512c9b9281084c154406fb368ab71bccb31a2738aef276afaaee053356cbd964fcbf919bf38b4c52ddb347c5bee895e2bfa3f358c
   languageName: node
   linkType: hard
 
@@ -2821,7 +2821,7 @@ __metadata:
     "@graphql-tools/resolvers-composition": "npm:^7.0.0"
     "@graphql-tools/schema": "npm:^10.0.0"
     "@graphql-tools/utils": "npm:11.0.0"
-    "@neo4j/cypher-builder": "npm:3.0.0"
+    "@neo4j/cypher-builder": "npm:3.0.1"
     "@types/is-uuid": "npm:1.0.2"
     "@types/jest": "npm:30.0.0"
     "@types/jsonwebtoken": "npm:9.0.10"


### PR DESCRIPTION
# Description

Update cypher builder to 3.0.1, to avoid using module system instead of cjs
