### PR TITLE
Validate vector provider config at schema construction

### DIFF
--- a/.changeset/eager-places-count.md
+++ b/.changeset/eager-places-count.md
@@ -1,0 +1,9 @@
+---
+"@neo4j/graphql": patch
+---
+
+`@vector` provider configuration is now validated at schema build time.
+
+Previously, when a `@vector` index declared a `provider` but no matching
+configuration was supplied in `features.vector`, this only surfaced as an error
+at query time.

--- a/packages/graphql/src/graphql/directives/vector.ts
+++ b/packages/graphql/src/graphql/directives/vector.ts
@@ -14,7 +14,7 @@ import {
     GraphQLString,
 } from "graphql";
 
-export const vectorProviderNames = {
+const vectorProviderNames = {
     VERTEX_AI: "VertexAI",
     OPEN_AI: "OpenAI",
     AZURE_OPEN_AI: "AzureOpenAI",

--- a/packages/graphql/src/graphql/directives/vector.ts
+++ b/packages/graphql/src/graphql/directives/vector.ts
@@ -14,7 +14,7 @@ import {
     GraphQLString,
 } from "graphql";
 
-const vectorProviderNames = {
+export const vectorProviderNames = {
     VERTEX_AI: "VertexAI",
     OPEN_AI: "OpenAI",
     AZURE_OPEN_AI: "AzureOpenAI",

--- a/packages/graphql/src/schema/validation/Neo4jValidationContext.ts
+++ b/packages/graphql/src/schema/validation/Neo4jValidationContext.ts
@@ -19,7 +19,7 @@ import type {
 } from "graphql";
 import { Kind } from "graphql";
 import { SDLValidationContext } from "graphql/validation/ValidationContext";
-import { Neo4jVectorSettings } from "../../types";
+import type { Neo4jVectorSettings } from "../../types";
 
 export type TypeMapWithExtensions = Record<
     string,

--- a/packages/graphql/src/schema/validation/Neo4jValidationContext.ts
+++ b/packages/graphql/src/schema/validation/Neo4jValidationContext.ts
@@ -19,7 +19,7 @@ import type {
 } from "graphql";
 import { Kind } from "graphql";
 import { SDLValidationContext } from "graphql/validation/ValidationContext";
-import { Neo4jVectorSettings } from "src/types";
+import { Neo4jVectorSettings } from "../../types";
 
 export type TypeMapWithExtensions = Record<
     string,

--- a/packages/graphql/src/schema/validation/Neo4jValidationContext.ts
+++ b/packages/graphql/src/schema/validation/Neo4jValidationContext.ts
@@ -19,6 +19,7 @@ import type {
 } from "graphql";
 import { Kind } from "graphql";
 import { SDLValidationContext } from "graphql/validation/ValidationContext";
+import { Neo4jVectorSettings } from "src/types";
 
 export type TypeMapWithExtensions = Record<
     string,
@@ -35,15 +36,18 @@ export class Neo4jValidationContext extends SDLValidationContext {
     public readonly typeMapWithExtensions?: TypeMapWithExtensions;
     public readonly interfacesMap?: Record<string, Array<ObjectTypeDefinitionNode>>;
     public readonly callbacks?: any;
+    public readonly vectors?: Neo4jVectorSettings;
 
     constructor(
         ast: DocumentNode,
         schema: Maybe<GraphQLSchema>,
         onError: (error: GraphQLError) => void,
-        callbacks?: any
+        callbacks?: any,
+        vectors?: Neo4jVectorSettings
     ) {
         super(ast, schema, onError);
         this.callbacks = callbacks;
+        this.vectors = vectors;
         this.typeMapWithExtensions = buildTypeMapWithExtensions(ast.definitions);
 
         this.interfacesMap = buildInterfacesMap(ast.definitions, this.typeMapWithExtensions);

--- a/packages/graphql/src/schema/validation/custom-rules/directives/vector.ts
+++ b/packages/graphql/src/schema/validation/custom-rules/directives/vector.ts
@@ -3,7 +3,7 @@
  * Neo4j Sweden AB [http://neo4j.com]
  */
 
-import type { ASTVisitor, DirectiveNode, ObjectTypeDefinitionNode } from "graphql";
+import type { ASTVisitor, ObjectTypeDefinitionNode } from "graphql";
 import { vectorDirective } from "../../../../graphql/directives/vector";
 import type { VectorField } from "../../../../schema-model/annotation/VectorAnnotation";
 import { parseValueNode } from "../../../../schema-model/parser/parse-value-node";
@@ -42,8 +42,17 @@ export function validateVectorDirective(context: Neo4jValidationContext): ASTVis
                     );
                 }
                 for (const vectorDirectiveOnNode of vectorDirectivesOnNode) {
-                    assertMaxPhraseLengthIsValid(vectorDirectiveOnNode);
-                    assertIndexProviderValid(vectorDirectiveOnNode, context.vectors);
+                    const indexesArg = vectorDirectiveOnNode.arguments?.find(
+                        (argument) => argument.name.value === "indexes"
+                    );
+                    if (!indexesArg) {
+                        continue;
+                    }
+
+                    const indexes = asArray(parseValueNode(indexesArg.value)) as VectorField[];
+
+                    assertMaxPhraseLengthIsValid(indexes);
+                    assertIndexProviderValid(indexes, context.vectors);
                 }
             });
             const pathToNode = getPathToNode(path, ancestors);
@@ -61,16 +70,7 @@ export function validateVectorDirective(context: Neo4jValidationContext): ASTVis
 }
 
 // When a provider is specified by an index, ensure that it has a valid configuration
-function assertIndexProviderValid(
-    vectorDirectiveOnNode: DirectiveNode,
-    vectors: Neo4jVectorSettings | undefined
-): void {
-    const indexesArg = vectorDirectiveOnNode.arguments?.find((argument) => argument.name.value === "indexes");
-    if (!indexesArg) {
-        return;
-    }
-
-    const indexes = asArray(parseValueNode(indexesArg.value)) as VectorField[];
+function assertIndexProviderValid(indexes: VectorField[], vectors: Neo4jVectorSettings | undefined): void {
     for (const index of indexes) {
         const provider = index?.provider;
         if (provider == null) {
@@ -102,12 +102,7 @@ function assertIndexProviderValid(
     }
 }
 
-function assertMaxPhraseLengthIsValid(vectorDirectiveOnNode: DirectiveNode): void {
-    const indexesArg = vectorDirectiveOnNode.arguments?.find((argument) => argument.name.value === "indexes");
-    if (!indexesArg) {
-        return;
-    }
-    const indexes = asArray(parseValueNode(indexesArg.value)) as VectorField[];
+function assertMaxPhraseLengthIsValid(indexes: VectorField[]): void {
     for (const index of indexes) {
         const maxPhraseLength = index?.maxPhraseLength;
         if (maxPhraseLength == null) {

--- a/packages/graphql/src/schema/validation/custom-rules/directives/vector.ts
+++ b/packages/graphql/src/schema/validation/custom-rules/directives/vector.ts
@@ -12,7 +12,7 @@ import type { Neo4jValidationContext } from "../../Neo4jValidationContext";
 import { assertValid, createGraphQLError, DocumentValidationError } from "../utils/document-validation-error";
 import { typeIsANodeType } from "../utils/location-helpers/is-node-type";
 import { getPathToNode } from "../utils/path-parser";
-import { Neo4jVectorSettings } from "src/types";
+import { Neo4jVectorSettings } from "../../../../types";
 
 export function validateVectorDirective(context: Neo4jValidationContext): ASTVisitor {
     const typeMapWithExtensions = context.typeMapWithExtensions;

--- a/packages/graphql/src/schema/validation/custom-rules/directives/vector.ts
+++ b/packages/graphql/src/schema/validation/custom-rules/directives/vector.ts
@@ -66,21 +66,21 @@ export function validateVectorDirective(context: Neo4jValidationContext): ASTVis
 }
 
 // When a provider is specified by an index, ensure that it has a valid configuration
-function assertIndexProviderIsValid(indexes: VectorField[], vectors: Neo4jVectorSettings | undefined): void {
+function assertIndexProviderIsValid(indexes: VectorField[], vectorSettings: Neo4jVectorSettings | undefined): void {
     for (const index of indexes) {
         const provider = index?.provider;
         if (provider == null) {
             continue;
         }
 
-        if (vectors === undefined) {
+        if (vectorSettings === undefined) {
             throw new DocumentValidationError(
                 `@${vectorDirective.name}.indexes specifies a provider, but no vector providers configuration exists.`,
                 ["indexes"]
             );
         }
 
-        if (!(provider in vectors)) {
+        if (!(provider in vectorSettings)) {
             throw new DocumentValidationError(
                 `@${vectorDirective.name}.indexes specifies a provider that doesn't exist in the vector providers configuration.`,
                 ["indexes"]

--- a/packages/graphql/src/schema/validation/custom-rules/directives/vector.ts
+++ b/packages/graphql/src/schema/validation/custom-rules/directives/vector.ts
@@ -52,7 +52,7 @@ export function validateVectorDirective(context: Neo4jValidationContext): ASTVis
                     const indexes = asArray(parseValueNode(indexesArg.value)) as VectorField[];
 
                     assertMaxPhraseLengthIsValid(indexes);
-                    assertIndexProviderValid(indexes, context.vectors);
+                    assertIndexProviderIsValid(indexes, context.vectors);
                 }
             });
             const pathToNode = getPathToNode(path, ancestors);
@@ -70,7 +70,7 @@ export function validateVectorDirective(context: Neo4jValidationContext): ASTVis
 }
 
 // When a provider is specified by an index, ensure that it has a valid configuration
-function assertIndexProviderValid(indexes: VectorField[], vectors: Neo4jVectorSettings | undefined): void {
+function assertIndexProviderIsValid(indexes: VectorField[], vectors: Neo4jVectorSettings | undefined): void {
     for (const index of indexes) {
         const provider = index?.provider;
         if (provider == null) {

--- a/packages/graphql/src/schema/validation/custom-rules/directives/vector.ts
+++ b/packages/graphql/src/schema/validation/custom-rules/directives/vector.ts
@@ -12,6 +12,7 @@ import type { Neo4jValidationContext } from "../../Neo4jValidationContext";
 import { assertValid, createGraphQLError, DocumentValidationError } from "../utils/document-validation-error";
 import { typeIsANodeType } from "../utils/location-helpers/is-node-type";
 import { getPathToNode } from "../utils/path-parser";
+import { Neo4jVectorSettings } from "src/types";
 
 export function validateVectorDirective(context: Neo4jValidationContext): ASTVisitor {
     const typeMapWithExtensions = context.typeMapWithExtensions;
@@ -42,6 +43,7 @@ export function validateVectorDirective(context: Neo4jValidationContext): ASTVis
                 }
                 for (const vectorDirectiveOnNode of vectorDirectivesOnNode) {
                     assertMaxPhraseLengthIsValid(vectorDirectiveOnNode);
+                    assertIndexProviderValid(vectorDirectiveOnNode, context.vectors);
                 }
             });
             const pathToNode = getPathToNode(path, ancestors);
@@ -56,6 +58,48 @@ export function validateVectorDirective(context: Neo4jValidationContext): ASTVis
             }
         },
     };
+}
+
+// When a provider is specified by an index, ensure that it has a valid configuration
+function assertIndexProviderValid(
+    vectorDirectiveOnNode: DirectiveNode,
+    vectors: Neo4jVectorSettings | undefined
+): void {
+    const indexesArg = vectorDirectiveOnNode.arguments?.find((argument) => argument.name.value === "indexes");
+    if (!indexesArg) {
+        return;
+    }
+
+    const indexes = asArray(parseValueNode(indexesArg.value)) as VectorField[];
+    for (const index of indexes) {
+        const provider = index?.provider;
+        if (provider == null) {
+            continue;
+        }
+
+        if (vectors === undefined) {
+            throw new DocumentValidationError(
+                `@${vectorDirective.name}.indexes specifies a provider, but no vector providers configuration exists.`,
+                ["indexes"]
+            );
+        }
+
+        const providerName = providerIdToName(provider);
+        if (providerName === undefined) {
+            throw new DocumentValidationError(
+                `@${vectorDirective.name}.indexes specifies a provider that doesn't exist in the vector providers configuration.`,
+                ["indexes"]
+            );
+        }
+
+        const providerHasConfig = providerName in vectors;
+        if (!providerHasConfig) {
+            throw new DocumentValidationError(
+                `@${vectorDirective.name}.indexes specifies a provider that doesn't exist in the vector providers configuration.`,
+                ["indexes"]
+            );
+        }
+    }
 }
 
 function assertMaxPhraseLengthIsValid(vectorDirectiveOnNode: DirectiveNode): void {
@@ -83,5 +127,19 @@ function assertMaxPhraseLengthIsValid(vectorDirectiveOnNode: DirectiveNode): voi
                 ["indexes"]
             );
         }
+    }
+}
+
+// Convert provider ID from @vector directive to names expected by user configuration
+function providerIdToName(id: string): string | undefined {
+    switch (id) {
+        case "OPEN_AI":
+            return "OpenAI";
+        case "BEDROCK":
+            return "Bedrock";
+        case "VERTEX_AI":
+            return "VertexAI";
+        case "AZURE_OPEN_AI":
+            return "AzureOpenAI";
     }
 }

--- a/packages/graphql/src/schema/validation/custom-rules/directives/vector.ts
+++ b/packages/graphql/src/schema/validation/custom-rules/directives/vector.ts
@@ -4,9 +4,9 @@
  */
 
 import type { ASTVisitor, ObjectTypeDefinitionNode } from "graphql";
-import { vectorDirective, vectorProviderNames } from "../../../../graphql/directives/vector";
+import { vectorDirective } from "../../../../graphql/directives/vector";
 import type { VectorField } from "../../../../schema-model/annotation/VectorAnnotation";
-import { parseValueNode } from "../../../../schema-model/parser/parse-value-node";
+import { parseArguments } from "../../../../schema-model/parser/parse-arguments";
 import { asArray } from "../../../../utils/utils";
 import type { Neo4jValidationContext } from "../../Neo4jValidationContext";
 import { assertValid, createGraphQLError, DocumentValidationError } from "../utils/document-validation-error";
@@ -42,14 +42,10 @@ export function validateVectorDirective(context: Neo4jValidationContext): ASTVis
                     );
                 }
                 for (const vectorDirectiveOnNode of vectorDirectivesOnNode) {
-                    const indexesArg = vectorDirectiveOnNode.arguments?.find(
-                        (argument) => argument.name.value === "indexes"
+                    const { indexes } = parseArguments<{ indexes: VectorField[] }>(
+                        vectorDirective,
+                        vectorDirectiveOnNode
                     );
-                    if (!indexesArg) {
-                        continue;
-                    }
-
-                    const indexes = asArray(parseValueNode(indexesArg.value)) as VectorField[];
 
                     assertMaxPhraseLengthIsValid(indexes);
                     assertIndexProviderIsValid(indexes, context.vectors);
@@ -84,16 +80,7 @@ function assertIndexProviderIsValid(indexes: VectorField[], vectors: Neo4jVector
             );
         }
 
-        const providerName = vectorProviderNames[provider];
-        if (providerName === undefined) {
-            throw new DocumentValidationError(
-                `@${vectorDirective.name}.indexes specifies a provider that doesn't exist in the vector providers configuration.`,
-                ["indexes"]
-            );
-        }
-
-        const providerHasConfig = providerName in vectors;
-        if (!providerHasConfig) {
+        if (!(provider in vectors)) {
             throw new DocumentValidationError(
                 `@${vectorDirective.name}.indexes specifies a provider that doesn't exist in the vector providers configuration.`,
                 ["indexes"]

--- a/packages/graphql/src/schema/validation/custom-rules/directives/vector.ts
+++ b/packages/graphql/src/schema/validation/custom-rules/directives/vector.ts
@@ -4,7 +4,7 @@
  */
 
 import type { ASTVisitor, ObjectTypeDefinitionNode } from "graphql";
-import { vectorDirective } from "../../../../graphql/directives/vector";
+import { vectorDirective, vectorProviderNames } from "../../../../graphql/directives/vector";
 import type { VectorField } from "../../../../schema-model/annotation/VectorAnnotation";
 import { parseValueNode } from "../../../../schema-model/parser/parse-value-node";
 import { asArray } from "../../../../utils/utils";
@@ -84,7 +84,7 @@ function assertIndexProviderIsValid(indexes: VectorField[], vectors: Neo4jVector
             );
         }
 
-        const providerName = providerIdToName(provider);
+        const providerName = vectorProviderNames[provider];
         if (providerName === undefined) {
             throw new DocumentValidationError(
                 `@${vectorDirective.name}.indexes specifies a provider that doesn't exist in the vector providers configuration.`,
@@ -122,19 +122,5 @@ function assertMaxPhraseLengthIsValid(indexes: VectorField[]): void {
                 ["indexes"]
             );
         }
-    }
-}
-
-// Convert provider ID from @vector directive to names expected by user configuration
-function providerIdToName(id: string): string | undefined {
-    switch (id) {
-        case "OPEN_AI":
-            return "OpenAI";
-        case "BEDROCK":
-            return "Bedrock";
-        case "VERTEX_AI":
-            return "VertexAI";
-        case "AZURE_OPEN_AI":
-            return "AzureOpenAI";
     }
 }

--- a/packages/graphql/src/schema/validation/custom-rules/directives/vector.ts
+++ b/packages/graphql/src/schema/validation/custom-rules/directives/vector.ts
@@ -7,12 +7,12 @@ import type { ASTVisitor, ObjectTypeDefinitionNode } from "graphql";
 import { vectorDirective } from "../../../../graphql/directives/vector";
 import type { VectorField } from "../../../../schema-model/annotation/VectorAnnotation";
 import { parseArguments } from "../../../../schema-model/parser/parse-arguments";
+import type { Neo4jVectorSettings } from "../../../../types";
 import { asArray } from "../../../../utils/utils";
 import type { Neo4jValidationContext } from "../../Neo4jValidationContext";
 import { assertValid, createGraphQLError, DocumentValidationError } from "../utils/document-validation-error";
 import { typeIsANodeType } from "../utils/location-helpers/is-node-type";
 import { getPathToNode } from "../utils/path-parser";
-import { Neo4jVectorSettings } from "../../../../types";
 
 export function validateVectorDirective(context: Neo4jValidationContext): ASTVisitor {
     const typeMapWithExtensions = context.typeMapWithExtensions;

--- a/packages/graphql/src/schema/validation/validate-document.test.ts
+++ b/packages/graphql/src/schema/validation/validate-document.test.ts
@@ -6729,7 +6729,12 @@ describe("validation 2.0", () => {
                 }
             `;
 
-            const executeValidate = () => validateDocument({ document: doc, features: {}, additionalDefinitions });
+            const vector = {
+                OpenAI: { token: "" },
+            };
+
+            const executeValidate = () =>
+                validateDocument({ document: doc, features: { vector: vector }, additionalDefinitions });
             expect(executeValidate).not.toThrow();
         });
 
@@ -6753,7 +6758,12 @@ describe("validation 2.0", () => {
                 }
             `;
 
-            const executeValidate = () => validateDocument({ document: doc, features: {}, additionalDefinitions });
+            const vectors = {
+                OpenAI: { token: "" },
+            };
+
+            const executeValidate = () =>
+                validateDocument({ document: doc, features: { vector: vectors }, additionalDefinitions });
             expect(executeValidate).not.toThrow();
         });
 
@@ -6897,7 +6907,12 @@ describe("validation 2.0", () => {
                     )
             `;
 
-            const executeValidate = () => validateDocument({ document: doc, features: {}, additionalDefinitions });
+            const vectors = {
+                OpenAI: { token: "" },
+            };
+
+            const executeValidate = () =>
+                validateDocument({ document: doc, features: { vector: vectors }, additionalDefinitions });
             expect(executeValidate).not.toThrow();
         });
 
@@ -6985,7 +7000,12 @@ describe("validation 2.0", () => {
                 }
             `;
 
-            const executeValidate = () => validateDocument({ document: doc, features: {}, additionalDefinitions });
+            const vectors = {
+                OpenAI: { token: "" },
+            };
+
+            const executeValidate = () =>
+                validateDocument({ document: doc, features: { vector: vectors }, additionalDefinitions });
             expect(executeValidate).not.toThrow();
         });
 
@@ -7031,7 +7051,12 @@ describe("validation 2.0", () => {
                 }
             `;
 
-            const executeValidate = () => validateDocument({ document: doc, features: {}, additionalDefinitions });
+            const vectors = {
+                OpenAI: { token: "" },
+            };
+
+            const executeValidate = () =>
+                validateDocument({ document: doc, features: { vector: vectors }, additionalDefinitions });
 
             const errors = getError(executeValidate);
 
@@ -7072,6 +7097,78 @@ describe("validation 2.0", () => {
             expect(errors[0]).toHaveProperty(
                 "message",
                 "@vector.indexes maxPhraseLength can only be set on an index with a provider (used for query by phrase)."
+            );
+            expect(errors[0]).toHaveProperty("path", ["User", "indexes"]);
+        });
+
+        test("invalid when provider is specified with no vector configurations in features", () => {
+            const doc = gql`
+                type User
+                    @node
+                    @vector(
+                        indexes: [
+                            {
+                                indexName: "UserIndex"
+                                embeddingProperty: "embedding"
+                                queryName: "userQuery"
+                                provider: OPEN_AI
+                            }
+                        ]
+                    ) {
+                    id: ID
+                    name: String
+                }
+            `;
+
+            const executeValidate = () => validateDocument({ document: doc, features: {}, additionalDefinitions });
+
+            const errors = getError(executeValidate);
+
+            expect(errors).toHaveLength(1);
+            expect(errors[0]).not.toBeInstanceOf(NoErrorThrownError);
+            expect(errors[0]).toHaveProperty(
+                "message",
+                "@vector.indexes specifies a provider, but no vector providers configuration exists."
+            );
+            expect(errors[0]).toHaveProperty("path", ["User", "indexes"]);
+        });
+
+        test("invalid when provider is specified without its provider present within vector configuration in features", () => {
+            const doc = gql`
+                type User
+                    @node
+                    @vector(
+                        indexes: [
+                            {
+                                indexName: "UserIndex"
+                                embeddingProperty: "embedding"
+                                queryName: "userQuery"
+                                provider: OPEN_AI
+                            }
+                        ]
+                    ) {
+                    id: ID
+                    name: String
+                }
+            `;
+
+            const vector = {
+                Bedrock: {
+                    accessKeyId: "",
+                    secretAccessKey: "",
+                },
+            };
+
+            const executeValidate = () =>
+                validateDocument({ document: doc, features: { vector: vector }, additionalDefinitions });
+
+            const errors = getError(executeValidate);
+
+            expect(errors).toHaveLength(1);
+            expect(errors[0]).not.toBeInstanceOf(NoErrorThrownError);
+            expect(errors[0]).toHaveProperty(
+                "message",
+                "@vector.indexes specifies a provider that doesn't exist in the vector providers configuration."
             );
             expect(errors[0]).toHaveProperty("path", ["User", "indexes"]);
         });

--- a/packages/graphql/src/schema/validation/validate-document.test.ts
+++ b/packages/graphql/src/schema/validation/validate-document.test.ts
@@ -6758,12 +6758,12 @@ describe("validation 2.0", () => {
                 }
             `;
 
-            const vectors = {
+            const vector = {
                 OpenAI: { token: "" },
             };
 
             const executeValidate = () =>
-                validateDocument({ document: doc, features: { vector: vectors }, additionalDefinitions });
+                validateDocument({ document: doc, features: { vector: vector }, additionalDefinitions });
             expect(executeValidate).not.toThrow();
         });
 
@@ -6907,12 +6907,12 @@ describe("validation 2.0", () => {
                     )
             `;
 
-            const vectors = {
+            const vector = {
                 OpenAI: { token: "" },
             };
 
             const executeValidate = () =>
-                validateDocument({ document: doc, features: { vector: vectors }, additionalDefinitions });
+                validateDocument({ document: doc, features: { vector: vector }, additionalDefinitions });
             expect(executeValidate).not.toThrow();
         });
 
@@ -7000,12 +7000,12 @@ describe("validation 2.0", () => {
                 }
             `;
 
-            const vectors = {
+            const vector = {
                 OpenAI: { token: "" },
             };
 
             const executeValidate = () =>
-                validateDocument({ document: doc, features: { vector: vectors }, additionalDefinitions });
+                validateDocument({ document: doc, features: { vector: vector }, additionalDefinitions });
             expect(executeValidate).not.toThrow();
         });
 
@@ -7051,12 +7051,12 @@ describe("validation 2.0", () => {
                 }
             `;
 
-            const vectors = {
+            const vector = {
                 OpenAI: { token: "" },
             };
 
             const executeValidate = () =>
-                validateDocument({ document: doc, features: { vector: vectors }, additionalDefinitions });
+                validateDocument({ document: doc, features: { vector: vector }, additionalDefinitions });
 
             const errors = getError(executeValidate);
 

--- a/packages/graphql/src/schema/validation/validate-document.test.ts
+++ b/packages/graphql/src/schema/validation/validate-document.test.ts
@@ -6729,12 +6729,12 @@ describe("validation 2.0", () => {
                 }
             `;
 
-            const vector = {
+            const vectorSettings = {
                 OpenAI: { token: "" },
             };
 
             const executeValidate = () =>
-                validateDocument({ document: doc, features: { vector: vector }, additionalDefinitions });
+                validateDocument({ document: doc, features: { vector: vectorSettings }, additionalDefinitions });
             expect(executeValidate).not.toThrow();
         });
 
@@ -6758,12 +6758,12 @@ describe("validation 2.0", () => {
                 }
             `;
 
-            const vector = {
+            const vectorSettings = {
                 OpenAI: { token: "" },
             };
 
             const executeValidate = () =>
-                validateDocument({ document: doc, features: { vector: vector }, additionalDefinitions });
+                validateDocument({ document: doc, features: { vector: vectorSettings }, additionalDefinitions });
             expect(executeValidate).not.toThrow();
         });
 
@@ -6907,12 +6907,12 @@ describe("validation 2.0", () => {
                     )
             `;
 
-            const vector = {
+            const vectorSettings = {
                 OpenAI: { token: "" },
             };
 
             const executeValidate = () =>
-                validateDocument({ document: doc, features: { vector: vector }, additionalDefinitions });
+                validateDocument({ document: doc, features: { vector: vectorSettings }, additionalDefinitions });
             expect(executeValidate).not.toThrow();
         });
 
@@ -7000,12 +7000,12 @@ describe("validation 2.0", () => {
                 }
             `;
 
-            const vector = {
+            const vectorSettings = {
                 OpenAI: { token: "" },
             };
 
             const executeValidate = () =>
-                validateDocument({ document: doc, features: { vector: vector }, additionalDefinitions });
+                validateDocument({ document: doc, features: { vector: vectorSettings }, additionalDefinitions });
             expect(executeValidate).not.toThrow();
         });
 
@@ -7051,12 +7051,12 @@ describe("validation 2.0", () => {
                 }
             `;
 
-            const vector = {
+            const vectorSettings = {
                 OpenAI: { token: "" },
             };
 
             const executeValidate = () =>
-                validateDocument({ document: doc, features: { vector: vector }, additionalDefinitions });
+                validateDocument({ document: doc, features: { vector: vectorSettings }, additionalDefinitions });
 
             const errors = getError(executeValidate);
 
@@ -7152,7 +7152,7 @@ describe("validation 2.0", () => {
                 }
             `;
 
-            const vector = {
+            const vectorSettings = {
                 Bedrock: {
                     accessKeyId: "",
                     secretAccessKey: "",
@@ -7160,7 +7160,7 @@ describe("validation 2.0", () => {
             };
 
             const executeValidate = () =>
-                validateDocument({ document: doc, features: { vector: vector }, additionalDefinitions });
+                validateDocument({ document: doc, features: { vector: vectorSettings }, additionalDefinitions });
 
             const errors = getError(executeValidate);
 

--- a/packages/graphql/src/schema/validation/validate-document.ts
+++ b/packages/graphql/src/schema/validation/validate-document.ts
@@ -249,7 +249,8 @@ function runValidationRulesOnFilteredDocument({
             validateGroupByDirective,
         ],
         schema,
-        features?.populatedBy?.callbacks
+        features?.populatedBy?.callbacks,
+        features?.vector
     );
     const filteredErrors = errors.filter((e) => e.message !== "Query root type must be provided.");
     if (filteredErrors.length) {

--- a/packages/graphql/src/schema/validation/validate-sdl.ts
+++ b/packages/graphql/src/schema/validation/validate-sdl.ts
@@ -7,7 +7,7 @@ import type { Maybe } from "@graphql-tools/utils";
 import type { ASTVisitor, DocumentNode, GraphQLError, GraphQLSchema } from "graphql";
 import { visit, visitInParallel } from "graphql";
 import type { SDLValidationContext } from "graphql/validation/ValidationContext";
-import type { Neo4jGraphQLCallbacks } from "../../types";
+import type { Neo4jGraphQLCallbacks, Neo4jVectorSettings } from "../../types";
 import { Neo4jValidationContext } from "./Neo4jValidationContext";
 import { mapError } from "./utils/map-error";
 
@@ -17,7 +17,8 @@ export function validateSDL(
     documentAST: DocumentNode,
     rules: ReadonlyArray<Neo4jValidationRule>,
     schemaToExtend?: Maybe<GraphQLSchema>,
-    callbacks?: Neo4jGraphQLCallbacks
+    callbacks?: Neo4jGraphQLCallbacks,
+    vectors?: Neo4jVectorSettings
 ): ReadonlyArray<GraphQLError> {
     const errors: Array<GraphQLError> = [];
     const context = new Neo4jValidationContext(
@@ -27,7 +28,8 @@ export function validateSDL(
             const mappedError = mapError(error);
             errors.push(mappedError);
         },
-        callbacks
+        callbacks,
+        vectors
     );
     const visitors = rules.map((rule) => rule(context));
     visit(documentAST, visitInParallel(visitors));


### PR DESCRIPTION
# Description

Currently, you can specify a provider in a `@vector` index that hasn't been configured in `features`, and this doesn't surface as an error until a request is made to the server.

This change ensures that when the schema is validated, missing provider configurations throw an error.
## Complexity

Complexity: Low

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
