### PR TITLE
Parameterise AI provider token

### DIFF
--- a/.changeset/nine-cloths-bet.md
+++ b/.changeset/nine-cloths-bet.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+Parameterise AI provider API keys.

--- a/packages/graphql/src/translate/queryAST/ast/selection/VectorSelection.ts
+++ b/packages/graphql/src/translate/queryAST/ast/selection/VectorSelection.ts
@@ -63,17 +63,46 @@ export class VectorSelection extends EntitySelection {
             }
 
             const providerSettings = this.settings[this.vectorOptions.index.provider];
-            const providerSettingsParam = {
-                ...providerSettings,
+            
+            let providerSettingsParams = {};
+            if(this.vectorOptions.index.provider === "VertexAI") {
+                providerSettingsParams = {
                 token: new Cypher.Param(providerSettings.token),
-            };
+                projectId: new Cypher.Param(providerSettings.projectId),
+                model: new Cypher.Param(providerSettings.model),
+                region: new Cypher.Param(providerSettings.region),
+                }
+            }
+            if(this.vectorOptions.index.provider === "OpenAI") {
+                providerSettingsParams = {
+                    token: new Cypher.Param(providerSettings.token),
+                    model: new Cypher.Param(providerSettings.model),
+                    dimensions: new Cypher.Param(providerSettings.dimensions),
+                };
+            }
+            if(this.vectorOptions.index.provider === "AzureOpenAI") {
+                providerSettingsParams = {
+                    token: new Cypher.Param(providerSettings.token),
+                    resource: new Cypher.Param(providerSettings.resource),
+                    deployment: new Cypher.Param(providerSettings.deployment),
+                };
+            }
+            if(this.vectorOptions.index.provider === "Bedrock") {
+                providerSettingsParams = {
+                    accessKeyId: new Cypher.Param(providerSettings.accessKeyId),
+                    secretAccessKey: new Cypher.Param(providerSettings.secretAccessKey),
+                    model: new Cypher.Param(providerSettings.model),
+                    region: new Cypher.Param(providerSettings.region),
+                };
+            }
+
             const asQueryVector = new Cypher.Variable();
             const vectorProcedure = Cypher.db.index.vector.queryNodes(indexName, 4, asQueryVector);
 
             const encodeFunction = Cypher.genai.vector.encode(
                 phraseParam,
                 this.vectorOptions.index.provider,
-                providerSettingsParam
+                providerSettingsParams
             );
 
             vectorClause = new Cypher.With([encodeFunction, asQueryVector])

--- a/packages/graphql/src/translate/queryAST/ast/selection/VectorSelection.ts
+++ b/packages/graphql/src/translate/queryAST/ast/selection/VectorSelection.ts
@@ -63,13 +63,17 @@ export class VectorSelection extends EntitySelection {
             }
 
             const providerSettings = this.settings[this.vectorOptions.index.provider];
+            const providerSettingsParam = {
+                ...providerSettings,
+                token: new Cypher.Param(providerSettings.token),
+            };
             const asQueryVector = new Cypher.Variable();
             const vectorProcedure = Cypher.db.index.vector.queryNodes(indexName, 4, asQueryVector);
 
             const encodeFunction = Cypher.genai.vector.encode(
                 phraseParam,
                 this.vectorOptions.index.provider,
-                providerSettings
+                providerSettingsParam
             );
 
             vectorClause = new Cypher.With([encodeFunction, asQueryVector])

--- a/packages/graphql/src/translate/queryAST/ast/selection/VectorSelection.ts
+++ b/packages/graphql/src/translate/queryAST/ast/selection/VectorSelection.ts
@@ -63,31 +63,31 @@ export class VectorSelection extends EntitySelection {
             }
 
             const providerSettings = this.settings[this.vectorOptions.index.provider];
-            
+
             let providerSettingsParams = {};
-            if(this.vectorOptions.index.provider === "VertexAI") {
+            if (this.vectorOptions.index.provider === "VertexAI") {
                 providerSettingsParams = {
-                token: new Cypher.Param(providerSettings.token),
-                projectId: new Cypher.Param(providerSettings.projectId),
-                model: new Cypher.Param(providerSettings.model),
-                region: new Cypher.Param(providerSettings.region),
-                }
+                    token: new Cypher.Param(providerSettings.token),
+                    projectId: new Cypher.Param(providerSettings.projectId),
+                    model: new Cypher.Param(providerSettings.model),
+                    region: new Cypher.Param(providerSettings.region),
+                };
             }
