### PR TITLE
Conditionally return edges only if requested

### DIFF
--- a/.changeset/tricky-peaches-film.md
+++ b/.changeset/tricky-peaches-film.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+Conditionally return edges and totalCount when querying abstract types

--- a/packages/graphql/src/translate/queryAST/ast/operations/ConnectionReadOperation.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/ConnectionReadOperation.ts
@@ -39,7 +39,8 @@ export class ConnectionReadOperation extends Operation {
     protected needsPageInfo: boolean = false;
     protected selection: EntitySelection;
 
-    private hasTotalCount = false;
+    protected hasTotalCount = false;
+    protected nodeFieldsRequested = false;
     private aggregationField: ConnectionAggregationField | undefined;
 
     constructor({
@@ -55,6 +56,10 @@ export class ConnectionReadOperation extends Operation {
         this.relationship = relationship;
         this.target = target;
         this.selection = selection;
+    }
+
+    public setNodeFieldsRequested(value: boolean): void {
+        this.nodeFieldsRequested = value;
     }
 
     public setHasTotalCount(value: boolean): void {

--- a/packages/graphql/src/translate/queryAST/ast/operations/composite/CompositeConnectionPartial.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/composite/CompositeConnectionPartial.ts
@@ -11,10 +11,10 @@ import { ConnectionReadOperation } from "../ConnectionReadOperation";
 import type { OperationTranspileResult } from "../operations";
 
 export class CompositeConnectionPartial extends ConnectionReadOperation {
-    get hasTotalCountValue(): boolean {
+    public get hasTotalCountValue(): boolean {
         return this.hasTotalCount;
     }
-    get shouldProjectEdgesValue(): boolean {
+    public get shouldProjectEdgesValue(): boolean {
         return this.shouldProjectEdges() || this.nodeFieldsRequested;
     }
 

--- a/packages/graphql/src/translate/queryAST/ast/operations/composite/CompositeConnectionPartial.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/composite/CompositeConnectionPartial.ts
@@ -11,6 +11,13 @@ import { ConnectionReadOperation } from "../ConnectionReadOperation";
 import type { OperationTranspileResult } from "../operations";
 
 export class CompositeConnectionPartial extends ConnectionReadOperation {
+    get hasTotalCountValue(): boolean {
+        return this.hasTotalCount;
+    }
+    get shouldProjectEdgesValue(): boolean {
+        return this.shouldProjectEdges() || this.nodeFieldsRequested;
+    }
+
     /** Prints the name of the Node */
     public print(): string {
         return `${super.print()} <${this.target.name}>`;

--- a/packages/graphql/src/translate/queryAST/ast/operations/composite/CompositeConnectionReadOperation.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/composite/CompositeConnectionReadOperation.ts
@@ -100,14 +100,24 @@ export class CompositeConnectionReadOperation extends Operation {
             ...aggregateVariables
         );
 
-        const returnClause = new Cypher.Return([
-            new Cypher.Map({
-                edges: returnEdgesVar,
-                totalCount: totalCount,
-                ...aggregateReturnMap,
-            }),
-            context.returnVariable,
-        ]);
+        const shouldReturnTotalCount = this.children.find((x) => x.hasTotalCountValue);
+        const shouldReturnEdges = this.children.find((x) => x.shouldProjectEdgesValue);
+
+        const projectionMap = new Cypher.Map();
+
+        if (shouldReturnEdges) {
+            projectionMap.set("edges", returnEdgesVar);
+        }
+
+        if (shouldReturnTotalCount) {
+            projectionMap.set("totalCount", totalCount);
+        }
+
+        projectionMap.set({
+            ...aggregateReturnMap,
+        });
+
+        const returnClause = new Cypher.Return([projectionMap, context.returnVariable]);
 
         return {
             clauses: [

--- a/packages/graphql/src/translate/queryAST/factory/Operations/ConnectionFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/Operations/ConnectionFactory.ts
@@ -513,6 +513,7 @@ export class ConnectionFactory {
         });
 
         operation.setHasTotalCount(Boolean(totalCount || pageInfo));
+        operation.setNodeFieldsRequested(nodeFieldsRaw.length > 0);
 
         // This is an edge-case where the client requests only the cursor field on the edge
         const selectedEdgeCursor = findFieldsByNameInFieldsByTypeNameField(resolveTreeEdgeFields, "cursor").length > 0;

--- a/packages/graphql/tests/tck/aggregations/where/connection-filters-with-aggregations.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/connection-filters-with-aggregations.test.ts
@@ -147,7 +147,7 @@ describe("Field Level Aggregations Edge Filters", () => {
               }
               WITH edges, {node: {title: this8}} AS var9
               WITH edges, size(edges) AS totalCount, var9
-              RETURN {edges: edges, totalCount: totalCount, aggregate: var9} AS var10
+              RETURN {aggregate: var9} AS var10
             }
             RETURN this { actedInConnection: var10 } AS this"
         `);

--- a/packages/graphql/tests/tck/connections/interfaces.test.ts
+++ b/packages/graphql/tests/tck/connections/interfaces.test.ts
@@ -88,7 +88,7 @@ describe("Cypher -> Connections -> Interfaces", () => {
               }
               WITH edges
               WITH edges, size(edges) AS totalCount
-              RETURN {edges: edges, totalCount: totalCount} AS var4
+              RETURN {edges: edges} AS var4
             }
             RETURN this { .name, actedInConnection: var4 } AS this"
         `);
@@ -145,7 +145,7 @@ describe("Cypher -> Connections -> Interfaces", () => {
               }
               WITH edges
               WITH edges, size(edges) AS totalCount
-              RETURN {edges: edges, totalCount: totalCount} AS var4
+              RETURN {edges: edges} AS var4
             }
             RETURN this { .name, actedInConnection: var4 } AS this"
         `);
@@ -207,7 +207,7 @@ describe("Cypher -> Connections -> Interfaces", () => {
               }
               WITH edges
               WITH edges, size(edges) AS totalCount
-              RETURN {edges: edges, totalCount: totalCount} AS var4
+              RETURN {edges: edges} AS var4
             }
             RETURN this { .name, actedInConnection: var4 } AS this"
         `);
@@ -281,7 +281,7 @@ describe("Cypher -> Connections -> Interfaces", () => {
                         ORDER BY edge.properties.screenTime ASC
                         RETURN collect(edge) AS var4
                       }
-                      RETURN {edges: var4, totalCount: totalCount} AS var5
+                      RETURN {edges: var4} AS var5
                     }
                     RETURN this { .name, actedInConnection: var5 } AS this"
                 `);
@@ -342,7 +342,7 @@ describe("Cypher -> Connections -> Interfaces", () => {
                         ORDER BY edge.node.title ASC
                         RETURN collect(edge) AS var4
                       }
-                      RETURN {edges: var4, totalCount: totalCount} AS var5
+                      RETURN {edges: var4} AS var5
                     }
                     RETURN this { .name, actedInConnection: var5 } AS this"
                 `);
@@ -402,7 +402,7 @@ describe("Cypher -> Connections -> Interfaces", () => {
                         ORDER BY edge.properties.screenTime ASC
                         RETURN collect(edge) AS var4
                       }
-                      RETURN {edges: var4, totalCount: totalCount} AS var5
+                      RETURN {edges: var4} AS var5
                     }
                     RETURN this { .name, actedInConnection: var5 } AS this"
                 `);
@@ -462,7 +462,7 @@ describe("Cypher -> Connections -> Interfaces", () => {
                         ORDER BY edge.node.title ASC
                         RETURN collect(edge) AS var4
                       }
-                      RETURN {edges: var4, totalCount: totalCount} AS var5
+                      RETURN {edges: var4} AS var5
                     }
                     RETURN this { .name, actedInConnection: var5 } AS this"
                 `);

--- a/packages/graphql/tests/tck/connections/projections/projections.test.ts
+++ b/packages/graphql/tests/tck/connections/projections/projections.test.ts
@@ -231,7 +231,7 @@ describe("Relay Cursor Connection projections", () => {
               }
               WITH edges
               WITH edges, size(edges) AS totalCount
-              RETURN {edges: edges, totalCount: totalCount} AS var4
+              RETURN {totalCount: totalCount} AS var4
             }
             RETURN this { .name, productionsConnection: var4 } AS this"
         `);

--- a/packages/graphql/tests/tck/connections/top-level-interfaces.test.ts
+++ b/packages/graphql/tests/tck/connections/top-level-interfaces.test.ts
@@ -81,7 +81,7 @@ describe("Top level interface connections", () => {
             }
             WITH edges
             WITH edges, size(edges) AS totalCount
-            RETURN {edges: edges, totalCount: totalCount} AS this"
+            RETURN {edges: edges} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -133,7 +133,7 @@ describe("Top level interface connections", () => {
               LIMIT $param2
               RETURN collect(edge) AS var2
             }
-            RETURN {edges: var2, totalCount: totalCount} AS this"
+            RETURN {edges: var2} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/connections/unions.test.ts
+++ b/packages/graphql/tests/tck/connections/unions.test.ts
@@ -85,7 +85,7 @@ describe("Cypher -> Connections -> Unions", () => {
               }
               WITH edges
               WITH edges, size(edges) AS totalCount
-              RETURN {edges: edges, totalCount: totalCount} AS var4
+              RETURN {edges: edges} AS var4
             }
             RETURN this { .name, publicationsConnection: var4 } AS this"
         `);
@@ -146,7 +146,7 @@ describe("Cypher -> Connections -> Unions", () => {
               }
               WITH edges
               WITH edges, size(edges) AS totalCount
-              RETURN {edges: edges, totalCount: totalCount} AS var4
+              RETURN {edges: edges} AS var4
             }
             RETURN this { .name, publicationsConnection: var4 } AS this"
         `);
@@ -209,7 +209,7 @@ describe("Cypher -> Connections -> Unions", () => {
               }
               WITH edges
               WITH edges, size(edges) AS totalCount
-              RETURN {edges: edges, totalCount: totalCount} AS var4
+              RETURN {edges: edges} AS var4
             }
             RETURN this { .name, publicationsConnection: var4 } AS this"
         `);
@@ -281,7 +281,7 @@ describe("Cypher -> Connections -> Unions", () => {
               }
               WITH edges
               WITH edges, size(edges) AS totalCount
-              RETURN {edges: edges, totalCount: totalCount} AS var4
+              RETURN {edges: edges} AS var4
             }
             RETURN this { .name, publicationsConnection: var4 } AS this"
         `);
@@ -354,7 +354,7 @@ describe("Cypher -> Connections -> Unions", () => {
                 ORDER BY edge.properties.words ASC
                 RETURN collect(edge) AS var4
               }
-              RETURN {edges: var4, totalCount: totalCount} AS var5
+              RETURN {edges: var4} AS var5
             }
             RETURN this { .name, publicationsConnection: var5 } AS this"
         `);

--- a/packages/graphql/tests/tck/directives/authorization/arguments/roles-where.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/roles-where.test.ts
@@ -483,7 +483,7 @@ describe("Cypher Auth Where with Roles", () => {
               }
               WITH edges
               WITH edges, size(edges) AS totalCount
-              RETURN {edges: edges, totalCount: totalCount} AS var3
+              RETURN {edges: edges} AS var3
             }
             RETURN this { .id, contentConnection: var3 } AS this"
         `);
@@ -550,7 +550,7 @@ describe("Cypher Auth Where with Roles", () => {
               }
               WITH edges
               WITH edges, size(edges) AS totalCount
-              RETURN {edges: edges, totalCount: totalCount} AS var3
+              RETURN {edges: edges} AS var3
             }
             RETURN this { .id, contentConnection: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/directives/authorization/arguments/where/connection-auth-filter.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/where/connection-auth-filter.test.ts
@@ -513,7 +513,7 @@ describe("Connection auth filter", () => {
                 }
                 WITH edges
                 WITH edges, size(edges) AS totalCount
-                RETURN {edges: edges, totalCount: totalCount} AS var4
+                RETURN {edges: edges} AS var4
               }
               RETURN collect({node: {id: this0.id, contentConnection: var4, __resolveType: 'User'}}) AS var5
             }
@@ -584,7 +584,7 @@ describe("Connection auth filter", () => {
                 }
                 WITH edges
                 WITH edges, size(edges) AS totalCount
-                RETURN {edges: edges, totalCount: totalCount} AS var4
+                RETURN {edges: edges} AS var4
               }
               RETURN collect({node: {id: this0.id, contentConnection: var4, __resolveType: 'User'}}) AS var5
             }

--- a/packages/graphql/tests/tck/directives/authorization/arguments/where/interface-relationships/implementation-where.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/where/interface-relationships/implementation-where.test.ts
@@ -259,7 +259,7 @@ describe("Cypher Auth Where", () => {
               }
               WITH edges
               WITH edges, size(edges) AS totalCount
-              RETURN {edges: edges, totalCount: totalCount} AS var5
+              RETURN {edges: edges} AS var5
             }
             RETURN this { .id, contentConnection: var5 } AS this"
         `);
@@ -325,7 +325,7 @@ describe("Cypher Auth Where", () => {
               }
               WITH edges
               WITH edges, size(edges) AS totalCount
-              RETURN {edges: edges, totalCount: totalCount} AS var5
+              RETURN {edges: edges} AS var5
             }
             RETURN this { .id, contentConnection: var5 } AS this"
         `);

--- a/packages/graphql/tests/tck/directives/authorization/arguments/where/where.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/where/where.test.ts
@@ -443,7 +443,7 @@ describe("Cypher Auth Where", () => {
               }
               WITH edges
               WITH edges, size(edges) AS totalCount
-              RETURN {edges: edges, totalCount: totalCount} AS var3
+              RETURN {edges: edges} AS var3
             }
             RETURN this { .id, contentConnection: var3 } AS this"
         `);
@@ -505,7 +505,7 @@ describe("Cypher Auth Where", () => {
               }
               WITH edges
               WITH edges, size(edges) AS totalCount
-              RETURN {edges: edges, totalCount: totalCount} AS var3
+              RETURN {edges: edges} AS var3
             }
             RETURN this { .id, contentConnection: var3 } AS this"
         `);

--- a/packages/graphql/tests/tck/directives/authorization/projection-connection-union.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/projection-connection-union.test.ts
@@ -105,7 +105,7 @@ describe("Cypher Auth Projection On Connections On Unions", () => {
               }
               WITH edges
               WITH edges, size(edges) AS totalCount
-              RETURN {edges: edges, totalCount: totalCount} AS var7
+              RETURN {edges: edges} AS var7
             }
             RETURN this { contentConnection: var7 } AS this"
         `);

