### PR TITLE
fix: store Int @populatedBy callback values as Neo4j integers (#7315)

### DIFF
--- a/.changeset/curly-pugs-tap.md
+++ b/.changeset/curly-pugs-tap.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+`@populatedBy` callback values for `Int` fields are now stored as Neo4j integers instead of floats (fixes [#7315](https://github.com/neo4j/graphql/issues/7315)).

--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ performance.json
 .history
 
 package-lock.json
+
+# Plans
+.plans

--- a/packages/graphql/src/translate/queryAST/utils/callback-bucket.ts
+++ b/packages/graphql/src/translate/queryAST/utils/callback-bucket.ts
@@ -98,7 +98,7 @@ export class CallbackBucket {
 
         switch (type.name) {
             case "Int":
-                return neo4j.int(GraphQLInt.parseValue(result) as number);
+                return neo4j.int(GraphQLInt.parseValue(result));
             case "Float":
                 return GraphQLFloat.parseValue(result);
             case "String":

--- a/packages/graphql/src/translate/queryAST/utils/callback-bucket.ts
+++ b/packages/graphql/src/translate/queryAST/utils/callback-bucket.ts
@@ -5,6 +5,7 @@
 
 import type Cypher from "@neo4j/cypher-builder";
 import { GraphQLBoolean, GraphQLError, GraphQLFloat, GraphQLID, GraphQLInt, GraphQLString } from "graphql";
+import neo4j from "neo4j-driver";
 import type { DateTime, Duration, Integer, LocalDateTime, LocalTime, Date as Neo4jDate, Time } from "neo4j-driver";
 import {
     GraphQLBigInt,
@@ -97,7 +98,7 @@ export class CallbackBucket {
 
         switch (type.name) {
             case "Int":
-                return GraphQLInt.parseValue(result);
+                return neo4j.int(GraphQLInt.parseValue(result) as number);
             case "Float":
                 return GraphQLFloat.parseValue(result);
             case "String":

--- a/packages/graphql/tests/integration/issues/7315.int.test.ts
+++ b/packages/graphql/tests/integration/issues/7315.int.test.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import neo4j from "neo4j-driver";
+import { TestHelper } from "../../utils/tests-helper";
+
+describe("https://github.com/neo4j/graphql/issues/7315", () => {
+    const testHelper = new TestHelper();
+
+    afterEach(async () => {
+        await testHelper.close();
+    });
+
+    test("Int @populatedBy callback value on CREATE is stored as a Neo4j integer, not a float", async () => {
+        const Movie = testHelper.createUniqueType("Movie");
+        const expected = 123456;
+
+        const callback = () => Promise.resolve(expected);
+
+        const typeDefs = /* GraphQL */ `
+            type ${Movie.name} @node {
+                id: ID
+                callback: Int! @populatedBy(operations: [CREATE], callback: "callback")
+            }
+        `;
+
+        await testHelper.initNeo4jGraphQL({
+            typeDefs,
+            features: {
+                populatedBy: {
+                    callbacks: {
+                        callback,
+                    },
+                },
+            },
+        });
+
+        const movieId = "movie_id";
+
+        const mutation = /* GraphQL */ `
+            mutation {
+                ${Movie.operations.create}(input: [{ id: "${movieId}" }]) {
+                    ${Movie.plural} {
+                        id
+                        callback
+                    }
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(mutation);
+
+        expect(result.errors).toBeUndefined();
+        expect(result.data as any).toMatchObject({
+            [Movie.operations.create]: {
+                [Movie.plural]: [
+                    {
+                        id: movieId,
+                        callback: expected,
+                    },
+                ],
+            },
+        });
+
+        const dbResult = await testHelper.executeCypher(
+            `MATCH (m:${Movie.name} { id: $id }) RETURN m.callback AS callback`,
+            { id: movieId }
+        );
+
+        const storedValue = dbResult.records[0]?.get("callback");
+
+        expect(neo4j.isInt(storedValue)).toBe(true);
+        expect(neo4j.isInt(storedValue) && storedValue.toNumber()).toBe(expected);
+    });
+});

--- a/packages/graphql/tests/integration/issues/7315.int.test.ts
+++ b/packages/graphql/tests/integration/issues/7315.int.test.ts
@@ -88,4 +88,295 @@ describe("https://github.com/neo4j/graphql/issues/7315", () => {
         expect(neo4j.isInt(storedValue)).toBe(true);
         expect(neo4j.isInt(storedValue) && storedValue.toNumber()).toBe(expected);
     });
+
+    test("Int @populatedBy callback value on UPDATE is stored as a Neo4j integer, not a float", async () => {
+        const Movie = testHelper.createUniqueType("Movie");
+        const expected = 123456;
+
+        const callback = () => Promise.resolve(expected);
+
+        const typeDefs = /* GraphQL */ `
+            type ${Movie.name} @node {
+                id: ID
+                callback: Int! @populatedBy(operations: [UPDATE], callback: "callback")
+            }
+        `;
+
+        await testHelper.initNeo4jGraphQL({
+            typeDefs,
+            features: {
+                populatedBy: {
+                    callbacks: {
+                        callback,
+                    },
+                },
+            },
+        });
+
+        const movieId = "movie_id";
+
+        await testHelper.executeCypher(`CREATE (:${Movie.name} { id: $id })`, { id: movieId });
+
+        const mutation = /* GraphQL */ `
+            mutation {
+                ${Movie.operations.update}(where: { id_EQ: "${movieId}" }, update: { id_SET: "${movieId}" }) {
+                    ${Movie.plural} {
+                        id
+                        callback
+                    }
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(mutation);
+
+        expect(result.errors).toBeUndefined();
+        expect(result.data as any).toMatchObject({
+            [Movie.operations.update]: {
+                [Movie.plural]: [
+                    {
+                        id: movieId,
+                        callback: expected,
+                    },
+                ],
+            },
+        });
+
+        const dbResult = await testHelper.executeCypher(
+            `MATCH (m:${Movie.name} { id: $id }) RETURN m.callback AS callback`,
+            { id: movieId }
+        );
+
+        const storedValue = dbResult.records[0]?.get("callback");
+
+        expect(neo4j.isInt(storedValue)).toBe(true);
+        expect(neo4j.isInt(storedValue) && storedValue.toNumber()).toBe(expected);
+    });
+
+    test("[Int!] @populatedBy callback list stores every element as a Neo4j integer, not a float", async () => {
+        const Movie = testHelper.createUniqueType("Movie");
+        const expected = [1, 2, 3, 123456];
+
+        const callback = () => Promise.resolve(expected);
+
+        const typeDefs = /* GraphQL */ `
+            type ${Movie.name} @node {
+                id: ID
+                callback: [Int!]! @populatedBy(operations: [CREATE], callback: "callback")
+            }
+        `;
+
+        await testHelper.initNeo4jGraphQL({
+            typeDefs,
+            features: {
+                populatedBy: {
+                    callbacks: {
+                        callback,
+                    },
+                },
+            },
+        });
+
+        const movieId = "movie_id";
+
+        const mutation = /* GraphQL */ `
+            mutation {
+                ${Movie.operations.create}(input: [{ id: "${movieId}" }]) {
+                    ${Movie.plural} {
+                        id
+                        callback
+                    }
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(mutation);
+
+        expect(result.errors).toBeUndefined();
+        expect(result.data as any).toMatchObject({
+            [Movie.operations.create]: {
+                [Movie.plural]: [
+                    {
+                        id: movieId,
+                        callback: expected,
+                    },
+                ],
+            },
+        });
+
+        const dbResult = await testHelper.executeCypher(
+            `MATCH (m:${Movie.name} { id: $id }) RETURN m.callback AS callback`,
+            { id: movieId }
+        );
+
+        const storedValue = dbResult.records[0]?.get("callback");
+
+        expect(Array.isArray(storedValue)).toBe(true);
+        expect(storedValue.every((v) => neo4j.isInt(v))).toBe(true);
+        expect(storedValue.map((v) => v.toNumber())).toEqual(expected);
+    });
+
+    test("Int @populatedBy callback on a relationship property is stored as a Neo4j integer, not a float", async () => {
+        const Movie = testHelper.createUniqueType("Movie");
+        const Genre = testHelper.createUniqueType("Genre");
+        const expected = 123456;
+
+        const callback = () => Promise.resolve(expected);
+
+        const typeDefs = /* GraphQL */ `
+            type ${Movie.name} @node {
+                id: ID
+                genres: [${Genre.name}!]! @relationship(
+                    type: "IN_GENRE",
+                    direction: OUT,
+                    properties: "RelProperties"
+                )
+            }
+
+            type RelProperties @relationshipProperties {
+                id: ID!
+                callback: Int! @populatedBy(operations: [CREATE], callback: "callback")
+            }
+
+            type ${Genre.name} @node {
+                id: ID!
+            }
+        `;
+
+        await testHelper.initNeo4jGraphQL({
+            typeDefs,
+            features: {
+                populatedBy: {
+                    callbacks: {
+                        callback,
+                    },
+                },
+            },
+        });
+
+        const movieId = "movie_id";
+        const genreId = "genre_id";
+        const relId = "relationship_id";
+
+        const mutation = /* GraphQL */ `
+            mutation {
+                ${Movie.operations.create}(input: [
+                    {
+                        id: "${movieId}",
+                        genres: {
+                            create: [
+                                {
+                                    node: { id: "${genreId}" },
+                                    edge: { id: "${relId}" }
+                                }
+                            ]
+                        }
+                    }
+                ]) {
+                    ${Movie.plural} {
+                        id
+                        genresConnection {
+                            edges {
+                                properties { callback }
+                                node { id }
+                            }
+                        }
+                    }
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(mutation);
+
+        expect(result.errors).toBeUndefined();
+        expect(result.data as any).toMatchObject({
+            [Movie.operations.create]: {
+                [Movie.plural]: [
+                    {
+                        id: movieId,
+                        genresConnection: {
+                            edges: [
+                                {
+                                    properties: { callback: expected },
+                                    node: { id: genreId },
+                                },
+                            ],
+                        },
+                    },
+                ],
+            },
+        });
+
+        const dbResult = await testHelper.executeCypher(
+            `MATCH (:${Movie.name} { id: $movieId })-[r:IN_GENRE]->(:${Genre.name} { id: $genreId }) RETURN r.callback AS callback`,
+            { movieId, genreId }
+        );
+
+        const storedValue = dbResult.records[0]?.get("callback");
+
+        expect(neo4j.isInt(storedValue)).toBe(true);
+        expect(neo4j.isInt(storedValue) && storedValue.toNumber()).toBe(expected);
+    });
+
+    test("BigInt @populatedBy callback value is stored as a Neo4j integer (regression guard)", async () => {
+        const Movie = testHelper.createUniqueType("Movie");
+        const expected = "9007199254740993";
+
+        const callback = () => Promise.resolve(expected);
+
+        const typeDefs = /* GraphQL */ `
+            type ${Movie.name} @node {
+                id: ID
+                callback: BigInt! @populatedBy(operations: [CREATE], callback: "callback")
+            }
+        `;
+
+        await testHelper.initNeo4jGraphQL({
+            typeDefs,
+            features: {
+                populatedBy: {
+                    callbacks: {
+                        callback,
+                    },
+                },
+            },
+        });
+
+        const movieId = "movie_id";
+
+        const mutation = /* GraphQL */ `
+            mutation {
+                ${Movie.operations.create}(input: [{ id: "${movieId}" }]) {
+                    ${Movie.plural} {
+                        id
+                        callback
+                    }
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(mutation);
+
+        expect(result.errors).toBeUndefined();
+        expect(result.data as any).toMatchObject({
+            [Movie.operations.create]: {
+                [Movie.plural]: [
+                    {
+                        id: movieId,
+                        callback: expected,
+                    },
+                ],
+            },
+        });
+
+        const dbResult = await testHelper.executeCypher(
+            `MATCH (m:${Movie.name} { id: $id }) RETURN m.callback AS callback`,
+            { id: movieId }
+        );
+
+        const storedValue = dbResult.records[0]?.get("callback");
+
+        expect(neo4j.isInt(storedValue)).toBe(true);
+        expect(neo4j.isInt(storedValue) && storedValue.toString()).toBe(expected);
+    });
 });

--- a/packages/graphql/tests/integration/issues/7315.int.test.ts
+++ b/packages/graphql/tests/integration/issues/7315.int.test.ts
@@ -119,7 +119,7 @@ describe("https://github.com/neo4j/graphql/issues/7315", () => {
 
         const mutation = /* GraphQL */ `
             mutation {
-                ${Movie.operations.update}(where: { id_EQ: "${movieId}" }, update: { id_SET: "${movieId}" }) {
+                ${Movie.operations.update}(where: { id: { eq: "${movieId}" } }, update: { id: { set: "${movieId}"} }) {
                     ${Movie.plural} {
                         id
                         callback


### PR DESCRIPTION
## Summary
Bug fix. `@populatedBy` callback values for `Int`-typed fields were persisted to Neo4j as `Float` instead of `Int`. The callback path returned a bare JS `number`, which the driver serialises as a 64-bit float, diverging from every other mutation-input path. Fixes #7315.

## Changes
- `parseCallbackResult` now wraps the `Int` case with `neo4j.int(...)`, mirroring the canonical conversion in `get-neo4j-resolve-tree.ts`. `GraphQLInt.parseValue` is retained, so 32-bit/integer validation is unchanged; only the `Int` branch is touched.
- Added `tests/integration/issues/7315.int.test.ts` asserting the **stored DB value** (via `executeCypher` + `neo4j.isInt`) — covering CREATE, UPDATE, `[Int!]` lists, and relationship properties, plus a `BigInt` regression guard. The bug was invisible to response-only assertions, so these inspect the database directly.
- Patch changeset for `@neo4j/graphql`.

## User-facing impact
`Int` fields populated by an `@populatedBy` callback are now stored as Neo4j integers (`neo4j.isInt` true) rather than floats. GraphQL responses are unchanged (the numeric value is still returned), so this is transparent at the API layer; it corrects the underlying property type in the database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)