### PR TITLE
update cypher builder dependency

### DIFF
--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -85,7 +85,7 @@
         "@graphql-tools/resolvers-composition": "^7.0.0",
         "@graphql-tools/schema": "^10.0.0",
         "@graphql-tools/utils": "^11.0.0",
-        "@neo4j/cypher-builder": "3.0.1",
+        "@neo4j/cypher-builder": "3.2.2",
         "camelcase": "^6.3.0",
         "debug": "^4.3.4",
         "dot-prop": "^6.0.1",

--- a/packages/graphql/src/translate/queryAST/ast/filters/aggregation/AggregationPropertyFilter.ts
+++ b/packages/graphql/src/translate/queryAST/ast/filters/aggregation/AggregationPropertyFilter.ts
@@ -131,10 +131,7 @@ export class AggregationPropertyFilter extends AggregationFilter {
         throw new Error("Transpilation error, relationship on filter not available");
     }
 
-    private getAggregateOperation(
-        property: Cypher.Property | Cypher.Function | Cypher.Case,
-        aggregationOperator: string
-    ): Cypher.Function {
+    private getAggregateOperation(property: Cypher.Expr, aggregationOperator: string): Cypher.Function {
         switch (aggregationOperator) {
             case "AVERAGE":
                 return Cypher.avg(property);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2620,10 +2620,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@neo4j/cypher-builder@npm:3.0.1":
-  version: 3.0.1
-  resolution: "@neo4j/cypher-builder@npm:3.0.1"
-  checksum: 10c0/36d2f9c2b075aa6f89435ba512c9b9281084c154406fb368ab71bccb31a2738aef276afaaee053356cbd964fcbf919bf38b4c52ddb347c5bee895e2bfa3f358c
+"@neo4j/cypher-builder@npm:3.2.2":
+  version: 3.2.2
+  resolution: "@neo4j/cypher-builder@npm:3.2.2"
+  checksum: 10c0/8c38e7d96ec13dc6b6c1bcec69cd172a1c87a1700b7971ad0010cd6c90a2cf7b69d364a3d7b41664a163eb407a57236c03885ebef6198d21d18d63ae80a00399
   languageName: node
   linkType: hard
 
@@ -2645,7 +2645,7 @@ __metadata:
     "@graphql-tools/resolvers-composition": "npm:^7.0.0"
     "@graphql-tools/schema": "npm:^10.0.0"
     "@graphql-tools/utils": "npm:^11.0.0"
-    "@neo4j/cypher-builder": "npm:3.0.1"
+    "@neo4j/cypher-builder": "npm:3.2.2"
     "@types/is-uuid": "npm:1.0.2"
     "@types/jest": "npm:30.0.0"
     "@types/jsonwebtoken": "npm:9.0.10"


### PR DESCRIPTION
# Description

After a bug introduced in Cypher Builder 3.0.1, it has not been possible to update it. This was fixed in 3.2.2 