### PR TITLE
Warnings should not appear for user's own deprecated fields which share the same type

### DIFF
--- a/.changeset/nine-sheep-poke.md
+++ b/.changeset/nine-sheep-poke.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+Relax validation of @relationship field uniqueness when duplicate relationship has the @deprecated annotation

--- a/packages/graphql/src/schema/validation/custom-rules/directives/relationship-validation.test.ts
+++ b/packages/graphql/src/schema/validation/custom-rules/directives/relationship-validation.test.ts
@@ -186,4 +186,50 @@ describe("@relationship validation", () => {
         const errors = getError(executeValidate);
         expect(errors).toBeInstanceOf(NoErrorThrownError);
     });
+
+    test("@deprecated fields should be ignored by relationship uniqueness validation", () => {
+        const doc = gql`
+            type Movie @node {
+                someActors: [Person!]! @relationship(type: "ACTED_IN", direction: IN) @deprecated
+                newActors: [Person!]! @relationship(type: "ACTED_IN", direction: IN)
+            }
+
+            type Person @node {
+                name: String
+            }
+        `;
+
+        const executeValidate = () =>
+            validateDocument({
+                document: doc,
+                additionalDefinitions,
+                features: {},
+            });
+
+        const errors = getError(executeValidate);
+        expect(errors).toBeInstanceOf(NoErrorThrownError);
+    });
+
+    test("multiple @deprecated fields with the same direction and type should not be an error", () => {
+        const doc = gql`
+            type Movie @node {
+                someActors: [Person!]! @relationship(type: "ACTED_IN", direction: IN) @deprecated
+                newActors: [Person!]! @relationship(type: "ACTED_IN", direction: IN) @deprecated
+            }
+
+            type Person @node {
+                name: String
+            }
+        `;
+
+        const executeValidate = () =>
+            validateDocument({
+                document: doc,
+                additionalDefinitions,
+                features: {},
+            });
+
+        const errors = getError(executeValidate);
+        expect(errors).toBeInstanceOf(NoErrorThrownError);
+    });
 });

--- a/packages/graphql/src/schema/validation/custom-rules/directives/relationship.ts
+++ b/packages/graphql/src/schema/validation/custom-rules/directives/relationship.ts
@@ -10,6 +10,7 @@ import {
     type ObjectTypeDefinitionNode,
     type ObjectTypeExtensionNode,
 } from "graphql";
+import { DEPRECATED } from "../../../../constants";
 import {
     declareRelationshipDirective,
     relationshipDirective,
@@ -39,6 +40,12 @@ export function validateRelationshipDirective(context: Neo4jValidationContext): 
             ).flatMap((extension) => extension.fields ?? []);
 
             [...(objectTypeDefinitionNode.fields ?? []), ...extensionsFields].forEach((field) => {
+                // don't count deprecated fields towards uniqueness
+                const isDeprecated = field.directives?.find((directive) => directive.name.value === DEPRECATED);
+                if (isDeprecated) {
+                    return;
+                }
+
                 const appliedRelationship = field.directives?.find(
                     (directive) => directive.name.value === relationshipDirective.name
                 );


### PR DESCRIPTION
# Description

When we validate `@relationship` directives, we check that there are no duplicate field type + relationship type + relationship direction combinations.

This should be relaxed if the duplicate relationship has the `@deprecated` annotation, since that behaviour would be more expected by users.

Example:

```gql
type Movie {
    title: String!
    actors: [Actor!]! @relationship(type: "ACTED_IN", direction: IN) @deprecated
    newActors: [Actor!]! @relationship(type: "ACTED_IN", direction: IN)
}
```

## Complexity

Complexity: low

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
