### PR TITLE
7293 authorization directive for operations create relationship and delete relationship leads to cypher syntax errors and thus failing mutations

### DIFF
--- a/.changeset/loose-towns-flash.md
+++ b/.changeset/loose-towns-flash.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+Fix authorization validation rules for CREATE_RELATIONSHIP and DELETE_RELATIONSHIP rules

--- a/packages/graphql/src/translate/queryAST/ast/operations/ConnectOperation.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/ConnectOperation.ts
@@ -139,21 +139,11 @@ export class ConnectOperation extends MutationOperation {
         filterSubqueries.push(
             ...this.authFilters
                 .flatMap((authFilter) => {
-                    const authSubqueries = authFilter.getSubqueriesBefore(nestedContext);
-                    return authSubqueries;
+                    return authFilter.getSubqueriesBefore(nestedContext);
                 })
                 .map((sq) => {
                     return new Cypher.Call(sq, [nestedContext.target]);
                 })
-            // TODO: Subqueries for BEFORE auth on CREATE_RELATIONSHIP source node
-            // ...this.sourceAuthFilters
-            //     .flatMap((authFilter) => {
-            //         const authSubqueries = authFilter.getSubqueriesBefore(context);
-            //         return authSubqueries;
-            //     })
-            //     .map((sq) => {
-            //         return new Cypher.Call(sq, [context.target]);
-            //     })
         );
         const afterFilterSubqueries: Cypher.Clause[] = [...this.authFilters, ...this.sourceAuthFilters]
             .flatMap((authFilter) => {
@@ -204,8 +194,6 @@ export class ConnectOperation extends MutationOperation {
         const clauses = Cypher.utils.concat(
             matchClause,
             ...this.getAuthorizationClauses(nestedContext), // THESE ARE "BEFORE" AUTH
-            // TODO: validations for BEFORE auth on CREATE_RELATIONSHIP source node
-            // ...this.getSourceAuthorizationClausesBefore(context), // THESE ARE "BEFORE" AUTH
             ...mutationSubqueries,
             connectClause,
             ...afterFilterSubqueries,
@@ -255,22 +243,6 @@ export class ConnectOperation extends MutationOperation {
 
         if (validationsAfter.length > 0) {
             return [new Cypher.With("*"), ...validationsAfter];
-        }
-        return [];
-    }
-
-    // TODO: source node BEFORE validations on CREATE_RELATIONSHIP ???
-    private getSourceAuthorizationClausesBefore(context: QueryASTContext): Cypher.Clause[] {
-        const validationsBefore: Cypher.VoidProcedure[] = [];
-        for (const authFilter of this.sourceAuthFilters) {
-            const validationBefore = authFilter.getValidation(context, "BEFORE");
-            if (validationBefore) {
-                validationsBefore.push(validationBefore);
-            }
-        }
-
-        if (validationsBefore.length > 0) {
-            return [new Cypher.With("*"), ...validationsBefore];
         }
         return [];
     }

--- a/packages/graphql/src/translate/queryAST/ast/operations/ConnectOperation.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/ConnectOperation.ts
@@ -53,6 +53,7 @@ export class ConnectOperation extends MutationOperation {
             this.selectionPattern,
             ...this.filters,
             ...this.authFilters,
+            ...this.sourceAuthFilters,
             ...this.inputFields.values(),
         ]);
     }
@@ -104,7 +105,6 @@ export class ConnectOperation extends MutationOperation {
         if (!context.hasTarget()) {
             throw new Error("No parent node found!");
         }
-
         const { nestedContext } = this.selectionPattern.apply(context);
         this.nestedContext = nestedContext;
 
@@ -135,10 +135,39 @@ export class ConnectOperation extends MutationOperation {
             labels: getEntityLabels(this.target, context.neo4jGraphQLContext),
         });
 
+        const filterSubqueries = wrapSubqueriesInCypherCalls(nestedContext, this.filters, [nestedContext.target]);
+        filterSubqueries.push(
+            ...this.authFilters
+                .flatMap((authFilter) => {
+                    const authSubqueries = authFilter.getSubqueriesBefore(nestedContext);
+                    return authSubqueries;
+                })
+                .map((sq) => {
+                    return new Cypher.Call(sq, [nestedContext.target]);
+                })
+            // TODO: Subqueries for BEFORE auth on CREATE_RELATIONSHIP source node
+            // ...this.sourceAuthFilters
+            //     .flatMap((authFilter) => {
+            //         const authSubqueries = authFilter.getSubqueriesBefore(context);
+            //         return authSubqueries;
+            //     })
+            //     .map((sq) => {
+            //         return new Cypher.Call(sq, [context.target]);
+            //     })
+        );
+        const afterFilterSubqueries: Cypher.Clause[] = [...this.authFilters, ...this.sourceAuthFilters]
+            .flatMap((authFilter) => {
+                const authSubqueries = authFilter.getSubqueriesAfter(nestedContext);
+                return authSubqueries;
+            })
+            .map((sq) => {
+                return new Cypher.Call(sq, [nestedContext.target]);
+            });
+        if (afterFilterSubqueries.length > 0) {
+            afterFilterSubqueries.unshift(new Cypher.With("*"));
+        }
+
         const allFilters = [...this.authFilters, ...this.filters];
-
-        const filterSubqueries = wrapSubqueriesInCypherCalls(nestedContext, allFilters, [nestedContext.target]);
-
         const predicate = Cypher.and(...allFilters.map((f) => f.getPredicate(nestedContext)));
         let matchClause: Cypher.Clause;
         if (filterSubqueries.length > 0) {
@@ -175,8 +204,11 @@ export class ConnectOperation extends MutationOperation {
         const clauses = Cypher.utils.concat(
             matchClause,
             ...this.getAuthorizationClauses(nestedContext), // THESE ARE "BEFORE" AUTH
+            // TODO: validations for BEFORE auth on CREATE_RELATIONSHIP source node
+            // ...this.getSourceAuthorizationClausesBefore(context), // THESE ARE "BEFORE" AUTH
             ...mutationSubqueries,
             connectClause,
+            ...afterFilterSubqueries,
             ...this.getAuthorizationClausesAfter(nestedContext), // THESE ARE "AFTER" AUTH
             ...this.getSourceAuthorizationClausesAfter(context) // ONLY RUN "AFTER" AUTH ON THE SOURCE NODE
         );
@@ -190,11 +222,11 @@ export class ConnectOperation extends MutationOperation {
     }
 
     private getAuthorizationClauses(context: QueryASTContext): Cypher.Clause[] {
-        const { subqueries, validations } = this.transpileAuthClauses(context);
+        const { validations } = this.transpileAuthClauses(context);
         if (!validations.length) {
             return [];
         }
-        return [...subqueries, ...validations];
+        return validations;
     }
 
     private getAuthorizationClausesAfter(context: QueryASTContext): Cypher.Clause[] {
@@ -227,6 +259,22 @@ export class ConnectOperation extends MutationOperation {
         return [];
     }
 
+    // TODO: source node BEFORE validations on CREATE_RELATIONSHIP ???
+    private getSourceAuthorizationClausesBefore(context: QueryASTContext): Cypher.Clause[] {
+        const validationsBefore: Cypher.VoidProcedure[] = [];
+        for (const authFilter of this.sourceAuthFilters) {
+            const validationBefore = authFilter.getValidation(context, "BEFORE");
+            if (validationBefore) {
+                validationsBefore.push(validationBefore);
+            }
+        }
+
+        if (validationsBefore.length > 0) {
+            return [new Cypher.With("*"), ...validationsBefore];
+        }
+        return [];
+    }
+
     private transpileAuthClauses(context: QueryASTContext): {
         selections: (Cypher.With | Cypher.Match)[];
         subqueries: Cypher.Clause[];
@@ -253,6 +301,7 @@ export class ConnectOperation extends MutationOperation {
                 validations.push(validation);
             }
         }
+
         return { selections, subqueries, predicates, validations };
     }
 }

--- a/packages/graphql/src/translate/queryAST/ast/operations/DisconnectOperation.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/DisconnectOperation.ts
@@ -52,6 +52,7 @@ export class DisconnectOperation extends MutationOperation {
             this.selectionPattern,
             ...this.filters,
             ...this.authFilters,
+            ...this.sourceAuthFilters,
             ...this.inputFields.values(),
         ]);
     }
@@ -131,7 +132,37 @@ export class DisconnectOperation extends MutationOperation {
 
         const allFilters = [...this.authFilters, ...this.filters];
 
-        const filterSubqueries = wrapSubqueriesInCypherCalls(nestedContext, allFilters, [nestedContext.target]);
+        const filterSubqueries = wrapSubqueriesInCypherCalls(nestedContext, this.filters, [nestedContext.target]);
+        filterSubqueries.push(
+            ...this.authFilters
+                .flatMap((authFilter) => {
+                    const authSubqueries = authFilter.getSubqueriesBefore(nestedContext);
+                    return authSubqueries;
+                })
+                .map((sq) => {
+                    return new Cypher.Call(sq, [nestedContext.target]);
+                }),
+            // TODO: Subqueries for BEFORE auth on DELETE_RELATIONSHIP source node
+            ...this.sourceAuthFilters
+                .flatMap((authFilter) => {
+                    const authSubqueries = authFilter.getSubqueriesBefore(context);
+                    return authSubqueries;
+                })
+                .map((sq) => {
+                    return new Cypher.Call(sq, [context.target]);
+                })
+        );
+        const afterFilterSubqueries: Cypher.Clause[] = [...this.authFilters, ...this.sourceAuthFilters]
+            .flatMap((authFilter) => {
+                const authSubqueries = authFilter.getSubqueriesAfter(nestedContext);
+                return authSubqueries;
+            })
+            .map((sq) => {
+                return new Cypher.Call(sq, [nestedContext.target]);
+            });
+        if (afterFilterSubqueries.length > 0) {
+            afterFilterSubqueries.unshift(new Cypher.With("*"));
+        }
 
         const predicate = Cypher.and(...allFilters.map((f) => f.getPredicate(nestedContext)));
         let matchClause: Cypher.Clause;
@@ -163,6 +194,7 @@ export class DisconnectOperation extends MutationOperation {
             ...this.getSourceAuthorizationClauses(context, "BEFORE"),
             ...mutationSubqueries,
             deleteClause,
+            ...afterFilterSubqueries,
             ...this.getAuthorizationClausesAfter(nestedContext),
             ...this.getSourceAuthorizationClauses(context, "AFTER")
         );
@@ -180,7 +212,8 @@ export class DisconnectOperation extends MutationOperation {
         if (!validations.length) {
             return [];
         }
-        return [...subqueries, ...validations];
+        // return [...subqueries, ...validations];
+        return validations;
     }
 
     private getAuthorizationClausesAfter(context: QueryASTContext): Cypher.Clause[] {

--- a/packages/graphql/src/translate/queryAST/ast/operations/DisconnectOperation.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/DisconnectOperation.ts
@@ -142,7 +142,6 @@ export class DisconnectOperation extends MutationOperation {
                 .map((sq) => {
                     return new Cypher.Call(sq, [nestedContext.target]);
                 }),
-            // TODO: Subqueries for BEFORE auth on DELETE_RELATIONSHIP source node
             ...this.sourceAuthFilters
                 .flatMap((authFilter) => {
                     const authSubqueries = authFilter.getSubqueriesBefore(context);
@@ -208,11 +207,10 @@ export class DisconnectOperation extends MutationOperation {
     }
 
     private getAuthorizationClauses(context: QueryASTContext): Cypher.Clause[] {
-        const { subqueries, validations } = this.transpileAuthClauses(context);
+        const { validations } = this.transpileAuthClauses(context);
         if (!validations.length) {
             return [];
         }
-        // return [...subqueries, ...validations];
         return validations;
     }
 

--- a/packages/graphql/tests/integration/issues/7293-full.int.test.ts
+++ b/packages/graphql/tests/integration/issues/7293-full.int.test.ts
@@ -1,0 +1,561 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ */
+
+import { gql } from "graphql-tag";
+import type { UniqueType } from "../../utils/graphql-types";
+import { TestHelper } from "../../utils/tests-helper";
+
+describe("https://github.com/neo4j/graphql/issues/7293 full type defs", () => {
+    const testHelper = new TestHelper();
+
+    let Continent: UniqueType;
+    let Country: UniqueType;
+    let Company: UniqueType;
+    let Triad: UniqueType;
+
+    beforeEach(async () => {
+        Continent = testHelper.createUniqueType("Continent");
+        Country = testHelper.createUniqueType("Country");
+        Company = testHelper.createUniqueType("Company");
+        Triad = testHelper.createUniqueType("Triad");
+
+        const typeDefs = /* GraphQL */ `
+            type ${Company}
+                @mutation(operations: [DELETE, CREATE, UPDATE])
+                @node
+                @subscription(events: [])
+                @authorization(
+                    filter: [
+                        {
+                            requireAuthentication: false
+                            operations: [READ]
+                            where: { node: { _hasAccess_READ: { eq: true } } }
+                        }
+                        {
+                            requireAuthentication: false
+                            operations: [AGGREGATE]
+                            where: { node: { _hasAccess_AGGREGATE: { eq: true } } }
+                        }
+                    ]
+                    validate: [
+                        {
+                            requireAuthentication: false
+                            operations: [CREATE]
+                            when: [AFTER]
+                            where: { node: { _hasAccess_CREATE: { eq: true } } }
+                        }
+                        {
+                            requireAuthentication: false
+                            operations: [UPDATE]
+                            when: [BEFORE, AFTER]
+                            where: { node: { _hasAccess_UPDATE: { eq: true } } }
+                        }
+                        {
+                            requireAuthentication: false
+                            operations: [DELETE]
+                            when: [BEFORE]
+                            where: { node: { _hasAccess_DELETE: { eq: true } } }
+                        }
+                        {
+                            requireAuthentication: false
+                            operations: [CREATE_RELATIONSHIP]
+                            when: [BEFORE, AFTER]
+                            where: { node: { _hasAccess_CREATE_RELATIONSHIP: { eq: true } } }
+                        }
+                        {
+                            requireAuthentication: false
+                            operations: [DELETE_RELATIONSHIP]
+                            when: [BEFORE, AFTER]
+                            where: { node: { _hasAccess_DELETE_RELATIONSHIP: { eq: true } } }
+                        }
+                    ]
+                ) {
+                _hasAccess_AGGREGATE: Boolean!
+                    @selectable(onRead: false, onAggregate: false)
+                    @cypher(
+                        statement: """
+                        RETURN true as result
+                        """
+                        columnName: "result"
+                    )
+                _hasAccess_CREATE: Boolean!
+                    @selectable(onRead: false, onAggregate: false)
+                    @cypher(
+                        statement: """
+                        RETURN true as result
+                        """
+                        columnName: "result"
+                    )
+                _hasAccess_CREATE_RELATIONSHIP: Boolean!
+                    @selectable(onRead: false, onAggregate: false)
+                    @cypher(
+                        statement: """
+                        RETURN true as result
+                        """
+                        columnName: "result"
+                    )
+                _hasAccess_DELETE: Boolean!
+                    @selectable(onRead: false, onAggregate: false)
+                    @cypher(
+                        statement: """
+                        RETURN true as result
+                        """
+                        columnName: "result"
+                    )
+                _hasAccess_DELETE_RELATIONSHIP: Boolean!
+                    @selectable(onRead: false, onAggregate: false)
+                    @cypher(
+                        statement: """
+                        RETURN true as result
+                        """
+                        columnName: "result"
+                    )
+                _hasAccess_READ: Boolean!
+                    @selectable(onRead: false, onAggregate: false)
+                    @cypher(
+                        statement: """
+                        RETURN true as result
+                        """
+                        columnName: "result"
+                    )
+                _hasAccess_UPDATE: Boolean!
+                    @selectable(onRead: false, onAggregate: false)
+                    @cypher(
+                        statement: """
+                        RETURN true as result
+                        """
+                        columnName: "result"
+                    )
+
+                id: Int! @settable(onCreate: true, onUpdate: false)
+            }
+
+            type ${Continent}
+                @mutation(operations: [CREATE, UPDATE, DELETE])
+                @node
+                @subscription(events: [])
+                @authorization(
+                    filter: [
+                        {
+                            requireAuthentication: false
+                            operations: [READ]
+                            where: { node: { _hasAccess_READ: { eq: true } } }
+                        }
+                        {
+                            requireAuthentication: false
+                            operations: [AGGREGATE]
+                            where: { node: { _hasAccess_AGGREGATE: { eq: true } } }
+                        }
+                    ]
+                    validate: [
+                        {
+                            requireAuthentication: false
+                            operations: [CREATE]
+                            when: [AFTER]
+                            where: { node: { _hasAccess_CREATE: { eq: true } } }
+                        }
+                        {
+                            requireAuthentication: false
+                            operations: [UPDATE]
+                            when: [BEFORE, AFTER]
+                            where: { node: { _hasAccess_UPDATE: { eq: true } } }
+                        }
+                        {
+                            requireAuthentication: false
+                            operations: [DELETE]
+                            when: [BEFORE]
+                            where: { node: { _hasAccess_DELETE: { eq: true } } }
+                        }
+                        {
+                            requireAuthentication: false
+                            operations: [CREATE_RELATIONSHIP]
+                            when: [BEFORE, AFTER]
+                            where: { node: { _hasAccess_CREATE_RELATIONSHIP: { eq: true } } }
+                        }
+                        {
+                            requireAuthentication: false
+                            operations: [DELETE_RELATIONSHIP]
+                            when: [BEFORE, AFTER]
+                            where: { node: { _hasAccess_DELETE_RELATIONSHIP: { eq: true } } }
+                        }
+                    ]
+                ) {
+                _hasAccess_AGGREGATE: Boolean!
+                    @selectable(onRead: false, onAggregate: false)
+                    @cypher(
+                        statement: """
+                        RETURN true as result
+                        """
+                        columnName: "result"
+                    )
+                _hasAccess_CREATE: Boolean!
+                    @selectable(onRead: false, onAggregate: false)
+                    @cypher(
+                        statement: """
+                        RETURN true as result
+                        """
+                        columnName: "result"
+                    )
+                _hasAccess_CREATE_RELATIONSHIP: Boolean!
+                    @selectable(onRead: false, onAggregate: false)
+                    @cypher(
+                        statement: """
+                        RETURN true as result
+                        """
+                        columnName: "result"
+                    )
+                _hasAccess_DELETE: Boolean!
+                    @selectable(onRead: false, onAggregate: false)
+                    @cypher(
+                        statement: """
+                        RETURN true as result
+                        """
+                        columnName: "result"
+                    )
+                _hasAccess_DELETE_RELATIONSHIP: Boolean!
+                    @selectable(onRead: false, onAggregate: false)
+                    @cypher(
+                        statement: """
+                        RETURN true as result
+                        """
+                        columnName: "result"
+                    )
+                _hasAccess_READ: Boolean!
+                    @selectable(onRead: false, onAggregate: false)
+                    @cypher(
+                        statement: """
+                        RETURN true as result
+                        """
+                        columnName: "result"
+                    )
+                _hasAccess_UPDATE: Boolean!
+                    @selectable(onRead: false, onAggregate: false)
+                    @cypher(
+                        statement: """
+                        RETURN true as result
+                        """
+                        columnName: "result"
+                    )
+
+                id: Int! @settable(onCreate: true, onUpdate: false)
+            }
+
+            type ${Country}
+                @mutation(operations: [CREATE, UPDATE, DELETE])
+                @node
+                @subscription(events: [])
+                @authorization(
+                    filter: [
+                        {
+                            requireAuthentication: false
+                            operations: [READ]
+                            where: { node: { _hasAccess_READ: { eq: true } } }
+                        }
+                        {
+                            requireAuthentication: false
+                            operations: [AGGREGATE]
+                            where: { node: { _hasAccess_AGGREGATE: { eq: true } } }
+                        }
+                    ]
+                    validate: [
+                        {
+                            requireAuthentication: false
+                            operations: [CREATE]
+                            when: [AFTER]
+                            where: { node: { _hasAccess_CREATE: { eq: true } } }
+                        }
+                        {
+                            requireAuthentication: false
+                            operations: [UPDATE]
+                            when: [BEFORE, AFTER]
+                            where: { node: { _hasAccess_UPDATE: { eq: true } } }
+                        }
+                        {
+                            requireAuthentication: false
+                            operations: [DELETE]
+                            when: [BEFORE]
+                            where: { node: { _hasAccess_DELETE: { eq: true } } }
+                        }
+                        {
+                            requireAuthentication: false
+                            operations: [CREATE_RELATIONSHIP]
+                            when: [BEFORE, AFTER]
+                            where: { node: { _hasAccess_CREATE_RELATIONSHIP: { eq: true } } }
+                        }
+                        {
+                            requireAuthentication: false
+                            operations: [DELETE_RELATIONSHIP]
+                            when: [BEFORE, AFTER]
+                            where: { node: { _hasAccess_DELETE_RELATIONSHIP: { eq: true } } }
+                        }
+                    ]
+                ) {
+                _hasAccess_AGGREGATE: Boolean!
+                    @selectable(onRead: false, onAggregate: false)
+                    @cypher(
+                        statement: """
+                        RETURN true as result
+                        """
+                        columnName: "result"
+                    )
+                _hasAccess_CREATE: Boolean!
+                    @selectable(onRead: false, onAggregate: false)
+                    @cypher(
+                        statement: """
+                        RETURN true as result
+                        """
+                        columnName: "result"
+                    )
+                _hasAccess_CREATE_RELATIONSHIP: Boolean!
+                    @selectable(onRead: false, onAggregate: false)
+                    @cypher(
+                        statement: """
+                        RETURN true as result
+                        """
+                        columnName: "result"
+                    )
+                _hasAccess_DELETE: Boolean!
+                    @selectable(onRead: false, onAggregate: false)
+                    @cypher(
+                        statement: """
+                        RETURN true as result
+                        """
+                        columnName: "result"
+                    )
+                _hasAccess_DELETE_RELATIONSHIP: Boolean!
+                    @selectable(onRead: false, onAggregate: false)
+                    @cypher(
+                        statement: """
+                        RETURN true as result
+                        """
+                        columnName: "result"
+                    )
+                _hasAccess_READ: Boolean!
+                    @selectable(onRead: false, onAggregate: false)
+                    @cypher(
+                        statement: """
+                        RETURN true as result
+                        """
+                        columnName: "result"
+                    )
+                _hasAccess_UPDATE: Boolean!
+                    @selectable(onRead: false, onAggregate: false)
+                    @cypher(
+                        statement: """
+                        RETURN true as result
+                        """
+                        columnName: "result"
+                    )
+
+                code: String! @settable(onCreate: true, onUpdate: false)
+                continent: [${Continent}!]!
+                    @relationship(
+                        type: "CONTINENT_HAS_COUNTRY"
+                        direction: IN
+                        nestedOperations: [CREATE, UPDATE, DELETE, CONNECT, DISCONNECT]
+                        queryDirection: DIRECTED
+                    )
+                    @settable(onCreate: true, onUpdate: true)
+                name_en: String!
+                responsibleCompanies: [${Company}!]!
+                    @relationship(
+                        type: "COMPANY_IS_RESPONSIBLE_FOR_COUNTRY"
+                        direction: IN
+                        nestedOperations: [CREATE, UPDATE, DELETE, CONNECT, DISCONNECT]
+                        queryDirection: DIRECTED
+                    )
+                    @settable(onCreate: true, onUpdate: true)
+                triad: [${Triad}!]!
+                    @relationship(
+                        type: "COUNTRY_IS_IN_TRIAD"
+                        direction: OUT
+                        nestedOperations: [CREATE, UPDATE, DELETE, CONNECT, DISCONNECT]
+                        queryDirection: DIRECTED
+                    )
+                    @settable(onCreate: true, onUpdate: true)
+            }
+
+            type ${Triad}
+                @mutation(operations: [CREATE, UPDATE, DELETE])
+                @node
+                @subscription(events: [])
+                @authorization(
+                    filter: [
+                        {
+                            requireAuthentication: false
+                            operations: [READ]
+                            where: { node: { _hasAccess_READ: { eq: true } } }
+                        }
+                        {
+                            requireAuthentication: false
+                            operations: [AGGREGATE]
+                            where: { node: { _hasAccess_AGGREGATE: { eq: true } } }
+                        }
+                    ]
+                    validate: [
+                        {
+                            requireAuthentication: false
+                            operations: [CREATE]
+                            when: [AFTER]
+                            where: { node: { _hasAccess_CREATE: { eq: true } } }
+                        }
+                        {
+                            requireAuthentication: false
+                            operations: [UPDATE]
+                            when: [BEFORE, AFTER]
+                            where: { node: { _hasAccess_UPDATE: { eq: true } } }
+                        }
+                        {
+                            requireAuthentication: false
+                            operations: [DELETE]
+                            when: [BEFORE]
+                            where: { node: { _hasAccess_DELETE: { eq: true } } }
+                        }
+                        {
+                            requireAuthentication: false
+                            operations: [CREATE_RELATIONSHIP]
+                            when: [BEFORE, AFTER]
+                            where: { node: { _hasAccess_CREATE_RELATIONSHIP: { eq: true } } }
+                        }
+                        {
+                            requireAuthentication: false
+                            operations: [DELETE_RELATIONSHIP]
+                            when: [BEFORE, AFTER]
+                            where: { node: { _hasAccess_DELETE_RELATIONSHIP: { eq: true } } }
+                        }
+                    ]
+                ) {
+                _hasAccess_AGGREGATE: Boolean!
+                    @selectable(onRead: false, onAggregate: false)
+                    @cypher(
+                        statement: """
+                        RETURN true as result
+                        """
+                        columnName: "result"
+                    )
+                _hasAccess_CREATE: Boolean!
+                    @selectable(onRead: false, onAggregate: false)
+                    @cypher(
+                        statement: """
+                        RETURN true as result
+                        """
+                        columnName: "result"
+                    )
+                _hasAccess_CREATE_RELATIONSHIP: Boolean!
+                    @selectable(onRead: false, onAggregate: false)
+                    @cypher(
+                        statement: """
+                        RETURN true as result
+                        """
+                        columnName: "result"
+                    )
+                _hasAccess_DELETE: Boolean!
+                    @selectable(onRead: false, onAggregate: false)
+                    @cypher(
+                        statement: """
+                        RETURN true as result
+                        """
+                        columnName: "result"
+                    )
+                _hasAccess_DELETE_RELATIONSHIP: Boolean!
+                    @selectable(onRead: false, onAggregate: false)
+                    @cypher(
+                        statement: """
+                        RETURN true as result
+                        """
+                        columnName: "result"
+                    )
+                _hasAccess_READ: Boolean!
+                    @selectable(onRead: false, onAggregate: false)
+                    @cypher(
+                        statement: """
+                        RETURN true as result
+                        """
+                        columnName: "result"
+                    )
+                _hasAccess_UPDATE: Boolean!
+                    @selectable(onRead: false, onAggregate: false)
+                    @cypher(
+                        statement: """
+                        RETURN true as result
+                        """
+                        columnName: "result"
+                    )
+
+                id: Int! @settable(onCreate: true, onUpdate: false)
+            }
+        `;
+
+        await testHelper.initNeo4jGraphQL({ typeDefs, features: { authorization: { key: "secret" } } });
+    });
+
+    afterEach(async () => {
+        await testHelper.close();
+    });
+    test("Update with inner connect should not error", async () => {
+        await testHelper.executeCypher(`
+            CREATE (c:${Country} { code: "DE", name_en: "Germany" })
+            CREATE (co:${Continent} { id: 5 })
+        `);
+        const query = /* GraphQL */ `
+            mutation {
+                ${Country.operations.update}(
+                    where: { code: { eq: "DE" } }
+                    update: { continent: [{ connect: { where: { node: { id: { eq: 5 } } } } }] }
+                ) {
+                    info {
+                        nodesCreated
+                    }
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+
+        expect(result.errors).toBeUndefined();
+    });
+
+    test("Update with inner disconnect should not error", async () => {
+        const query = /* GraphQL */ `
+            mutation {
+                ${Country.operations.update}(
+                    where: { code: { eq: "DE" } }
+                    update: { continent: [{ disconnect: { where: { node: { id: { eq: 5 } } } } }] }
+                ) {
+                    info {
+                        nodesCreated
+                    }
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+
+        expect(result.errors).toBeUndefined();
+    });
+
+    test("Create with inner connect should not error", async () => {
+        await testHelper.executeCypher(`
+            CREATE (co:${Continent} { id: 5 })
+        `);
+        const query = /* GraphQL */ `
+            mutation {
+                ${Country.operations.create}(
+                    input: [
+                        { code: "DE", name_en: "test", continent: { connect: { where: { node: { id: { eq: 5 } } } } } }
+                    ]
+                ) {
+                    info {
+                        nodesCreated
+                    }
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+
+        expect(result.errors).toBeUndefined();
+    });
+});

--- a/packages/graphql/tests/integration/issues/7293-full.int.test.ts
+++ b/packages/graphql/tests/integration/issues/7293-full.int.test.ts
@@ -3,7 +3,6 @@
  * Neo4j Sweden AB [http://neo4j.com]
  */
 
-import { gql } from "graphql-tag";
 import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../../utils/tests-helper";
 

--- a/packages/graphql/tests/integration/issues/7293.int.test.ts
+++ b/packages/graphql/tests/integration/issues/7293.int.test.ts
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ */
+
+import { gql } from "graphql-tag";
+import type { UniqueType } from "../../utils/graphql-types";
+import { TestHelper } from "../../utils/tests-helper";
+
+describe("https://github.com/neo4j/graphql/issues/7205", () => {
+    const testHelper = new TestHelper();
+
+    let Continent: UniqueType;
+    let Country: UniqueType;
+
+    beforeEach(async () => {
+        Continent = testHelper.createUniqueType("Continent");
+        Country = testHelper.createUniqueType("Country");
+
+        const typeDefs = /* GraphQL */ `
+            
+            type ${Continent}
+                @mutation(operations: [CREATE, UPDATE, DELETE])
+                @node
+                @authorization(
+                    validate: [
+                        {
+                            requireAuthentication: false
+                            operations: [CREATE_RELATIONSHIP]
+                            when: [BEFORE, AFTER]
+                            where: { node: { _hasAccess_CREATE_RELATIONSHIP: { eq: true } } }
+                        }
+                        {
+                            requireAuthentication: false
+                            operations: [DELETE_RELATIONSHIP]
+                            when: [BEFORE, AFTER]
+                            where: { node: { _hasAccess_DELETE_RELATIONSHIP: { eq: true } } }
+                        }
+                    ]
+                ) {
+                _hasAccess_CREATE_RELATIONSHIP: Boolean!
+                    @selectable(onRead: false, onAggregate: false)
+                    @cypher(
+                        statement: """
+                        RETURN "continentCreateRelationship" as result
+                        """
+                        columnName: "result"
+                    )
+                _hasAccess_DELETE_RELATIONSHIP: Boolean!
+                    @selectable(onRead: false, onAggregate: false)
+                    @cypher(
+                        statement: """
+                        RETURN "continentDeleteRelationship" as result
+                        """
+                        columnName: "result"
+                    )
+
+                id: Int! @settable(onCreate: true, onUpdate: false)
+            }
+
+            type ${Country}
+                @mutation(operations: [CREATE, UPDATE, DELETE])
+                @node
+                @authorization(
+                    validate: [
+                        {
+                            requireAuthentication: false
+                            operations: [CREATE]
+                            when: [AFTER]
+                            where: { node: { _hasAccess_CREATE: { eq: true } } }
+                        }
+                        {
+                            requireAuthentication: false
+                            operations: [CREATE_RELATIONSHIP]
+                            when: [BEFORE, AFTER]
+                            where: { node: { _hasAccess_CREATE_RELATIONSHIP: { eq: true } } }
+                        }
+                    ]
+                ) {
+                _hasAccess_CREATE: Boolean!
+                    @selectable(onRead: false, onAggregate: false)
+                    @cypher(
+                        statement: """
+                        RETURN "countryCreate" as result
+                        """
+                        columnName: "result"
+                    )
+                _hasAccess_CREATE_RELATIONSHIP: Boolean!
+                    @selectable(onRead: false, onAggregate: false)
+                    @cypher(
+                        statement: """
+                        RETURN "countryCreateRelationship" as result
+                        """
+                        columnName: "result"
+                    )
+
+                code: String! @settable(onCreate: true, onUpdate: false)
+                continent: [${Continent}!]!
+                    @relationship(
+                        type: "CONTINENT_HAS_COUNTRY"
+                        direction: IN
+                        nestedOperations: [CREATE, UPDATE, DELETE, CONNECT, DISCONNECT]
+                        queryDirection: DIRECTED
+                    )
+                    @settable(onCreate: true, onUpdate: true)
+                name_en: String!
+            }
+        
+        `;
+
+        await testHelper.initNeo4jGraphQL({ typeDefs, features: { authorization: { key: "secret" } } });
+    });
+
+    afterEach(async () => {
+        await testHelper.close();
+    });
+    test("Update with inner connect should not error", async () => {
+        const query = /* GraphQL */ `
+            mutation {
+                ${Country.operations.update}(
+                    where: { code: { eq: "DE" } }
+                    update: { continent: [{ connect: { where: { node: { id: { eq: 5 } } } } }] }
+                ) {
+                    info {
+                        nodesCreated
+                    }
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+
+        expect(result.errors).toBeUndefined();
+    });
+
+    test("Update with inner disconnect should not error", async () => {
+        const query = /* GraphQL */ `
+            mutation {
+                ${Country.operations.update}(
+                    where: { code: { eq: "DE" } }
+                    update: { continent: [{ disconnect: { where: { node: { id: { eq: 5 } } } } }] }
+                ) {
+                    info {
+                        nodesCreated
+                    }
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+
+        expect(result.errors).toBeUndefined();
+    });
+
+    test("Create with inner connect should not error", async () => {
+        const query = /* GraphQL */ `
+            mutation {
+                ${Country.operations.create}(
+                    input: [
+                        { code: "DE", name_en: "test", continent: { connect: { where: { node: { id: { eq: 1 } } } } } }
+                    ]
+                ) {
+                    info {
+                        nodesCreated
+                    }
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+
+        expect(result.errors).toBeUndefined();
+    });
+});

--- a/packages/graphql/tests/integration/issues/7293.int.test.ts
+++ b/packages/graphql/tests/integration/issues/7293.int.test.ts
@@ -3,7 +3,6 @@
  * Neo4j Sweden AB [http://neo4j.com]
  */
 
-import { gql } from "graphql-tag";
 import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../../utils/tests-helper";
 

--- a/packages/graphql/tests/integration/issues/7293.int.test.ts
+++ b/packages/graphql/tests/integration/issues/7293.int.test.ts
@@ -7,7 +7,7 @@ import { gql } from "graphql-tag";
 import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../../utils/tests-helper";
 
-describe("https://github.com/neo4j/graphql/issues/7205", () => {
+describe("https://github.com/neo4j/graphql/issues/7293", () => {
     const testHelper = new TestHelper();
 
     let Continent: UniqueType;
@@ -42,7 +42,7 @@ describe("https://github.com/neo4j/graphql/issues/7205", () => {
                     @selectable(onRead: false, onAggregate: false)
                     @cypher(
                         statement: """
-                        RETURN "continentCreateRelationship" as result
+                        RETURN true as result
                         """
                         columnName: "result"
                     )
@@ -50,7 +50,7 @@ describe("https://github.com/neo4j/graphql/issues/7205", () => {
                     @selectable(onRead: false, onAggregate: false)
                     @cypher(
                         statement: """
-                        RETURN "continentDeleteRelationship" as result
+                        RETURN true as result
                         """
                         columnName: "result"
                     )
@@ -81,7 +81,7 @@ describe("https://github.com/neo4j/graphql/issues/7205", () => {
                     @selectable(onRead: false, onAggregate: false)
                     @cypher(
                         statement: """
-                        RETURN "countryCreate" as result
+                        RETURN true as result
                         """
                         columnName: "result"
                     )
@@ -89,7 +89,7 @@ describe("https://github.com/neo4j/graphql/issues/7205", () => {
                     @selectable(onRead: false, onAggregate: false)
                     @cypher(
                         statement: """
-                        RETURN "countryCreateRelationship" as result
+                        RETURN true as result
                         """
                         columnName: "result"
                     )
@@ -115,6 +115,10 @@ describe("https://github.com/neo4j/graphql/issues/7205", () => {
         await testHelper.close();
     });
     test("Update with inner connect should not error", async () => {
+        await testHelper.executeCypher(`
+            CREATE (c:${Country} { code: "DE", name_en: "Germany" })
+            CREATE (co:${Continent} { id: 5 })
+        `);
         const query = /* GraphQL */ `
             mutation {
                 ${Country.operations.update}(
@@ -153,11 +157,14 @@ describe("https://github.com/neo4j/graphql/issues/7205", () => {
     });
 
     test("Create with inner connect should not error", async () => {
+        await testHelper.executeCypher(`
+            CREATE (co:${Continent} { id: 5 })
+        `);
         const query = /* GraphQL */ `
             mutation {
                 ${Country.operations.create}(
                     input: [
-                        { code: "DE", name_en: "test", continent: { connect: { where: { node: { id: { eq: 1 } } } } } }
+                        { code: "DE", name_en: "test", continent: { connect: { where: { node: { id: { eq: 5 } } } } } }
                     ]
                 ) {
                     info {

--- a/packages/graphql/tests/tck/issues/7293.test.ts
+++ b/packages/graphql/tests/tck/issues/7293.test.ts
@@ -143,34 +143,31 @@ describe("https://github.com/neo4j/graphql/issues/7293", () => {
                   WITH result AS this1
                   RETURN this1 AS var2
                 }
+                WITH *
+                WHERE this0.id = $param1
+                CALL apoc.util.validate(NOT (var2 = $param2), '@neo4j/graphql/FORBIDDEN', [])
+                CREATE (this)<-[this3:CONTINENT_HAS_COUNTRY]-(this0)
+                WITH *
                 CALL (this0) {
                   CALL (this0) {
                     WITH this0 AS this
                     RETURN \\"continentCreateRelationship\\" as result
                   }
-                  WITH result AS this3
-                  RETURN this3 AS var4
+                  WITH result AS this4
+                  RETURN this4 AS var5
                 }
-                WITH *
-                WHERE this0.id = $param1
                 CALL (this0) {
-                  WITH this0 AS this
-                  RETURN \\"continentCreateRelationship\\" as result
+                  CALL (this0) {
+                    WITH this0 AS this
+                    RETURN \\"countryCreateRelationship\\" as result
+                  }
+                  WITH result AS this6
+                  RETURN this6 AS var7
                 }
-                WITH result AS this5
-                RETURN this5 AS var2
-                CALL (this0) {
-                  WITH this0 AS this
-                  RETURN \\"continentCreateRelationship\\" as result
-                }
-                WITH result AS this6
-                RETURN this6 AS var4
-                CALL apoc.util.validate(NOT (var2 = $param2), '@neo4j/graphql/FORBIDDEN', [])
-                CREATE (this)<-[this7:CONTINENT_HAS_COUNTRY]-(this0)
                 WITH *
-                CALL apoc.util.validate(NOT (var4 = $param3), '@neo4j/graphql/FORBIDDEN', [])
+                CALL apoc.util.validate(NOT (var5 = $param3), '@neo4j/graphql/FORBIDDEN', [])
                 WITH *
-                CALL apoc.util.validate(NOT (var8 = $param4), '@neo4j/graphql/FORBIDDEN', [])
+                CALL apoc.util.validate(NOT (var7 = $param4), '@neo4j/graphql/FORBIDDEN', [])
               }
             }
             FINISH"
@@ -223,6 +220,12 @@ describe("https://github.com/neo4j/graphql/issues/7293", () => {
                   WITH result AS this2
                   RETURN this2 AS var3
                 }
+                WITH *
+                WHERE this1.id = $param1
+                CALL apoc.util.validate(NOT (var3 = $param2), '@neo4j/graphql/FORBIDDEN', [])
+                WITH *
+                DELETE this0
+                WITH *
                 CALL (this1) {
                   CALL (this1) {
                     WITH this1 AS this
@@ -231,23 +234,6 @@ describe("https://github.com/neo4j/graphql/issues/7293", () => {
                   WITH result AS this4
                   RETURN this4 AS var5
                 }
-                WITH *
-                WHERE this1.id = $param1
-                CALL (this1) {
-                  WITH this1 AS this
-                  RETURN \\"continentDeleteRelationship\\" as result
-                }
-                WITH result AS this6
-                RETURN this6 AS var3
-                CALL (this1) {
-                  WITH this1 AS this
-                  RETURN \\"continentDeleteRelationship\\" as result
-                }
-                WITH result AS this7
-                RETURN this7 AS var5
-                CALL apoc.util.validate(NOT (var3 = $param2), '@neo4j/graphql/FORBIDDEN', [])
-                WITH *
-                DELETE this0
                 WITH *
                 CALL apoc.util.validate(NOT (var5 = $param3), '@neo4j/graphql/FORBIDDEN', [])
               }
@@ -303,34 +289,31 @@ describe("https://github.com/neo4j/graphql/issues/7293", () => {
                   WITH result AS this2
                   RETURN this2 AS var3
                 }
+                WITH *
+                WHERE this1.id = $param2
+                CALL apoc.util.validate(NOT (var3 = $param3), '@neo4j/graphql/FORBIDDEN', [])
+                CREATE (this0)<-[this4:CONTINENT_HAS_COUNTRY]-(this1)
+                WITH *
                 CALL (this1) {
                   CALL (this1) {
                     WITH this1 AS this
                     RETURN \\"continentCreateRelationship\\" as result
                   }
-                  WITH result AS this4
-                  RETURN this4 AS var5
+                  WITH result AS this5
+                  RETURN this5 AS var6
                 }
-                WITH *
-                WHERE this1.id = $param2
                 CALL (this1) {
-                  WITH this1 AS this
-                  RETURN \\"continentCreateRelationship\\" as result
+                  CALL (this1) {
+                    WITH this1 AS this
+                    RETURN \\"countryCreateRelationship\\" as result
+                  }
+                  WITH result AS this7
+                  RETURN this7 AS var8
                 }
-                WITH result AS this6
-                RETURN this6 AS var3
-                CALL (this1) {
-                  WITH this1 AS this
-                  RETURN \\"continentCreateRelationship\\" as result
-                }
-                WITH result AS this7
-                RETURN this7 AS var5
-                CALL apoc.util.validate(NOT (var3 = $param3), '@neo4j/graphql/FORBIDDEN', [])
-                CREATE (this0)<-[this8:CONTINENT_HAS_COUNTRY]-(this1)
                 WITH *
-                CALL apoc.util.validate(NOT (var5 = $param4), '@neo4j/graphql/FORBIDDEN', [])
+                CALL apoc.util.validate(NOT (var6 = $param4), '@neo4j/graphql/FORBIDDEN', [])
                 WITH *
-                CALL apoc.util.validate(NOT (var9 = $param5), '@neo4j/graphql/FORBIDDEN', [])
+                CALL apoc.util.validate(NOT (var8 = $param5), '@neo4j/graphql/FORBIDDEN', [])
               }
               WITH *
               CALL (*) {
@@ -339,10 +322,10 @@ describe("https://github.com/neo4j/graphql/issues/7293", () => {
                     WITH this0 AS this
                     RETURN \\"countryCreate\\" as result
                   }
-                  WITH result AS this10
-                  RETURN this10 AS var11
+                  WITH result AS this9
+                  RETURN this9 AS var10
                 }
-                CALL apoc.util.validate(NOT (var11 = $param6), '@neo4j/graphql/FORBIDDEN', [])
+                CALL apoc.util.validate(NOT (var10 = $param6), '@neo4j/graphql/FORBIDDEN', [])
               }
               RETURN this0 AS this
             }

--- a/packages/graphql/tests/tck/issues/7293.test.ts
+++ b/packages/graphql/tests/tck/issues/7293.test.ts
@@ -1,0 +1,367 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ */
+
+import { Neo4jGraphQL } from "../../../src";
+import { formatCypher, formatParams, translateQuery } from "../utils/tck-test-utils";
+
+describe("https://github.com/neo4j/graphql/issues/7293", () => {
+    let typeDefs: string;
+    let neoSchema: Neo4jGraphQL;
+
+    beforeAll(() => {
+        typeDefs = /* GraphQL */ `
+            type Continent
+                @mutation(operations: [CREATE, UPDATE, DELETE])
+                @node
+                @authorization(
+                    validate: [
+                        {
+                            requireAuthentication: false
+                            operations: [CREATE_RELATIONSHIP]
+                            when: [BEFORE, AFTER]
+                            where: { node: { _hasAccess_CREATE_RELATIONSHIP: { eq: true } } }
+                        }
+                        {
+                            requireAuthentication: false
+                            operations: [DELETE_RELATIONSHIP]
+                            when: [BEFORE, AFTER]
+                            where: { node: { _hasAccess_DELETE_RELATIONSHIP: { eq: true } } }
+                        }
+                    ]
+                ) {
+                _hasAccess_CREATE_RELATIONSHIP: Boolean!
+                    @selectable(onRead: false, onAggregate: false)
+                    @cypher(
+                        statement: """
+                        RETURN "continentCreateRelationship" as result
+                        """
+                        columnName: "result"
+                    )
+                _hasAccess_DELETE_RELATIONSHIP: Boolean!
+                    @selectable(onRead: false, onAggregate: false)
+                    @cypher(
+                        statement: """
+                        RETURN "continentDeleteRelationship" as result
+                        """
+                        columnName: "result"
+                    )
+
+                id: Int! @settable(onCreate: true, onUpdate: false)
+            }
+
+            type Country
+                @mutation(operations: [CREATE, UPDATE, DELETE])
+                @node
+                @authorization(
+                    validate: [
+                        {
+                            requireAuthentication: false
+                            operations: [CREATE]
+                            when: [AFTER]
+                            where: { node: { _hasAccess_CREATE: { eq: true } } }
+                        }
+                        {
+                            requireAuthentication: false
+                            operations: [CREATE_RELATIONSHIP]
+                            when: [BEFORE, AFTER]
+                            where: { node: { _hasAccess_CREATE_RELATIONSHIP: { eq: true } } }
+                        }
+                    ]
+                ) {
+                _hasAccess_CREATE: Boolean!
+                    @selectable(onRead: false, onAggregate: false)
+                    @cypher(
+                        statement: """
+                        RETURN "countryCreate" as result
+                        """
+                        columnName: "result"
+                    )
+                _hasAccess_CREATE_RELATIONSHIP: Boolean!
+                    @selectable(onRead: false, onAggregate: false)
+                    @cypher(
+                        statement: """
+                        RETURN "countryCreateRelationship" as result
+                        """
+                        columnName: "result"
+                    )
+
+                code: String! @settable(onCreate: true, onUpdate: false)
+                continent: [Continent!]!
+                    @relationship(
+                        type: "CONTINENT_HAS_COUNTRY"
+                        direction: IN
+                        nestedOperations: [CREATE, UPDATE, DELETE, CONNECT, DISCONNECT]
+                        queryDirection: DIRECTED
+                    )
+                    @settable(onCreate: true, onUpdate: true)
+                name_en: String!
+            }
+        `;
+
+        neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            features: {
+                authorization: {
+                    key: "secret",
+                },
+            },
+        });
+    });
+
+    test("Update with inner connect", async () => {
+        const query = /* GraphQL */ `
+            mutation {
+                updateCountries(
+                    where: { code: { eq: "DE" } }
+                    update: { continent: [{ connect: { where: { node: { id: { eq: 5 } } } } }] }
+                ) {
+                    info {
+                        nodesCreated
+                    }
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "CYPHER 5
+            MATCH (this:Country)
+            WITH *
+            WHERE this.code = $param0
+            WITH *
+            CALL (*) {
+              CALL (this) {
+                MATCH (this0:Continent)
+                CALL (this0) {
+                  CALL (this0) {
+                    WITH this0 AS this
+                    RETURN \\"continentCreateRelationship\\" as result
+                  }
+                  WITH result AS this1
+                  RETURN this1 AS var2
+                }
+                CALL (this0) {
+                  CALL (this0) {
+                    WITH this0 AS this
+                    RETURN \\"continentCreateRelationship\\" as result
+                  }
+                  WITH result AS this3
+                  RETURN this3 AS var4
+                }
+                WITH *
+                WHERE this0.id = $param1
+                CALL (this0) {
+                  WITH this0 AS this
+                  RETURN \\"continentCreateRelationship\\" as result
+                }
+                WITH result AS this5
+                RETURN this5 AS var2
+                CALL (this0) {
+                  WITH this0 AS this
+                  RETURN \\"continentCreateRelationship\\" as result
+                }
+                WITH result AS this6
+                RETURN this6 AS var4
+                CALL apoc.util.validate(NOT (var2 = $param2), '@neo4j/graphql/FORBIDDEN', [])
+                CREATE (this)<-[this7:CONTINENT_HAS_COUNTRY]-(this0)
+                WITH *
+                CALL apoc.util.validate(NOT (var4 = $param3), '@neo4j/graphql/FORBIDDEN', [])
+                WITH *
+                CALL apoc.util.validate(NOT (var8 = $param4), '@neo4j/graphql/FORBIDDEN', [])
+              }
+            }
+            FINISH"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"DE\\",
+                \\"param1\\": {
+                    \\"low\\": 5,
+                    \\"high\\": 0
+                },
+                \\"param2\\": true,
+                \\"param3\\": true,
+                \\"param4\\": true
+            }"
+        `);
+    });
+
+    test("Update with inner disconnect", async () => {
+        const query = /* GraphQL */ `
+            mutation {
+                updateCountries(
+                    where: { code: { eq: "DE" } }
+                    update: { continent: [{ disconnect: { where: { node: { id: { eq: 5 } } } } }] }
+                ) {
+                    info {
+                        nodesCreated
+                    }
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "CYPHER 5
+            MATCH (this:Country)
+            WITH *
+            WHERE this.code = $param0
+            WITH *
+            CALL (*) {
+              CALL (this) {
+                OPTIONAL MATCH (this)<-[this0:CONTINENT_HAS_COUNTRY]-(this1:Continent)
+                CALL (this1) {
+                  CALL (this1) {
+                    WITH this1 AS this
+                    RETURN \\"continentDeleteRelationship\\" as result
+                  }
+                  WITH result AS this2
+                  RETURN this2 AS var3
+                }
+                CALL (this1) {
+                  CALL (this1) {
+                    WITH this1 AS this
+                    RETURN \\"continentDeleteRelationship\\" as result
+                  }
+                  WITH result AS this4
+                  RETURN this4 AS var5
+                }
+                WITH *
+                WHERE this1.id = $param1
+                CALL (this1) {
+                  WITH this1 AS this
+                  RETURN \\"continentDeleteRelationship\\" as result
+                }
+                WITH result AS this6
+                RETURN this6 AS var3
+                CALL (this1) {
+                  WITH this1 AS this
+                  RETURN \\"continentDeleteRelationship\\" as result
+                }
+                WITH result AS this7
+                RETURN this7 AS var5
+                CALL apoc.util.validate(NOT (var3 = $param2), '@neo4j/graphql/FORBIDDEN', [])
+                WITH *
+                DELETE this0
+                WITH *
+                CALL apoc.util.validate(NOT (var5 = $param3), '@neo4j/graphql/FORBIDDEN', [])
+              }
+            }
+            FINISH"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"DE\\",
+                \\"param1\\": {
+                    \\"low\\": 5,
+                    \\"high\\": 0
+                },
+                \\"param2\\": true,
+                \\"param3\\": true
+            }"
+        `);
+    });
+
+    test("Create with inner connect", async () => {
+        const query = /* GraphQL */ `
+            mutation {
+                createCountries(
+                    input: [
+                        { code: "DE", name_en: "test", continent: { connect: { where: { node: { id: { eq: 1 } } } } } }
+                    ]
+                ) {
+                    info {
+                        nodesCreated
+                    }
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "CYPHER 5
+            CALL {
+              CREATE (this0:Country)
+              SET
+                this0.code = $param0,
+                this0.name_en = $param1
+              WITH *
+              CALL (this0) {
+                MATCH (this1:Continent)
+                CALL (this1) {
+                  CALL (this1) {
+                    WITH this1 AS this
+                    RETURN \\"continentCreateRelationship\\" as result
+                  }
+                  WITH result AS this2
+                  RETURN this2 AS var3
+                }
+                CALL (this1) {
+                  CALL (this1) {
+                    WITH this1 AS this
+                    RETURN \\"continentCreateRelationship\\" as result
+                  }
+                  WITH result AS this4
+                  RETURN this4 AS var5
+                }
+                WITH *
+                WHERE this1.id = $param2
+                CALL (this1) {
+                  WITH this1 AS this
+                  RETURN \\"continentCreateRelationship\\" as result
+                }
+                WITH result AS this6
+                RETURN this6 AS var3
+                CALL (this1) {
+                  WITH this1 AS this
+                  RETURN \\"continentCreateRelationship\\" as result
+                }
+                WITH result AS this7
+                RETURN this7 AS var5
+                CALL apoc.util.validate(NOT (var3 = $param3), '@neo4j/graphql/FORBIDDEN', [])
+                CREATE (this0)<-[this8:CONTINENT_HAS_COUNTRY]-(this1)
+                WITH *
+                CALL apoc.util.validate(NOT (var5 = $param4), '@neo4j/graphql/FORBIDDEN', [])
+                WITH *
+                CALL apoc.util.validate(NOT (var9 = $param5), '@neo4j/graphql/FORBIDDEN', [])
+              }
+              WITH *
+              CALL (*) {
+                CALL (*) {
+                  CALL (this0) {
+                    WITH this0 AS this
+                    RETURN \\"countryCreate\\" as result
+                  }
+                  WITH result AS this10
+                  RETURN this10 AS var11
+                }
+                CALL apoc.util.validate(NOT (var11 = $param6), '@neo4j/graphql/FORBIDDEN', [])
+              }
+              RETURN this0 AS this
+            }
+            FINISH"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"DE\\",
+                \\"param1\\": \\"test\\",
+                \\"param2\\": {
+                    \\"low\\": 1,
+                    \\"high\\": 0
+                },
+                \\"param3\\": true,
+                \\"param4\\": true,
+                \\"param5\\": true,
+                \\"param6\\": true
+            }"
+        `);
+    });
+});


### PR DESCRIPTION
# Description

Auth validation subqueries are added twice for create relationship and delete relationship.

## Complexity

Complexity: Low

# Issue

Closes #7293 

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