--- a/packages/graphql/tests/tck/directives/interface-relationships/read.test.ts
+++ b/packages/graphql/tests/tck/directives/interface-relationships/read.test.ts
@@ -187,7 +187,7 @@ describe("Interface Relationships", () => {
               }
               WITH edges
               WITH edges, size(edges) AS totalCount
-              RETURN {edges: edges, totalCount: totalCount} AS var4
+              RETURN {edges: edges} AS var4
             }
             RETURN this { actedInConnection: var4 } AS this"
         `);
@@ -245,7 +245,7 @@ describe("Interface Relationships", () => {
               }
               WITH edges
               WITH edges, size(edges) AS totalCount
-              RETURN {edges: edges, totalCount: totalCount} AS var4
+              RETURN {edges: edges} AS var4
             }
             RETURN this { actedInConnection: var4 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/1150.test.ts
+++ b/packages/graphql/tests/tck/issues/1150.test.ts
@@ -124,7 +124,7 @@ describe("https://github.com/neo4j/graphql/issues/1150", () => {
                   }
                   WITH edges
                   WITH edges, size(edges) AS totalCount
-                  RETURN {edges: edges, totalCount: totalCount} AS var6
+                  RETURN {edges: edges} AS var6
                 }
                 RETURN collect({node: {driveComponentConnection: var6, __resolveType: 'DriveComposition'}}) AS var7
               }

--- a/packages/graphql/tests/tck/issues/1348.test.ts
+++ b/packages/graphql/tests/tck/issues/1348.test.ts
@@ -142,7 +142,7 @@ describe("https://github.com/neo4j/graphql/issues/1348", () => {
               }
               WITH edges
               WITH edges, size(edges) AS totalCount
-              RETURN {edges: edges, totalCount: totalCount} AS var6
+              RETURN {edges: edges} AS var6
             }
             RETURN this { .productTitle, .episodeNumber, releatsToConnection: var6 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/4287.test.ts
+++ b/packages/graphql/tests/tck/issues/4287.test.ts
@@ -74,7 +74,7 @@ describe("https://github.com/neo4j/graphql/issues/4287", () => {
               }
               WITH edges
               WITH edges, size(edges) AS totalCount
-              RETURN {edges: edges, totalCount: totalCount} AS var4
+              RETURN {edges: edges} AS var4
             }
             RETURN this { actedInConnection: var4 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/4432.test.ts
+++ b/packages/graphql/tests/tck/issues/4432.test.ts
@@ -80,7 +80,7 @@ describe("https://github.com/neo4j/graphql/issues/4532", () => {
                 ORDER BY edge.properties.order ASC
                 RETURN collect(edge) AS var4
               }
-              RETURN {edges: var4, totalCount: totalCount} AS var5
+              RETURN {edges: var4} AS var5
             }
             RETURN this { .id, childrenConnection: var5 } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/4814.test.ts
+++ b/packages/graphql/tests/tck/issues/4814.test.ts
@@ -78,7 +78,7 @@ describe("https://github.com/neo4j/graphql/issues/4814", () => {
                 }
                 WITH edges
                 WITH edges, size(edges) AS totalCount
-                RETURN {edges: edges, totalCount: totalCount} AS var5
+                RETURN {edges: edges} AS var5
               }
               WITH this0 { nextsConnection: var5, __resolveType: 'AStep', __id: elementId(this0) } AS this
               RETURN this
@@ -102,7 +102,7 @@ describe("https://github.com/neo4j/graphql/issues/4814", () => {
                 }
                 WITH edges
                 WITH edges, size(edges) AS totalCount
-                RETURN {edges: edges, totalCount: totalCount} AS var11
+                RETURN {edges: edges} AS var11
               }
               WITH this6 { nextsConnection: var11, __resolveType: 'BStep', __id: elementId(this6) } AS this
               RETURN this
@@ -160,7 +160,7 @@ describe("https://github.com/neo4j/graphql/issues/4814", () => {
                 }
                 WITH edges
                 WITH edges, size(edges) AS totalCount
-                RETURN {edges: edges, totalCount: totalCount} AS var5
+                RETURN {edges: edges} AS var5
               }
               WITH this0 { prevsConnection: var5, __resolveType: 'AStep', __id: elementId(this0) } AS this
               RETURN this
@@ -184,7 +184,7 @@ describe("https://github.com/neo4j/graphql/issues/4814", () => {
                 }
                 WITH edges
                 WITH edges, size(edges) AS totalCount
-                RETURN {edges: edges, totalCount: totalCount} AS var11
+                RETURN {edges: edges} AS var11
               }
               WITH this6 { prevsConnection: var11, __resolveType: 'BStep', __id: elementId(this6) } AS this
               RETURN this

--- a/packages/graphql/tests/tck/issues/6031.test.ts
+++ b/packages/graphql/tests/tck/issues/6031.test.ts
@@ -75,7 +75,7 @@ describe("https://github.com/neo4j/graphql/issues/6031", () => {
             }
             WITH edges
             WITH edges, size(edges) AS totalCount
-            RETURN {edges: edges, totalCount: totalCount} AS this"
+            RETURN {edges: edges} AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -129,7 +129,7 @@ describe("https://github.com/neo4j/graphql/issues/6031", () => {
                 }
                 WITH edges
                 WITH edges, size(edges) AS totalCount
-                RETURN {edges: edges, totalCount: totalCount} AS var5
+                RETURN {edges: edges} AS var5
               }
               RETURN collect({node: {name: this0.name, productionsConnection: var5, __resolveType: 'Actor'}}) AS var6
             }

--- a/packages/graphql/tests/tck/issues/7261.test.ts
+++ b/packages/graphql/tests/tck/issues/7261.test.ts
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ */
+
+import { Neo4jGraphQL } from "../../../src";
+import { formatCypher, formatParams, translateQuery } from "../utils/tck-test-utils";
+
+describe("https://github.com/neo4j/graphql/issues/7261", () => {
+    let typeDefs: string;
+    let neoSchema: Neo4jGraphQL;
+
+    beforeAll(() => {
+        typeDefs = /* GraphQL */ `
+            interface HasFile {
+                id: String
+            }
+
+            interface DigitalAssetDerivative implements HasFile {
+                id: String
+            }
+
+            type Something @node {
+                id: String
+            }
+
+            type AssetA implements DigitalAssetDerivative & HasFile
+                @node(labels: ["AssetA ", "DigitalAssetDerivative", "HasFile"]) {
+                id: String
+            }
+            type AssetB implements DigitalAssetDerivative & HasFile
+                @node(labels: ["AssetB ", "DigitalAssetDerivative", "HasFile"]) {
+                id: String
+            }
+        `;
+
+        neoSchema = new Neo4jGraphQL({
+            typeDefs,
+        });
+    });
+
+    test("Should only return totalCount when edges are not requested", async () => {
+        const query = /* GraphQL */ `
+            query {
+                hasFilesConnection {
+                    totalCount
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "CYPHER 5
+            CALL () {
+              CALL () {
+                MATCH (this0:\`AssetA \`&DigitalAssetDerivative&HasFile)
+                WITH {node: {__resolveType: 'AssetA', __id: elementId(this0)}} AS edge
+                RETURN edge
+                UNION
+                MATCH (this1:\`AssetB \`&DigitalAssetDerivative&HasFile)
+                WITH {node: {__resolveType: 'AssetB', __id: elementId(this1)}} AS edge
+                RETURN edge
+              }
+              RETURN collect(edge) AS edges
+            }
+            WITH edges
+            WITH edges, size(edges) AS totalCount
+            RETURN {totalCount: totalCount} AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
+    });
+
+    test("Should return only edges", async () => {
+        const query = /* GraphQL */ `
+            query {
+                hasFilesConnection {
+                    edges {
+                        node {
+                            id
+                        }
+                    }
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "CYPHER 5
+            CALL () {
+              CALL () {
+                MATCH (this0:\`AssetA \`&DigitalAssetDerivative&HasFile)
+                WITH {node: {__resolveType: 'AssetA', __id: elementId(this0), id: this0.id}} AS edge
+                RETURN edge
+                UNION
+                MATCH (this1:\`AssetB \`&DigitalAssetDerivative&HasFile)
+                WITH {node: {__resolveType: 'AssetB', __id: elementId(this1), id: this1.id}} AS edge
+                RETURN edge
+              }
+              RETURN collect(edge) AS edges
+            }
+            WITH edges
+            WITH edges, size(edges) AS totalCount
+            RETURN {edges: edges} AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
+    });
+
+    test("Should return both totalCount and edges", async () => {
+        const query = /* GraphQL */ `
+            query {
+                hasFilesConnection {
+                    totalCount
+                    edges {
+                        node {
+                            id
+                        }
+                    }
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "CYPHER 5
+            CALL () {
+              CALL () {
+                MATCH (this0:\`AssetA \`&DigitalAssetDerivative&HasFile)
+                WITH {node: {__resolveType: 'AssetA', __id: elementId(this0), id: this0.id}} AS edge
+                RETURN edge
+                UNION
+                MATCH (this1:\`AssetB \`&DigitalAssetDerivative&HasFile)
+                WITH {node: {__resolveType: 'AssetB', __id: elementId(this1), id: this1.id}} AS edge
+                RETURN edge
+              }
+              RETURN collect(edge) AS edges
+            }
+            WITH edges
+            WITH edges, size(edges) AS totalCount
+            RETURN {edges: edges, totalCount: totalCount} AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
+    });
+});


### PR DESCRIPTION
# Description

Unifies querying behaviour of abstract and object types: only return edges and totalCount when they are requested.

## Complexity

Complexity: Low

# Issue

Closes #7261 

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
