### PR TITLE
chore: add npmMinimalAgeGate to yarn config

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,5 @@
 nodeLinker: node-modules
 
+npmMinimalAgeGate: "1w"
+
 yarnPath: .yarn/releases/yarn-4.14.1.cjs


### PR DESCRIPTION
## Description

Adds the [`npmMinimalAgeGate`](https://yarnpkg.com/configuration/yarnrc#npmMinimalAgeGate) setting to `.yarnrc.yml`, set to `1w`.

This establishes a minimum age threshold (based on the npm registry publish date) before a package version is eligible for installation. Versions newer than the gate are skipped, which reduces the risk of pulling in a freshly-compromised or soon-to-be-unpublished package.

```yaml
npmMinimalAgeGate: "1w"
```

`1w` is Yarn's documented default for this setting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)