### PR TITLE
Fix source auth not applied correctly on create relationship

### DIFF
--- a/.changeset/nine-sheep.md
+++ b/.changeset/nine-sheep.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+Fix authorization rules not applied correctly on create relationship

--- a/packages/graphql/src/translate/queryAST/ast/operations/ConnectOperation.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/ConnectOperation.ts
@@ -136,23 +136,10 @@ export class ConnectOperation extends MutationOperation {
         });
 
         const filterSubqueries = wrapSubqueriesInCypherCalls(nestedContext, this.filters, [nestedContext.target]);
-        filterSubqueries.push(
-            ...this.authFilters
-                .flatMap((authFilter) => {
-                    return authFilter.getSubqueriesBefore(nestedContext);
-                })
-                .map((sq) => {
-                    return new Cypher.Call(sq, [nestedContext.target]);
-                })
-        );
-        const afterFilterSubqueries: Cypher.Clause[] = [...this.authFilters, ...this.sourceAuthFilters]
-            .flatMap((authFilter) => {
-                const authSubqueries = authFilter.getSubqueriesAfter(nestedContext);
-                return authSubqueries;
-            })
-            .map((sq) => {
-                return new Cypher.Call(sq, [nestedContext.target]);
-            });
+        filterSubqueries.push(...this.getFiltersSubqueries(this.authFilters, "BEFORE", nestedContext));
+
+        const afterFilterSubqueries = this.getFiltersSubqueries(this.authFilters, "AFTER", nestedContext);
+        afterFilterSubqueries.push(...this.getFiltersSubqueries(this.sourceAuthFilters, "AFTER", context));
         if (afterFilterSubqueries.length > 0) {
             afterFilterSubqueries.unshift(new Cypher.With("*"));
         }
@@ -207,6 +194,24 @@ export class ConnectOperation extends MutationOperation {
             projectionExpr: context.returnVariable,
             clauses: [callClause],
         };
