### PR TITLE
Fix - Cypher params should not override resolver properties.

### DIFF
--- a/.changeset/heavy-sloths-yawn.md
+++ b/.changeset/heavy-sloths-yawn.md
@@ -3,4 +3,4 @@
 ---
 
 Context.cypherParams properties no longer override resolver generated one.
-In case of a conflict an error is now thrown.
+In case of a conflict, an error is now thrown.

--- a/.changeset/heavy-sloths-yawn.md
+++ b/.changeset/heavy-sloths-yawn.md
@@ -1,0 +1,6 @@
+---
+"@neo4j/graphql": patch
+---
+
+Context.cypherParams properties no longer override resolver generated one.
+In case of a conflict an error is now thrown.

--- a/packages/graphql/src/classes/Executor.ts
+++ b/packages/graphql/src/classes/Executor.ts
@@ -113,7 +113,19 @@ export class Executor {
         sessionMode: SessionMode,
         info?: GraphQLResolveInfo
     ): Promise<QueryResult> {
-        const params = { ...parameters, ...this.cypherParams };
+        // validate no overrides between ...this.cypherParams and ...parameters
+        const cypherParamsKeys = Object.keys(this.cypherParams ?? {});
+        const parametersKeys = Object.keys(parameters ?? {});
+        const intersection = cypherParamsKeys.filter((key) => parametersKeys.includes(key));
+        if (intersection.length > 0) {
+            throw new Error(
+                `Duplicate parameter keys detected between Executor.cypherParams and provided parameters: [${intersection.join(
+                    ", "
+                )}]`
+            );
+        }
+
+        const params = { ...this.cypherParams, ...parameters };
         try {
             if (isDriverLike(this.executionContext)) {
                 return await this.driverRun({

--- a/packages/graphql/src/classes/Executor.ts
+++ b/packages/graphql/src/classes/Executor.ts
@@ -113,18 +113,7 @@ export class Executor {
         sessionMode: SessionMode,
         info?: GraphQLResolveInfo
     ): Promise<QueryResult> {
-        // validate no overrides between ...this.cypherParams and ...parameters
-        const cypherParamsKeys = Object.keys(this.cypherParams ?? {});
-        const parametersKeys = Object.keys(parameters ?? {});
-        const intersection = cypherParamsKeys.filter((key) => parametersKeys.includes(key));
-        if (intersection.length > 0) {
-            throw new Error(
-                `Duplicate parameter keys detected between Executor.cypherParams and provided parameters: [${intersection.join(
-                    ", "
-                )}]`
-            );
-        }
-
+        this.validateAgainstConflictingParams(parameters);
         const params = { ...this.cypherParams, ...parameters };
         try {
             if (isDriverLike(this.executionContext)) {
@@ -287,5 +276,18 @@ export class Executor {
         debugCypherAndParams(debug, queryToRun, parameters);
 
         return transaction.run(queryToRun, parameters);
+    }
+
+    private validateAgainstConflictingParams(parameters: Record<string, any>) {
+        const cypherParamsKeys = Object.keys(this.cypherParams);
+        const parametersKeys = Object.keys(parameters);
+        const intersection = cypherParamsKeys.filter((key) => parametersKeys.includes(key));
+        if (intersection.length > 0) {
+            throw new Error(
+                `Duplicate parameter keys detected between Executor.cypherParams and provided parameters: [${intersection.join(
+                    ", "
+                )}]`
+            );
+        }
     }
 }

--- a/packages/graphql/tests/integration/issues/cypher-params-jwt-override.int.test.ts
+++ b/packages/graphql/tests/integration/issues/cypher-params-jwt-override.int.test.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ */
+import { createBearerToken } from "../../utils/create-bearer-token";
+import type { UniqueType } from "../../utils/graphql-types";
+import { TestHelper } from "../../utils/tests-helper";
+
+describe("Executor cypherParams must not override resolver-generated parameters", () => {
+    const testHelper = new TestHelper();
+    const secret = "secret";
+    let Document: UniqueType;
+
+    beforeEach(async () => {
+        Document = testHelper.createUniqueType("Document");
+
+        const typeDefs = /* GraphQL */ `
+            type JWT @jwt {
+                sub: String
+                roles: [String!]
+            }
+
+            type ${Document} @node
+                @authorization(
+                    validate: [
+                        {
+                            operations: [READ]
+                            when: [BEFORE]
+                            where: { jwt: { roles: { includes: "admin" } } }
+                        }
+                    ]
+                ) {
+                id: ID! @id
+                title: String
+            }
+        `;
+
+        await testHelper.initNeo4jGraphQL({
+            typeDefs,
+            features: {
+                authorization: { key: secret },
+            },
+        });
+
+        await testHelper.executeCypher(`CREATE (:${Document} {id: "doc-1", title: "Test document"})`);
+    });
+
+    afterEach(async () => {
+        await testHelper.close();
+    });
+
+    test("cypherParams jwt should not override the JWT extracted from the signed token", async () => {
+        const query = /* GraphQL */ `
+            query {
+                ${Document.plural} {
+                    id
+                    title
+                }
+            }
+        `;
+
+        // Sign a token that does NOT carry the "admin" role — authorization should deny this request.
+        const nonAdminToken = createBearerToken(secret, { roles: ["user"] });
+
+        // Attempt to mutate privileges by injecting an admin jwt via context.cypherParams.
+        const gqlResult = await testHelper.executeGraphQL(query, {
+            contextValue: {
+                token: nonAdminToken,
+                cypherParams: { jwt: { roles: ["admin"] } },
+            },
+        });
+
+        expect(gqlResult.errors).toBeDefined();
+        expect(gqlResult.errors?.[0]?.message).toBe(
+            "Duplicate parameter keys detected between Executor.cypherParams and provided parameters: [jwt]"
+        );
+        expect(gqlResult.data).toBeNull();
+    });
+});

--- a/packages/graphql/tests/tck/issues/context-variable-not-always-resolved-on-cypher-queries.test.ts
+++ b/packages/graphql/tests/tck/issues/context-variable-not-always-resolved-on-cypher-queries.test.ts
@@ -96,12 +96,12 @@ describe("context-variable-not-always-resolved-on-cypher-queries", () => {
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
+                \\"tenant\\": \\"test\\",
                 \\"param0\\": \\"http://data.somesite.com/crown/test-id\\",
                 \\"param1\\": {
                     \\"low\\": 1,
                     \\"high\\": 0
-                },
-                \\"tenant\\": \\"test\\"
+                }
             }"
         `);
     });
@@ -169,12 +169,12 @@ describe("context-variable-not-always-resolved-on-cypher-queries", () => {
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
+                \\"tenant\\": \\"test\\",
                 \\"param0\\": \\"http://data.somesite.com/crown/test-id\\",
                 \\"param1\\": {
                     \\"low\\": 1,
                     \\"high\\": 0
-                },
-                \\"tenant\\": \\"test\\"
+                }
             }"
         `);
     });
@@ -237,12 +237,12 @@ describe("context-variable-not-always-resolved-on-cypher-queries", () => {
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
+                \\"tenant\\": \\"test\\",
                 \\"param0\\": \\"http://data.somesite.com/crown/test-id\\",
                 \\"param1\\": {
                     \\"low\\": 1,
                     \\"high\\": 0
-                },
-                \\"tenant\\": \\"test\\"
+                }
             }"
         `);
     });


### PR DESCRIPTION
Fix merge order in Executor.execute so resolver-generated parameters always take precedence over context.cypherParams.

Previously, overlapping keys in cypherParams silently override the library's computed properties making the library to have an unexpected behaviour.

In case of conflict between the CypherParams and the resolver-generated parameters an error is now thrown.