### PR TITLE
moving as-integrations/express4 to devDependencies as it's only used for testing purpose

### DIFF
--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -48,6 +48,7 @@
     "devDependencies": {
         "@apollo/gateway": "2.13.3",
         "@apollo/server": "5.5.0",
+        "@as-integrations/express4": "^1.1.2",
         "@types/is-uuid": "1.0.2",
         "@types/jest": "30.0.0",
         "@types/jsonwebtoken": "9.0.10",
@@ -80,7 +81,6 @@
     },
     "dependencies": {
         "@apollo/subgraph": "^2.2.3",
-        "@as-integrations/express4": "^1.1.2",
         "@graphql-tools/merge": "^9.0.0",
         "@graphql-tools/resolvers-composition": "^7.0.0",
         "@graphql-tools/schema": "^10.0.0",


### PR DESCRIPTION
When Apollo server was updated to v5 the Express integration is no longer built-in, it was mistakenly put as dependency but as this is required by Apollo/server and only used for tests, then this PR move this dependency to be a devDependency only.
Reference: https://www.apollographql.com/docs/apollo-server/migration#separate-package-for-the-express-integration