### PR TITLE
Fix source auth not applied correctly on disconnect relationship

### DIFF
--- a/.changeset/empty-regions-poke.md
+++ b/.changeset/empty-regions-poke.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+Fix source authorization rules not applied to the source node on delete relationship

--- a/packages/graphql/src/translate/queryAST/ast/operations/ConnectOperation.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/ConnectOperation.ts
@@ -10,7 +10,7 @@ import { filterTruthy } from "../../../../utils/utils";
 import { checkEntityAuthentication } from "../../../authorization/check-authentication";
 import { getEntityLabels } from "../../utils/create-node-from-entity";
 import { isConcreteEntity } from "../../utils/is-concrete-entity";
-import { wrapSubqueriesInCypherCalls } from "../../utils/wrap-subquery-in-calls";
+import { wrapAuthFiltersInCypherCalls, wrapSubqueriesInCypherCalls } from "../../utils/wrap-subquery-in-calls";
 import type { QueryASTContext } from "../QueryASTContext";
 import type { QueryASTNode } from "../QueryASTNode";
 import type { Filter } from "../filters/Filter";
@@ -136,10 +136,10 @@ export class ConnectOperation extends MutationOperation {
         });
 
         const filterSubqueries = wrapSubqueriesInCypherCalls(nestedContext, this.filters, [nestedContext.target]);
-        filterSubqueries.push(...this.getFiltersSubqueries(this.authFilters, "BEFORE", nestedContext));
+        filterSubqueries.push(...wrapAuthFiltersInCypherCalls(this.authFilters, "BEFORE", nestedContext));
 
-        const afterFilterSubqueries = this.getFiltersSubqueries(this.authFilters, "AFTER", nestedContext);
-        afterFilterSubqueries.push(...this.getFiltersSubqueries(this.sourceAuthFilters, "AFTER", context));
+        const afterFilterSubqueries = wrapAuthFiltersInCypherCalls(this.authFilters, "AFTER", nestedContext);
+        afterFilterSubqueries.push(...wrapAuthFiltersInCypherCalls(this.sourceAuthFilters, "AFTER", context));
         if (afterFilterSubqueries.length > 0) {
             afterFilterSubqueries.unshift(new Cypher.With("*"));
         }
@@ -194,24 +194,6 @@ export class ConnectOperation extends MutationOperation {
             projectionExpr: context.returnVariable,
             clauses: [callClause],
         };