+    }
+
+    private getFiltersSubqueries(
+        filters: AuthorizationFilters[],
+        when: "BEFORE" | "AFTER",
+        context: QueryASTContext<Cypher.Node>
+    ): Cypher.Clause[] {
+        return filters
+            .flatMap((authFilter) => {
+                if (when === "BEFORE") {
+                    return authFilter.getSubqueriesBefore(context);
+                }
+
+                return authFilter.getSubqueriesAfter(context);
+            })
+            .map((sq) => {
+                return new Cypher.Call(sq, [context.target]);
+            });
     }
 
     private getAuthorizationClauses(context: QueryASTContext): Cypher.Clause[] {

--- a/packages/graphql/tests/integration/issues/7372.int.test.ts
+++ b/packages/graphql/tests/integration/issues/7372.int.test.ts
@@ -1,0 +1,298 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { UniqueType } from "../../utils/graphql-types";
+import { TestHelper } from "../../utils/tests-helper";
+
+describe("https://github.com/neo4j/graphql/issues/7372", () => {
+    let ProductClass: UniqueType;
+    let ProductClassSystem: UniqueType;
+
+    const testHelper = new TestHelper();
+
+    beforeAll(async () => {
+        ProductClass = testHelper.createUniqueType("ProductClass");
+        ProductClassSystem = testHelper.createUniqueType("ProductClassSystem");
+
+        const typeDefs = /* GraphQL */ `
+            type ${ProductClass}
+                @mutation(operations: [CREATE, DELETE, UPDATE])
+                @authorization(
+                    validate: [
+                        {
+                            requireAuthentication: false
+                            operations: [UPDATE]
+                            when: [BEFORE, AFTER]
+                            where: { node: { _hasAccess_UPDATE: { eq: true } } }
+                        }
+                        {
+                            requireAuthentication: false
+                            operations: [CREATE_RELATIONSHIP]
+                            when: [AFTER]
+                            where: { node: { _hasAccess_CREATE_RELATIONSHIP: { eq: true } } }
+                        }
+                        {
+                            requireAuthentication: false
+                            operations: [DELETE]
+                            when: [BEFORE]
+                            where: { node: { _hasAccess_DELETE: { eq: true } } }
+                        }
+                        {
+                            requireAuthentication: false
+                            operations: [DELETE_RELATIONSHIP]
+                            when: [BEFORE, AFTER]
+                            where: { node: { _hasAccess_DELETE_RELATIONSHIP: { eq: true } } }
+                        }
+                    ]
+                )
+                @node
+                @subscription(events: []) {
+                _hasAccess_CREATE_RELATIONSHIP: Boolean!
+                    @selectable(onRead: false, onAggregate: false)
+                    @filterable(byValue: true, byAggregate: false)
+                    @sortable(byValue: false)
+                    @cypher(
+                        statement: """
+                        RETURN COALESCE(
+                        	(
+                        		this.createdByApiUserName = 'test'
+                        	),
+                        	false
+                        )
+                        AS result
+                        """
+                        columnName: "result"
+                    )
+                _hasAccess_DELETE: Boolean!
+                    @selectable(onRead: false, onAggregate: false)
+                    @filterable(byValue: true, byAggregate: false)
+                    @sortable(byValue: false)
+                    @cypher(
+                        statement: """
+                        RETURN COALESCE(
+                        	(
+                        		this.createdByApiUserName = 'test'
+                        	),
+                        	false
+                        )
+                        AS result
+                        """
+                        columnName: "result"
+                    )
+                _hasAccess_DELETE_RELATIONSHIP: Boolean!
+                    @selectable(onRead: false, onAggregate: false)
+                    @filterable(byValue: true, byAggregate: false)
+                    @sortable(byValue: false)
+                    @cypher(
+                        statement: """
+                        RETURN COALESCE(
+                        	(
+                        		this.createdByApiUserName = 'test'
+                        	),
+                        	false
+                        )
+                        AS result
+                        """
+                        columnName: "result"
+                    )
+                _hasAccess_UPDATE: Boolean!
+                    @selectable(onRead: false, onAggregate: false)
+                    @filterable(byValue: true, byAggregate: false)
+                    @sortable(byValue: false)
+                    @cypher(
+                        statement: """
+                        RETURN COALESCE(
+                        	(
+                        		this.createdByApiUserName = 'test'
+                        	),
+                        	false
+                        )
+                        AS result
+                        """
+                        columnName: "result"
+                    )
+
+                createdByApiUserName: String
+                id: Int
+                productClassSystem: [${ProductClassSystem}!]!
+                    @relationship(
+                        type: "PRODUCTCLASSSYSTEM_HAS_PRODUCTCLASS"
+                        direction: IN
+                        nestedOperations: [CONNECT, DISCONNECT]
+                        queryDirection: DIRECTED
+                    )
+            }
+
+            type ${ProductClassSystem}
+                @mutation(operations: [UPDATE])
+                @authorization(
+                    validate: [
+                        {
+                            requireAuthentication: false
+                            operations: [DELETE_RELATIONSHIP]
+                            when: [BEFORE, AFTER]
+                            where: { node: { _hasAccess_DELETE_RELATIONSHIP: { eq: true } } }
+                        }
+                        {
+                            requireAuthentication: false
+                            operations: [CREATE_RELATIONSHIP]
+                            when: [AFTER]
+                            where: { node: { _hasAccess_CREATE_RELATIONSHIP: { eq: true } } }
+                        }
+                    ]
+                )
+                @node
+                @subscription(events: []) {
+                _hasAccess_CREATE_RELATIONSHIP: Boolean!
+                    @selectable(onRead: false, onAggregate: false)
+                    @filterable(byValue: true, byAggregate: false)
+                    @sortable(byValue: false)
+                    @cypher(
+                        statement: """
+                        RETURN COALESCE(
+                        	(
+                        			EXISTS {
+                        				WITH this
+                        				WHERE this.id IN [123, 456]
+                        			}
+                        	),
+                        	false
+                        )
+                        AS result
+                        """
+                        columnName: "result"
+                    )
+                _hasAccess_DELETE_RELATIONSHIP: Boolean!
+                    @selectable(onRead: false, onAggregate: false)
+                    @filterable(byValue: true, byAggregate: false)
+                    @sortable(byValue: false)
+                    @cypher(
+                        statement: """
+                        RETURN COALESCE(
+                        	(
+                        			EXISTS {
+                        				WITH this
+                        				WHERE this.id IN [123, 456]
+                        			}
+                        	),
+                        	false
+                        )
+                        AS result
+                        """
+                        columnName: "result"
+                    )
+                id: Int!
+                productClasses: [${ProductClass}!]!
+                    @relationship(
+                        type: "PRODUCTCLASSSYSTEM_HAS_PRODUCTCLASS"
+                        direction: OUT
+                        nestedOperations: [CREATE, UPDATE, DELETE, CONNECT, DISCONNECT]
+                        queryDirection: DIRECTED
+                    )
+            }
+        `;
+        await testHelper.initNeo4jGraphQL({
+            typeDefs,
+            features: {
+                authorization: {
+                    key: "secret",
+                },
+            },
+        });
+    });
+
+    afterAll(async () => {
+        await testHelper.close();
+    });
+
+    test("should create node and relationship", async () => {
+        const query = /* GraphQL */ `
+           mutation {
+                ${ProductClass.operations.create}(
+                    input: [
+                        {
+                            id: 1
+                            createdByApiUserName: "test"
+                            productClassSystem: {
+                                connect: [{ where: { node: { id: { eq: 123 } } } }]
+                            }
+                        }
+                    ]
+                ) {
+                    info {
+                        nodesCreated
+                        relationshipsCreated
+                    }
+                }
+           }
+        `;
+
+        await testHelper.executeCypher(`
+            CREATE (:${ProductClassSystem} {id: 123})
+        `);
+
+        const result = await testHelper.executeGraphQL(query);
+
+        expect(result.errors).toBeFalsy();
+        expect(result?.data?.[ProductClass.operations.create]).toEqual({
+            info: {
+                nodesCreated: 1,
+                relationshipsCreated: 1,
+            },
+        });
+
+        await testHelper.expectNode(ProductClass).toEqual([
+            {
+                createdByApiUserName: "test",
+                id: 1,
+            },
+        ]);
+    });
+
+    test("should throw", async () => {
+        const query = /* GraphQL */ `
+           mutation {
+                ${ProductClass.operations.create}(
+                    input: [
+                        {
+                            id: 1
+                            createdByApiUserName: "test"
+                            productClassSystem: {
+                                connect: [{ where: { node: { id: { eq: 1 } } } }]
+                            }
+                        }
+                    ]
+                ) {
+                    info {
+                        nodesCreated
+                        relationshipsCreated
+                    }
+                }
+           }
+        `;
+
+        await testHelper.executeCypher(`
+            CREATE (:${ProductClassSystem} {id: 1})
+        `);
+
+        const result = await testHelper.executeGraphQL(query);
+
+        expect((result.errors as any[])[0].message).toBe("Forbidden");
+    });
+});

--- a/packages/graphql/tests/tck/issues/7293.test.ts
+++ b/packages/graphql/tests/tck/issues/7293.test.ts
@@ -156,9 +156,9 @@ describe("https://github.com/neo4j/graphql/issues/7293", () => {
                   WITH result AS this4
                   RETURN this4 AS var5
                 }
-                CALL (this0) {
-                  CALL (this0) {
-                    WITH this0 AS this
+                CALL (this) {
+                  CALL (this) {
+                    WITH this AS this
                     RETURN \\"countryCreateRelationship\\" as result
                   }
                   WITH result AS this6
@@ -302,9 +302,9 @@ describe("https://github.com/neo4j/graphql/issues/7293", () => {
                   WITH result AS this5
                   RETURN this5 AS var6
                 }
-                CALL (this1) {
-                  CALL (this1) {
-                    WITH this1 AS this
+                CALL (this0) {
+                  CALL (this0) {
+                    WITH this0 AS this
                     RETURN \\"countryCreateRelationship\\" as result
                   }
                   WITH result AS this7


### PR DESCRIPTION
# Description

Authorization validation rule AFTER on create relationship is erroneously taking the target node instead of source node for validation subqueries.

## Complexity

Complexity: Low

# Issue

Closes #7372

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
