### PR TITLE
Fix 7205 existence filter on single relationships

### DIFF
--- a/.changeset/fresh-kings-lead.md
+++ b/.changeset/fresh-kings-lead.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+Fix relationship existence filter on single relationships to take null check as a conceptual "no relationship exists"

--- a/packages/graphql/src/translate/queryAST/factory/FilterFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/FilterFactory.ts
@@ -302,6 +302,7 @@ export class FilterFactory {
         /**
          * The logic below can be confusing, but it's to handle the following cases:
          * 1. where: { actors: null } -> in this case we want to return an Exists filter as showed by tests packages/graphql/tests/tck/null.test.ts
+         *    1.1 where: { directors: null } -> this is single relationship case, and we want an Exists NONE as shown by tests packages/graphql/tests/integration/issues/7205.int.test.ts
          * 2. where: {} -> in this case we want to not apply any filter, as showed by tests packages/graphql/tests/tck/issues/402.test.ts
          **/
         const isNull = where === null;
@@ -312,10 +313,16 @@ export class FilterFactory {
         const filteredEntities = getConcreteEntities(relationship.target, where);
         const relationshipFilters: RelationshipFilter[] = [];
         for (const concreteEntity of filteredEntities) {
+            let defaultOperator: RelationshipWhereOperator = "SOME";
+            if (isNull && !relationship.isList) {
+                // Case 1.1 above
+                // TBD if we want to apply the same logic for list relationships
+                defaultOperator = "NONE";
+            }
             const relationshipFilter = this.createRelationshipFilterTreeNode({
                 relationship,
                 target: concreteEntity,
-                operator: operator ?? "SOME",
+                operator: operator ?? defaultOperator,
             });
 
             if (!isNull) {

--- a/packages/graphql/src/translate/queryAST/factory/FilterFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/FilterFactory.ts
@@ -316,7 +316,6 @@ export class FilterFactory {
             let defaultOperator: RelationshipWhereOperator = "SOME";
             if (isNull && !relationship.isList) {
                 // Case 1.1 above
-                // TBD if we want to apply the same logic for list relationships
                 defaultOperator = "NONE";
             }
             const relationshipFilter = this.createRelationshipFilterTreeNode({

--- a/packages/graphql/tests/integration/issues/7205.int.test.ts
+++ b/packages/graphql/tests/integration/issues/7205.int.test.ts
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ */
+
+import { gql } from "graphql-tag";
+import type { UniqueType } from "../../utils/graphql-types";
+import { TestHelper } from "../../utils/tests-helper";
+
+describe("https://github.com/neo4j/graphql/issues/7205", () => {
+    const testHelper = new TestHelper();
+
+    let Person: UniqueType;
+    let Employer: UniqueType;
+
+    beforeEach(async () => {
+        Person = testHelper.createUniqueType("Person");
+        Employer = testHelper.createUniqueType("Employer");
+
+        const typeDefs = gql`
+            type ${Person} @node {
+                name: String!
+                employer: ${Employer} @relationship(type: "WORKS_AT", direction: OUT)
+            }
+
+            type ${Employer} @node {
+                name: String!
+            }
+        `;
+
+        await testHelper.initNeo4jGraphQL({ typeDefs });
+
+        await testHelper.executeCypher(`
+            CREATE (m:${Person.name} {name: "Bob"})
+            CREATE (:${Person.name} {name: "Alice"})-[:WORKS_AT]->(:${Employer.name} {name: "Some Inc"})
+            `);
+    });
+
+    afterEach(async () => {
+        await testHelper.close();
+    });
+
+    test("should return nodes where there is NO relationship", async () => {
+        const query = /*GraphQL*/ `
+            {
+                ${Person.plural}(where: { employer: null }) {
+                    name
+                    employer {
+                        name
+                    }
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+
+        expect(result.errors).toBeUndefined();
+
+        expect(result.data).toEqual({
+            [Person.plural]: [
+                {
+                    name: "Bob",
+                    employer: null,
+                },
+            ],
+        });
+    });
+    test("should return all nodes unfiltered", async () => {
+        const query = /*GraphQL*/ `
+            {
+                ${Person.plural}(where: { NOT: { employer: {} } }) {
+                    name
+                    employer {
+                        name
+                    }
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+
+        expect(result.errors).toBeUndefined();
+
+        expect(result.data).toEqual({
+            [Person.plural]: expect.toIncludeSameMembers([
+                {
+                    name: "Bob",
+                    employer: null,
+                },
+                {
+                    name: "Alice",
+                    employer: {
+                        name: "Some Inc",
+                    },
+                },
+            ]),
+        });
+    });
+    test("should return nodes where there is a relationship", async () => {
+        const query = /*GraphQL*/ `
+            {
+                ${Person.plural}(where: { NOT: { employer: null } }) {
+                    name
+                    employer {
+                        name
+                    }
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+
+        expect(result.errors).toBeUndefined();
+
+        expect(result.data).toEqual({
+            [Person.plural]: [
+                {
+                    name: "Alice",
+                    employer: {
+                        name: "Some Inc",
+                    },
+                },
+            ],
+        });
+    });
+});

--- a/packages/graphql/tests/integration/issues/7205.int.test.ts
+++ b/packages/graphql/tests/integration/issues/7205.int.test.ts
@@ -17,7 +17,7 @@ describe("https://github.com/neo4j/graphql/issues/7205", () => {
         Person = testHelper.createUniqueType("Person");
         Employer = testHelper.createUniqueType("Employer");
 
-        const typeDefs = gql`
+        const typeDefs = /* GraphQL */ `
             type ${Person} @node {
                 name: String!
                 employer: ${Employer} @relationship(type: "WORKS_AT", direction: OUT)
@@ -31,7 +31,7 @@ describe("https://github.com/neo4j/graphql/issues/7205", () => {
         await testHelper.initNeo4jGraphQL({ typeDefs });
 
         await testHelper.executeCypher(`
-            CREATE (m:${Person.name} {name: "Bob"})
+            CREATE (m:${Person} {name: "Bob"})
             CREATE (:${Person.name} {name: "Alice"})-[:WORKS_AT]->(:${Employer.name} {name: "Some Inc"})
             `);
     });


### PR DESCRIPTION
# Description

Relationship existence filters logic was inherited from many-to-many relationships. This PR changes the behaviour for single relationships such that a null check is a conceptual "no relationship exists".

## Complexity

Complexity: Low

# Issue

Closes #7205

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