-    }
-
-    private getFiltersSubqueries(
-        filters: AuthorizationFilters[],
-        when: "BEFORE" | "AFTER",
-        context: QueryASTContext<Cypher.Node>
-    ): Cypher.Clause[] {
-        return filters
-            .flatMap((authFilter) => {
-                if (when === "BEFORE") {
-                    return authFilter.getSubqueriesBefore(context);
-                }
-
-                return authFilter.getSubqueriesAfter(context);
-            })
-            .map((sq) => {
-                return new Cypher.Call(sq, [context.target]);
-            });
     }
 
     private getAuthorizationClauses(context: QueryASTContext): Cypher.Clause[] {

--- a/packages/graphql/src/translate/queryAST/ast/operations/DisconnectOperation.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/DisconnectOperation.ts
@@ -134,31 +134,12 @@ export class DisconnectOperation extends MutationOperation {
 
         const filterSubqueries = wrapSubqueriesInCypherCalls(nestedContext, this.filters, [nestedContext.target]);
         filterSubqueries.push(
-            ...this.authFilters
-                .flatMap((authFilter) => {
-                    const authSubqueries = authFilter.getSubqueriesBefore(nestedContext);
-                    return authSubqueries;
-                })
-                .map((sq) => {
-                    return new Cypher.Call(sq, [nestedContext.target]);
-                }),
-            ...this.sourceAuthFilters
-                .flatMap((authFilter) => {
-                    const authSubqueries = authFilter.getSubqueriesBefore(context);
-                    return authSubqueries;
-                })
-                .map((sq) => {
-                    return new Cypher.Call(sq, [context.target]);
-                })
+            ...this.getFiltersSubqueries(this.authFilters, "BEFORE", nestedContext),
+            ...this.getFiltersSubqueries(this.sourceAuthFilters, "BEFORE", context)
         );
-        const afterFilterSubqueries: Cypher.Clause[] = [...this.authFilters, ...this.sourceAuthFilters]
-            .flatMap((authFilter) => {
-                const authSubqueries = authFilter.getSubqueriesAfter(nestedContext);
-                return authSubqueries;
-            })
-            .map((sq) => {
-                return new Cypher.Call(sq, [nestedContext.target]);
-            });
+
+        const afterFilterSubqueries = this.getFiltersSubqueries(this.authFilters, "AFTER", nestedContext);
+        afterFilterSubqueries.push(...this.getFiltersSubqueries(this.sourceAuthFilters, "AFTER", context));
         if (afterFilterSubqueries.length > 0) {
             afterFilterSubqueries.unshift(new Cypher.With("*"));
         }
@@ -204,6 +185,24 @@ export class DisconnectOperation extends MutationOperation {
             projectionExpr: context.returnVariable,
             clauses: [callClause],
         };
+    }
+
+    private getFiltersSubqueries(
+        filters: AuthorizationFilters[],
+        when: "BEFORE" | "AFTER",
+        context: QueryASTContext<Cypher.Node>
+    ): Cypher.Clause[] {
+        return filters
+            .flatMap((authFilter) => {
+                if (when === "BEFORE") {
+                    return authFilter.getSubqueriesBefore(context);
+                }
+
+                return authFilter.getSubqueriesAfter(context);
+            })
+            .map((sq) => {
+                return new Cypher.Call(sq, [context.target]);
+            });
     }
 
     private getAuthorizationClauses(context: QueryASTContext): Cypher.Clause[] {

--- a/packages/graphql/src/translate/queryAST/ast/operations/DisconnectOperation.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/DisconnectOperation.ts
@@ -9,7 +9,7 @@ import type { RelationshipAdapter } from "../../../../schema-model/relationship/
 import { filterTruthy } from "../../../../utils/utils";
 import { checkEntityAuthentication } from "../../../authorization/check-authentication";
 import { isConcreteEntity } from "../../utils/is-concrete-entity";
-import { wrapSubqueriesInCypherCalls } from "../../utils/wrap-subquery-in-calls";
+import { wrapAuthFiltersInCypherCalls, wrapSubqueriesInCypherCalls } from "../../utils/wrap-subquery-in-calls";
 import type { QueryASTContext } from "../QueryASTContext";
 import type { QueryASTNode } from "../QueryASTNode";
 import type { Filter } from "../filters/Filter";
@@ -134,12 +134,12 @@ export class DisconnectOperation extends MutationOperation {
 
         const filterSubqueries = wrapSubqueriesInCypherCalls(nestedContext, this.filters, [nestedContext.target]);
         filterSubqueries.push(
-            ...this.getFiltersSubqueries(this.authFilters, "BEFORE", nestedContext),
-            ...this.getFiltersSubqueries(this.sourceAuthFilters, "BEFORE", context)
+            ...wrapAuthFiltersInCypherCalls(this.authFilters, "BEFORE", nestedContext),
+            ...wrapAuthFiltersInCypherCalls(this.sourceAuthFilters, "BEFORE", context)
         );
 
-        const afterFilterSubqueries = this.getFiltersSubqueries(this.authFilters, "AFTER", nestedContext);
-        afterFilterSubqueries.push(...this.getFiltersSubqueries(this.sourceAuthFilters, "AFTER", context));
+        const afterFilterSubqueries = wrapAuthFiltersInCypherCalls(this.authFilters, "AFTER", nestedContext);
+        afterFilterSubqueries.push(...wrapAuthFiltersInCypherCalls(this.sourceAuthFilters, "AFTER", context));
         if (afterFilterSubqueries.length > 0) {
             afterFilterSubqueries.unshift(new Cypher.With("*"));
         }
@@ -185,24 +185,6 @@ export class DisconnectOperation extends MutationOperation {
             projectionExpr: context.returnVariable,
             clauses: [callClause],
         };
-    }
-
-    private getFiltersSubqueries(
-        filters: AuthorizationFilters[],
-        when: "BEFORE" | "AFTER",
-        context: QueryASTContext<Cypher.Node>
-    ): Cypher.Clause[] {
-        return filters
-            .flatMap((authFilter) => {
-                if (when === "BEFORE") {
-                    return authFilter.getSubqueriesBefore(context);
-                }
-
-                return authFilter.getSubqueriesAfter(context);
-            })
-            .map((sq) => {
-                return new Cypher.Call(sq, [context.target]);
-            });
     }
 
     private getAuthorizationClauses(context: QueryASTContext): Cypher.Clause[] {

--- a/packages/graphql/src/translate/queryAST/utils/wrap-subquery-in-calls.ts
+++ b/packages/graphql/src/translate/queryAST/utils/wrap-subquery-in-calls.ts
@@ -7,6 +7,7 @@ import Cypher from "@neo4j/cypher-builder";
 import { filterTruthy } from "../../../utils/utils";
 import type { QueryASTContext } from "../ast/QueryASTContext";
 import type { QueryASTNode } from "../ast/QueryASTNode";
+import type { AuthorizationFilters } from "../ast/filters/authorization-filters/AuthorizationFilters";
 
 /** Gets subqueries from fields and map these to Call statements with inner target */
 export function wrapSubqueriesInCypherCalls(
@@ -21,4 +22,23 @@ export function wrapSubqueriesInCypherCalls(
     ).map((sq) => {
         return new Cypher.Call(sq, withArgs);
     });
+}
+
+/** Gets the BEFORE or AFTER subqueries from authorization filters and maps these to Call statements with the context target */
+export function wrapAuthFiltersInCypherCalls(
+    filters: AuthorizationFilters[],
+    when: "BEFORE" | "AFTER",
+    context: QueryASTContext<Cypher.Node>
+): Cypher.Clause[] {
+    return filters
+        .flatMap((authFilter) => {
+            if (when === "BEFORE") {
+                return authFilter.getSubqueriesBefore(context);
+            }
+
+            return authFilter.getSubqueriesAfter(context);
+        })
+        .map((sq) => {
+            return new Cypher.Call(sq, [context.target]);
+        });
 }

--- a/packages/graphql/tests/integration/issues/7376.int.test.ts
+++ b/packages/graphql/tests/integration/issues/7376.int.test.ts
@@ -1,0 +1,348 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { UniqueType } from "../../utils/graphql-types";
+import { TestHelper } from "../../utils/tests-helper";
+
+describe("https://github.com/neo4j/graphql/issues/7376", () => {
+    let ProductClass: UniqueType;
+    let ProductClassSystem: UniqueType;
+
+    const testHelper = new TestHelper();
+
+    beforeAll(async () => {
+        ProductClass = testHelper.createUniqueType("ProductClass");
+        ProductClassSystem = testHelper.createUniqueType("ProductClassSystem");
+
+        const typeDefs = /* GraphQL */ `
+            type ${ProductClass}
+                @mutation(operations: [CREATE, DELETE, UPDATE])
+                @authorization(
+                    validate: [
+                        {
+                            requireAuthentication: false
+                            operations: [UPDATE]
+                            when: [BEFORE, AFTER]
+                            where: { node: { _hasAccess_UPDATE: { eq: true } } }
+                        }
+                        {
+                            requireAuthentication: false
+                            operations: [CREATE_RELATIONSHIP]
+                            when: [AFTER]
+                            where: { node: { _hasAccess_CREATE_RELATIONSHIP: { eq: true } } }
+                        }
+                        {
+                            requireAuthentication: false
+                            operations: [DELETE]
+                            when: [BEFORE]
+                            where: { node: { _hasAccess_DELETE: { eq: true } } }
+                        }
+                        {
+                            requireAuthentication: false
+                            operations: [DELETE_RELATIONSHIP]
+                            when: [BEFORE, AFTER]
+                            where: { node: { _hasAccess_DELETE_RELATIONSHIP: { eq: true } } }
+                        }
+                    ]
+                )
+                @node
+                @subscription(events: []) {
+                _hasAccess_CREATE_RELATIONSHIP: Boolean!
+                    @selectable(onRead: false, onAggregate: false)
+                    @filterable(byValue: true, byAggregate: false)
+                    @sortable(byValue: false)
+                    @cypher(
+                        statement: """
+                        RETURN COALESCE(
+                        	(
+                        		this.createdByApiUserName = 'test'
+                        	),
+                        	false
+                        )
+                        AS result
+                        """
+                        columnName: "result"
+                    )
+                _hasAccess_DELETE: Boolean!
+                    @selectable(onRead: false, onAggregate: false)
+                    @filterable(byValue: true, byAggregate: false)
+                    @sortable(byValue: false)
+                    @cypher(
+                        statement: """
+                        RETURN COALESCE(
+                        	(
+                        		this.createdByApiUserName = 'test'
+                        	),
+                        	false
+                        )
+                        AS result
+                        """
+                        columnName: "result"
+                    )
+                _hasAccess_DELETE_RELATIONSHIP: Boolean!
+                    @selectable(onRead: false, onAggregate: false)
+                    @filterable(byValue: true, byAggregate: false)
+                    @sortable(byValue: false)
+                    @cypher(
+                        statement: """
+                        RETURN COALESCE(
+                        	(
+                        		this.createdByApiUserName = 'test'
+                        	),
+                        	false
+                        )
+                        AS result
+                        """
+                        columnName: "result"
+                    )
+                _hasAccess_UPDATE: Boolean!
+                    @selectable(onRead: false, onAggregate: false)
+                    @filterable(byValue: true, byAggregate: false)
+                    @sortable(byValue: false)
+                    @cypher(
+                        statement: """
+                        RETURN COALESCE(
+                        	(
+                        		this.createdByApiUserName = 'test'
+                        	),
+                        	false
+                        )
+                        AS result
+                        """
+                        columnName: "result"
+                    )
+
+                createdByApiUserName: String
+                id: Int
+                productClassSystem: [${ProductClassSystem}!]!
+                    @relationship(
+                        type: "PRODUCTCLASSSYSTEM_HAS_PRODUCTCLASS"
+                        direction: IN
+                        nestedOperations: [CONNECT, DISCONNECT]
+                        queryDirection: DIRECTED
+                    )
+            }
+
+            type ${ProductClassSystem}
+                @mutation(operations: [UPDATE])
+                @authorization(
+                    validate: [
+                        {
+                            requireAuthentication: false
+                            operations: [DELETE_RELATIONSHIP]
+                            when: [BEFORE, AFTER]
+                            where: { node: { _hasAccess_DELETE_RELATIONSHIP: { eq: true } } }
+                        }
+                        {
+                            requireAuthentication: false
+                            operations: [CREATE_RELATIONSHIP]
+                            when: [AFTER]
+                            where: { node: { _hasAccess_CREATE_RELATIONSHIP: { eq: true } } }
+                        }
+                    ]
+                )
+                @node
+                @subscription(events: []) {
+                _hasAccess_CREATE_RELATIONSHIP: Boolean!
+                    @selectable(onRead: false, onAggregate: false)
+                    @filterable(byValue: true, byAggregate: false)
+                    @sortable(byValue: false)
+                    @cypher(
+                        statement: """
+                        RETURN COALESCE(
+                        	(
+                        			EXISTS {
+                        				WITH this
+                        				WHERE this.id IN [123, 456]
+                        			}
+                        	),
+                        	false
+                        )
+                        AS result
+                        """
+                        columnName: "result"
+                    )
+                _hasAccess_DELETE_RELATIONSHIP: Boolean!
+                    @selectable(onRead: false, onAggregate: false)
+                    @filterable(byValue: true, byAggregate: false)
+                    @sortable(byValue: false)
+                    @cypher(
+                        statement: """
+                        RETURN COALESCE(
+                        	(
+                        			EXISTS {
+                        				WITH this
+                        				WHERE this.id IN [123, 456]
+                        			}
+                        	),
+                        	false
+                        )
+                        AS result
+                        """
+                        columnName: "result"
+                    )
+                id: Int!
+                productClasses: [${ProductClass}!]!
+                    @relationship(
+                        type: "PRODUCTCLASSSYSTEM_HAS_PRODUCTCLASS"
+                        direction: OUT
+                        nestedOperations: [CREATE, UPDATE, DELETE, CONNECT, DISCONNECT]
+                        queryDirection: DIRECTED
+                    )
+            }
+        `;
+        await testHelper.initNeo4jGraphQL({
+            typeDefs,
+            features: {
+                authorization: {
+                    key: "secret",
+                },
+            },
+        });
+    });
+
+    afterAll(async () => {
+        await testHelper.close();
+    });
+
+    test("should disconnect the relationship, applying the source authorization rule to the source node", async () => {
+        await testHelper.executeCypher(`
+            CREATE (:${ProductClassSystem} {id: 123})-[:PRODUCTCLASSSYSTEM_HAS_PRODUCTCLASS]->(:${ProductClass} {id: 1, createdByApiUserName: 'test'})
+        `);
+
+        const query = /* GraphQL */ `
+            mutation {
+                ${ProductClass.operations.update}(
+                    where: { id: { eq: 1 } }
+                    update: { productClassSystem: { disconnect: [{ where: { node: { id: { eq: 123 } } } }] } }
+                ) {
+                    info {
+                        relationshipsDeleted
+                    }
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+
+        expect(result.errors).toBeFalsy();
+        expect(result?.data?.[ProductClass.operations.update]).toEqual({
+            info: {
+                relationshipsDeleted: 1,
+            },
+        });
+    });
+
+    test("should disconnect the relationship when disconnecting from the other side", async () => {
+        await testHelper.executeCypher(`
+            CREATE (:${ProductClassSystem} {id: 456})-[:PRODUCTCLASSSYSTEM_HAS_PRODUCTCLASS]->(:${ProductClass} {id: 2, createdByApiUserName: 'test'})
+        `);
+
+        const query = /* GraphQL */ `
+            mutation {
+                ${ProductClassSystem.operations.update}(
+                    where: { id: { eq: 456 } }
+                    update: { productClasses: { disconnect: [{ where: { node: { id: { eq: 2 } } } }] } }
+                ) {
+                    info {
+                        relationshipsDeleted
+                    }
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+
+        expect(result.errors).toBeFalsy();
+        expect(result?.data?.[ProductClassSystem.operations.update]).toEqual({
+            info: {
+                relationshipsDeleted: 1,
+            },
+        });
+    });
+
+    test("should throw when the source node does not pass its own DELETE_RELATIONSHIP rule", async () => {
+        await testHelper.executeCypher(`
+            CREATE (:${ProductClassSystem} {id: 999})-[:PRODUCTCLASSSYSTEM_HAS_PRODUCTCLASS]->(:${ProductClass} {id: 3, createdByApiUserName: 'test'})
+        `);
+
+        const query = /* GraphQL */ `
+            mutation {
+                ${ProductClassSystem.operations.update}(
+                    where: { id: { eq: 999 } }
+                    update: { productClasses: { disconnect: [{ where: { node: { id: { eq: 3 } } } }] } }
+                ) {
+                    info {
+                        relationshipsDeleted
+                    }
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+
+        expect((result.errors as any[])[0].message).toBe("Forbidden");
+    });
+
+    test("should throw when the target node does not pass its own DELETE_RELATIONSHIP rule", async () => {
+        await testHelper.executeCypher(`
+            CREATE (:${ProductClassSystem} {id: 111})-[:PRODUCTCLASSSYSTEM_HAS_PRODUCTCLASS]->(:${ProductClass} {id: 4, createdByApiUserName: 'test'})
+        `);
+
+        const query = /* GraphQL */ `
+            mutation {
+                ${ProductClass.operations.update}(
+                    where: { id: { eq: 4 } }
+                    update: { productClassSystem: { disconnect: [{ where: { node: { id: { eq: 111 } } } }] } }
+                ) {
+                    info {
+                        relationshipsDeleted
+                    }
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+
+        expect((result.errors as any[])[0].message).toBe("Forbidden");
+    });
+
+    test("should delete the node when the relationship is deleted implicitly by the node deletion", async () => {
+        await testHelper.executeCypher(`
+            CREATE (:${ProductClassSystem} {id: 123})-[:PRODUCTCLASSSYSTEM_HAS_PRODUCTCLASS]->(:${ProductClass} {id: 5, createdByApiUserName: 'test'})
+        `);
+
+        const query = /* GraphQL */ `
+            mutation {
+                ${ProductClass.operations.delete}(where: { id: { eq: 5 } }) {
+                    nodesDeleted
+                    relationshipsDeleted
+                }
+            }
+        `;
+
+        const result = await testHelper.executeGraphQL(query);
+
+        expect(result.errors).toBeFalsy();
+        expect(result?.data?.[ProductClass.operations.delete]).toEqual({
+            nodesDeleted: 1,
+            relationshipsDeleted: 1,
+        });
+    });
+});


### PR DESCRIPTION
# Description

Authorization validation rule AFTER on disconnect relationship is erroneously taking the target node instead of source node for validation subqueries.

## Complexity

Complexity: Low

# Issue

Closes #7376 

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