-            if(this.vectorOptions.index.provider === "OpenAI") {
+            if (this.vectorOptions.index.provider === "OpenAI") {
                 providerSettingsParams = {
                     token: new Cypher.Param(providerSettings.token),
                     model: new Cypher.Param(providerSettings.model),
                     dimensions: new Cypher.Param(providerSettings.dimensions),
                 };
             }
-            if(this.vectorOptions.index.provider === "AzureOpenAI") {
+            if (this.vectorOptions.index.provider === "AzureOpenAI") {
                 providerSettingsParams = {
                     token: new Cypher.Param(providerSettings.token),
                     resource: new Cypher.Param(providerSettings.resource),
                     deployment: new Cypher.Param(providerSettings.deployment),
                 };
             }
-            if(this.vectorOptions.index.provider === "Bedrock") {
+            if (this.vectorOptions.index.provider === "Bedrock") {
                 providerSettingsParams = {
                     accessKeyId: new Cypher.Param(providerSettings.accessKeyId),
                     secretAccessKey: new Cypher.Param(providerSettings.secretAccessKey),

--- a/packages/graphql/tests/tck/directives/vector/phrase.test.ts
+++ b/packages/graphql/tests/tck/directives/vector/phrase.test.ts
@@ -72,9 +72,9 @@ describe("phrase input - genAI plugin", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
-            WITH genai.vector.encode($param0, 'OpenAI', {token: 'my-token', model: 'my-model', dimensions: 256}) AS var0
+            WITH genai.vector.encode($param0, 'OpenAI', {token: $param1, model: 'my-model', dimensions: 256}) AS var0
             CALL db.index.vector.queryNodes('movie_index', 4, var0) YIELD node AS this1, score AS var2
-            WHERE $param1 IN labels(this1)
+            WHERE $param2 IN labels(this1)
             WITH collect({node: this1, score: var2}) AS edges
             WITH edges, size(edges) AS totalCount
             CALL (edges) {
@@ -88,7 +88,8 @@ describe("phrase input - genAI plugin", () => {
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
                 \\"param0\\": \\"test phrase\\",
-                \\"param1\\": \\"Movie\\"
+                \\"param1\\": \\"my-token\\",
+                \\"param2\\": \\"Movie\\"
             }"
         `);
     });

--- a/packages/graphql/tests/tck/directives/vector/phrase.test.ts
+++ b/packages/graphql/tests/tck/directives/vector/phrase.test.ts
@@ -72,9 +72,9 @@ describe("phrase input - genAI plugin", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CYPHER 5
-            WITH genai.vector.encode($param0, 'OpenAI', {token: $param1, model: 'my-model', dimensions: 256}) AS var0
+            WITH genai.vector.encode($param0, 'OpenAI', {token: $param1, model: $param2, dimensions: $param3}) AS var0
             CALL db.index.vector.queryNodes('movie_index', 4, var0) YIELD node AS this1, score AS var2
-            WHERE $param2 IN labels(this1)
+            WHERE $param4 IN labels(this1)
             WITH collect({node: this1, score: var2}) AS edges
             WITH edges, size(edges) AS totalCount
             CALL (edges) {
@@ -89,7 +89,9 @@ describe("phrase input - genAI plugin", () => {
             "{
                 \\"param0\\": \\"test phrase\\",
                 \\"param1\\": \\"my-token\\",
-                \\"param2\\": \\"Movie\\"
+                \\"param2\\": \\"my-model\\",
+                \\"param3\\": 256,
+                \\"param4\\": \\"Movie\\"
             }"
         `);
     });

--- a/packages/graphql/tests/tck/directives/vector/provider.test.ts
+++ b/packages/graphql/tests/tck/directives/vector/provider.test.ts
@@ -1,0 +1,304 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ */
+
+import { Neo4jGraphQL } from "../../../../src";
+import { formatCypher, formatParams, translateQuery } from "../../utils/tck-test-utils";
+
+const queryName = "moviesVectorQuery";
+
+describe("provider settings - genAI plugin", () => {
+    let verifyTCK;
+
+    beforeAll(() => {
+        // NOTE: tck verification is skipped for vector tests as vector is not supported on Neo4j 4.x
+        if (process.env.VERIFY_TCK) {
+            verifyTCK = process.env.VERIFY_TCK;
+            delete process.env.VERIFY_TCK;
+        }
+    });
+
+    afterAll(() => {
+        if (verifyTCK) {
+            process.env.VERIFY_TCK = verifyTCK;
+        }
+    });
+
+    test("OpenAI provider settings", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Movie
+                @node
+                @vector(indexes: [{ indexName: "movie_index", embeddingProperty: "movieVector", queryName: "${queryName}", provider: OPEN_AI }]) {
+                title: String!
+                released: Int!
+            }
+        `;
+
+        const neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            features: {
+                vector: {
+                    OpenAI: {
+                        token: "my-token",
+                        model: "my-model",
+                        dimensions: 256,
+                    },
+                },
+            },
+        });
+
+        const query = /* GraphQL */ `
+            query MovieVectorQuery($phrase: String!) {
+                ${queryName}(phrase: $phrase) {
+                    edges {
+                        cursor
+                        score
+                        node {
+                            title
+                        }
+                    }
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query, {
+            variableValues: {
+                phrase: "test phrase",
+            },
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "CYPHER 5
+            WITH genai.vector.encode($param0, 'OpenAI', {token: $param1, model: $param2, dimensions: $param3}) AS var0
+            CALL db.index.vector.queryNodes('movie_index', 4, var0) YIELD node AS this1, score AS var2
+            WHERE $param4 IN labels(this1)
+            WITH collect({node: this1, score: var2}) AS edges
+            WITH edges, size(edges) AS totalCount
+            CALL (edges) {
+              UNWIND edges AS edge
+              WITH edge.node AS this1, edge.score AS var2
+              RETURN collect({node: {title: this1.title, __resolveType: 'Movie'}, score: var2}) AS var3
+            }
+            RETURN {edges: var3} AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"test phrase\\",
+                \\"param1\\": \\"my-token\\",
+                \\"param2\\": \\"my-model\\",
+                \\"param3\\": 256,
+                \\"param4\\": \\"Movie\\"
+            }"
+        `);
+    });
+    test("VertexAI provider settings", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Movie
+                @node
+                @vector(indexes: [{ indexName: "movie_index", embeddingProperty: "movieVector", queryName: "${queryName}", provider: VERTEX_AI }]) {
+                title: String!
+                released: Int!
+            }
+        `;
+
+        const neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            features: {
+                vector: {
+                    VertexAI: {
+                        token: "my-token",
+                        projectId: "my-project-id",
+                        model: "my-model",
+                        region: "my-region",
+                    },
+                },
+            },
+        });
+
+        const query = /* GraphQL */ `
+            query MovieVectorQuery($phrase: String!) {
+                ${queryName}(phrase: $phrase) {
+                    edges {
+                        cursor
+                        score
+                        node {
+                            title
+                        }
+                    }
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query, {
+            variableValues: {
+                phrase: "test phrase",
+            },
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "CYPHER 5
+            WITH genai.vector.encode($param0, 'VertexAI', {token: $param1, projectId: $param2, model: $param3, region: $param4}) AS var0
+            CALL db.index.vector.queryNodes('movie_index', 4, var0) YIELD node AS this1, score AS var2
+            WHERE $param5 IN labels(this1)
+            WITH collect({node: this1, score: var2}) AS edges
+            WITH edges, size(edges) AS totalCount
+            CALL (edges) {
+              UNWIND edges AS edge
+              WITH edge.node AS this1, edge.score AS var2
+              RETURN collect({node: {title: this1.title, __resolveType: 'Movie'}, score: var2}) AS var3
+            }
+            RETURN {edges: var3} AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"test phrase\\",
+                \\"param1\\": \\"my-token\\",
+                \\"param2\\": \\"my-project-id\\",
+                \\"param3\\": \\"my-model\\",
+                \\"param4\\": \\"my-region\\",
+                \\"param5\\": \\"Movie\\"
+            }"
+        `);
+    });
+    test("AzureOpenAI provider settings", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Movie
+                @node
+                @vector(indexes: [{ indexName: "movie_index", embeddingProperty: "movieVector", queryName: "${queryName}", provider: AZURE_OPEN_AI }]) {
+                title: String!
+                released: Int!
+            }
+        `;
+
+        const neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            features: {
+                vector: {
+                    AzureOpenAI: {
+                        token: "my-token",
+                        resource: "my-resource",
+                        deployment: "my-deployment",
+                    },
+                },
+            },
+        });
+
+        const query = /* GraphQL */ `
+            query MovieVectorQuery($phrase: String!) {
+                ${queryName}(phrase: $phrase) {
+                    edges {
+                        cursor
+                        score
+                        node {
+                            title
+                        }
+                    }
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query, {
+            variableValues: {
+                phrase: "test phrase",
+            },
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "CYPHER 5
+            WITH genai.vector.encode($param0, 'AzureOpenAI', {token: $param1, resource: $param2, deployment: $param3}) AS var0
+            CALL db.index.vector.queryNodes('movie_index', 4, var0) YIELD node AS this1, score AS var2
+            WHERE $param4 IN labels(this1)
+            WITH collect({node: this1, score: var2}) AS edges
+            WITH edges, size(edges) AS totalCount
+            CALL (edges) {
+              UNWIND edges AS edge
+              WITH edge.node AS this1, edge.score AS var2
+              RETURN collect({node: {title: this1.title, __resolveType: 'Movie'}, score: var2}) AS var3
+            }
+            RETURN {edges: var3} AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"test phrase\\",
+                \\"param1\\": \\"my-token\\",
+                \\"param2\\": \\"my-resource\\",
+                \\"param3\\": \\"my-deployment\\",
+                \\"param4\\": \\"Movie\\"
+            }"
+        `);
+    });
+    test("Bedrock provider settings", async () => {
+        const typeDefs = /* GraphQL */ `
+            type Movie
+                @node
+                @vector(indexes: [{ indexName: "movie_index", embeddingProperty: "movieVector", queryName: "${queryName}", provider: BEDROCK }]) {
+                title: String!
+                released: Int!
+            }
+        `;
+
+        const neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            features: {
+                vector: {
+                    Bedrock: {
+                        accessKeyId: "my-access-key-id",
+                        secretAccessKey: "my-secret-access-key",
+                        model: "my-model",
+                        region: "my-region",
+                    },
+                },
+            },
+        });
+
+        const query = /* GraphQL */ `
+            query MovieVectorQuery($phrase: String!) {
+                ${queryName}(phrase: $phrase) {
+                    edges {
+                        cursor
+                        score
+                        node {
+                            title
+                        }
+                    }
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query, {
+            variableValues: {
+                phrase: "test phrase",
+            },
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "CYPHER 5
+            WITH genai.vector.encode($param0, 'Bedrock', {accessKeyId: $param1, secretAccessKey: $param2, model: $param3, region: $param4}) AS var0
+            CALL db.index.vector.queryNodes('movie_index', 4, var0) YIELD node AS this1, score AS var2
+            WHERE $param5 IN labels(this1)
+            WITH collect({node: this1, score: var2}) AS edges
+            WITH edges, size(edges) AS totalCount
+            CALL (edges) {
+              UNWIND edges AS edge
+              WITH edge.node AS this1, edge.score AS var2
+              RETURN collect({node: {title: this1.title, __resolveType: 'Movie'}, score: var2}) AS var3
+            }
+            RETURN {edges: var3} AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"test phrase\\",
+                \\"param1\\": \\"my-access-key-id\\",
+                \\"param2\\": \\"my-secret-access-key\\",
+                \\"param3\\": \\"my-model\\",
+                \\"param4\\": \\"my-region\\",
+                \\"param5\\": \\"Movie\\"
+            }"
+        `);
+    });
+});


### PR DESCRIPTION
# Description
Fix issue where AI provider API keys are being written into database logs in plain text.

> **Note**
> Token is currently being exposed in `query.log` when using the @vector directive with AI embedding. Parameterise token as a fix.

## Complexity

Complexity: Low

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] Documentation has been updated
- [x] TCK tests have been updated
- [x] Integration tests have been updated
- [x] Example applications have been updated
- [x] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
