### PR TITLE
 Fix type-level `@authentication` not enforced on entities returned by `@cypher` fields

### DIFF
--- a/.changeset/fifty-doors-listen.md
+++ b/.changeset/fifty-doors-listen.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+Fix type-level `@authentication` not enforced on entities returned by `@cypher` fields

--- a/packages/graphql/src/translate/queryAST/factory/Operations/CustomCypherFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/Operations/CustomCypherFactory.ts
@@ -7,6 +7,7 @@ import type { ResolveTree } from "graphql-parse-resolve-info";
 import { AttributeAdapter } from "../../../../schema-model/attribute/model-adapters/AttributeAdapter";
 import type { EntityAdapter } from "../../../../schema-model/entity/EntityAdapter";
 import type { Neo4jGraphQLTranslationContext } from "../../../../types/neo4j-graphql-translation-context";
+import { checkEntityAuthentication } from "../../../authorization/check-authentication";
 import { TypenameFilter } from "../../ast/filters/property-filters/TypenameFilter";
 import { CypherAttributeOperation } from "../../ast/operations/CypherAttributeOperation";
 import { CypherEntityOperation } from "../../ast/operations/CypherEntityOperation";
@@ -49,6 +50,12 @@ export class CustomCypherFactory {
             return new CypherAttributeOperation(selection, cypherAttributeField, true);
         }
         if (isConcreteEntity(entity)) {
+            checkEntityAuthentication({
+                entity: entity.entity,
+                targetOperations: ["READ"],
+                context,
+            });
+
             const customCypher = new CypherEntityOperation({
                 cypherAttributeField: cypherAttributeField,
                 target: entity,
@@ -115,6 +122,12 @@ export class CustomCypherFactory {
             return new CypherAttributeOperation(selection, operationField, false);
         }
         if (isConcreteEntity(entity)) {
+            checkEntityAuthentication({
+                entity: entity.entity,
+                targetOperations: ["READ"],
+                context,
+            });
+
             const customCypher = new CypherEntityOperation({
                 cypherAttributeField: operationField,
                 target: entity,

--- a/packages/graphql/tests/integration/issues/3746.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3746.int.test.ts
@@ -21,6 +21,255 @@ describe("https://github.com/neo4j/graphql/issues/3746", () => {
         await testHelper.close();
     });
 
+    describe("type-level authentication on entities returned by @cypher fields", () => {
+        const initSchema = async () => {
+            const typeDefs = /* GraphQL */ `
+                type ${User} @node @authentication {
+                    name: String
+                    secret: String
+                }
+
+                type Query {
+                    topUser: ${User}
+                        @cypher(statement: "MATCH (u:${User}) RETURN u ORDER BY u.name LIMIT 1", columnName: "u")
+                    allUsers: [${User}!]!
+                        @cypher(statement: "MATCH (u:${User}) RETURN u ORDER BY u.name", columnName: "u")
+                }
+            `;
+
+            await testHelper.initNeo4jGraphQL({
+                typeDefs,
+                features: {
+                    authorization: {
+                        key: secret,
+                    },
+                },
+            });
+
+            await testHelper.executeCypher(`
+                CREATE (:${User} { name: "Alice", secret: "alice-secret" })
+                CREATE (:${User} { name: "Bob", secret: "bob-secret" })
+            `);
+        };
+
+        test("should throw unauthenticated on a single @cypher field when unauthenticated", async () => {
+            await initSchema();
+
+            const query = /* GraphQL */ `
+                {
+                    topUser {
+                        name
+                        secret
+                    }
+                }
+            `;
+
+            const gqlResult = await testHelper.executeGraphQL(query);
+
+            expect(gqlResult.errors).toHaveLength(1);
+            expect(gqlResult.errors?.[0]?.message).toBe("Unauthenticated");
+            expect(gqlResult.data?.topUser).toBeFalsy();
+        });
+
+        test("should throw unauthenticated on a list @cypher field when unauthenticated", async () => {
+            await initSchema();
+
+            const query = /* GraphQL */ `
+                {
+                    allUsers {
+                        name
+                        secret
+                    }
+                }
+            `;
+
+            const gqlResult = await testHelper.executeGraphQL(query);
+
+            expect(gqlResult.errors).toHaveLength(1);
+            expect(gqlResult.errors?.[0]?.message).toBe("Unauthenticated");
+            expect(gqlResult.data?.allUsers).toBeFalsy();
+        });
+
+        test("should return data from a @cypher field when authenticated", async () => {
+            await initSchema();
+
+            const query = /* GraphQL */ `
+                {
+                    topUser {
+                        name
+                        secret
+                    }
+                    allUsers {
+                        name
+                    }
+                }
+            `;
+
+            const token = createBearerToken(secret, { sub: generate({ charset: "alphabetic" }) });
+
+            const gqlResult = await testHelper.executeGraphQLWithToken(query, token);
+
+            expect(gqlResult.errors).toBeUndefined();
+            expect(gqlResult.data).toEqual({
+                topUser: { name: "Alice", secret: "alice-secret" },
+                allUsers: [{ name: "Alice" }, { name: "Bob" }],
+            });
+        });
+
+        test("should throw unauthenticated on a nested @cypher field returning a protected type", async () => {
+            const typeDefs = /* GraphQL */ `
+                type ${User} @node {
+                    name: String
+                    profile: ${User.name}Profile
+                        @cypher(statement: "MATCH (p:${User.name}Profile) RETURN p LIMIT 1", columnName: "p")
+                }
+
+                type ${User.name}Profile @node @authentication {
+                    email: String
+                    secret: String
+                }
+            `;
+
+            await testHelper.initNeo4jGraphQL({
+                typeDefs,
+                features: {
+                    authorization: {
+                        key: secret,
+                    },
+                },
+            });
+
+            await testHelper.executeCypher(`
+                CREATE (:${User} { name: "Keanu" })
+                CREATE (:${User.name}Profile { email: "keanu@example.com", secret: "keanu-secret" })
+            `);
+
+            const query = /* GraphQL */ `
+                {
+                    ${User.plural} {
+                        name
+                        profile {
+                            email
+                            secret
+                        }
+                    }
+                }
+            `;
+
+            const unauthenticatedResult = await testHelper.executeGraphQL(query);
+
+            expect(unauthenticatedResult.errors).toHaveLength(1);
+            expect(unauthenticatedResult.errors?.[0]?.message).toBe("Unauthenticated");
+
+            const token = createBearerToken(secret, { sub: generate({ charset: "alphabetic" }) });
+            const authenticatedResult = await testHelper.executeGraphQLWithToken(query, token);
+
+            expect(authenticatedResult.errors).toBeUndefined();
+            expect(authenticatedResult.data).toEqual({
+                [User.plural]: [{ name: "Keanu", profile: { email: "keanu@example.com", secret: "keanu-secret" } }],
+            });
+        });
+
+        test("should throw unauthenticated on a root @cypher field on Mutation returning a protected type", async () => {
+            const typeDefs = /* GraphQL */ `
+                type ${User} @node @authentication {
+                    name: String
+                    secret: String
+                }
+
+                type Mutation {
+                    makeUser(name: String!): ${User}
+                        @cypher(statement: "CREATE (u:${User} { name: $name }) RETURN u", columnName: "u")
+                }
+            `;
+
+            await testHelper.initNeo4jGraphQL({
+                typeDefs,
+                features: {
+                    authorization: {
+                        key: secret,
+                    },
+                },
+            });
+
+            const query = /* GraphQL */ `
+                mutation {
+                    makeUser(name: "Alice") {
+                        name
+                    }
+                }
+            `;
+
+            const unauthenticatedResult = await testHelper.executeGraphQL(query);
+
+            expect(unauthenticatedResult.errors).toHaveLength(1);
+            expect(unauthenticatedResult.errors?.[0]?.message).toBe("Unauthenticated");
+
+            const token = createBearerToken(secret, { sub: generate({ charset: "alphabetic" }) });
+            const authenticatedResult = await testHelper.executeGraphQLWithToken(query, token);
+
+            expect(authenticatedResult.errors).toBeUndefined();
+            expect(authenticatedResult.data).toEqual({
+                makeUser: { name: "Alice" },
+            });
+        });
+
+        test("should throw unauthenticated on a nested @cypher field selected in a generated mutation response", async () => {
+            const typeDefs = /* GraphQL */ `
+                type ${User} @node {
+                    name: String
+                    profile: ${User.name}Profile
+                        @cypher(statement: "MATCH (p:${User.name}Profile) RETURN p LIMIT 1", columnName: "p")
+                }
+
+                type ${User.name}Profile @node @authentication {
+                    email: String
+                }
+            `;
+
+            await testHelper.initNeo4jGraphQL({
+                typeDefs,
+                features: {
+                    authorization: {
+                        key: secret,
+                    },
+                },
+            });
+
+            await testHelper.executeCypher(`
+                CREATE (:${User.name}Profile { email: "keanu@example.com" })
+            `);
+
+            const query = /* GraphQL */ `
+                mutation {
+                    ${User.operations.create}(input: [{ name: "Keanu" }]) {
+                        ${User.plural} {
+                            name
+                            profile {
+                                email
+                            }
+                        }
+                    }
+                }
+            `;
+
+            const unauthenticatedResult = await testHelper.executeGraphQL(query);
+
+            expect(unauthenticatedResult.errors).toHaveLength(1);
+            expect(unauthenticatedResult.errors?.[0]?.message).toBe("Unauthenticated");
+
+            const token = createBearerToken(secret, { sub: generate({ charset: "alphabetic" }) });
+            const authenticatedResult = await testHelper.executeGraphQLWithToken(query, token);
+
+            expect(authenticatedResult.errors).toBeUndefined();
+            expect(authenticatedResult.data).toEqual({
+                [User.operations.create]: {
+                    [User.plural]: [{ name: "Keanu", profile: { email: "keanu@example.com" } }],
+                },
+            });
+        });
+    });
+
     test("should apply field-level authentication to root field on Query - pass", async () => {
         const typeDefs = /* GraphQL */ `
             type ${User} @node {


### PR DESCRIPTION
# Description

Fix type-level `@authentication` not enforced on entities returned by `@cypher` fields

## Complexity

Complexity: Low

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [x] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
