### PR TITLE
fix(release): pin npm to v11 to unbreak changeset publish (lts)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,8 +41,8 @@ jobs:
           registry-url: https://registry.npmjs.org
           package-manager-cache: false
 
-      - name: Update npm # Need at least 11.5.1 for OIDC publishing
-        run: npm install -g npm@latest
+      - name: Update npm # Need at least 11.5.1 for OIDC publishing. Pinned to v11: npm 12 changed `npm info --json` output and "already published" errors, breaking `changeset publish` (https://github.com/changesets/changesets/issues/2099)
+        run: npm install -g npm@11.19.0
 
       - name: Install Dependencies
         run: yarn

--- a/packages/apollo-federation-subgraph-compatibility/package.json
+++ b/packages/apollo-federation-subgraph-compatibility/package.json
@@ -1,6 +1,7 @@
 {
     "name": "apollo-federation-subgraph-compatibility",
     "version": "1.0.0",
+    "private": true,
     "packageManager": "yarn@4.14.1",
     "scripts": {
         "build": "webpack --config webpack.config.js",


### PR DESCRIPTION
## Problem

Every `changeset publish` on `dev`/`lts` has failed since 2026-07-13 (DEVSURF-1346), which also suppresses the Slack release announcement (it depends on the `published` output that never gets set when publish errors).

## Root cause

The release workflow runs `npm install -g npm@latest`, and npm 12 was tagged `latest` on 2026-07-08 — between the last green run (07-01) and the first red one (07-13). npm 12 breaks `@changesets/cli@2.31.x` in two compounding ways:

1. **`npm info <pkg> --json` now returns an array instead of an object.** Changesets' pre-publish check reads `.versions` from the parsed output, gets `undefined`, and concludes *every* package is unpublished — so it attempts to republish packages already on npm (visible in the run logs: `X is being published because our local version has not been published on npm` for all three public packages).
2. **The resulting "You cannot publish over the previously published versions" rejection comes from npm's client-side preflight and carries no `error.code`.** Changesets' graceful already-published skip requires `code === "E403"`, so it hard-fails instead — the `an error occurred while publishing ...: undefined You cannot publish over...` in the logs. This is changesets/changesets#2099; the fix (changesets/changesets#2132) is only in `3.0.0-next`, not in any stable release (verified against the `2.31.1` tarball).

## Fix

- Pin the workflow to `npm@11.19.0` (latest v11, still maintained, satisfies the ≥11.5.1 OIDC requirement). The dev PR (#7349) adds a renovate custom manager that keeps this pin up to date; renovate reads its config from the default branch and `baseBranchPatterns` already includes `lts`, so this branch's pin is covered by that config with no changes here.
- Mark `apollo-federation-subgraph-compatibility` as `"private": true` — it's a compatibility test harness that should never be published, and the `.changeset/config.json` `ignore` list only governs `changeset version`, not publish. (`changeset publish` filters private packages out before any registry call.)

## Verification (no publish performed)

Replicated the exact registry check changesets performs (`npm info <pkg> --json` → read `.versions`) against the real registry under both npm versions, for the public packages of **both** `dev` and `lts`:

| Package | npm 11.19.0 | npm 12.0.2 |
|---|---|---|
| `@neo4j/graphql` (7.5.4 dev / 5.12.13 lts) | object → correctly skipped | array, 0 versions → would republish |
| `@neo4j/introspector` (5.0.1 dev / 3.0.2 lts) | object → correctly skipped | array, 0 versions → would republish |
| `apollo-federation-subgraph-compatibility` 1.0.0 | object → correctly skipped | array, 0 versions → would republish |

The npm 12 column reproduces the failing CI logs line-for-line (run 29214459625). Additionally, npm 12 requires Node ≥ 22.22.2 / ≥ 24.15.0, another hazard of floating `npm@latest` under `node-version: lts/*`.

Since there are currently no pending changesets on either branch and every current version is already on npm, the first push after merge is itself a safe end-to-end check: `changeset publish` should find nothing to publish and exit 0 (green run, no Slack message, nothing released).

## Longer term

Once a stable `@changesets/cli` ships with the changesets#2132 fix, the npm pin can be revisited — but only after confirming changesets also handles npm 12's array-shaped `--json` output, which #2132 does not address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

