### PR TITLE
remove --since from changeset version

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "build": "tsc --build tsconfig.production.json",
         "lint": "eslint --cache .",
         "test": "jest",
-        "changeset-version": "changeset version --since $BRANCH && yarn",
+        "changeset-version": "changeset version && yarn",
         "release-dev": "yarn build && changeset publish",
         "release-lts": "yarn build && changeset publish --tag lts",
         "release-previous": "yarn build && changeset publish --tag previous"


### PR DESCRIPTION
# Description

After the update of `@changeset/cli` in #7260, the [release pipeline is broken](https://github.com/neo4j/graphql/actions/runs/26158406543/job/76950630721)

This seems to be caused by [this change](https://github.com/changesets/changesets/pull/1889) in changeset, that now fails when using invalid commands.

We were using `changeset version --since`, `--since` is not a valid flag in `version` and was likely ignore previously

This PR removes that flag from the pipeline