### PR TITLE
fix: store Int @populatedBy callback values as Neo4j integers (#7315) [lts]

### DIFF
--- a/.changeset/populatedby-int-7315.md
+++ b/.changeset/populatedby-int-7315.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+`@populatedBy` callback values for `Int` fields are now stored as Neo4j integers instead of floats (fixes [#7315](https://github.com/neo4j/graphql/issues/7315)).

--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ performance.json
 .history
 
 package-lock.json
+
+# Plans
+.plans

--- a/packages/graphql/src/classes/CallbackBucket.ts
+++ b/packages/graphql/src/classes/CallbackBucket.ts
@@ -18,6 +18,7 @@
  */
 
 import { GraphQLBoolean, GraphQLError, GraphQLFloat, GraphQLID, GraphQLInt, GraphQLString } from "graphql";
+import neo4j from "neo4j-driver";
 import type { DateTime, Duration, Integer, LocalDateTime, LocalTime, Date as Neo4jDate, Time } from "neo4j-driver";
 import {
     GraphQLBigInt,
@@ -114,7 +115,7 @@ export class CallbackBucket {
 
         switch (type.name) {
             case "Int":
-                return GraphQLInt.parseValue(result);
+                return neo4j.int(GraphQLInt.parseValue(result));
             case "Float":
                 return GraphQLFloat.parseValue(result);
             case "String":

--- a/packages/graphql/tests/integration/issues/7315.int.test.ts
+++ b/packages/graphql/tests/integration/issues/7315.int.test.ts
@@ -1,0 +1,272 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import neo4j from "neo4j-driver";
+import { TestHelper } from "../../utils/tests-helper";
+
+describe("https://github.com/neo4j/graphql/issues/7315", () => {
+    const testHelper = new TestHelper();
+
+    afterEach(async () => {
+        await testHelper.close();
+    });
+
+    test("Int @populatedBy callback value is stored as a Neo4j integer on CREATE", async () => {
+        const Movie = testHelper.createUniqueType("Movie");
+        const int1 = 123456;
+
+        const callback = () => Promise.resolve(int1);
+
+        const typeDefs = /* GraphQL */ `
+            type ${Movie.name} {
+                id: ID
+                callback: Int! @populatedBy(operations: [CREATE], callback: "callback")
+            }
+        `;
+
+        await testHelper.initNeo4jGraphQL({
+            typeDefs,
+            features: { populatedBy: { callbacks: { callback } } },
+        });
+
+        const movieId = "movie_id";
+
+        const mutation = `
+            mutation {
+                ${Movie.operations.create}(input: [{ id: "${movieId}" }]) {
+                    ${Movie.plural} {
+                        id
+                        callback
+                    }
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(mutation);
+        expect(result.errors).toBeUndefined();
+
+        const cypherResult = await testHelper.executeCypher(
+            `MATCH (m:${Movie.name} { id: $id }) RETURN m.callback AS callback`,
+            { id: movieId }
+        );
+        const stored = cypherResult.records[0]?.get("callback");
+        expect(neo4j.isInt(stored)).toBe(true);
+    });
+
+    test("Int @populatedBy callback value is stored as a Neo4j integer on UPDATE", async () => {
+        const Movie = testHelper.createUniqueType("Movie");
+        const int1 = 123456;
+
+        const callback = () => Promise.resolve(int1);
+
+        const typeDefs = /* GraphQL */ `
+            type ${Movie.name} {
+                id: ID
+                callback: Int! @populatedBy(operations: [UPDATE], callback: "callback")
+            }
+        `;
+
+        await testHelper.initNeo4jGraphQL({
+            typeDefs,
+            features: { populatedBy: { callbacks: { callback } } },
+        });
+
+        const movieId = "movie_id";
+
+        await testHelper.executeCypher(`CREATE (:${Movie.name} { id: "${movieId}" })`);
+
+        const mutation = `
+            mutation {
+                ${Movie.operations.update}(where: { id: "${movieId}" }, update: { id: "${movieId}" }) {
+                    ${Movie.plural} {
+                        id
+                        callback
+                    }
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(mutation);
+        expect(result.errors).toBeUndefined();
+
+        const cypherResult = await testHelper.executeCypher(
+            `MATCH (m:${Movie.name} { id: $id }) RETURN m.callback AS callback`,
+            { id: movieId }
+        );
+        const stored = cypherResult.records[0]?.get("callback");
+        expect(neo4j.isInt(stored)).toBe(true);
+    });
+
+    test("[Int!] @populatedBy callback list stores each element as a Neo4j integer", async () => {
+        const Movie = testHelper.createUniqueType("Movie");
+        const ints = [123456, 654321, 111111];
+
+        const callback = () => Promise.resolve(ints);
+
+        const typeDefs = /* GraphQL */ `
+            type ${Movie.name} {
+                id: ID
+                callback: [Int!]! @populatedBy(operations: [CREATE], callback: "callback")
+            }
+        `;
+
+        await testHelper.initNeo4jGraphQL({
+            typeDefs,
+            features: { populatedBy: { callbacks: { callback } } },
+        });
+
+        const movieId = "movie_id";
+
+        const mutation = `
+            mutation {
+                ${Movie.operations.create}(input: [{ id: "${movieId}" }]) {
+                    ${Movie.plural} {
+                        id
+                        callback
+                    }
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(mutation);
+        expect(result.errors).toBeUndefined();
+
+        const cypherResult = await testHelper.executeCypher(
+            `MATCH (m:${Movie.name} { id: $id }) RETURN m.callback AS callback`,
+            { id: movieId }
+        );
+        const stored = cypherResult.records[0]?.get("callback") as unknown[];
+        expect(Array.isArray(stored)).toBe(true);
+        expect(stored).toHaveLength(ints.length);
+        for (const element of stored) {
+            expect(neo4j.isInt(element)).toBe(true);
+        }
+    });
+
+    test("Int @populatedBy callback value on a relationship property is stored as a Neo4j integer", async () => {
+        const Movie = testHelper.createUniqueType("Movie");
+        const Genre = testHelper.createUniqueType("Genre");
+        const int1 = 123456;
+
+        const callback = () => Promise.resolve(int1);
+
+        const typeDefs = /* GraphQL */ `
+            type ${Movie.name} {
+                id: ID
+                genres: [${Genre.name}!]! @relationship(
+                    type: "IN_GENRE",
+                    direction: OUT,
+                    properties: "RelProperties"
+                )
+            }
+
+            type RelProperties @relationshipProperties {
+                id: ID!
+                callback: Int! @populatedBy(operations: [CREATE], callback: "callback")
+            }
+
+            type ${Genre.name} {
+                id: ID!
+            }
+        `;
+
+        await testHelper.initNeo4jGraphQL({
+            typeDefs,
+            features: { populatedBy: { callbacks: { callback } } },
+        });
+
+        const movieId = "movie_id";
+        const genreId = "genre_id";
+        const relId = "relationship_id";
+
+        const mutation = `
+            mutation {
+                ${Movie.operations.create}(input: [
+                    {
+                        id: "${movieId}",
+                        genres: {
+                            create: [
+                                {
+                                    node: { id: "${genreId}" },
+                                    edge: { id: "${relId}" }
+                                }
+                            ]
+                        }
+                    }
+                ]) {
+                    ${Movie.plural} {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(mutation);
+        expect(result.errors).toBeUndefined();
+
+        const cypherResult = await testHelper.executeCypher(
+            `MATCH (:${Movie.name} { id: $movieId })-[r:IN_GENRE]->(:${Genre.name} { id: $genreId }) RETURN r.callback AS callback`,
+            { movieId, genreId }
+        );
+        const stored = cypherResult.records[0]?.get("callback");
+        expect(neo4j.isInt(stored)).toBe(true);
+    });
+
+    test("BigInt @populatedBy callback value is stored as a Neo4j integer (regression guard)", async () => {
+        const Movie = testHelper.createUniqueType("Movie");
+        const bigInt1 = "2147483648";
+
+        const callback = () => Promise.resolve(bigInt1);
+
+        const typeDefs = /* GraphQL */ `
+            type ${Movie.name} {
+                id: ID
+                callback: BigInt! @populatedBy(operations: [CREATE], callback: "callback")
+            }
+        `;
+
+        await testHelper.initNeo4jGraphQL({
+            typeDefs,
+            features: { populatedBy: { callbacks: { callback } } },
+        });
+
+        const movieId = "movie_id";
+
+        const mutation = `
+            mutation {
+                ${Movie.operations.create}(input: [{ id: "${movieId}" }]) {
+                    ${Movie.plural} {
+                        id
+                        callback
+                    }
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(mutation);
+        expect(result.errors).toBeUndefined();
+
+        const cypherResult = await testHelper.executeCypher(
+            `MATCH (m:${Movie.name} { id: $id }) RETURN m.callback AS callback`,
+            { id: movieId }
+        );
+        const stored = cypherResult.records[0]?.get("callback");
+        expect(neo4j.isInt(stored)).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary
Bug fix (backport of #7316 to the `lts` line). `@populatedBy` callback values for `Int`-typed fields were persisted to Neo4j as `Float` instead of `Int`. The callback path returned a bare JS `number`, which the driver serialises as a 64-bit float, diverging from every other mutation-input path. Fixes #7315 on `lts`.

## Changes
- `parseCallbackResult` in `packages/graphql/src/classes/CallbackBucket.ts` now wraps the `Int` case with `neo4j.int(...)`, bringing it in line with the `BigInt`/temporal branches that already yield driver `Integer`s. `GraphQLInt.parseValue` is retained, so 32-bit/integer validation is unchanged; only the `Int` branch is touched.
- Added `tests/integration/issues/7315.int.test.ts` asserting the **stored DB value** (via `executeCypher` + `neo4j.isInt`) across CREATE, UPDATE, `[Int!]` lists, and relationship properties, plus a `BigInt` regression guard. The bug was invisible to response-only assertions, so these inspect the database directly.
- Patch changeset for `@neo4j/graphql`.

> Note: on `lts` the callback class lives at `src/classes/CallbackBucket.ts` (vs. `dev`'s `queryAST/utils/callback-bucket.ts`); the fix is otherwise identical to #7316.

## User-facing impact
`Int` fields populated by an `@populatedBy` callback are now stored as Neo4j integers (`neo4j.isInt` true) rather than floats. GraphQL responses are unchanged (the numeric value is still returned), so this is transparent at the API layer; it corrects the underlying property type in the database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)