### PR TITLE
fix: remove invalid --since flag from changeset-version on lts

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "lint": "eslint --cache .",
         "test": "jest",
         "test-docker": "docker-compose up --build --abort-on-container-exit",
-        "changeset-version": "changeset version --since $BRANCH && yarn",
+        "changeset-version": "changeset version && yarn",
         "release-dev": "yarn build && changeset publish",
         "release-lts": "yarn build && changeset publish --tag lts",
         "release-previous": "yarn build && changeset publish --tag previous"


### PR DESCRIPTION
## Problem

The `Release` workflow on the `lts` branch has been failing for the last several runs (e.g. [run 27792534063](https://github.com/neo4j/graphql/actions/runs/27792534063)), while it succeeds on `dev`.

The `Create release PR or release` step (`changesets/action`) runs `yarn changeset-version` and fails:

```
[command]/usr/local/bin/yarn changeset-version
🦋  error Unknown flag for version: --since
🦋  error Usage: changeset version [--ignore] [--snapshot <?name>] ...
##[error]Error: The process '/usr/local/bin/yarn' failed with exit code 1
```

`changeset version` has no `--since` flag, so the command exits 1 and the release / "Version Packages" PR is never opened.

## Fix

The `changeset-version` script on `lts` still passes the invalid flag:

```diff
-        "changeset-version": "changeset version --since $BRANCH && yarn",
+        "changeset-version": "changeset version && yarn",
```

This was already fixed on `dev` in 806c47d22 ("remove --since from changeset version") but was never backported to `lts`. This PR brings `lts` in line with `dev`.

## User-facing impact

None to library consumers. CI/release-only change — it unblocks the release workflow on `lts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)