### PR TITLE
fix flaky tests in advance filtering

### DIFF
--- a/packages/graphql/tests/integration/filtering/advanced-filtering.int.test.ts
+++ b/packages/graphql/tests/integration/filtering/advanced-filtering.int.test.ts
@@ -638,6 +638,7 @@ describe("Advanced Filtering", () => {
     });
 
     describe.each(["Int", "Float"] as const)("%s Filtering", (type) => {
+        // NOTE: FLAKY https://github.com/neo4j/graphql/actions/runs/23420627072/job/68124740873
         test("should find Movies NOT number", async () => {
             const randomType = testHelper.createUniqueType("Movie");
 
@@ -652,17 +653,17 @@ describe("Advanced Filtering", () => {
             let property: number;
 
             if (type === "Int") {
-                property = Math.floor(Math.random() * 9999);
+                property = 10;
             } else {
-                property = Math.floor(Math.random() * 9999) + 0.5;
+                property = 10.5;
             }
 
             let notProperty: number;
 
             if (type === "Int") {
-                notProperty = Math.floor(Math.random() * 9999);
+                notProperty = 12;
             } else {
-                notProperty = Math.floor(Math.random() * 9999) + 0.5;
+                notProperty = 20.5;
             }
 
             await testHelper.executeCypher(
@@ -703,25 +704,25 @@ describe("Advanced Filtering", () => {
             let value: number;
 
             if (type === "Int") {
-                value = Math.floor(Math.random() * 9999);
+                value = 10;
             } else {
-                value = Math.floor(Math.random() * 9999) + 0.5;
+                value = 10.5;
             }
 
             let randomValue1: number;
 
             if (type === "Int") {
-                randomValue1 = Math.floor(Math.random() * 9999);
+                randomValue1 = 20;
             } else {
-                randomValue1 = Math.floor(Math.random() * 9999) + 0.5;
+                randomValue1 = 20.5;
             }
 
             let randomValue2: number;
 
             if (type === "Int") {
-                randomValue2 = Math.floor(Math.random() * 9999);
+                randomValue2 = 30;
             } else {
-                randomValue2 = Math.floor(Math.random() * 9999) + 0.5;
+                randomValue2 = 30.5;
             }
 
             await testHelper.executeCypher(
@@ -761,9 +762,9 @@ describe("Advanced Filtering", () => {
             let value: number;
 
             if (type === "Int") {
-                value = Math.floor(Math.random() * 9999);
+                value = 10;
             } else {
-                value = Math.floor(Math.random() * 9999) + 0.5;
+                value = 10.5;
             }
 
             const lessThanValue = value - (value + 1);
@@ -806,9 +807,9 @@ describe("Advanced Filtering", () => {
             let value: number;
 
             if (type === "Int") {
-                value = Math.floor(Math.random() * 9999);
+                value = 10;
             } else {
-                value = Math.floor(Math.random() * 9999) + 0.5;
+                value = 10.5;
             }
 
             const lessThanValue = value - (value + 1);
@@ -850,9 +851,9 @@ describe("Advanced Filtering", () => {
             let value: number;
 
             if (type === "Int") {
-                value = Math.floor(Math.random() * 9999);
+                value = 10;
             } else {
-                value = Math.floor(Math.random() * 9999) + 0.5;
+                value = 10.5;
             }
 
             const graterThanValue = value + 1;
@@ -895,9 +896,9 @@ describe("Advanced Filtering", () => {
             let value: number;
 
             if (type === "Int") {
-                value = Math.floor(Math.random() * 9999);
+                value = 10;
             } else {
-                value = Math.floor(Math.random() * 9999) + 0.5;
+                value = 10.5;
             }
 
             const greaterThan = value + 1;


### PR DESCRIPTION
# Description

Fix flaky test failing [here](https://github.com/neo4j/graphql/actions/runs/23420627072/job/68124740873)

This was caused by 2 values in our tests: `property = Math.floor(Math.random() * 9999);` intended to be different. This means once every 10000 runs, on average, it will fail, by both values being the same